### PR TITLE
Python: Don't regen requirements.txt

### DIFF
--- a/python/.openapi-generator-ignore
+++ b/python/.openapi-generator-ignore
@@ -35,3 +35,4 @@ docs/
 test/
 test-requirements.txt
 tox.ini
+requirements.txt

--- a/python/.openapi-generator-ignore
+++ b/python/.openapi-generator-ignore
@@ -34,5 +34,5 @@
 docs/
 test/
 test-requirements.txt
-tox.ini
 requirements.txt
+tox.ini


### PR DESCRIPTION
We have a new requirement that doesn't come from the generator
so we shouldn't regenerate this file anymore.