### PR TITLE
Add implementation for "List Attempts by Endpoint" endpoint

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -73,7 +73,7 @@ jobs:
       env:
         DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/postgres"
         SVIX_REDIS_DSN: "redis://localhost:6379"
-        SVIX_QUEUE_TYPE: "redis"
+        SVIX_QUEUE_TYPE: "memory"
         SVIX_JWT_SECRET: "test value"
       with:
         command: test

--- a/server/svix-server/src/core/types.rs
+++ b/server/svix-server/src/core/types.rs
@@ -542,8 +542,20 @@ pub enum MessageStatus {
     Sending = 3,
 }
 
+#[repr(i16)]
+#[derive(Clone, Debug, Copy, PartialEq, IntoPrimitive, TryFromPrimitive)]
+pub enum StatusCodeClass {
+    CodeNone = 0,
+    Code1xx = 100,
+    Code2xx = 200,
+    Code3xx = 300,
+    Code4xx = 400,
+    Code5xx = 500,
+}
+
 enum_wrapper!(MessageAttemptTriggerType);
 enum_wrapper!(MessageStatus);
+enum_wrapper!(StatusCodeClass);
 
 #[cfg(test)]
 mod tests {

--- a/server/svix-server/src/test_util.rs
+++ b/server/svix-server/src/test_util.rs
@@ -201,11 +201,8 @@ async fn test_receiver_route(
     code
 }
 
-pub async fn run_with_retries<F: Future<Output = Result<()>>, C: Fn() -> F>(
-    f: C,
-    max_attempts: usize,
-) -> Result<()> {
-    for attempt in 0..max_attempts {
+pub async fn run_with_retries<F: Future<Output = Result<()>>, C: Fn() -> F>(f: C) -> Result<()> {
+    for attempt in 0..20 {
         let out = f().await;
         if out.is_ok() {
             return Ok(());

--- a/server/svix-server/src/test_util.rs
+++ b/server/svix-server/src/test_util.rs
@@ -1,9 +1,10 @@
-use std::net::TcpListener;
+use std::{future::Future, net::TcpListener};
 
 use anyhow::{Context, Result};
 
 use reqwest::{Client, RequestBuilder, StatusCode};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use tokio::sync::mpsc;
 
 use crate::core::security::test_util::generate_token_random_org;
 
@@ -151,4 +152,69 @@ pub fn start_svix_server() -> (TestClient, tokio::task::JoinHandle<()>) {
     let jh = tokio::spawn(crate::run(cfg, Some(listener)));
 
     (TestClient::new(base_uri, &token), jh)
+}
+
+pub struct TestReceiver {
+    pub endpoint: String,
+    pub jh: tokio::task::JoinHandle<()>,
+    pub data_recv: mpsc::Receiver<serde_json::Value>,
+}
+
+impl TestReceiver {
+    pub fn start(resp_with: axum::http::StatusCode) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let endpoint = format!("http://{}/", listener.local_addr().unwrap());
+
+        let (tx, data_recv) = mpsc::channel(32);
+
+        let jh = tokio::spawn(async move {
+            axum::Server::from_tcp(listener)
+                .unwrap()
+                .serve(
+                    axum::Router::new()
+                        .route(
+                            "/",
+                            axum::routing::post(test_receiver_route).get(test_receiver_route),
+                        )
+                        .layer(axum::extract::Extension(tx))
+                        .layer(axum::extract::Extension(resp_with))
+                        .into_make_service(),
+                )
+                .await
+                .unwrap();
+        });
+
+        TestReceiver {
+            endpoint,
+            jh,
+            data_recv,
+        }
+    }
+}
+
+async fn test_receiver_route(
+    axum::Json(json): axum::Json<serde_json::Value>,
+    axum::extract::Extension(ref tx): axum::extract::Extension<mpsc::Sender<serde_json::Value>>,
+    axum::extract::Extension(code): axum::extract::Extension<axum::http::StatusCode>,
+) -> axum::http::StatusCode {
+    tx.send(json).await.unwrap();
+    code
+}
+
+pub async fn run_with_retries<F: Future<Output = Result<()>>, C: Fn() -> F>(
+    f: C,
+    max_attempts: usize,
+) -> Result<()> {
+    for attempt in 0..max_attempts {
+        let out = f().await;
+        if out.is_ok() {
+            return Ok(());
+        }
+
+        println!("Attempt {}: {}", attempt, out.unwrap_err());
+
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    anyhow::bail!("All attempts failed");
 }

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -6,7 +6,8 @@ use crate::{
         security::AuthenticatedApplication,
         types::{
             ApplicationId, ApplicationIdOrUid, BaseId, EndpointId, EndpointIdOrUid, EventChannel,
-            MessageAttemptId, MessageAttemptTriggerType, MessageId, MessageIdOrUid, MessageStatus,
+            EventTypeNameSet, MessageAttemptId, MessageAttemptTriggerType, MessageId,
+            MessageIdOrUid, MessageStatus, StatusCodeClass,
         },
     },
     db::models::{endpoint, message, messagedestination},
@@ -159,6 +160,18 @@ async fn list_attempted_messages(
             .collect::<Result<_>>()?,
         limit as usize,
     )))
+}
+
+/// Additional parameters (besides pagination) in the query string for the "List Attempts by
+/// Endpoint" enpoint.
+#[derive(Debug, Deserialize, Validate)]
+pub struct ListAttemptsByEndpointQueryParameters {
+    status: Option<MessageStatus>,
+    status_code_class: Option<StatusCodeClass>,
+    #[validate]
+    event_types: Option<EventTypeNameSet>,
+    #[validate]
+    channel: Option<EventChannel>,
 }
 
 #[derive(Debug, Deserialize, Validate)]

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -215,8 +215,12 @@ async fn list_attempts_by_endpoint(
     }
 
     query = match status_code_class {
+        Some(StatusCodeClass::CodeNone) => {
+            query.filter(messageattempt::Column::ResponseStatusCode.between(0, 99))
+        }
+
         Some(StatusCodeClass::Code1xx) => {
-            query.filter(messageattempt::Column::ResponseStatusCode.lt(200))
+            query.filter(messageattempt::Column::ResponseStatusCode.between(100, 199))
         }
 
         Some(StatusCodeClass::Code2xx) => {
@@ -235,7 +239,6 @@ async fn list_attempts_by_endpoint(
             query.filter(messageattempt::Column::ResponseStatusCode.between(500, 599))
         }
 
-        Some(StatusCodeClass::CodeNone) => query,
         None => query,
     };
 

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -498,41 +498,6 @@ mod tests {
         let receiver_1 = TestReceiver::start(axum::http::StatusCode::OK);
         let receiver_2 = TestReceiver::start(axum::http::StatusCode::OK);
 
-        // Wait at most a second (50ms * 20 retries) for a successful response from that endpoint
-        run_with_retries(|| {
-            let endp_1 = receiver_1.endpoint.clone();
-            let endp_2 = receiver_2.endpoint.clone();
-            async {
-                let client = reqwest::Client::new();
-
-                if client
-                    .post(endp_1)
-                    .json(&serde_json::json!({"test": "value"}))
-                    .send()
-                    .await?
-                    .status()
-                    != StatusCode::OK
-                {
-                    anyhow::bail!("Status not OK")
-                };
-
-                if client
-                    .post(endp_2)
-                    .json(&serde_json::json!({"test": "value"}))
-                    .send()
-                    .await?
-                    .status()
-                    != StatusCode::OK
-                {
-                    anyhow::bail!("Status not OK")
-                };
-
-                Ok(())
-            }
-        })
-        .await
-        .unwrap();
-
         let endp_id_1 = create_test_endpoint(&client, &app_id, &receiver_1.endpoint)
             .await
             .unwrap();

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -44,9 +44,11 @@ struct MessageAttemptOut {
     response_status_code: i16,
     status: MessageStatus,
     trigger_type: MessageAttemptTriggerType,
+    msg_id: MessageId,
     endpoint_id: EndpointId,
 
     id: MessageAttemptId,
+
     #[serde(rename = "timestamp")]
     created_at: DateTime<Utc>,
 }
@@ -59,6 +61,7 @@ impl From<messageattempt::Model> for MessageAttemptOut {
             response_status_code: model.response_status_code,
             status: model.status,
             trigger_type: model.trigger_type,
+            msg_id: model.msg_id,
             endpoint_id: model.endp_id,
 
             id: model.id,

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -216,23 +216,23 @@ async fn list_attempts_by_endpoint(
 
     query = match status_code_class {
         Some(StatusCodeClass::Code1xx) => {
-            query.filter(messageattempt::Column::ResponseStatusCode.lt(100i16))
+            query.filter(messageattempt::Column::ResponseStatusCode.lt(200))
         }
 
         Some(StatusCodeClass::Code2xx) => {
-            query.filter(messageattempt::Column::ResponseStatusCode.between(199i16, 300i16))
+            query.filter(messageattempt::Column::ResponseStatusCode.between(200, 299))
         }
 
         Some(StatusCodeClass::Code3xx) => {
-            query.filter(messageattempt::Column::ResponseStatusCode.between(299i16, 400i16))
+            query.filter(messageattempt::Column::ResponseStatusCode.between(300, 399))
         }
 
         Some(StatusCodeClass::Code4xx) => {
-            query.filter(messageattempt::Column::ResponseStatusCode.between(399i16, 500i16))
+            query.filter(messageattempt::Column::ResponseStatusCode.between(400, 499))
         }
 
         Some(StatusCodeClass::Code5xx) => {
-            query.filter(messageattempt::Column::ResponseStatusCode.between(599i16, 600i16))
+            query.filter(messageattempt::Column::ResponseStatusCode.between(500, 599))
         }
 
         Some(StatusCodeClass::CodeNone) => query,

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -515,7 +515,7 @@ mod tests {
             .await
             .unwrap();
 
-        // And wait at most two seconds for all attempts to be processed
+        // And wait at most one second for all attempts to be processed
         run_with_retries(|| async {
             let list_1: ListResponse<MessageAttemptOut> = client
                 .get(


### PR DESCRIPTION
Adds the endpoint, associated models, a basic test, and associated test utilities. Additionally changes the queue type for CI tests to in-memory to avoid aborted threads mid-database-transaction.