### PR TITLE
Correct CI errors in release publishing and `aarch64` building from PR #325

### DIFF
--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -48,6 +48,6 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: svix-server-${{ matrix.target }}
-          path: server/target/release/svix-server*
+          path: server/svix-server/target/release/svix-server*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -44,11 +44,6 @@ jobs:
           command: build
           args: --target ${{ matrix.target }} --release --manifest-path server/svix-server/Cargo.toml
 
-      - name: Set environment variables for aarch64 MacOS
-        if: ${{ matrix.target == 'aarch64-apple-darwin' }}
-        run: echo SDKROOT="$(xcrun -sdk macosx11.1 --show-sdk-path)" >> "$GITHUB_ENV" && \
-             echo MACOSX_DEPLOYMENT_TARGET="$(xcrun -sdk macosx11.1 --show-sdk-platform-version)" >> "$GITHUB_ENV"
-
       - name: Release
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Simply  attempts to fix errors that occur in previous PR #325 