### PR TITLE
Bump spec, fixes key regex

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -311,7 +311,7 @@
                     "secret": {
                         "description": "The endpoint's verification secret. If `null` is passed, a secret is automatically generated.",
                         "example": "whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD",
-                        "pattern": "^whsec_[a-zA-Z0-9+\\/]{32}$",
+                        "pattern": "^whsec_[a-zA-Z0-9+/]{32}$",
                         "title": "Secret",
                         "type": "string"
                     },
@@ -482,7 +482,7 @@
                     "key": {
                         "description": "The endpoint's verification secret. If `null` is passed, a secret is automatically generated.",
                         "example": "whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD",
-                        "pattern": "^whsec_[a-zA-Z0-9+\\/]{32}$",
+                        "pattern": "^whsec_[a-zA-Z0-9+/]{32}$",
                         "title": "Key",
                         "type": "string"
                     }
@@ -498,7 +498,7 @@
                     "key": {
                         "description": "The endpoint's verification secret. If `null` is passed, a secret is automatically generated.",
                         "example": "whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD",
-                        "pattern": "^whsec_[a-zA-Z0-9+\\/]{32}$",
+                        "pattern": "^whsec_[a-zA-Z0-9+/]{32}$",
                         "title": "Key",
                         "type": "string"
                     }


### PR DESCRIPTION
The regex in our open API spec was incorrect and in turn this was generating invalid ruby code for client side regex verification