### PR TITLE
Cleanup: make generate_token accept an org_id.

### DIFF
--- a/server/svix-server/src/core/security.rs
+++ b/server/svix-server/src/core/security.rs
@@ -22,7 +22,7 @@ use crate::{
 use super::types::{ApplicationIdOrUid, OrganizationId};
 
 /// The default org_id we use (useful for generating JWTs when testing).
-fn org_id() -> OrganizationId {
+pub fn default_org_id() -> OrganizationId {
     OrganizationId("org_23rb8YdGqMT0qIzpgGwdXfHirMu".to_owned())
 }
 
@@ -114,10 +114,10 @@ where
     }
 }
 
-pub fn generate_token(keys: &Keys) -> Result<String> {
+pub fn generate_token(keys: &Keys, org_id: OrganizationId) -> Result<String> {
     let claims = Claims::create(Duration::from_hours(24 * 365 * 10))
         .with_issuer(env!("CARGO_PKG_NAME"))
-        .with_subject(org_id().0);
+        .with_subject(org_id.0);
     Ok(keys.key.authenticate(claims).unwrap())
 }
 
@@ -131,18 +131,5 @@ impl Keys {
         Self {
             key: HS256Key::from_bytes(secret),
         }
-    }
-}
-
-#[cfg(test)]
-pub(crate) mod test_util {
-    use super::*;
-    use crate::core::types::BaseId;
-
-    pub fn generate_token_random_org(keys: &Keys) -> Result<String> {
-        let claims = Claims::create(Duration::from_hours(24 * 365 * 10))
-            .with_issuer(env!("CARGO_PKG_NAME"))
-            .with_subject(OrganizationId::new(None, None).0);
-        Ok(keys.key.authenticate(claims).unwrap())
     }
 }

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -17,7 +17,10 @@ use tower_http::trace::TraceLayer;
 
 use crate::{
     cfg::Configuration,
-    core::{cache::RedisCache, security::generate_token},
+    core::{
+        cache::RedisCache,
+        security::{default_org_id, generate_token},
+    },
     db::init_db,
     worker::worker_loop,
 };
@@ -169,7 +172,7 @@ async fn main() {
         command: JwtCommands::Generate,
     }) = &args.command
     {
-        let token = generate_token(&cfg.jwt_secret).unwrap();
+        let token = generate_token(&cfg.jwt_secret, default_org_id()).unwrap();
         println!("Token (Bearer): {}", token);
         exit(0);
     }

--- a/server/svix-server/src/test_util.rs
+++ b/server/svix-server/src/test_util.rs
@@ -2,11 +2,13 @@ use std::{future::Future, net::TcpListener, sync::Arc};
 
 use anyhow::{Context, Result};
 
+use crate::core::{
+    security::generate_token,
+    types::{BaseId, OrganizationId},
+};
 use reqwest::{Client, RequestBuilder, StatusCode};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tokio::sync::mpsc;
-
-use crate::core::security::test_util::generate_token_random_org;
 
 pub struct TestClient {
     base_uri: String,
@@ -153,7 +155,7 @@ pub fn start_svix_server() -> (TestClient, tokio::task::JoinHandle<()>) {
     cfg.queue_type = crate::cfg::QueueType::Memory;
     let cfg = Arc::new(cfg);
 
-    let token = generate_token_random_org(&cfg.jwt_secret).unwrap();
+    let token = generate_token(&cfg.jwt_secret, OrganizationId::new(None, None)).unwrap();
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let base_uri = format!("http://{}", listener.local_addr().unwrap());
 


### PR DESCRIPTION
This removes some redundancy and is needed for other changes I'm making.
