### PR TITLE
Remove unwrap in create_message.

### DIFF
--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -273,7 +273,7 @@ async fn create_message(
             .exec(db)
             .await?;
     }
-    txn.commit().await.unwrap();
+    txn.commit().await?;
     for task in tasks {
         queue_tx.send(task, None).await?;
     }


### PR DESCRIPTION
I don't know how it got there, but it should have always been a ?.