### PR TITLE
Kotlin: Build for java 11

### DIFF
--- a/.github/workflows/kotlin-release.yml
+++ b/.github/workflows/kotlin-release.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '11'
 
       - name: Regen openapi libs
         run: |


### PR DESCRIPTION
We should build against LTS not 17