### PR TITLE
Launch dependencies before server unit tests

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -54,7 +54,7 @@ jobs:
     - uses: Swatinem/rust-cache@v1
 
     - name: Start dependencies
-      run: docker-compose -f "server/docker-compose.yml" up --no-build -d
+      run: docker-compose -f "server/testing-docker-compose.yml" up -d
 
     - name: Run tests
       uses: actions-rs/cargo@v1

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -25,11 +25,13 @@ jobs:
         profile: minimal
         components: clippy, rustfmt
     - uses: Swatinem/rust-cache@v1
+
     - name: Check
       uses: actions-rs/cargo@v1
       with:
         command: clippy
         args: --manifest-path server/Cargo.toml --all --all-targets --all-features
+        
     - name: rustfmt
       uses: actions-rs/cargo@v1
       with:
@@ -50,11 +52,23 @@ jobs:
         override: true
         profile: minimal
     - uses: Swatinem/rust-cache@v1
+
+    - name: Start dependencies
+      run: docker-compose -f "server/docker-compose.yml" up -d --build
+
     - name: Run tests
       uses: actions-rs/cargo@v1
+      env:
+        DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/postgres"
+        SVIX_REDIS_DSN: "redis://localhost:6379"
+        SVIX_QUEUE_TYPE: "redis"
+        SVIX_JWT_SECRET: "test value"
       with:
         command: test
         args: --manifest-path server/Cargo.toml  --all --all-features --all-targets
+
+    - name: Stop dependencies
+      run: docker-compose -f "server/docker-compose.yml" down
 
 #  deny-check:
 #    name: cargo-deny check

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -54,7 +54,7 @@ jobs:
     - uses: Swatinem/rust-cache@v1
 
     - name: Start dependencies
-      run: docker-compose -f "server/docker-compose.yml" up -d
+      run: docker-compose -f "server/docker-compose.yml" up --no-build -d
 
     - name: Run tests
       uses: actions-rs/cargo@v1

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -54,7 +54,7 @@ jobs:
     - uses: Swatinem/rust-cache@v1
 
     - name: Start dependencies
-      run: docker-compose -f "server/docker-compose.yml" up -d --build
+      run: docker-compose -f "server/docker-compose.yml" up -d
 
     - name: Run tests
       uses: actions-rs/cargo@v1

--- a/server/testing-docker-compose.yml
+++ b/server/testing-docker-compose.yml
@@ -6,19 +6,6 @@ services:
       - "postgres-data:/var/lib/postgresql/data/"
     environment:
       POSTGRES_PASSWORD: postgres
-
-  pgbouncer:
-    image: edoburu/pgbouncer:1.15.0
-    healthcheck:
-      test: "pg_isready -h localhost"
-      interval: 30s
-      timeout: 10s
-      retries: 3
-    environment:
-      DB_HOST: "postgres"
-      DB_USER: "postgres"
-      DB_PASSWORD: "postgres"
-      MAX_CLIENT_CONN: 500
     ports:
       - "5432:5432"
 

--- a/server/testing-docker-compose.yml
+++ b/server/testing-docker-compose.yml
@@ -1,0 +1,27 @@
+version: "3.7"
+services:
+  postgres:
+    image: postgres:13.4
+    volumes:
+      - "postgres-data:/var/lib/postgresql/data/"
+    environment:
+      POSTGRES_PASSWORD: postgres
+
+  pgbouncer:
+    image: edoburu/pgbouncer:1.15.0
+    healthcheck:
+      test: "pg_isready -h localhost"
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    environment:
+      DB_HOST: "postgres"
+      DB_USER: "postgres"
+      DB_PASSWORD: "postgres"
+      MAX_CLIENT_CONN: 500
+
+  redis:
+    image: "redis:6.2-alpine"
+
+volumes:
+  postgres-data:

--- a/server/testing-docker-compose.yml
+++ b/server/testing-docker-compose.yml
@@ -19,9 +19,13 @@ services:
       DB_USER: "postgres"
       DB_PASSWORD: "postgres"
       MAX_CLIENT_CONN: 500
+    ports:
+      - "5432:5432"
 
   redis:
     image: "redis:6.2-alpine"
+    ports:
+      - "6379:6379"
 
 volumes:
   postgres-data:


### PR DESCRIPTION
Launches PostgreSQL and Redis via the  `docker-compose.yml` for the server before running unit tests.