### PR TITLE
Java: Build for java 11

### DIFF
--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '11'
 
       - name: Regen openapi libs
         run: |


### PR DESCRIPTION
We should be building against 11 which is the minimum we wish to support