### PR TITLE
Change base Docker image to debian-slim

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,30 +1,28 @@
 # Base build
-FROM rust:1.58-alpine3.15 AS build
+FROM rust:1.59-slim-bullseye AS build
 
 RUN set -ex ; \
         mkdir -p /app ;\
-        addgroup -S appgroup ;\
-        adduser -S appuser -G appgroup ;\
+        useradd appuser ;\
         chown -R appuser: /app ;\
         mkdir -p /home/appuser ;\
         chown -R appuser: /home/appuser
-
-RUN apk add --no-cache musl-dev
 
 USER appuser
 
 WORKDIR /app
 COPY . .
 
-RUN cd svix-server && cargo install --path .
+WORKDIR /app/svix-server
+RUN cargo install --path .
 
 # Production
-FROM alpine:3.15 AS prod
-# It can probably be scratch, just need to statically link musl
+FROM debian:11.2-slim AS prod
 
 RUN set -ex ; \
-        addgroup -S appgroup ;\
-        adduser -S appuser -G appgroup ;\
+        mkdir -p /app ;\
+        useradd appuser ;\
+        chown -R appuser: /app ;\
         mkdir -p /home/appuser ;\
         chown -R appuser: /home/appuser
 
@@ -34,6 +32,8 @@ EXPOSE 8080
 COPY ./wait-for /usr/local/bin/wait-for
 COPY --from=build /usr/local/cargo/bin/svix-server /usr/local/bin/svix-server
 
+# Ignoring this lint, because it's an embedded shell script
+# hadolint ignore=DL3025
 CMD \
     set -ex ; \
     if [ ! -z "$WAIT_FOR" ]; then \


### PR DESCRIPTION
musl is claimed to have performance issues and random DNS bugs.
It's just not worth the hassle, especially given debian-slim should be
fine.

Ref: https://news.ycombinator.com/item?id=30635160

Fixes #302