### PR TITLE
CI: Decrease ruby bundle size

### DIFF
--- a/.github/workflows/ruby-release.yml
+++ b/.github/workflows/ruby-release.yml
@@ -3,7 +3,7 @@ name: Ruby Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   dotnet:
@@ -17,13 +17,16 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-          bundler-cache: true
-          working-directory: ruby
 
       - name: Regen openapi libs
         run: |
           yarn
           ./regen_openapi.sh
+
+      - name: Install dependencies
+        run: |
+          cd ruby
+          bundler install
 
       - name: Build
         run: |


### PR DESCRIPTION
The bundle cache directory is in `${pwd}` so we were erroneously including
in our CI builds.  This disables the cache for now, decreasing our build size.

Fixes https://github.com/svix/svix-webhooks/issues/316.