### PR TITLE
Fix clippy lint in several points in tests/utils/mod.rs

### DIFF
--- a/server/svix-server/tests/utils/mod.rs
+++ b/server/svix-server/tests/utils/mod.rs
@@ -72,10 +72,9 @@ impl TestClient {
             );
         }
 
-        Ok(resp
-            .json()
+        resp.json()
             .await
-            .context("error receiving/parsing response")?)
+            .context("error receiving/parsing response")
     }
 
     pub async fn post<I: Serialize, O: DeserializeOwned>(
@@ -97,10 +96,9 @@ impl TestClient {
             );
         }
 
-        Ok(resp
-            .json()
+        resp.json()
             .await
-            .context("error receiving/parsing response")?)
+            .context("error receiving/parsing response")
     }
 
     pub async fn put<I: Serialize, O: DeserializeOwned>(
@@ -122,10 +120,9 @@ impl TestClient {
             );
         }
 
-        Ok(resp
-            .json()
+        resp.json()
             .await
-            .context("error receiving/parsing response")?)
+            .context("error receiving/parsing response")
     }
 
     pub async fn delete<O: DeserializeOwned>(
@@ -146,10 +143,9 @@ impl TestClient {
             );
         }
 
-        Ok(resp
-            .json()
+        resp.json()
             .await
-            .context("error receiving/parsing response")?)
+            .context("error receiving/parsing response")
     }
 }
 


### PR DESCRIPTION
Fixes a newly present `clippy` lint in the test utility functions.