### PR TITLE
Python: Fix typing for non-structured dicts

### DIFF
--- a/python/templates/endpoint_macros.py.jinja
+++ b/python/templates/endpoint_macros.py.jinja
@@ -57,7 +57,9 @@ params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
     {% set property = endpoint.json_body %}
     {% set destination = "json_" + property.python_name %}
     {% import "property_templates/" + property.template as prop_template %}
-    {% if prop_template.transform %}
+    {% if property.class_info and property.required_properties == [] and property.optional_properties == [] %}
+{{ destination }} = {{ property.python_name }}
+    {% elif prop_template.transform %}
 {{ prop_template.transform(property, property.python_name, destination) }}
     {% else %}
 {{ destination }} = {{ property.python_name }}

--- a/python/templates/endpoint_module.py.jinja
+++ b/python/templates/endpoint_module.py.jinja
@@ -68,7 +68,9 @@ def _parse_response(*, response: httpx.Response) -> {{ return_type }}:
     {% endfor %}
     {%set ok_response = endpoint.responses[0]%}
     {% import "property_templates/" + ok_response.prop.template as ok_response_prop_template %}
-    {% if ok_response_prop_template.construct %}
+    {% if ok_response.prop and ok_response.prop.required_properties == [] and ok_response.prop.optional_properties == [] %}
+    {{ ok_response.prop.python_name }} = {{ ok_response.prop.class_info.name }}({{ ok_response.source }})
+    {% elif ok_response_prop_template.construct %}
     {{ ok_response_prop_template.construct(ok_response.prop, ok_response.source) | indent(8) }}
     {% else %}
     {{ ok_response.prop.python_name }} = None

--- a/python/templates/model.py.jinja
+++ b/python/templates/model.py.jinja
@@ -144,7 +144,7 @@ return field_dict
     {% endif %}
     {% import "property_templates/" + property.template as prop_template %}
     {% if prop_template.construct %}
-        {% if property.class_info and property.required_properties == [] and property.optional_properties == []%}
+        {% if property.class_info and property.required_properties == [] and property.optional_properties == [] %}
         {{ property.name }} = dict_copy.pop("{{ property.name }}")
         {% else %}
         {{ prop_template.construct(property, property_source) | indent(8) }}

--- a/python/templates/model.py.jinja
+++ b/python/templates/model.py.jinja
@@ -1,7 +1,5 @@
 {% set class_name = model.class_info.name %}
-{# TODO: This is a hack to fix the typing of payloads, ideally we'd fix the generator so we don't need to manually add them here #}
-{% set dict_classes = ['EndpointMessageOutPayload', 'MessageInPayload', 'MessageOutPayload'] %}
-{% if class_name in dict_classes %}
+{% if model.required_properties == [] and model.optional_properties == [] %}
 from typing import Any, Dict
 
 {{ class_name }} = Dict[str, Any]
@@ -77,11 +75,10 @@ class {{ class_name }}({{"Exception" if is_exception}}):
     {% if model.additional_properties %}
     additional_properties: Dict[str, {{ additional_property_type }}] = attr.ib(init=False, factory=dict)
     {% endif %}
-
 {% macro _to_dict(multipart=False) %}
 {% for property in model.required_properties + model.optional_properties %}
 {% import "property_templates/" + property.template as prop_template %}
-{% if property.class_info and property.class_info.name in dict_classes %}
+{% if property.class_info and property.required_properties == [] and property.optional_properties == [] %}
 {{ property.python_name }} = self.{{ property.python_name }}
 {% elif prop_template.transform %}
 {{ prop_template.transform(property, "self." + property.python_name, property.python_name, multipart=multipart) }}
@@ -147,7 +144,7 @@ return field_dict
     {% endif %}
     {% import "property_templates/" + property.template as prop_template %}
     {% if prop_template.construct %}
-        {% if property.class_info and property.class_info.name in dict_classes %}
+        {% if property.class_info and property.required_properties == [] and property.optional_properties == []%}
         {{ property.name }} = dict_copy.pop("{{ property.name }}")
         {% else %}
         {{ prop_template.construct(property, property_source) | indent(8) }}


### PR DESCRIPTION
Unstructured dicts such as `payload` and `headers` should be of type
Dict[str, Any] not empty classes.