### PR TITLE
Bump axum version

### DIFF
--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -19,7 +19,7 @@ dotenv = "0.15.0"
 getrandom = "0.2.4"
 hmac-sha256 = "1"
 clap = { version = "3.0.10", features = ["derive"] }
-axum = { version = "0.4.8", features = ["headers"] }
+axum = { version = "0.5.1", features = ["headers"] }
 base64 = "0.13.0"
 hyper = { version = "0.14.16", features = ["full"] }
 tokio = { version = "1.15.0", features = ["full"] }

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -682,7 +682,7 @@ pub fn router() -> Router {
         "/app/:app_id/",
         Router::new()
             .nest(
-                "msg/:msg_id",
+                "/msg/:msg_id",
                 Router::new()
                     // NOTE: [`list_messageattempts`] is deprecated
                     .route("/attempt/", get(list_messageattempts))
@@ -695,9 +695,12 @@ pub fn router() -> Router {
                         get(list_attempts_for_endpoint),
                     ),
             )
-            .route("endpoint/:endp_id/msg/", get(list_attempted_messages))
-            .route("attempt/endpoint/:endp_id/", get(list_attempts_by_endpoint))
-            .route("attempt/msg/:msg_id/", get(list_attempts_by_msg)),
+            .route("/endpoint/:endp_id/msg/", get(list_attempted_messages))
+            .route(
+                "/attempt/endpoint/:endp_id/",
+                get(list_attempts_by_endpoint),
+            )
+            .route("/attempt/msg/:msg_id/", get(list_attempts_by_msg)),
     )
 }
 

--- a/server/svix-server/src/v1/mod.rs
+++ b/server/svix-server/src/v1/mod.rs
@@ -59,7 +59,7 @@ mod development {
         type Rejection = Error;
 
         async fn from_request(req: &mut RequestParts<B>) -> Result<Self> {
-            let headers = format!("{:?}", req.headers().unwrap());
+            let headers = format!("{:?}", req.headers());
             Ok(EchoData { headers })
         }
     }

--- a/server/svix-server/tests/e2e_event_type.rs
+++ b/server/svix-server/tests/e2e_event_type.rs
@@ -37,7 +37,7 @@ async fn test_event_type_create_read_list() {
     );
 
     let list: ListResponse<EventTypeOut> = client
-        .get("api/v1/event-type?with_content=true", StatusCode::OK)
+        .get("api/v1/event-type/?with_content=true", StatusCode::OK)
         .await
         .unwrap();
     assert_eq!(list.data.len(), 1);

--- a/server/svix-server/tests/e2e_message.rs
+++ b/server/svix-server/tests/e2e_message.rs
@@ -103,7 +103,7 @@ async fn test_message_create_read_list_with_content() {
 
     let msg_2_wo_payload: MessageOut = client
         .post(
-            &format!("api/v1/app/{}/msg?with_content=false", &app_id),
+            &format!("api/v1/app/{}/msg/?with_content=false", &app_id),
             message_in(&app_id, msg_payload.clone()).unwrap(),
             StatusCode::ACCEPTED,
         )
@@ -138,7 +138,7 @@ async fn test_message_create_read_list_with_content() {
         assert_eq!(
             client
                 .get::<MessageOut>(
-                    &format!("api/v1/app/{}/msg/{}?with_content=false", &app_id, &m.id),
+                    &format!("api/v1/app/{}/msg/{}/?with_content=false", &app_id, &m.id),
                     StatusCode::OK
                 )
                 .await
@@ -157,7 +157,7 @@ async fn test_message_create_read_list_with_content() {
 
     let list: ListResponse<MessageOut> = client
         .get(
-            &format!("api/v1/app/{}/msg?with_content=false", &app_id),
+            &format!("api/v1/app/{}/msg/?with_content=false", &app_id),
             StatusCode::OK,
         )
         .await


### PR DESCRIPTION
Bump `axum` version to 0.5.1, fix associated compilation errors, and fix errors in tests without trailing slashes.