### PR TITLE
server: PATCH Endpoint Headers

### DIFF
--- a/server/svix-server/src/core/types.rs
+++ b/server/svix-server/src/core/types.rs
@@ -490,7 +490,7 @@ pub struct ExpiringSigningKey {
     pub expiration: DateTime<Utc>,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Default)]
 pub struct EndpointHeaders(pub HashMap<String, String>);
 json_wrapper!(EndpointHeaders);
 


### PR DESCRIPTION
## Motivation

Implement PATCH method for updating endpoint headers; update axum extension setup to remove deprecated APIs

## Solution

Merge new/modified headers with existing