### PR TITLE
Db models: use the same timestamp for ID and created_at.

### DIFF
--- a/server/svix-server/src/db/models/application.rs
+++ b/server/svix-server/src/db/models/application.rs
@@ -44,10 +44,11 @@ impl Related<super::message::Entity> for Entity {
 
 impl ActiveModelBehavior for ActiveModel {
     fn new() -> Self {
+        let timestamp = Utc::now();
         Self {
-            id: Set(ApplicationId::new(None, None)),
-            created_at: Set(Utc::now().into()),
-            updated_at: Set(Utc::now().into()),
+            id: Set(ApplicationId::new(timestamp.into(), None)),
+            created_at: Set(timestamp.into()),
+            updated_at: Set(timestamp.into()),
             deleted: Set(false),
             ..ActiveModelTrait::default()
         }

--- a/server/svix-server/src/db/models/endpoint.rs
+++ b/server/svix-server/src/db/models/endpoint.rs
@@ -60,10 +60,11 @@ impl Related<super::messagedestination::Entity> for Entity {
 
 impl ActiveModelBehavior for ActiveModel {
     fn new() -> Self {
+        let timestamp = Utc::now();
         Self {
-            id: Set(EndpointId::new(None, None)),
-            created_at: Set(Utc::now().into()),
-            updated_at: Set(Utc::now().into()),
+            id: Set(EndpointId::new(timestamp.into(), None)),
+            created_at: Set(timestamp.into()),
+            updated_at: Set(timestamp.into()),
             deleted: Set(false),
             ..ActiveModelTrait::default()
         }

--- a/server/svix-server/src/db/models/eventtype.rs
+++ b/server/svix-server/src/db/models/eventtype.rs
@@ -31,10 +31,11 @@ impl RelationTrait for Relation {
 
 impl ActiveModelBehavior for ActiveModel {
     fn new() -> Self {
+        let timestamp = Utc::now();
         Self {
-            id: Set(EventTypeId::new(None, None)),
-            created_at: Set(Utc::now().into()),
-            updated_at: Set(Utc::now().into()),
+            id: Set(EventTypeId::new(timestamp.into(), None)),
+            created_at: Set(timestamp.into()),
+            updated_at: Set(timestamp.into()),
             deleted: Set(false),
             ..ActiveModelTrait::default()
         }

--- a/server/svix-server/src/db/models/message.rs
+++ b/server/svix-server/src/db/models/message.rs
@@ -53,10 +53,11 @@ impl Related<super::messagedestination::Entity> for Entity {
 
 impl ActiveModelBehavior for ActiveModel {
     fn new() -> Self {
+        let timestamp = Utc::now();
         Self {
-            id: Set(MessageId::new(None, None)),
-            created_at: Set(Utc::now().into()),
-            updated_at: Set(Utc::now().into()),
+            id: Set(MessageId::new(timestamp.into(), None)),
+            created_at: Set(timestamp.into()),
+            updated_at: Set(timestamp.into()),
             ..ActiveModelTrait::default()
         }
     }

--- a/server/svix-server/src/db/models/messageattempt.rs
+++ b/server/svix-server/src/db/models/messageattempt.rs
@@ -49,10 +49,11 @@ impl Related<super::messagedestination::Entity> for Entity {
 
 impl ActiveModelBehavior for ActiveModel {
     fn new() -> Self {
+        let timestamp = Utc::now();
         Self {
-            id: Set(MessageAttemptId::new(None, None)),
-            created_at: Set(Utc::now().into()),
-            updated_at: Set(Utc::now().into()),
+            id: Set(MessageAttemptId::new(timestamp.into(), None)),
+            created_at: Set(timestamp.into()),
+            updated_at: Set(timestamp.into()),
             ..ActiveModelTrait::default()
         }
     }

--- a/server/svix-server/src/db/models/messagedestination.rs
+++ b/server/svix-server/src/db/models/messagedestination.rs
@@ -62,10 +62,11 @@ impl Related<super::messageattempt::Entity> for Entity {
 
 impl ActiveModelBehavior for ActiveModel {
     fn new() -> Self {
+        let timestamp = Utc::now();
         Self {
-            id: Set(MessageEndpointId::new(None, None)),
-            created_at: Set(Utc::now().into()),
-            updated_at: Set(Utc::now().into()),
+            id: Set(MessageEndpointId::new(timestamp.into(), None)),
+            created_at: Set(timestamp.into()),
+            updated_at: Set(timestamp.into()),
             ..ActiveModelTrait::default()
         }
     }


### PR DESCRIPTION
We want them to be the same because they actually hold the same
information. We show the created_at, but we use the ID for the sorting.

We should probably get rid of created_at down the line because it's
already encoded in the ID, but at least then, make sure they are
identical.