### PR TITLE
Validate input strings against control sequences

### DIFF
--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -4,7 +4,10 @@
 use crate::{
     core::types::{ApplicationId, ApplicationIdOrUid, ApplicationUid},
     error::{HttpError, Result},
-    v1::utils::{EmptyResponse, ListResponse, ModelIn, ModelOut, ValidatedJson, ValidatedQuery, validate_no_control_characters},
+    v1::utils::{
+        validate_no_control_characters, EmptyResponse, ListResponse, ModelIn, ModelOut,
+        ValidatedJson, ValidatedQuery,
+    },
 };
 use axum::{
     extract::{Extension, Path},

--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -195,11 +195,11 @@ mod tests {
         let invalid_1: ApplicationIn =
             serde_json::from_value(json!({ "name": APP_NAME_INVALID })).unwrap();
         let invalid_2: ApplicationIn = serde_json::from_value(json!({
-                    "name": APP_NAME_VALID, 
+                    "name": APP_NAME_VALID,
                     "rateLimit": RATE_LIMIT_INVALID }))
         .unwrap();
-        let invalid_3: ApplicationIn = serde_json::from_value(json!({ 
-                    "name": APP_NAME_VALID, 
+        let invalid_3: ApplicationIn = serde_json::from_value(json!({
+                    "name": APP_NAME_VALID,
                     "uid": UID_INVALID }))
         .unwrap();
 

--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -4,7 +4,7 @@
 use crate::{
     core::types::{ApplicationId, ApplicationIdOrUid, ApplicationUid},
     error::{HttpError, Result},
-    v1::utils::{EmptyResponse, ListResponse, ModelIn, ModelOut, ValidatedJson, ValidatedQuery},
+    v1::utils::{EmptyResponse, ListResponse, ModelIn, ModelOut, ValidatedJson, ValidatedQuery, validate_no_control_characters},
 };
 use axum::{
     extract::{Extension, Path},
@@ -26,7 +26,10 @@ use crate::v1::utils::Pagination;
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, Validate, ModelIn)]
 #[serde(rename_all = "camelCase")]
 pub struct ApplicationIn {
-    #[validate(length(min = 1, message = "Application names must be at least one character"))]
+    #[validate(
+        length(min = 1, message = "Application names must be at least one character"),
+        custom = "validate_no_control_characters"
+    )]
     pub name: String,
 
     #[validate(range(min = 1, message = "Application rate limits must be at least 1 if set"))]

--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -7,7 +7,7 @@ mod secrets;
 
 use crate::{
     core::types::{EndpointId, EndpointUid, EventChannelSet, EventTypeNameSet},
-    v1::utils::{api_not_implemented, ModelIn},
+    v1::utils::{api_not_implemented, validate_no_control_characters, ModelIn},
 };
 use axum::{
     routing::{get, post},
@@ -54,6 +54,7 @@ pub fn validate_channels_endpoint(
 pub struct EndpointIn {
     #[serde(default)]
     #[serde(skip_serializing_if = "String::is_empty")]
+    #[validate(custom = "validate_no_control_characters")]
     pub description: String,
 
     #[validate(range(min = 1, message = "Endpoint rate limits must be at least one if set"))]

--- a/server/svix-server/src/v1/endpoints/event_type.rs
+++ b/server/svix-server/src/v1/endpoints/event_type.rs
@@ -5,7 +5,7 @@ use crate::{
     core::types::EventTypeName,
     error::{HttpError, Result},
     v1::utils::{
-        api_not_implemented, EmptyResponse, ListResponse, ModelIn, ModelOut, ValidatedJson,
+        api_not_implemented, validate_no_control_characters, EmptyResponse, ListResponse, ModelIn, ModelOut, ValidatedJson,
         ValidatedQuery,
     },
 };
@@ -30,6 +30,7 @@ use crate::v1::utils::Pagination;
 #[serde(rename_all = "camelCase")]
 pub struct EventTypeIn {
     pub name: EventTypeName,
+    #[validate(custom = "validate_no_control_characters")]
     pub description: String,
     #[serde(default, rename = "archived")]
     pub deleted: bool,

--- a/server/svix-server/src/v1/endpoints/event_type.rs
+++ b/server/svix-server/src/v1/endpoints/event_type.rs
@@ -5,8 +5,8 @@ use crate::{
     core::types::EventTypeName,
     error::{HttpError, Result},
     v1::utils::{
-        api_not_implemented, validate_no_control_characters, EmptyResponse, ListResponse, ModelIn, ModelOut, ValidatedJson,
-        ValidatedQuery,
+        api_not_implemented, validate_no_control_characters, EmptyResponse, ListResponse, ModelIn,
+        ModelOut, ValidatedJson, ValidatedQuery,
     },
 };
 use axum::{

--- a/server/svix-server/src/v1/endpoints/event_type.rs
+++ b/server/svix-server/src/v1/endpoints/event_type.rs
@@ -52,6 +52,7 @@ impl ModelIn for EventTypeIn {
 #[derive(Clone, Debug, PartialEq, Deserialize, Validate, ModelIn)]
 #[serde(rename_all = "camelCase")]
 struct EventTypeUpdate {
+    #[validate(custom = "validate_no_control_characters")]
     description: String,
     #[serde(default, rename = "archived")]
     deleted: bool,

--- a/server/svix-server/src/v1/utils.rs
+++ b/server/svix-server/src/v1/utils.rs
@@ -469,7 +469,6 @@ mod tests {
         let b = "Test\u{0000}";
 
         assert!(validate_no_control_characters(a).is_ok());
-        print!("{:?}", b);
         assert!(validate_no_control_characters(b).is_err());
     }
 }

--- a/server/svix-server/src/v1/utils.rs
+++ b/server/svix-server/src/v1/utils.rs
@@ -345,7 +345,7 @@ pub fn validate_no_control_characters(str: &str) -> std::result::Result<(), Vali
 mod tests {
     use validator::Validate;
 
-    use super::{default_limit, validation_errors, Pagination};
+    use super::{default_limit, validate_no_control_characters, validation_errors, Pagination};
     use crate::core::types::ApplicationUid;
     use crate::error::ValidationErrorItem;
     use serde_json::json;
@@ -461,5 +461,15 @@ mod tests {
                 ))
             }
         );
+    }
+
+    #[test]
+    fn test_validate_no_control_characters() {
+        let a = "Test";
+        let b = "Test\u{0000}";
+
+        assert!(validate_no_control_characters(a).is_ok());
+        print!("{:?}", b);
+        assert!(validate_no_control_characters(b).is_err());
     }
 }

--- a/server/svix-server/src/v1/utils.rs
+++ b/server/svix-server/src/v1/utils.rs
@@ -12,8 +12,8 @@ use axum::{
 use chrono::{DateTime, Utc};
 use sea_orm::{ColumnTrait, QueryFilter, QueryOrder, QuerySelect};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-
-use validator::Validate;
+use validator::{Validate, ValidationError};
+use regex::Regex;
 
 use crate::{
     core::types::{BaseId, EventTypeName, EventTypeNameSet},
@@ -329,6 +329,14 @@ where
 
 pub async fn api_not_implemented() -> Result<()> {
     Err(HttpError::not_implemented(None, None).into())
+}
+
+pub fn validate_no_control_characters(str: &str) -> std::result::Result<(), ValidationError> {
+    let re = Regex::new(r"[\x00-\x08]").unwrap();
+    if re.is_match(str) {
+        return Err(ValidationError::new("Control characters 0x00-0x08 not allowed."));
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/server/svix-server/src/v1/utils.rs
+++ b/server/svix-server/src/v1/utils.rs
@@ -465,8 +465,8 @@ mod tests {
 
     #[test]
     fn test_validate_no_control_characters() {
-        let a = "Test";
-        let b = "Test\u{0000}";
+        let a = "A good string";
+        let b = "A\u{0000} bad string";
 
         assert!(validate_no_control_characters(a).is_ok());
         assert!(validate_no_control_characters(b).is_err());

--- a/server/svix-server/src/v1/utils.rs
+++ b/server/svix-server/src/v1/utils.rs
@@ -10,10 +10,10 @@ use axum::{
     BoxError,
 };
 use chrono::{DateTime, Utc};
+use regex::Regex;
 use sea_orm::{ColumnTrait, QueryFilter, QueryOrder, QuerySelect};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use validator::{Validate, ValidationError};
-use regex::Regex;
 
 use crate::{
     core::types::{BaseId, EventTypeName, EventTypeNameSet},
@@ -334,7 +334,9 @@ pub async fn api_not_implemented() -> Result<()> {
 pub fn validate_no_control_characters(str: &str) -> std::result::Result<(), ValidationError> {
     let re = Regex::new(r"[\x00-\x08]").unwrap();
     if re.is_match(str) {
-        return Err(ValidationError::new("Control characters 0x00-0x08 not allowed."));
+        return Err(ValidationError::new(
+            "Control characters 0x00-0x08 not allowed.",
+        ));
     }
     Ok(())
 }


### PR DESCRIPTION
## Motivation

Validate that incoming strings do not contain control sequences.

## Solution

A custom Validator function was created in utils.rs that checks strings against the regex `r"[\x00-\x08]"`, and implemented on request struct fields of type String.