### PR TITLE
Adds `prev` iterators as query filters for `list_attempts_by_endpoint` and `list_attempts_by_msg`

### DIFF
--- a/server/svix-server/src/core/types.rs
+++ b/server/svix-server/src/core/types.rs
@@ -294,6 +294,12 @@ macro_rules! create_id_type {
                 )))
             }
         }
+
+        impl From<String> for $name_id {
+            fn from(s: String) -> Self {
+                $name_id(s)
+            }
+        }
     };
 }
 

--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -98,6 +98,7 @@ async fn list_applications(
     Ok(Json(ApplicationOut::list_response(
         query.all(db).await?.into_iter().map(|x| x.into()).collect(),
         limit as usize,
+        false,
     )))
 }
 

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -182,7 +182,7 @@ pub struct ListAttemptsByEndpointQueryParameters {
 
 // Applies filters common to [`list_attempts_by_endpoint`] and [`list_attempts_by_msg`]
 fn list_attempts_by_endpoint_or_message_filters(
-    mut query: Select<messageattempt::Entity>,
+    query: Select<messageattempt::Entity>,
     limit: u64,
     iterator: Option<ReversibleIterator<MessageAttemptId>>,
     status: Option<MessageStatus>,
@@ -190,7 +190,7 @@ fn list_attempts_by_endpoint_or_message_filters(
     event_types: Option<EventTypeNameSet>,
     channel: Option<EventChannel>,
 ) -> Select<messageattempt::Entity> {
-    query = match iterator {
+    let query = match iterator {
         Some(ReversibleIterator::Prev(id)) => query.filter(
             Condition::any().add(
                 messageattempt::Column::Id.in_subquery(
@@ -207,7 +207,7 @@ fn list_attempts_by_endpoint_or_message_filters(
         None => query,
     };
 
-    query = query
+    let mut query = query
         .limit(limit + 1)
         .order_by_desc(messageattempt::Column::Id);
 

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -190,28 +190,25 @@ fn list_attempts_by_endpoint_or_message_filters(
     channel: Option<EventChannel>,
 ) -> Select<messageattempt::Entity> {
     query = match iterator {
-        Some(PaginationIterator::Prev(id)) => query
-            .filter(
-                Condition::any().add(
-                    messageattempt::Column::Id.in_subquery(
-                        Query::select()
-                            .column(messageattempt::Column::Id)
-                            .and_where(messageattempt::Column::Id.gt(id))
-                            .order_by_columns(vec![(messageattempt::Column::Id, Order::Asc)])
-                            .limit(limit + 1)
-                            .to_owned(),
-                    ),
+        Some(PaginationIterator::Prev(id)) => query.filter(
+            Condition::any().add(
+                messageattempt::Column::Id.in_subquery(
+                    Query::select()
+                        .column(messageattempt::Column::Id)
+                        .and_where(messageattempt::Column::Id.gt(id))
+                        .order_by_columns(vec![(messageattempt::Column::Id, Order::Asc)])
+                        .limit(limit + 1)
+                        .to_owned(),
                 ),
-            )
-            .order_by_desc(messageattempt::Column::Id),
-        Some(PaginationIterator::Normal(id)) => query
-            .limit(limit + 1)
-            .order_by_desc(messageattempt::Column::Id)
-            .filter(messageattempt::Column::Id.lt(id)),
-        None => query
-            .limit(limit + 1)
-            .order_by_desc(messageattempt::Column::Id),
+            ),
+        ),
+        Some(PaginationIterator::Normal(id)) => query.filter(messageattempt::Column::Id.lt(id)),
+        None => query,
     };
+
+    query = query
+        .limit(limit + 1)
+        .order_by_desc(messageattempt::Column::Id);
 
     if let Some(status) = status {
         query = query.filter(messageattempt::Column::Status.eq(status));

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -380,11 +380,13 @@ async fn list_attempts_by_msg(
         }
     }
 
-    let mut out: Vec<_> = query.all(db).await?.into_iter().map(Into::into).collect();
+    let out = query.all(db).await?.into_iter();
 
-    if is_prev {
-        out = out.into_iter().rev().collect();
-    }
+    let out = if is_prev {
+        out.rev().map(Into::into).collect()
+    } else {
+        out.map(Into::into).collect()
+    };
 
     Ok(Json(MessageAttemptOut::list_response(
         out,

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -164,6 +164,7 @@ async fn list_attempted_messages(
             )
             .collect::<Result<_>>()?,
         limit as usize,
+        false,
     )))
 }
 
@@ -285,6 +286,8 @@ async fn list_attempts_by_endpoint(
     let limit = pagination.limit;
     let iterator = pagination.iterator.take();
 
+    let is_prev = matches!(iterator, Some(ReversibleIterator::Prev(_)));
+
     // Confirm endpoint ID belongs to the given application
     if endpoint::Entity::secure_find_by_id(app.id, endp_id.clone())
         .one(db)
@@ -307,6 +310,7 @@ async fn list_attempts_by_endpoint(
     Ok(Json(MessageAttemptOut::list_response(
         query.all(db).await?.into_iter().map(Into::into).collect(),
         limit as usize,
+        is_prev,
     )))
 }
 
@@ -345,6 +349,8 @@ async fn list_attempts_by_msg(
     let limit = pagination.limit;
     let iterator = pagination.iterator.take();
 
+    let is_prev = matches!(iterator, Some(ReversibleIterator::Prev(_)));
+
     // Confirm message ID belongs to the given application
     if message::Entity::secure_find_by_id(app.id.clone(), msg_id.clone())
         .one(db)
@@ -380,6 +386,7 @@ async fn list_attempts_by_msg(
     Ok(Json(MessageAttemptOut::list_response(
         query.all(db).await?.into_iter().map(Into::into).collect(),
         limit as usize,
+        is_prev,
     )))
 }
 
@@ -459,6 +466,7 @@ async fn list_attempted_destinations(
             )
             .collect::<Result<_>>()?,
         limit as usize,
+        false,
     )))
 }
 
@@ -561,6 +569,7 @@ async fn list_messageattempts(
     Ok(Json(MessageAttemptOut::list_response(
         query.all(db).await?.into_iter().map(|x| x.into()).collect(),
         limit as usize,
+        false,
     )))
 }
 

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -190,7 +190,11 @@ fn list_attempts_by_endpoint_or_message_filters(
     event_types: Option<EventTypeNameSet>,
     channel: Option<EventChannel>,
 ) -> Select<messageattempt::Entity> {
-    let query = match iterator {
+    let query = query
+        .limit(limit + 1)
+        .order_by_desc(messageattempt::Column::Id);
+
+    let mut query = match iterator {
         Some(ReversibleIterator::Prev(id)) => query.filter(
             Condition::any().add(
                 messageattempt::Column::Id.in_subquery(
@@ -206,10 +210,6 @@ fn list_attempts_by_endpoint_or_message_filters(
         Some(ReversibleIterator::Normal(id)) => query.filter(messageattempt::Column::Id.lt(id)),
         None => query,
     };
-
-    let mut query = query
-        .limit(limit + 1)
-        .order_by_desc(messageattempt::Column::Id);
 
     if let Some(status) = status {
         query = query.filter(messageattempt::Column::Status.eq(status));

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -296,11 +296,13 @@ async fn list_attempts_by_endpoint(
         channel,
     );
 
-    let mut out: Vec<_> = query.all(db).await?.into_iter().map(Into::into).collect();
+    let out = query.all(db).await?.into_iter();
 
-    if is_prev {
-        out = out.into_iter().rev().collect();
-    }
+    let out = if is_prev {
+        out.rev().map(Into::into).collect()
+    } else {
+        out.map(Into::into).collect()
+    };
 
     Ok(Json(MessageAttemptOut::list_response(
         out,

--- a/server/svix-server/src/v1/endpoints/endpoint/crud.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/crud.rs
@@ -47,6 +47,7 @@ pub(super) async fn list_endpoints(
     Ok(Json(EndpointOut::list_response(
         query.all(db).await?.into_iter().map(|x| x.into()).collect(),
         limit as usize,
+        false,
     )))
 }
 

--- a/server/svix-server/src/v1/endpoints/event_type.rs
+++ b/server/svix-server/src/v1/endpoints/event_type.rs
@@ -126,6 +126,7 @@ async fn list_event_types(
     Ok(Json(EventTypeOut::list_response(
         query.all(db).await?.into_iter().map(|x| x.into()).collect(),
         limit as usize,
+        false,
     )))
 }
 

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -153,6 +153,7 @@ async fn list_messages(
     Ok(Json(MessageOut::list_response(
         query.all(db).await?.into_iter().map(|x| x.into()).collect(),
         limit as usize,
+        false,
     )))
 }
 

--- a/server/svix-server/src/v1/utils.rs
+++ b/server/svix-server/src/v1/utils.rs
@@ -32,7 +32,7 @@ pub struct Pagination<T: Validate> {
 }
 
 #[derive(Debug, Deserialize, Validate)]
-pub struct ReversablePagination<T: 'static + Validate + From<String>> {
+pub struct ReversiblePagination<T: 'static + Validate + From<String>> {
     #[serde(default = "default_limit")]
     pub limit: u64,
     #[validate]

--- a/server/svix-server/src/v1/utils.rs
+++ b/server/svix-server/src/v1/utils.rs
@@ -80,6 +80,7 @@ pub struct EmptyResponse {}
 pub struct ListResponse<T: Clone> {
     pub data: Vec<T>,
     pub iterator: Option<String>,
+    pub prev_iterator: Option<String>,
     pub done: bool,
 }
 
@@ -95,10 +96,14 @@ pub trait ModelOut {
     fn list_response<T: ModelOut + Clone>(mut data: Vec<T>, limit: usize) -> ListResponse<T> {
         let done = data.len() <= limit;
         data.truncate(limit);
+
+        let prev_iterator = data.first().map(|x| format!("-{}", x.id_copy()));
         let iterator = data.last().map(|x| x.id_copy());
+
         ListResponse {
             data,
             iterator,
+            prev_iterator,
             done,
         }
     }

--- a/server/svix-server/src/v1/utils.rs
+++ b/server/svix-server/src/v1/utils.rs
@@ -24,7 +24,7 @@ const fn default_limit() -> u64 {
 }
 
 #[derive(Debug, Deserialize, Validate)]
-pub struct Pagination<T: Validate + Clone> {
+pub struct Pagination<T: Validate> {
     #[serde(default = "default_limit")]
     pub limit: u64,
     #[validate]
@@ -32,20 +32,20 @@ pub struct Pagination<T: Validate + Clone> {
 }
 
 #[derive(Debug, Deserialize, Validate)]
-pub struct ReversablePagination<T: 'static + Validate + Clone + From<String>> {
+pub struct ReversablePagination<T: 'static + Validate + From<String>> {
     #[serde(default = "default_limit")]
     pub limit: u64,
     #[validate]
     pub iterator: Option<PaginationIterator<T>>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub enum PaginationIterator<T: Validate + Clone> {
+#[derive(Debug, PartialEq)]
+pub enum PaginationIterator<T: Validate> {
     Normal(T),
     Prev(T),
 }
 
-impl<'de, T: 'static + Deserialize<'de> + Validate + Clone + From<String>> Deserialize<'de>
+impl<'de, T: 'static + Deserialize<'de> + Validate + From<String>> Deserialize<'de>
     for PaginationIterator<T>
 {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
@@ -56,7 +56,7 @@ impl<'de, T: 'static + Deserialize<'de> + Validate + Clone + From<String>> Deser
     }
 }
 
-impl<T: Validate + Clone> Validate for PaginationIterator<T> {
+impl<T: Validate> Validate for PaginationIterator<T> {
     fn validate(&self) -> std::result::Result<(), validator::ValidationErrors> {
         match self {
             PaginationIterator::Normal(val) => val.validate(),
@@ -65,11 +65,9 @@ impl<T: Validate + Clone> Validate for PaginationIterator<T> {
     }
 }
 
-struct Visitor<'de, T: Deserialize<'de> + Validate + Clone>(
-    std::marker::PhantomData<fn() -> &'de T>,
-);
+struct Visitor<'de, T: Deserialize<'de> + Validate>(std::marker::PhantomData<fn() -> &'de T>);
 
-impl<'de, T: Deserialize<'de> + Validate + Clone + From<String>> serde::de::Visitor<'de>
+impl<'de, T: Deserialize<'de> + Validate + From<String>> serde::de::Visitor<'de>
     for Visitor<'de, T>
 {
     type Value = PaginationIterator<T>;

--- a/server/svix-server/src/v1/utils.rs
+++ b/server/svix-server/src/v1/utils.rs
@@ -85,9 +85,21 @@ pub trait ModelIn {
 pub trait ModelOut {
     fn id_copy(&self) -> String;
 
-    fn list_response<T: ModelOut + Clone>(mut data: Vec<T>, limit: usize) -> ListResponse<T> {
+    fn list_response<T: ModelOut + Clone>(
+        mut data: Vec<T>,
+        limit: usize,
+        is_prev_iter: bool,
+    ) -> ListResponse<T> {
         let done = data.len() <= limit;
-        data.truncate(limit);
+
+        if is_prev_iter {
+            let i = data.len() - limit;
+            if i > 0 {
+                data = data.drain(i..).collect();
+            }
+        } else {
+            data.truncate(limit);
+        }
 
         let prev_iterator = data.first().map(|x| format!("-{}", x.id_copy()));
         let iterator = data.last().map(|x| x.id_copy());

--- a/server/svix-server/src/v1/utils.rs
+++ b/server/svix-server/src/v1/utils.rs
@@ -91,12 +91,12 @@ pub trait ModelOut {
     ) -> ListResponse<T> {
         let done = data.len() <= limit;
 
-        if is_prev_iter {
-            if data.len() > limit {
+        if data.len() > limit {
+            if is_prev_iter {
                 data = data.drain(data.len() - limit..).collect();
+            } else {
+                data.truncate(limit);
             }
-        } else {
-            data.truncate(limit);
         }
 
         let prev_iterator = data.first().map(|x| format!("-{}", x.id_copy()));

--- a/server/svix-server/src/v1/utils.rs
+++ b/server/svix-server/src/v1/utils.rs
@@ -45,8 +45,7 @@ impl<'de, T: 'static + Deserialize<'de> + Validate + From<String>> Deserialize<'
         D: serde::Deserializer<'de>,
     {
         String::deserialize(deserializer).map(|s| {
-            if s.starts_with('-') {
-                let s = s.trim_start_matches('-');
+            if let Some(s) = s.strip_prefix('-') {
                 ReversibleIterator::Prev(T::from(s.to_owned()))
             } else {
                 ReversibleIterator::Normal(T::from(s))

--- a/server/svix-server/src/v1/utils.rs
+++ b/server/svix-server/src/v1/utils.rs
@@ -93,9 +93,8 @@ pub trait ModelOut {
         let done = data.len() <= limit;
 
         if is_prev_iter {
-            let i = data.len() - limit;
-            if i > 0 {
-                data = data.drain(i..).collect();
+            if data.len() > limit {
+                data = data.drain(data.len() - limit..).collect();
             }
         } else {
             data.truncate(limit);


### PR DESCRIPTION
Adds `prev` iterators for the `list_attempts_by_endpoint` and `list_attempts_by_msg` endpoints. To be followed by expanding endpoints covered by this structure and to add  `before` and `after` parameters. 