### PR TITLE
JS: IdempotencyKey, default to empty string

### DIFF
--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -126,6 +126,7 @@ class Authentication {
     return this.api.getDashboardAccessApiV1AuthDashboardAccessAppIdPost({
       appId,
       ...options,
+      idempotencyKey: options?.idempotencyKey || ""
     });
   }
 
@@ -185,7 +186,11 @@ class Application {
     applicationIn: ApplicationIn,
     options?: PostOptions
   ): Promise<ApplicationOut> {
-    return this.api.createApplicationApiV1AppPost({ applicationIn, ...options });
+    return this.api.createApplicationApiV1AppPost({
+      applicationIn,
+      ...options,
+      idempotencyKey: options?.idempotencyKey || ""
+    });
   }
 
   public get(appId: string): Promise<ApplicationOut> {
@@ -224,6 +229,7 @@ class Endpoint {
       appId,
       endpointIn,
       ...options,
+      idempotencyKey: options?.idempotencyKey || ""
     });
   }
 
@@ -268,6 +274,7 @@ class Endpoint {
       appId,
       endpointSecretRotateIn,
       ...options,
+      idempotencyKey: options?.idempotencyKey || ""
     });
   }
 
@@ -283,6 +290,7 @@ class Endpoint {
         endpointId,
         recoverIn,
         ...options,
+        idempotencyKey: options?.idempotencyKey || ""
       })
       .then(() => Promise.resolve());
   }
@@ -376,6 +384,7 @@ class Integration {
       appId,
       integrationIn,
       ...options,
+      idempotencyKey: options?.idempotencyKey || ""
     });
   }
 
@@ -418,6 +427,7 @@ class Integration {
       integId,
       appId,
       ...options,
+      idempotencyKey: options?.idempotencyKey || ""
     });
   }
 }
@@ -441,7 +451,12 @@ class Message {
     messageIn: MessageIn,
     options?: PostOptions
   ): Promise<MessageOut> {
-    return this.api.createMessageApiV1AppAppIdMsgPost({ appId, messageIn, ...options });
+    return this.api.createMessageApiV1AppAppIdMsgPost({
+      appId,
+      messageIn,
+      ...options,
+      idempotencyKey: options?.idempotencyKey || ""
+    });
   }
 
   public get(appId: string, msgId: string): Promise<MessageOut> {
@@ -514,6 +529,7 @@ class MessageAttempt {
       msgId,
       appId,
       ...options,
+      idempotencyKey: options?.idempotencyKey || ""
     });
   }
 


### PR DESCRIPTION
The JS templates erroneously sets the IdempotencyKey to literal string `undefined` if idempotencyKey is undefined.  This is extremely bad behavior, a quick fix is to set it to "" which is ignored by the API.  I will follow up with a fix to the templates shortly.