### PR TITLE
Javascript: Update Templates to conditionally set headers only if defined

### DIFF
--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -126,7 +126,6 @@ class Authentication {
     return this.api.getDashboardAccessApiV1AuthDashboardAccessAppIdPost({
       appId,
       ...options,
-      idempotencyKey: options?.idempotencyKey || ""
     });
   }
 
@@ -186,11 +185,7 @@ class Application {
     applicationIn: ApplicationIn,
     options?: PostOptions
   ): Promise<ApplicationOut> {
-    return this.api.createApplicationApiV1AppPost({
-      applicationIn,
-      ...options,
-      idempotencyKey: options?.idempotencyKey || ""
-    });
+    return this.api.createApplicationApiV1AppPost({ applicationIn, ...options });
   }
 
   public get(appId: string): Promise<ApplicationOut> {
@@ -229,7 +224,6 @@ class Endpoint {
       appId,
       endpointIn,
       ...options,
-      idempotencyKey: options?.idempotencyKey || ""
     });
   }
 
@@ -274,7 +268,6 @@ class Endpoint {
       appId,
       endpointSecretRotateIn,
       ...options,
-      idempotencyKey: options?.idempotencyKey || ""
     });
   }
 
@@ -290,7 +283,6 @@ class Endpoint {
         endpointId,
         recoverIn,
         ...options,
-        idempotencyKey: options?.idempotencyKey || ""
       })
       .then(() => Promise.resolve());
   }
@@ -384,7 +376,6 @@ class Integration {
       appId,
       integrationIn,
       ...options,
-      idempotencyKey: options?.idempotencyKey || ""
     });
   }
 
@@ -427,7 +418,6 @@ class Integration {
       integId,
       appId,
       ...options,
-      idempotencyKey: options?.idempotencyKey || ""
     });
   }
 }
@@ -451,12 +441,7 @@ class Message {
     messageIn: MessageIn,
     options?: PostOptions
   ): Promise<MessageOut> {
-    return this.api.createMessageApiV1AppAppIdMsgPost({
-      appId,
-      messageIn,
-      ...options,
-      idempotencyKey: options?.idempotencyKey || ""
-    });
+    return this.api.createMessageApiV1AppAppIdMsgPost({ appId, messageIn, ...options });
   }
 
   public get(appId: string, msgId: string): Promise<MessageOut> {
@@ -529,7 +514,6 @@ class MessageAttempt {
       msgId,
       appId,
       ...options,
-      idempotencyKey: options?.idempotencyKey || ""
     });
   }
 

--- a/javascript/templates/api/api.mustache
+++ b/javascript/templates/api/api.mustache
@@ -1,0 +1,219 @@
+// TODO: better import syntax?
+import { BaseAPIRequestFactory, RequiredError } from './baseapi{{extensionForDeno}}';
+import {Configuration} from '../configuration{{extensionForDeno}}';
+import { RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http{{extensionForDeno}}';
+{{#platforms}}
+{{#node}}
+import * as FormData from "form-data";
+{{/node}}
+{{/platforms}}
+import {ObjectSerializer} from '../models/ObjectSerializer{{extensionForDeno}}';
+import {ApiException} from './exception{{extensionForDeno}}';
+import {isCodeInRange} from '../util{{extensionForDeno}}';
+{{#useInversify}}
+import { injectable } from "inversify";
+{{/useInversify}}
+
+{{#imports}}
+import { {{classname}} } from '..{{filename}}{{extensionForDeno}}';
+{{/imports}}
+{{#operations}}
+
+/**
+ * {{#description}}{{{description}}}{{/description}}{{^description}}no description{{/description}}
+ */
+{{#useInversify}}
+@injectable()
+{{/useInversify}}
+export class {{classname}}RequestFactory extends BaseAPIRequestFactory {
+
+    {{#operation}}
+    /**
+     {{#notes}}
+     * {{&notes}}
+     {{/notes}}
+     {{#summary}}
+     * {{&summary}}
+     {{/summary}}
+     {{#allParams}}
+     * @param {{paramName}} {{description}}
+     {{/allParams}}
+     */
+    public async {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}_options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
+        {{#allParams}}
+
+        {{#required}}
+        // verify required parameter '{{paramName}}' is not null or undefined
+        if ({{paramName}} === null || {{paramName}} === undefined) {
+            throw new RequiredError('Required parameter {{paramName}} was null or undefined when calling {{nickname}}.');
+        }
+
+        {{/required}}
+        {{/allParams}}
+
+        // Path Params
+        const localVarPath = '{{{path}}}'{{#pathParams}}
+            .replace('{' + '{{baseName}}' + '}', encodeURIComponent(String({{paramName}}))){{/pathParams}};
+
+        // Make Request Context
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.{{httpMethod}});
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
+
+        // Query Params
+        {{#queryParams}}
+        if ({{paramName}} !== undefined) {
+            requestContext.setQueryParam("{{baseName}}", ObjectSerializer.serialize({{paramName}}, "{{{dataType}}}", "{{dataFormat}}"));
+        }
+        {{/queryParams}}
+
+        // Header Params
+        {{#headerParams}}
+        requestContext.setHeaderParam("{{baseName}}", ObjectSerializer.serialize({{paramName}}, "{{{dataType}}}", "{{dataFormat}}"));
+        {{/headerParams}}
+
+        // Form Params
+        {{#hasFormParams}}
+        let localVarFormParams = new FormData();
+        {{/hasFormParams}}
+
+        {{#formParams}}
+        {{#isArray}}
+        if ({{paramName}}) {
+        {{#isCollectionFormatMulti}}
+            {{paramName}}.forEach((element) => {
+                localVarFormParams.append('{{baseName}}', element as any);
+            })
+        {{/isCollectionFormatMulti}}
+        {{^isCollectionFormatMulti}}
+            // TODO: replace .append with .set
+            localVarFormParams.append('{{baseName}}', {{paramName}}.join(COLLECTION_FORMATS["{{collectionFormat}}"]));
+        {{/isCollectionFormatMulti}}
+        }
+        {{/isArray}}
+        {{^isArray}}
+        if ({{paramName}} !== undefined) {
+             // TODO: replace .append with .set
+             {{^isFile}}
+             localVarFormParams.append('{{baseName}}', {{paramName}} as any);
+             {{/isFile}}
+             {{#isFile}}
+             {{#platforms}}
+             {{#node}}
+             localVarFormParams.append('{{baseName}}', {{paramName}}.data, {{paramName}}.name);
+             {{/node}}
+             {{^node}}
+             localVarFormParams.append('{{baseName}}', {{paramName}}, {{paramName}}.name);
+             {{/node}}
+             {{/platforms}}
+             {{/isFile}}
+        }
+        {{/isArray}}
+        {{/formParams}}
+        {{#hasFormParams}}
+        requestContext.setBody(localVarFormParams);
+        {{/hasFormParams}}
+
+        // Body Params
+        {{#bodyParam}}
+        const contentType = ObjectSerializer.getPreferredMediaType([{{#consumes}}
+            "{{{mediaType}}}"{{^-last}},{{/-last}}
+        {{/consumes}}]);
+        requestContext.setHeaderParam("Content-Type", contentType);
+        const serializedBody = ObjectSerializer.stringify(
+            ObjectSerializer.serialize({{paramName}}, "{{{dataType}}}", "{{dataFormat}}"),
+            contentType
+        );
+        requestContext.setBody(serializedBody);
+        {{/bodyParam}}
+
+        {{#hasAuthMethods}}
+        let authMethod = null;
+        {{/hasAuthMethods}}
+        // Apply auth methods
+        {{#authMethods}}
+        authMethod = _config.authMethods["{{name}}"]
+        if (authMethod) {
+            await authMethod.applySecurityAuthentication(requestContext);
+        }
+        {{/authMethods}}
+
+        return requestContext;
+    }
+
+    {{/operation}}
+}
+{{/operations}}
+{{#operations}}
+
+{{#useInversify}}
+@injectable()
+{{/useInversify}}
+export class {{classname}}ResponseProcessor {
+
+    {{#operation}}
+    /**
+     * Unwraps the actual response sent by the server from the response context and deserializes the response content
+     * to the expected objects
+     *
+     * @params response Response returned by the server for a request to {{nickname}}
+     * @throws ApiException if the response code was not in [200, 299]
+     */
+     public async {{nickname}}(response: ResponseContext): Promise<{{#returnType}}{{{returnType}}}{{/returnType}} {{^returnType}}void{{/returnType}}> {
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
+        {{#responses}}
+        if (isCodeInRange("{{code}}", response.httpStatusCode)) {
+            {{#dataType}}
+            {{#isBinary}}
+            const body: {{{dataType}}} = await response.getBodyAsFile() as any as {{{returnType}}};
+            {{/isBinary}}
+            {{^isBinary}}
+            const body: {{{dataType}}} = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "{{{dataType}}}", "{{returnFormat}}"
+            ) as {{{dataType}}};
+            {{/isBinary}}
+            {{#is2xx}}
+            return body;
+            {{/is2xx}}
+            {{^is2xx}}
+            throw new ApiException<{{{dataType}}}>({{code}}, body);
+            {{/is2xx}}
+            {{/dataType}}
+            {{^dataType}}
+            {{#is2xx}}
+            return;
+            {{/is2xx}}
+            {{^is2xx}}
+            throw new ApiException<string>(response.httpStatusCode, "{{message}}");
+            {{/is2xx}}
+            {{/dataType}}
+        }
+        {{/responses}}
+
+        // Work around for missing responses in specification, e.g. for petstore.yaml
+        if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
+            {{#returnType}}
+            {{#isBinary}}
+            const body: {{{returnType}}} = await response.getBodyAsFile() as any as {{{returnType}}};
+            {{/isBinary}}
+            {{^isBinary}}
+            const body: {{{returnType}}} = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "{{{returnType}}}", "{{returnFormat}}"
+            ) as {{{returnType}}};
+            {{/isBinary}}
+            return body;
+            {{/returnType}}
+            {{^returnType}}
+            return;
+            {{/returnType}}
+        }
+
+        let body = response.body || "";
+        throw new ApiException<string>(response.httpStatusCode, "Unknown API Status Code!\nBody: \"" + body + "\"");
+    }
+
+    {{/operation}}
+}
+{{/operations}}

--- a/javascript/templates/api/api.mustache
+++ b/javascript/templates/api/api.mustache
@@ -69,7 +69,9 @@ export class {{classname}}RequestFactory extends BaseAPIRequestFactory {
 
         // Header Params
         {{#headerParams}}
-        requestContext.setHeaderParam("{{baseName}}", ObjectSerializer.serialize({{paramName}}, "{{{dataType}}}", "{{dataFormat}}"));
+        if ({{paramName}} !== undefined) {
+            requestContext.setHeaderParam("{{baseName}}", ObjectSerializer.serialize({{paramName}}, "{{{dataType}}}", "{{dataFormat}}"));
+        }
         {{/headerParams}}
 
         // Form Params

--- a/regen_openapi.sh
+++ b/regen_openapi.sh
@@ -8,7 +8,7 @@ fi
 
 yarn openapi-generator-cli generate -i openapi.json -g python -o python/ -c python/openapi-generator-config.json -t python/templates
 
-yarn openapi-generator-cli generate -i openapi.json -g typescript -o javascript/src/openapi -c javascript/openapi-generator-config.json
+yarn openapi-generator-cli generate -i openapi.json -g typescript -o javascript/src/openapi -c javascript/openapi-generator-config.json -t javascript/templates
 
 yarn openapi-generator-cli generate -i openapi.json -g go -o go/internal/openapi -c go/openapi-generator-config.json -t go/templates
 


### PR DESCRIPTION
This is a follow up to #273, #273 was a hotfix to set the idempotency key to an empty string if not set which works with our current server implementation but is way to fragile.  This updates the generator templates to properly ignore undefined fields.