### PR TITLE
Implement `Validate` for `IdOrUid` types

### DIFF
--- a/server/svix-server/src/core/types.rs
+++ b/server/svix-server/src/core/types.rs
@@ -342,6 +342,18 @@ macro_rules! create_all_id_types {
                 Self::String(Some(Box::new(v.0)))
             }
         }
+
+        impl Validate for $name_id_or_uid {
+            fn validate(&self) -> Result<(), validator::ValidationErrors> {
+                if self.0.starts_with($key_prefix) {
+                    let as_id: $name_id = self.clone().into();
+                    as_id.validate()
+                } else {
+                    let as_uid: $name_uid = self.clone().into();
+                    as_uid.validate()
+                }
+            }
+        }
     };
 }
 


### PR DESCRIPTION
Implements the `Validate` trait for `IdOrUid`  types  created with the `create_all_id_types` macro.