### PR TITLE
Tests: make a common test for testing list endpoints.

### DIFF
--- a/server/svix-server/tests/e2e_endpoint.rs
+++ b/server/svix-server/tests/e2e_endpoint.rs
@@ -7,7 +7,7 @@ use reqwest::StatusCode;
 use svix_server::{
     core::types::{ApplicationId, EndpointUid},
     v1::{
-        endpoints::endpoint::{EndpointOut, EndpointSecretOut},
+        endpoints::endpoint::{EndpointIn, EndpointOut, EndpointSecretOut},
         utils::ListResponse,
     },
 };
@@ -16,7 +16,8 @@ mod utils;
 
 use utils::{
     common_calls::{
-        create_test_app, create_test_endpoint, delete_test_app, endpoint_in, post_endpoint,
+        common_test_list, create_test_app, create_test_endpoint, delete_test_app, endpoint_in,
+        post_endpoint,
     },
     start_svix_server, IgnoredResponse, TestClient,
 };
@@ -194,6 +195,21 @@ async fn test_crud() {
     get_endpoint_404(&client, &app_2, &app_2_ep_2.id)
         .await
         .unwrap();
+}
+
+#[tokio::test]
+async fn test_list() {
+    let (client, _jh) = start_svix_server();
+
+    let app_id = create_test_app(&client, "App1").await.unwrap().id;
+    common_test_list::<EndpointOut, EndpointIn>(
+        &client,
+        &format!("api/v1/app/{app_id}/endpoint/"),
+        |i| endpoint_in(&format!("https://localhost/{i}")),
+        true,
+    )
+    .await
+    .unwrap();
 }
 
 /// Tests that there is at most one endpoint with a single UID for all endpoints associated with

--- a/server/svix-server/tests/e2e_event_type.rs
+++ b/server/svix-server/tests/e2e_event_type.rs
@@ -3,11 +3,17 @@
 
 use reqwest::StatusCode;
 
-use svix_server::v1::{endpoints::event_type::EventTypeOut, utils::ListResponse};
+use svix_server::v1::{
+    endpoints::event_type::{EventTypeIn, EventTypeOut},
+    utils::ListResponse,
+};
 
 mod utils;
 
-use utils::{common_calls::event_type_in, start_svix_server};
+use utils::{
+    common_calls::{common_test_list, event_type_in},
+    start_svix_server,
+};
 
 #[tokio::test]
 async fn test_event_type_create_read_list() {
@@ -46,4 +52,24 @@ async fn test_event_type_create_read_list() {
         schemas: None,
         ..et
     }));
+}
+
+#[tokio::test]
+async fn test_list() {
+    let (client, _jh) = start_svix_server();
+
+    common_test_list::<EventTypeOut, EventTypeIn>(
+        &client,
+        "api/v1/event-type/",
+        |i| {
+            event_type_in(
+                &format!("test-event-type-{i}"),
+                serde_json::json!({"test": "value"}),
+            )
+            .unwrap()
+        },
+        true,
+    )
+    .await
+    .unwrap();
 }

--- a/server/svix-server/tests/utils/mod.rs
+++ b/server/svix-server/tests/utils/mod.rs
@@ -217,14 +217,18 @@ async fn test_receiver_route(
     code
 }
 
-pub async fn run_with_retries<F: Future<Output = Result<()>>, C: Fn() -> F>(f: C) -> Result<()> {
+pub async fn run_with_retries<O, F, C>(f: C) -> Result<O>
+where
+    F: Future<Output = Result<O>>,
+    C: Fn() -> F,
+{
     for attempt in 0..20 {
         let out = f().await;
         if out.is_ok() {
-            return Ok(());
+            return out;
+        } else if let Err(err) = out {
+            println!("Attempt {}: {}", attempt, err);
         }
-
-        println!("Attempt {}: {}", attempt, out.unwrap_err());
 
         std::thread::sleep(std::time::Duration::from_millis(50));
     }


### PR DESCRIPTION
While doing it, also improved run_with_retries to return the successful value.