### PR TITLE
Update SeaORM to 0.6.0

### DIFF
--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -50,7 +50,7 @@ redis = { version = "0.21.5", features = ["tokio-comp"] }
 thiserror = "1.0.30"
 bytes = "1.1.0"
 # sea orm
-sea-orm = { version = "0.5.0", features = [ "sqlx-postgres", "runtime-tokio-rustls", "macros" ], default-features = false }
+sea-orm = { version = "0.6.0", features = [ "sqlx-postgres", "runtime-tokio-rustls", "macros" ], default-features = false }
 sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "postgres", "migrate" ] }
 http = "0.2"
 

--- a/server/svix-server/src/core/message_app.rs
+++ b/server/svix-server/src/core/message_app.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use chrono::{DateTime, FixedOffset};
-use sea_orm::{ConnectionTrait, DatabaseConnection, DatabaseTransaction};
+use sea_orm::{DatabaseConnection, DatabaseTransaction, TransactionTrait};
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -32,7 +32,7 @@ use sea_orm::{
     sea_query::{Expr, IntoCondition},
     ActiveValue::Set,
 };
-use sea_orm::{ActiveModelTrait, ConnectionTrait, DatabaseConnection, QuerySelect};
+use sea_orm::{ActiveModelTrait, DatabaseConnection, QuerySelect, TransactionTrait};
 use serde::{Deserialize, Serialize};
 
 use svix_server_derive::{ModelIn, ModelOut};


### PR DESCRIPTION
Simply updates the version and fixes compiler errors associated with the update's breaking changes. Motivated by the changes @tasn made for increased sanitation in macros.