### PR TITLE
Add EndpointSecret Validation

### DIFF
--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -80,6 +80,7 @@ pub struct EndpointIn {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub channels: Option<EventChannelSet>,
 
+    #[validate]
     #[serde(default)]
     #[serde(rename = "secret")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -147,6 +148,7 @@ impl From<endpoint::Model> for EndpointOut {
 #[derive(Clone, Debug, PartialEq, Validate, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EndpointSecretRotateIn {
+    #[validate]
     #[serde(default)]
     key: Option<EndpointSecret>,
 }

--- a/server/svix-server/tests/e2e_endpoint.rs
+++ b/server/svix-server/tests/e2e_endpoint.rs
@@ -668,7 +668,6 @@ async fn test_custom_endpoint_secret() {
     }
 }
 
-// TODO: this depends on proper validation of incoming EndpointSecrets
 #[tokio::test]
 #[ignore]
 async fn test_invalid_endpoint_secret() {
@@ -676,20 +675,25 @@ async fn test_invalid_endpoint_secret() {
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
-    let ep_in: serde_json::Value = serde_json::json!({
-        "url": "http://www.example.com".to_owned(),
-        "version": 1,
-        "secret": "whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD".to_owned(),
-    });
+    let secret_invalid_prefix = "hwsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD".to_owned();
+    let secret_too_short = "whsec_C2FVsBQIhrscChlQIM+b5sSYspob7oD".to_owned();
 
-    let _: IgnoredResponse = client
-        .post(
-            &format!("api/v1/app/{}/endpoint/", app_id),
-            ep_in,
-            StatusCode::UNPROCESSABLE_ENTITY,
-        )
-        .await
-        .unwrap();
+    for sec in [secret_invalid_prefix, secret_too_short] {
+        let ep_in: serde_json::Value = serde_json::json!({
+            "url": "http://www.example.com".to_owned(),
+            "version": 1,
+            "secret": sec,
+        });
+
+        let _: IgnoredResponse = client
+            .post(
+                &format!("api/v1/app/{}/endpoint/", app_id),
+                ep_in,
+                StatusCode::UNPROCESSABLE_ENTITY,
+            )
+            .await
+            .unwrap();
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
Ensure that incoming endpoint secrets are validated; this also fixes a possible panic in deserialization when an invalid secret shorter than the key prefix is submitted.
