### PR TITLE
Tests: EmptyResponse -> IgnoredResponse and fix parsing issue

### DIFF
--- a/server/svix-server/src/test_util.rs
+++ b/server/svix-server/src/test_util.rs
@@ -12,13 +12,15 @@ pub struct TestClient {
     client: Client,
 }
 
-pub struct EmptyResponse;
-impl<'de> Deserialize<'de> for EmptyResponse {
-    fn deserialize<D>(_: D) -> Result<Self, D::Error>
+/// This struct accepts any JSON response and just ignores it.
+pub struct IgnoredResponse;
+impl<'de> Deserialize<'de> for IgnoredResponse {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        Ok(EmptyResponse)
+        let _ = serde_json::Value::deserialize(deserializer);
+        Ok(IgnoredResponse)
     }
 }
 

--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -179,7 +179,7 @@ mod tests {
 
     use super::{ApplicationIn, ApplicationOut};
     use crate::{
-        test_util::{start_svix_server, EmptyResponse},
+        test_util::{start_svix_server, IgnoredResponse},
         v1::utils::ListResponse,
     };
 
@@ -276,22 +276,21 @@ mod tests {
         );
 
         // DELETE
-        let _: EmptyResponse = client
+        let _: IgnoredResponse = client
             .delete(&format!("api/v1/app/{}/", app_1.id), StatusCode::NO_CONTENT)
             .await
             .unwrap();
-        let _: EmptyResponse = client
+        let _: IgnoredResponse = client
             .delete(&format!("api/v1/app/{}/", app_2.id), StatusCode::NO_CONTENT)
             .await
             .unwrap();
 
         // CONFIRM DELETION
-        // Deserialize into a Value because it a basic JSON structure saying "Entity not found"
-        let _: serde_json::Value = client
+        let _: IgnoredResponse = client
             .get(&format!("api/v1/app/{}/", app_1.id), StatusCode::NOT_FOUND)
             .await
             .unwrap();
-        let _: serde_json::Value = client
+        let _: IgnoredResponse = client
             .get(&format!("api/v1/app/{}/", app_2.id), StatusCode::NOT_FOUND)
             .await
             .unwrap();


### PR DESCRIPTION
This fixes the issue that we were getting with input not being
exhausted when the response was not empty.

We made it completely ignore the response and always return an empty
response.
