### PR TITLE
Tests: remove the integration_test feature and rely on cargo.

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -123,7 +123,7 @@ cargo fmt
 
 ## Testing
 
-When run with the `integration_testing` feature, `cargo test` will run tests that assume a running PostgreSQL and Redis database.
+By default, `cargo test` will run the full test suite which assumes a running PostgreSQL and Redis database.
 These databases are configured with the same environment variables as with running the actual server.
 
 The easiest way to get these tests to pass is to:
@@ -132,4 +132,6 @@ The easiest way to get these tests to pass is to:
     3. Migrate the database with `cargo run -- migrate`.
     4. Run `cargo test --all-targets`
 
-Without this feature enabled, these tests will show as ignored when running `cargo test` and only pure functions may be tested.
+Alternatively, if you're only interested in running unit tests, you can just run `cargo test --lib`. These tests don't make any assumptions about the surrounding environment.
+
+To run only a specific test (e.g. only the application tests), you can use the `--test` flag to `cargo test` which supports common Unix glob patterns. For example: `cargo test --test '*app*'`.

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -11,11 +11,6 @@ readme = "../README.md"
 edition = "2021"
 publish = false
 
-[features]
-# This feature enables integration tests that require a running PostgreSQL and Redis instance
-# whose DSNs are set through environmental variables just like in the actual application
-integration_testing = []
-
 [dependencies]
 svix-server_derive = { path = "../svix-server_derive" }
 

--- a/server/svix-server/tests/e2e_application.rs
+++ b/server/svix-server/tests/e2e_application.rs
@@ -10,7 +10,6 @@ mod utils;
 use utils::{common_calls::application_in, start_svix_server, IgnoredResponse};
 
 #[tokio::test]
-#[cfg_attr(not(feature = "integration_testing"), ignore)]
 async fn test_crud() {
     let (client, _jh) = start_svix_server();
 
@@ -117,7 +116,6 @@ async fn test_crud() {
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature = "integration_testing"), ignore)]
 async fn test_list() {
     let (client, _jh) = start_svix_server();
 

--- a/server/svix-server/tests/e2e_attempt.rs
+++ b/server/svix-server/tests/e2e_attempt.rs
@@ -16,7 +16,6 @@ use utils::{
 };
 
 #[tokio::test]
-#[cfg_attr(not(feature = "integration_testing"), ignore)]
 async fn test_list_attempted_messages() {
     let (client, _jh) = start_svix_server();
 
@@ -70,7 +69,6 @@ async fn test_list_attempted_messages() {
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature = "integration_testing"), ignore)]
 async fn test_list_attempts_by_endpoint() {
     let (client, _jh) = start_svix_server();
 

--- a/server/svix-server/tests/e2e_endpoint.rs
+++ b/server/svix-server/tests/e2e_endpoint.rs
@@ -58,7 +58,6 @@ async fn delete_endpoint(client: &TestClient, app_id: &ApplicationId, ep_id: &st
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature = "integration_testing"), ignore)]
 async fn test_crud() {
     let (client, _jh) = start_svix_server();
 
@@ -200,7 +199,6 @@ async fn test_crud() {
 /// Tests that there is at most one endpoint with a single UID for all endpoints associated with
 /// any application
 #[tokio::test]
-#[cfg_attr(not(feature = "integration_testing"), ignore)]
 async fn test_uid() {
     let (client, _jh) = start_svix_server();
 
@@ -290,7 +288,6 @@ async fn test_uid() {
 
 // Simply tests that upon rotating an endpoint secret that it differs from the prior one
 #[tokio::test]
-#[cfg_attr(not(feature = "integration_testing"), ignore)]
 async fn test_endpoint_secret_get_and_rotation() {
     let (client, _jh) = start_svix_server();
 

--- a/server/svix-server/tests/e2e_message.rs
+++ b/server/svix-server/tests/e2e_message.rs
@@ -13,7 +13,6 @@ use utils::{
 };
 
 #[tokio::test]
-#[cfg_attr(not(feature = "integration_testing"), ignore)]
 async fn test_message_create_read_list() {
     let (client, _jh) = start_svix_server();
 


### PR DESCRIPTION
We can just use the built-in cargo integration tests filtering now
that they are separate. No need to have our own.

https://github.com/svix/svix-webhooks/pull/342\#issuecomment-1079540525
