### PR TITLE
Libs: Retry headers

### DIFF
--- a/go/internal/openapi/client.go
+++ b/go/internal/openapi/client.go
@@ -214,7 +214,7 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 			return resp, err
 		}
 		retryCount++
-		request.Header.Set("svix-retry-count",strconv.Itoa(retryCount))
+		request.Header.Set("svix-retry-count", strconv.Itoa(retryCount))
 		time.Sleep(sleepTime)
 		sleepTime = sleepTime * 2
 	}
@@ -363,7 +363,7 @@ func (c *APIClient) prepareRequest(
 	// Add the user agent to the request.
 	localVarRequest.Header.Add("User-Agent", c.cfg.UserAgent)
 	rand.Seed(time.Now().UnixNano())
-	localVarRequest.Header.Add("svix-req-id",strconv.FormatUint(rand.Uint64(), 10))
+	localVarRequest.Header.Add("svix-req-id", strconv.FormatUint(rand.Uint64(), 10))
 
 	if ctx != nil {
 		// add context to the request

--- a/go/templates/client.mustache
+++ b/go/templates/client.mustache
@@ -196,7 +196,7 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 			return resp, err
 		}
 		retryCount++
-		request.Header.Set("svix-retry-count",strconv.Itoa(retryCount))
+		request.Header.Set("svix-retry-count", strconv.Itoa(retryCount))
 		time.Sleep(sleepTime)
 		sleepTime = sleepTime * 2
 	}
@@ -345,7 +345,7 @@ func (c *APIClient) prepareRequest(
 	// Add the user agent to the request.
 	localVarRequest.Header.Add("User-Agent", c.cfg.UserAgent)
 	rand.Seed(time.Now().UnixNano())
-	localVarRequest.Header.Add("svix-req-id",strconv.FormatUint(rand.Uint64(), 10))
+	localVarRequest.Header.Add("svix-req-id", strconv.FormatUint(rand.Uint64(), 10))
 
 	if ctx != nil {
 		// add context to the request

--- a/go/templates/client.mustache
+++ b/go/templates/client.mustache
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
+	"math/rand"
 
 	"golang.org/x/oauth2"
 	{{#withAWSV4Signature}}
@@ -185,6 +186,7 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 	var resp *http.Response
 	var err error
 	sleepTime := time.Millisecond * 50
+	retryCount := 0
 	for try := 0; try < NumTries; try++ {
 		resp, err = c.cfg.HTTPClient.Do(request)
 		if err == nil && resp.StatusCode < 500 {
@@ -193,6 +195,8 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 		if try >= NumTries - 1 {
 			return resp, err
 		}
+		retryCount++
+		request.Header.Set("svix-retry-count",strconv.Itoa(retryCount))
 		time.Sleep(sleepTime)
 		sleepTime = sleepTime * 2
 	}
@@ -340,6 +344,8 @@ func (c *APIClient) prepareRequest(
 
 	// Add the user agent to the request.
 	localVarRequest.Header.Add("User-Agent", c.cfg.UserAgent)
+	rand.Seed(time.Now().UnixNano())
+	localVarRequest.Header.Add("svix-req-id",strconv.FormatUint(rand.Uint64(), 10))
 
 	if ctx != nil {
 		// add context to the request

--- a/java/templates/libraries/okhttp-gson/ApiClient.mustache
+++ b/java/templates/libraries/okhttp-gson/ApiClient.mustache
@@ -221,6 +221,9 @@ public class ApiClient {
 
         // Set default User-Agent.
         setUserAgent("{{#httpUserAgent}}{{{.}}}{{/httpUserAgent}}{{^httpUserAgent}}OpenAPI-Generator/{{{artifactVersion}}}/java{{/httpUserAgent}}");
+        Random randomGenerator = new Random();
+        long randomId = randomGenerator.nextLong();
+        addDefaultHeader("svix-req-id", String.valueOf(Math.abs(randomId)));
 
         authentications = new HashMap<String, Authentication>();
         {{#dynamicOperations}}
@@ -1116,6 +1119,7 @@ public class ApiClient {
     public <T> ApiResponse<T> execute(Call call, Type returnType) throws ApiException {
         int numRetries = 3;
         int sleepTime = 50;
+        int retryCount = 0;
         for (int retry = 0; retry < numRetries; retry++) {
             try {
                 try {
@@ -1137,6 +1141,8 @@ public class ApiClient {
             } catch (InterruptedException ex) {
                 Thread.currentThread().interrupt();
             }
+            retryCount++;
+            call = httpClient.newCall(call.request().newBuilder().header("svix-retry-count", String.valueOf(retryCount)).build());
             sleepTime = sleepTime * 2;
         }
         throw new ApiException("failed to execute api call");

--- a/javascript/src/openapi/http/isomorphic-fetch.ts
+++ b/javascript/src/openapi/http/isomorphic-fetch.ts
@@ -25,7 +25,7 @@ export class IsomorphicFetchHttpLibrary implements HttpLibrary {
       };
       await sleep(nextInterval);
       const headers = request.getHeaders();
-      headers['svix-retry-count'] = `${retryCount}`
+      headers['svix-retry-count'] = retryCount.toString()
       return await this.sendWithRetry(request, --triesLeft, nextInterval * 2, ++retryCount);
     }
   

--- a/javascript/src/openapi/http/isomorphic-fetch.ts
+++ b/javascript/src/openapi/http/isomorphic-fetch.ts
@@ -8,11 +8,11 @@ const sleep = (interval: number) => new Promise(resolve => setTimeout(resolve, i
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
-      const resultPromise = this.sendWithRetry(request, numRetries, 50);
+      const resultPromise = this.sendWithRetry(request, numRetries, 50, 1);
       return from<Promise<ResponseContext>>(resultPromise);
     }
 
-    private async sendWithRetry(request: RequestContext, triesLeft: number, nextInterval: number): Promise<ResponseContext> {
+    private async sendWithRetry(request: RequestContext, triesLeft: number, nextInterval: number, retryCount: number): Promise<ResponseContext> {
       try {
         const response = await this.sendOnce(request);
         if (triesLeft <= 0 || response.httpStatusCode < 500) {
@@ -24,7 +24,9 @@ export class IsomorphicFetchHttpLibrary implements HttpLibrary {
         }
       };
       await sleep(nextInterval);
-      return await this.sendWithRetry(request, --triesLeft, nextInterval * 2);
+      const headers = request.getHeaders();
+      headers['svix-retry-count'] = `${retryCount}`
+      return await this.sendWithRetry(request, --triesLeft, nextInterval * 2, ++retryCount);
     }
   
     private sendOnce(request: RequestContext): Promise<ResponseContext> {

--- a/javascript/templates/api/api.mustache
+++ b/javascript/templates/api/api.mustache
@@ -2,6 +2,7 @@
 import { BaseAPIRequestFactory, RequiredError } from './baseapi{{extensionForDeno}}';
 import {Configuration} from '../configuration{{extensionForDeno}}';
 import { RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http{{extensionForDeno}}';
+import { randomBytes } from 'crypto';
 {{#platforms}}
 {{#node}}
 import * as FormData from "form-data";
@@ -59,6 +60,7 @@ export class {{classname}}RequestFactory extends BaseAPIRequestFactory {
         // Make Request Context
         const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.{{httpMethod}});
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
+        requestContext.setHeaderParam("svix-req-id", randomBytes(32).toString('hex'))
 
         // Query Params
         {{#queryParams}}

--- a/javascript/templates/api/api.mustache
+++ b/javascript/templates/api/api.mustache
@@ -2,7 +2,6 @@
 import { BaseAPIRequestFactory, RequiredError } from './baseapi{{extensionForDeno}}';
 import {Configuration} from '../configuration{{extensionForDeno}}';
 import { RequestContext, HttpMethod, ResponseContext, HttpFile} from '../http/http{{extensionForDeno}}';
-import { randomBytes } from 'crypto';
 {{#platforms}}
 {{#node}}
 import * as FormData from "form-data";
@@ -60,7 +59,8 @@ export class {{classname}}RequestFactory extends BaseAPIRequestFactory {
         // Make Request Context
         const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.{{httpMethod}});
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
-        requestContext.setHeaderParam("svix-req-id", randomBytes(32).toString('base64'))
+        const randomId = Math.floor(Math.random() * Math.pow(2, 32))
+        requestContext.setHeaderParam("svix-req-id", randomId.toString())
 
         // Query Params
         {{#queryParams}}

--- a/javascript/templates/api/api.mustache
+++ b/javascript/templates/api/api.mustache
@@ -60,7 +60,7 @@ export class {{classname}}RequestFactory extends BaseAPIRequestFactory {
         // Make Request Context
         const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.{{httpMethod}});
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
-        requestContext.setHeaderParam("svix-req-id", randomBytes(32).toString('hex'))
+        requestContext.setHeaderParam("svix-req-id", randomBytes(32).toString('base64'))
 
         // Query Params
         {{#queryParams}}

--- a/kotlin/templates/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
+++ b/kotlin/templates/libraries/jvm-okhttp/infrastructure/ApiClient.kt.mustache
@@ -56,6 +56,7 @@ import org.threeten.bp.OffsetDateTime
 import org.threeten.bp.OffsetTime
 {{/threetenbp}}
 import kotlinx.coroutines.delay
+import kotlin.random.Random
 
 {{#nonPublicApi}}internal {{/nonPublicApi}}open class ApiClient(val baseUrl: String) {
     {{#nonPublicApi}}internal {{/nonPublicApi}}companion object {
@@ -305,6 +306,9 @@ import kotlinx.coroutines.delay
         if (requestConfig.headers[Accept].isNullOrEmpty()) {
             requestConfig.headers[Accept] = JsonMediaType
         }
+        if (requestConfig.headers["svix-req-id"].isNullOrEmpty()) {
+            requestConfig.headers["svix-req-id"] = Math.abs(Random.nextBits(32)).toString()
+        }
         val headers = requestConfig.headers
 
         if(headers[ContentType] ?: "" == "") {
@@ -334,14 +338,17 @@ import kotlinx.coroutines.delay
 
         var sleepTime = 50L
         val numRetries = 3
-        for (i in 0 until numRetries) {
-            if (response.isSuccessful && response.code < 500) {
+        var retryCount = 0
+        for (i in 0 until numRetries-1) {
+            if (response.isSuccessful || response.code < 500) {
                 break
             }
             response.close()
+            retryCount = retryCount.inc()
             delay(sleepTime)
             sleepTime = sleepTime * 2
-            response = client.newCall(request).execute()
+            var newRequest = request.newBuilder().header("svix-retry-count", retryCount.toString()).build()
+            response = client.newCall(newRequest).execute()
         }
 
         val accept = response.header(ContentType)?.substringBefore(";")?.lowercase(Locale.getDefault())

--- a/ruby/templates/api_client_typhoeus_partial.mustache
+++ b/ruby/templates/api_client_typhoeus_partial.mustache
@@ -5,7 +5,7 @@
     # @return [Array<(Object, Integer, Hash)>] an array of 3 elements:
     #   the data deserialized from response body (could be nil), response status code and response headers.
     def call_api(http_method, path, opts = {})
-      opts[:'header_params'][:'svix-req-id'] = SecureRandom.random_number( 2**32 ).to_s
+      opts[:'header_params'][:'svix-req-id'] = SecureRandom.random_number(2**32).to_s
       request = build_request(http_method, path, opts)
       response = request.run
 
@@ -14,7 +14,7 @@
       retry_count = 0
       (0..1).each do |n|
         break if response.success? || response.code < 500
-        retry_count+=1
+        retry_count += 1
         sleep(sleep_time)
         sleep_time = sleep_time * 2
         opts[:'header_params'][:'svix-retry-count'] = retry_count.to_s

--- a/ruby/templates/api_client_typhoeus_partial.mustache
+++ b/ruby/templates/api_client_typhoeus_partial.mustache
@@ -1,17 +1,24 @@
+    require 'securerandom'
+    
     # Call an API with given options.
     #
     # @return [Array<(Object, Integer, Hash)>] an array of 3 elements:
     #   the data deserialized from response body (could be nil), response status code and response headers.
     def call_api(http_method, path, opts = {})
+      opts[:'header_params'][:'svix-req-id'] = SecureRandom.random_number( 2**32 ).to_s
       request = build_request(http_method, path, opts)
       response = request.run
 
       # retry 500s
       sleep_time = 0.05
+      retry_count = 0
       (0..1).each do |n|
-        break if response.success? && response.code < 500
+        break if response.success? || response.code < 500
+        retry_count+=1
         sleep(sleep_time)
         sleep_time = sleep_time * 2
+        opts[:'header_params'][:'svix-retry-count'] = retry_count.to_s
+        request = build_request(http_method, path, opts)
         response = request.run
       end
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

For requests coming from svix-libs, it would add clarity to see a unique id for each request. 
Additionally, when retries are made for a request that returns a 5xx status code, there
should be an indication of how many retries were made before either success or retries
were exhausted. 

## Solution

I've updated the api_client templates for Javascript, Go, Ruby, Java, and Kotlin. Python was already
updated in a previous release. 

Two headers added: 

- "svix-req-id": random 32-bit integer
- "svix-retry-count" an integer that increases on each retry
