### PR TITLE
Draft: Enable clippy::pedantic lints and correct them

### DIFF
--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -138,6 +138,7 @@ impl ToString for LogLevel {
         .to_string()
     }
 }
+
 pub fn load() -> Result<Arc<ConfigurationInner>> {
     if let Ok(db_url) = std::env::var("DATABASE_URL") {
         // If we have DATABASE_URL set, we should potentially use it.

--- a/server/svix-server/src/core/cache.rs
+++ b/server/svix-server/src/core/cache.rs
@@ -54,7 +54,7 @@ macro_rules! kv_def {
 }
 pub(crate) use kv_def;
 
-/// A Redis-based cache of data to avoid expensive fetches from PostgreSQL. Simply a wrapper over
+/// A Redis-based cache of data to avoid expensive fetches from postgres. Simply a wrapper over
 /// Redis.
 #[derive(Debug, Clone)]
 pub struct RedisCache {
@@ -74,7 +74,7 @@ impl RedisCache {
             .transpose()?)
     }
 
-    /// Sets a CacheKey to its associated CacheValue.
+    /// Sets a [`CacheKey`] to its associated [`CacheValue`].
     /// Note that the [`Duration`] used is down to millisecond precision.
     pub async fn set<T: CacheValue>(&self, key: &T::Key, value: &T, ttl: Duration) -> Result<()> {
         let mut pool = self.redis.get().await?;

--- a/server/svix-server/src/core/types.rs
+++ b/server/svix-server/src/core/types.rs
@@ -14,7 +14,7 @@ use sea_orm::{
 };
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
-use svix_ksuid::*;
+use svix_ksuid::{Ksuid, KsuidLike};
 use validator::{Validate, ValidationError, ValidationErrors};
 
 const ALL_ERROR: &str = "__all__";
@@ -376,7 +376,7 @@ json_wrapper!(EventChannelSet);
 
 impl Validate for EventChannelSet {
     fn validate(&self) -> Result<(), validator::ValidationErrors> {
-        for item in self.0.iter() {
+        for item in &self.0 {
             item.validate()?;
         }
         Ok(())
@@ -389,7 +389,7 @@ json_wrapper!(EventTypeNameSet);
 
 impl Validate for EventTypeNameSet {
     fn validate(&self) -> Result<(), validator::ValidationErrors> {
-        for item in self.0.iter() {
+        for item in &self.0 {
             item.validate()?;
         }
         Ok(())

--- a/server/svix-server/src/db/models/application.rs
+++ b/server/svix-server/src/db/models/application.rs
@@ -76,7 +76,7 @@ impl Entity {
     ) -> Select<Entity> {
         Self::secure_find(org_id).filter(
             Condition::any()
-                .add(Column::Id.eq(id_or_uid.to_owned()))
+                .add(Column::Id.eq(id_or_uid.clone()))
                 .add(Column::Uid.eq(id_or_uid)),
         )
     }

--- a/server/svix-server/src/db/models/endpoint.rs
+++ b/server/svix-server/src/db/models/endpoint.rs
@@ -92,7 +92,7 @@ impl Entity {
     ) -> Select<Entity> {
         Self::secure_find(app_id).filter(
             Condition::any()
-                .add(Column::Id.eq(id_or_uid.to_owned()))
+                .add(Column::Id.eq(id_or_uid.clone()))
                 .add(Column::Uid.eq(id_or_uid)),
         )
     }

--- a/server/svix-server/src/db/models/message.rs
+++ b/server/svix-server/src/db/models/message.rs
@@ -82,7 +82,7 @@ impl Entity {
     ) -> Select<Entity> {
         Self::secure_find(app_id).filter(
             Condition::any()
-                .add(Column::Id.eq(id_or_uid.to_owned()))
+                .add(Column::Id.eq(id_or_uid.clone()))
                 .add(Column::Uid.eq(id_or_uid)),
         )
     }

--- a/server/svix-server/src/error.rs
+++ b/server/svix-server/src/error.rs
@@ -12,7 +12,7 @@ use sea_orm::DbErr;
 use serde::Serialize;
 use serde_json::json;
 
-/// A short-hand version of a [std::result::Result] that always returns an Svix [Error].
+/// A short-hand version of a [`std::result::Result`] that always returns an Svix [Error].
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// The error type returned from the Svix API
@@ -33,10 +33,9 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Error::Generic(s) => s.fmt(f),
-            Error::Database(s) => s.fmt(f),
-            Error::Queue(s) => s.fmt(f),
-            Error::Validation(s) => s.fmt(f),
+            Error::Generic(s) | Error::Database(s) | Error::Queue(s) | Error::Validation(s) => {
+                s.fmt(f)
+            }
             Error::Http(s) => s.fmt(f),
         }
     }

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -1,8 +1,13 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
-#![warn(clippy::all)]
 #![forbid(unsafe_code)]
+#![warn(clippy::all)]
+#![warn(clippy::pedantic)]
+// This lint warns on `..Default::default()` in struct initialization
+#![allow(clippy::default_trait_access)]
+// This lint warns on axum services that need to be async to route properly
+#![allow(clippy::unused_async)]
 
 use axum::{extract::Extension, Router};
 use bb8_redis::RedisConnectionManager;
@@ -14,7 +19,6 @@ use tower_http::trace::TraceLayer;
 use crate::{
     core::{cache::RedisCache, security::generate_token},
     db::init_db,
-    worker::worker_loop,
 };
 
 mod cfg;
@@ -137,7 +141,7 @@ async fn main() {
         async {
             if with_worker {
                 tracing::debug!("Worker: Initializing");
-                worker_loop(cfg, pool, redis_cache, queue_tx, queue_rx).await
+                worker::main_loop(cfg, pool, redis_cache, queue_tx, queue_rx).await
             } else {
                 tracing::debug!("Worker: off");
                 Ok(())

--- a/server/svix-server/src/queue/mod.rs
+++ b/server/svix-server/src/queue/mod.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use axum::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use svix_ksuid::*;
+use svix_ksuid::{Ksuid, KsuidLike};
 
 use crate::{
     core::types::{ApplicationId, EndpointId, MessageAttemptTriggerType, MessageId},

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -65,6 +65,8 @@ impl From<messageattempt::Model> for MessageAttemptOut {
     }
 }
 
+// [`AttemptListFetchOptions`] starting with `Attempt` seems justified here
+#[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Deserialize, Validate)]
 pub struct AttemptListFetchOptions {
     pub endpoint_id: Option<EndpointIdOrUid>,
@@ -105,7 +107,7 @@ async fn list_messageattempts(
         .limit(limit + 1);
 
     if let Some(iterator) = iterator {
-        query = query.filter(messageattempt::Column::Id.lt(iterator))
+        query = query.filter(messageattempt::Column::Id.lt(iterator));
     }
 
     if let Some(endpoint_id) = endpoint_id {
@@ -113,16 +115,16 @@ async fn list_messageattempts(
             .one(db)
             .await?
             .ok_or_else(|| HttpError::not_found(None, None))?;
-        query = query.filter(messageattempt::Column::EndpId.eq(endp.id))
+        query = query.filter(messageattempt::Column::EndpId.eq(endp.id));
     }
 
     if let Some(status) = status {
-        query = query.filter(messageattempt::Column::Status.eq(status))
+        query = query.filter(messageattempt::Column::Status.eq(status));
     }
 
     Ok(Json(MessageAttemptOut::list_response(
-        query.all(db).await?.into_iter().map(|x| x.into()).collect(),
-        limit as usize,
+        query.all(db).await?.into_iter().map(Into::into).collect(),
+        limit.try_into().expect("Limit could not fit into a usize"),
     )))
 }
 

--- a/server/svix-server/src/v1/utils.rs
+++ b/server/svix-server/src/v1/utils.rs
@@ -54,7 +54,7 @@ pub trait ModelOut {
     fn list_response<T: ModelOut>(mut data: Vec<T>, limit: usize) -> ListResponse<T> {
         let done = data.len() <= limit;
         data.truncate(limit);
-        let iterator = data.last().map(|x| x.id_copy());
+        let iterator = data.last().map(ModelOut::id_copy);
         ListResponse {
             data,
             iterator,
@@ -85,8 +85,7 @@ where
                     Some(
                         body_err
                             .source()
-                            .map(|x| x.to_string())
-                            .unwrap_or_else(|| err.to_string()),
+                            .map_or_else(|| err.to_string(), ToString::to_string),
                     ),
                 ),
                 _ => HttpError::bad_request(None, Some(err.to_string())),

--- a/server/svix-server/src/worker.rs
+++ b/server/svix-server/src/worker.rs
@@ -139,7 +139,7 @@ async fn dispatch(
     let res = client
         .post(&endp.url)
         .headers(headers)
-        .timeout(Duration::from_secs(cfg.worker_request_timeout as u64))
+        .timeout(Duration::from_secs(u64::from(cfg.worker_request_timeout)))
         .json(&msg.payload)
         .send()
         .await;
@@ -179,7 +179,11 @@ async fn dispatch(
     };
     let attempt = match res {
         Ok(res) => {
-            let status_code = res.status().as_u16() as i16;
+            let status_code = res
+                .status()
+                .as_u16()
+                .try_into()
+                .expect("HTTP status does not fit into u16");
             let status = if res.status().is_success() {
                 MessageStatus::Success
             } else {
@@ -274,7 +278,7 @@ async fn dispatch(
 }
 
 /// Listens on the message queue for new tasks
-pub async fn worker_loop(
+pub async fn main_loop(
     cfg: Configuration,
     pool: DatabaseConnection,
     redis_cache: Option<RedisCache>,


### PR DESCRIPTION
Simply enables most clippy pedantic lints (with some exclusions for false positives or necessary deviations).