### PR TITLE
Python: Fix payload typing

### DIFF
--- a/python/svix/api.py
+++ b/python/svix/api.py
@@ -65,6 +65,7 @@ from .internal.openapi_client.models.dashboard_access_out import DashboardAccess
 from .internal.openapi_client.models.endpoint_headers_in import EndpointHeadersIn
 from .internal.openapi_client.models.endpoint_headers_out import EndpointHeadersOut
 from .internal.openapi_client.models.endpoint_in import EndpointIn
+from .internal.openapi_client.models.endpoint_message_out_payload import EndpointMessageOutPayload
 from .internal.openapi_client.models.endpoint_out import EndpointOut
 from .internal.openapi_client.models.endpoint_secret_out import EndpointSecretOut
 from .internal.openapi_client.models.endpoint_secret_rotate_in import EndpointSecretRotateIn
@@ -89,7 +90,9 @@ from .internal.openapi_client.models.list_response_message_endpoint_out import L
 from .internal.openapi_client.models.list_response_message_out import ListResponseMessageOut
 from .internal.openapi_client.models.message_attempt_out import MessageAttemptOut
 from .internal.openapi_client.models.message_in import MessageIn
+from .internal.openapi_client.models.message_in_payload import MessageInPayload
 from .internal.openapi_client.models.message_out import MessageOut
+from .internal.openapi_client.models.message_out_payload import MessageOutPayload
 from .internal.openapi_client.models.message_status import MessageStatus
 from .internal.openapi_client.models.recover_in import RecoverIn
 from .internal.openapi_client.models.recover_out import RecoverOut
@@ -890,7 +893,10 @@ __all__ = [
     "ListResponseEventTypeOut",
     "ListResponseMessageOut",
     "MessageIn",
+    "MessageInPayload",
     "MessageOut",
+    "MessageOutPayload",
+    "EndpointMessageOutPayload",
     "ListResponseMessageAttemptOut",
     "ListResponseEndpointMessageOut",
     "ListResponseMessageEndpointOut",

--- a/python/templates/model.py.jinja
+++ b/python/templates/model.py.jinja
@@ -1,3 +1,11 @@
+{% set class_name = model.class_info.name %}
+{# TODO: This is a hack to fix the typing of payloads, ideally we'd fix the generator so we don't need to manually add them here #}
+{% set dict_classes = ['EndpointMessageOutPayload', 'MessageInPayload', 'MessageOutPayload'] %}
+{% if class_name in dict_classes %}
+from typing import Any, Dict
+
+{{ class_name }} = Dict[str, Any]
+{% else %}
 from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO
 
 {% if model.additional_properties %}
@@ -21,7 +29,6 @@ from ..types import UNSET, Unset
 {% set additional_property_type = 'Any' if model.additional_properties == True else model.additional_properties.get_type_string() %}
 {% endif %}
 
-{% set class_name = model.class_info.name %}
 {% set module_name = model.class_info.module_name %}
 {% set is_exception = class_name in ["HttpError", "HTTPValidationError", "ValidationError"]%}
 
@@ -74,7 +81,9 @@ class {{ class_name }}({{"Exception" if is_exception}}):
 {% macro _to_dict(multipart=False) %}
 {% for property in model.required_properties + model.optional_properties %}
 {% import "property_templates/" + property.template as prop_template %}
-{% if prop_template.transform %}
+{% if property.class_info and property.class_info.name in dict_classes %}
+{{ property.python_name }} = self.{{ property.python_name }}
+{% elif prop_template.transform %}
 {{ prop_template.transform(property, "self." + property.python_name, property.python_name, multipart=multipart) }}
 {% elif multipart %}
 {{ property.python_name }} = self.{{ property.python_name }} if isinstance(self.{{ property.python_name }}, Unset) else (None, str(self.{{ property.python_name }}).encode(), "text/plain")
@@ -138,7 +147,11 @@ return field_dict
     {% endif %}
     {% import "property_templates/" + property.template as prop_template %}
     {% if prop_template.construct %}
+        {% if property.class_info and property.class_info.name in dict_classes %}
+        {{ property.name }} = dict_copy.pop("{{ property.name }}")
+        {% else %}
         {{ prop_template.construct(property, property_source) | indent(8) }}
+        {% endif %}
     {% else %}
         {{ property.python_name }} = {{ property_source }}
     {% endif %}
@@ -187,3 +200,4 @@ return field_dict
         return key in self.additional_properties
     {% endif %}
     {%endif%}
+{% endif %}


### PR DESCRIPTION
This is quite a hack, but essentially all "Payload" models should just be Dict[str, Any]
not fancy classes.  This updates the template to check for specific schema names and sets them to
Dict[str, Any] if the names match.