### PR TITLE
Implement GET/PUT for Endpoint Headers

### DIFF
--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -44,3 +44,4 @@ redis = { version = "0.21.5", features = ["tokio-comp"] }
 # sea orm
 sea-orm = { version = "0.5.0", features = [ "sqlx-postgres", "runtime-tokio-rustls", "macros" ], default-features = false }
 sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "postgres", "migrate" ] }
+http = "0.2"

--- a/server/svix-server/migrations/20220218061228_endpoint_headers.down.sql
+++ b/server/svix-server/migrations/20220218061228_endpoint_headers.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE endpoint DROP COLUMN headers;

--- a/server/svix-server/migrations/20220218061228_endpoint_headers.up.sql
+++ b/server/svix-server/migrations/20220218061228_endpoint_headers.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE endpoint ADD COLUMN headers jsonb;

--- a/server/svix-server/src/db/models/endpoint.rs
+++ b/server/svix-server/src/db/models/endpoint.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 use crate::core::types::{
-    ApplicationId, BaseId, EndpointId, EndpointIdOrUid, EndpointSecret, EndpointUid,
-    EventChannelSet, EventTypeNameSet, ExpiringSigningKeys,
+    ApplicationId, BaseId, EndpointHeaders, EndpointId, EndpointIdOrUid, EndpointSecret,
+    EndpointUid, EventChannelSet, EventTypeNameSet, ExpiringSigningKeys,
 };
 use chrono::Utc;
 use sea_orm::ActiveValue::Set;
@@ -29,6 +29,7 @@ pub struct Model {
     pub uid: Option<EndpointUid>,
     pub old_keys: Option<ExpiringSigningKeys>,
     pub channels: Option<EventChannelSet>,
+    pub headers: Option<EndpointHeaders>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]


### PR DESCRIPTION
## Motivation
Add GET and PUT routes for retrieving and adding Endpoint Headers

## Solution
Represent headers as jsonb column in database; support basic validation of header names and values upon creation using functionality in 'http' crate; mask sensitive headers on retrieval.
