### PR TITLE
JS: Fix deprecation version

### DIFF
--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -468,7 +468,7 @@ class MessageAttempt {
   }
 
   /**
-   * @deprecated Since version 0.52.0. Use listByMsg or listByEndpoint instead.
+   * @deprecated Since version 0.48.0. Use listByMsg or listByEndpoint instead.
    */
   public list(
     appId: string,


### PR DESCRIPTION
The bump script erroneously updated this message, now that we are past this version it won't happen again.