### PR TITLE
Extend `prev_iterator` implementation

### DIFF
--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -279,9 +279,11 @@ async fn list_attempts_by_endpoint(
     let limit = pagination.limit;
     let iterator = pagination.iterator.take().or_else(|| {
         if let Some(before) = before {
-            Some(ReversibleIterator::Prev(MessageAttemptId::start_id(before)))
+            Some(ReversibleIterator::Normal(MessageAttemptId::start_id(
+                before,
+            )))
         } else {
-            after.map(|after| ReversibleIterator::Normal(MessageAttemptId::end_id(after)))
+            after.map(|after| ReversibleIterator::Prev(MessageAttemptId::end_id(after)))
         }
     });
 

--- a/server/svix-server/src/v1/utils.rs
+++ b/server/svix-server/src/v1/utils.rs
@@ -64,11 +64,21 @@ impl<T: Validate> Validate for ReversibleIterator<T> {
     }
 }
 
-pub enum ReversibleSelect<T: QuerySelect> {
-    Forward(T),
-    Reversed(T),
+/// For use in creating a [`ReversibleIterator`] from `before` and `after` timestamps should one not
+/// already be present
+pub fn iterator_from_before_or_after<I: BaseId<Output = I> + Validate>(
+    iterator: Option<ReversibleIterator<I>>,
+    before: Option<DateTime<Utc>>,
+    after: Option<DateTime<Utc>>,
+) -> Option<ReversibleIterator<I>> {
+    iterator.or_else(|| {
+        before
+            .map(|time| ReversibleIterator::Normal(I::start_id(time)))
+            .or_else(|| after.map(|time| ReversibleIterator::Prev(I::end_id(time))))
+    })
 }
 
+/// Applies sorting and filtration to a query from its iterator, sort column, and limit
 pub fn apply_pagination<
     Q: QuerySelect + QueryOrder + QueryFilter,
     C: ColumnTrait,
@@ -78,27 +88,19 @@ pub fn apply_pagination<
     sort_column: C,
     limit: u64,
     iterator: Option<ReversibleIterator<I>>,
-    before: Option<DateTime<Utc>>,
-    after: Option<DateTime<Utc>>,
-) -> ReversibleSelect<Q> {
-    let iterator = iterator.or_else(|| {
-        before
-            .map(|time| ReversibleIterator::Normal(I::start_id(time)))
-            .or_else(|| after.map(|time| ReversibleIterator::Prev(I::end_id(time))))
-    });
-
+) -> Q {
     let query = query.limit(limit + 1);
 
     match iterator {
         Some(ReversibleIterator::Prev(id)) => {
-            ReversibleSelect::Reversed(query.order_by_asc(sort_column).filter(sort_column.gt(id)))
+            query.order_by_asc(sort_column).filter(sort_column.gt(id))
         }
 
         Some(ReversibleIterator::Normal(id)) => {
-            ReversibleSelect::Forward(query.order_by_desc(sort_column).filter(sort_column.lt(id)))
+            query.order_by_desc(sort_column).filter(sort_column.lt(id))
         }
 
-        None => ReversibleSelect::Forward(query.order_by_desc(sort_column)),
+        None => query.order_by_desc(sort_column),
     }
 }
 

--- a/server/svix-server/tests/e2e_attempt.rs
+++ b/server/svix-server/tests/e2e_attempt.rs
@@ -313,10 +313,7 @@ async fn test_pagination_by_endpoint() {
 
         assert_eq!(all_attempts.data.len(), 6);
         assert_eq!(first_three.data.len(), 3);
-
-        assert_eq!(all_attempts.data[0], first_three.data[0]);
-        assert_eq!(all_attempts.data[1], first_three.data[1]);
-        assert_eq!(all_attempts.data[2], first_three.data[2]);
+        assert_eq!(&all_attempts.data[0..3], first_three.data.as_slice());
 
         // Forward iterator
         let last_three_manual: ListResponse<MessageAttemptOut> = client
@@ -346,9 +343,7 @@ async fn test_pagination_by_endpoint() {
         assert_eq!(last_three_manual.data, last_three_iter_field.data);
 
         assert_eq!(last_three_manual.data.len(), 3);
-        assert_eq!(all_attempts.data[3], last_three_manual.data[0]);
-        assert_eq!(all_attempts.data[4], last_three_manual.data[1]);
-        assert_eq!(all_attempts.data[5], last_three_manual.data[2]);
+        assert_eq!(&all_attempts.data[3..6], last_three_manual.data.as_slice());
         assert!(last_three_manual.done);
 
         // `prev` iterator
@@ -366,8 +361,7 @@ async fn test_pagination_by_endpoint() {
             .unwrap();
 
         assert_eq!(two_and_three.data.len(), 2);
-        assert_eq!(all_attempts.data[1], two_and_three.data[0]);
-        assert_eq!(all_attempts.data[2], two_and_three.data[1]);
+        assert_eq!(&all_attempts.data[1..3], two_and_three.data.as_slice());
         assert!(!two_and_three.done);
 
         let one: ListResponse<MessageAttemptOut> = client
@@ -399,9 +393,10 @@ async fn test_pagination_by_endpoint() {
             .await
             .unwrap();
         assert_eq!(first_three_by_time.data.len(), 3);
-        assert_eq!(all_attempts.data[0], first_three_by_time.data[0]);
-        assert_eq!(all_attempts.data[1], first_three_by_time.data[1]);
-        assert_eq!(all_attempts.data[2], first_three_by_time.data[2]);
+        assert_eq!(
+            &all_attempts.data[0..3],
+            first_three_by_time.data.as_slice()
+        );
 
         // `before field`
         let last_three_by_time: ListResponse<MessageAttemptOut> = client
@@ -415,9 +410,7 @@ async fn test_pagination_by_endpoint() {
             .await
             .unwrap();
         assert_eq!(last_three_by_time.data.len(), 3);
-        assert_eq!(all_attempts.data[3], last_three_by_time.data[0]);
-        assert_eq!(all_attempts.data[4], last_three_by_time.data[1]);
-        assert_eq!(all_attempts.data[5], last_three_by_time.data[2]);
+        assert_eq!(&all_attempts.data[3..6], last_three_by_time.data.as_slice());
     }
 }
 
@@ -498,9 +491,7 @@ async fn test_pagination_by_msg() {
         assert_eq!(all_attempts.data.len(), 6);
         assert_eq!(first_three.data.len(), 3);
 
-        assert_eq!(all_attempts.data[0], first_three.data[0]);
-        assert_eq!(all_attempts.data[1], first_three.data[1]);
-        assert_eq!(all_attempts.data[2], first_three.data[2]);
+        assert_eq!(&all_attempts.data[0..3], first_three.data.as_slice());
 
         // Forward iterator
         let last_three_manual: ListResponse<MessageAttemptOut> = client
@@ -530,9 +521,7 @@ async fn test_pagination_by_msg() {
         assert_eq!(last_three_manual.data, last_three_iter_field.data);
 
         assert_eq!(last_three_manual.data.len(), 3);
-        assert_eq!(all_attempts.data[3], last_three_manual.data[0]);
-        assert_eq!(all_attempts.data[4], last_three_manual.data[1]);
-        assert_eq!(all_attempts.data[5], last_three_manual.data[2]);
+        assert_eq!(&all_attempts.data[3..6], last_three_manual.data.as_slice());
         assert!(last_three_manual.done);
 
         // `prev` iterator
@@ -550,8 +539,7 @@ async fn test_pagination_by_msg() {
             .unwrap();
 
         assert_eq!(two_and_three.data.len(), 2);
-        assert_eq!(all_attempts.data[1], two_and_three.data[0]);
-        assert_eq!(all_attempts.data[2], two_and_three.data[1]);
+        assert_eq!(&all_attempts.data[1..3], two_and_three.data.as_slice());
         assert!(!two_and_three.done);
 
         let one: ListResponse<MessageAttemptOut> = client

--- a/server/svix-server/tests/e2e_attempt.rs
+++ b/server/svix-server/tests/e2e_attempt.rs
@@ -710,7 +710,7 @@ async fn test_pagination_forward_and_back() {
         iterator = out.iterator;
     }
 
-    assert_eq!(forward_msgs.len(), 28);
+    assert_eq!(forward_msgs.len(), messages.len());
 
     // Go backwards
     let mut backwards_msgs = Vec::new();
@@ -739,6 +739,7 @@ async fn test_pagination_forward_and_back() {
         prev_iterator = out.prev_iterator;
     }
 
+    // Skips the last eight because the prev_iterator is that of the third page of eight going forward
     assert_eq!(backwards_msgs.len(), 20);
     assert_eq!(&forward_msgs[0..10], &backwards_msgs[10..20]);
     assert_eq!(&forward_msgs[10..20], &backwards_msgs[0..10]);

--- a/server/svix-server/tests/e2e_attempt.rs
+++ b/server/svix-server/tests/e2e_attempt.rs
@@ -236,14 +236,14 @@ async fn test_message_attempts() {
 }
 
 #[tokio::test]
-async fn test_pagination() {
+async fn test_pagination_by_endpoint() {
     let (client, _jh) = start_svix_server();
 
-    // Setup three endpoints and six messages so there's a sufficient number to test pagination
+    // Setup six endpoints and six messages so there's a sufficient number to test pagination
     let app = create_test_app(&client, "app1").await.unwrap();
 
     let mut receivers = Vec::new();
-    for _ in 0..3 {
+    for _ in 0..6 {
         receivers.push(TestReceiver::start(StatusCode::OK));
     }
 
@@ -419,6 +419,227 @@ async fn test_pagination() {
         assert_eq!(all_attempts.data[4], last_three_by_time.data[1]);
         assert_eq!(all_attempts.data[5], last_three_by_time.data[2]);
     }
+}
 
-    // TODO: By message
+#[tokio::test]
+async fn test_pagination_by_msg() {
+    let (client, _jh) = start_svix_server();
+
+    // Setup six endpoints and six messages so there's a sufficient number to test pagination
+    let app = create_test_app(&client, "app1").await.unwrap();
+
+    let mut receivers = Vec::new();
+    for _ in 0..6 {
+        receivers.push(TestReceiver::start(StatusCode::OK));
+    }
+
+    let mut eps = Vec::new();
+    for receiver in &receivers {
+        eps.push(
+            create_test_endpoint(&client, &app.id, &receiver.endpoint)
+                .await
+                .unwrap(),
+        );
+    }
+
+    let mut messages = Vec::new();
+    for i in 1..=6usize {
+        messages.push(
+            create_test_message(
+                &client,
+                &app.id,
+                serde_json::json!({
+                    "test": i,
+                }),
+            )
+            .await
+            .unwrap(),
+        );
+    }
+
+    // Wait until all attempts were made
+    run_with_retries(|| async {
+        for endp_id in eps.iter().map(|ep| &ep.id) {
+            let list: ListResponse<MessageAttemptOut> = client
+                .get(
+                    &format!("api/v1/app/{}/attempt/endpoint/{}/", app.id, endp_id),
+                    StatusCode::OK,
+                )
+                .await
+                .unwrap();
+
+            if list.data.len() != 6 {
+                anyhow::bail!("list len {}, not 6", list.data.len());
+            }
+        }
+
+        Ok(())
+    })
+    .await
+    .unwrap(); // By message
+    for msg in &messages {
+        let all_attempts: ListResponse<MessageAttemptOut> = client
+            .get(
+                &format!("api/v1/app/{}/attempt/msg/{}/", app.id, msg.id),
+                StatusCode::OK,
+            )
+            .await
+            .unwrap();
+
+        // Test Limit
+        let first_three: ListResponse<MessageAttemptOut> = client
+            .get(
+                &format!("api/v1/app/{}/attempt/msg/{}/?limit=3", app.id, msg.id),
+                StatusCode::OK,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(all_attempts.data.len(), 6);
+        assert_eq!(first_three.data.len(), 3);
+
+        assert_eq!(all_attempts.data[0], first_three.data[0]);
+        assert_eq!(all_attempts.data[1], first_three.data[1]);
+        assert_eq!(all_attempts.data[2], first_three.data[2]);
+
+        // Forward iterator
+        let last_three_manual: ListResponse<MessageAttemptOut> = client
+            .get(
+                &format!(
+                    "api/v1/app/{}/attempt/msg/{}/?limit=3&iterator={}",
+                    app.id, msg.id, all_attempts.data[2].id
+                ),
+                StatusCode::OK,
+            )
+            .await
+            .unwrap();
+
+        let last_three_iter_field: ListResponse<MessageAttemptOut> = client
+            .get(
+                &format!(
+                    "api/v1/app/{}/attempt/msg/{}/?limit=3&iterator={}",
+                    app.id,
+                    msg.id,
+                    first_three.iterator.unwrap()
+                ),
+                StatusCode::OK,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(last_three_manual.data, last_three_iter_field.data);
+
+        assert_eq!(last_three_manual.data.len(), 3);
+        assert_eq!(all_attempts.data[3], last_three_manual.data[0]);
+        assert_eq!(all_attempts.data[4], last_three_manual.data[1]);
+        assert_eq!(all_attempts.data[5], last_three_manual.data[2]);
+        assert!(last_three_manual.done);
+
+        // `prev` iterator
+        let two_and_three: ListResponse<MessageAttemptOut> = client
+            .get(
+                &format!(
+                    "api/v1/app/{}/attempt/msg/{}/?limit=2&iterator={}",
+                    app.id,
+                    msg.id,
+                    last_three_manual.prev_iterator.unwrap()
+                ),
+                StatusCode::OK,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(two_and_three.data.len(), 2);
+        assert_eq!(all_attempts.data[1], two_and_three.data[0]);
+        assert_eq!(all_attempts.data[2], two_and_three.data[1]);
+        assert!(!two_and_three.done);
+
+        let one: ListResponse<MessageAttemptOut> = client
+            .get(
+                &format!(
+                    "api/v1/app/{}/attempt/msg/{}/?limit=2&iterator={}",
+                    app.id,
+                    msg.id,
+                    two_and_three.prev_iterator.unwrap()
+                ),
+                StatusCode::OK,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(one.data.len(), 1);
+        assert_eq!(all_attempts.data[0], one.data[0]);
+        assert!(one.done);
+
+        // Because messages are dispatched so quickly, a different approach than above needs to be tested
+        // for checking by time.
+
+        // `after` field
+        let all_six_by_time: ListResponse<MessageAttemptOut> = client
+            .get(
+                &format!(
+                    "api/v1/app/{}/attempt/msg/{}/?after={}",
+                    app.id,
+                    msg.id,
+                    sub_5ms(all_attempts.data[5].created_at)
+                ),
+                StatusCode::OK,
+            )
+            .await
+            .unwrap();
+        assert_eq!(all_attempts.data, all_six_by_time.data);
+
+        let none_by_time: ListResponse<MessageAttemptOut> = client
+            .get(
+                &format!(
+                    "api/v1/app/{}/attempt/msg/{}/?after={}",
+                    app.id,
+                    msg.id,
+                    add_5ms(all_attempts.data[0].created_at)
+                ),
+                StatusCode::OK,
+            )
+            .await
+            .unwrap();
+        assert!(none_by_time.data.is_empty());
+
+        // `before field`
+        let all_six_by_time: ListResponse<MessageAttemptOut> = client
+            .get(
+                &format!(
+                    "api/v1/app/{}/attempt/msg/{}/?before={}",
+                    app.id,
+                    msg.id,
+                    add_5ms(all_attempts.data[0].created_at),
+                ),
+                StatusCode::OK,
+            )
+            .await
+            .unwrap();
+        assert_eq!(all_attempts.data, all_six_by_time.data);
+
+        let none_by_time: ListResponse<MessageAttemptOut> = client
+            .get(
+                &format!(
+                    "api/v1/app/{}/attempt/msg/{}/?before={}",
+                    app.id,
+                    msg.id,
+                    sub_5ms(all_attempts.data[5].created_at),
+                ),
+                StatusCode::OK,
+            )
+            .await
+            .unwrap();
+        assert!(none_by_time.data.is_empty());
+    }
+
+    /// Adds 5ms to a [`chrono::DateTime`] for testing `before` and `after`
+    fn add_5ms<T: chrono::TimeZone>(dur: chrono::DateTime<T>) -> chrono::DateTime<T> {
+        dur + chrono::Duration::from_std(std::time::Duration::from_millis(5)).unwrap()
+    }
+
+    /// Subtracts 5ms to a [`chrono::DateTime`] for testing `before` and `after`
+    fn sub_5ms<T: chrono::TimeZone>(dur: chrono::DateTime<T>) -> chrono::DateTime<T> {
+        dur - chrono::Duration::from_std(std::time::Duration::from_millis(5)).unwrap()
+    }
 }

--- a/server/svix-server/tests/e2e_attempt.rs
+++ b/server/svix-server/tests/e2e_attempt.rs
@@ -647,7 +647,7 @@ async fn test_pagination_forward_and_back() {
         .unwrap();
 
     let mut messages = Vec::new();
-    for i in 1..=20usize {
+    for i in 1..=28usize {
         messages.push(
             create_test_message(
                 &client,
@@ -671,8 +671,8 @@ async fn test_pagination_forward_and_back() {
             .await
             .unwrap();
 
-        if list.data.len() != 20 {
-            anyhow::bail!("list len {}, not 20", list.data.len());
+        if list.data.len() != 28 {
+            anyhow::bail!("list len {}, not 28", list.data.len());
         }
 
         Ok(())
@@ -710,7 +710,7 @@ async fn test_pagination_forward_and_back() {
         iterator = out.iterator;
     }
 
-    assert_eq!(forward_msgs.len(), 20);
+    assert_eq!(forward_msgs.len(), 28);
 
     // Go backwards
     let mut backwards_msgs = Vec::new();
@@ -739,6 +739,7 @@ async fn test_pagination_forward_and_back() {
         prev_iterator = out.prev_iterator;
     }
 
-    assert_eq!(backwards_msgs.len(), 10);
-    assert_eq!(&forward_msgs[0..10], backwards_msgs.as_slice());
+    assert_eq!(backwards_msgs.len(), 20);
+    assert_eq!(&forward_msgs[0..10], &backwards_msgs[10..20]);
+    assert_eq!(&forward_msgs[10..20], &backwards_msgs[0..10]);
 }


### PR DESCRIPTION
Extends the `prev_iterator` implementation to include `before`/`after` query parameters and to apply this functionality to all list operations in the attempt API.