### PR TITLE
Add additional endpoint integration tests

### DIFF
--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -166,11 +166,11 @@ pub struct RecoverIn {
     pub since: DateTime<Utc>,
 }
 
-#[derive(Clone, Debug, PartialEq, Validate, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Validate, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EndpointHeadersIn {
     #[validate]
-    headers: EndpointHeaders,
+    pub headers: EndpointHeaders,
 }
 
 impl ModelIn for EndpointHeadersIn {
@@ -181,11 +181,11 @@ impl ModelIn for EndpointHeadersIn {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Default)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
-struct EndpointHeadersOut {
-    headers: HashMap<String, String>,
-    sensitive: HashSet<String>,
+pub struct EndpointHeadersOut {
+    pub headers: HashMap<String, String>,
+    pub sensitive: HashSet<String>,
 }
 
 impl EndpointHeadersOut {
@@ -212,11 +212,11 @@ impl From<EndpointHeaders> for EndpointHeadersOut {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Validate, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Validate, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct EndpointHeadersPatchIn {
+pub struct EndpointHeadersPatchIn {
     #[validate]
-    headers: EndpointHeaders,
+    pub headers: EndpointHeaders,
 }
 
 impl ModelIn for EndpointHeadersPatchIn {

--- a/server/svix-server/tests/utils/mod.rs
+++ b/server/svix-server/tests/utils/mod.rs
@@ -149,6 +149,30 @@ impl TestClient {
             .await
             .context("error receiving/parsing response")
     }
+
+    pub async fn patch<I: Serialize, O: DeserializeOwned>(
+        &self,
+        endpoint: &str,
+        input: I,
+        expected_code: StatusCode,
+    ) -> Result<O> {
+        let mut req = self.client.patch(self.build_uri(endpoint));
+        req = self.add_headers(req).json(&input);
+
+        let resp = req.send().await.context("error sending request")?;
+
+        if resp.status() != expected_code {
+            anyhow::bail!(
+                "assertation failed: expected status {}, actual status {}",
+                expected_code,
+                resp.status()
+            );
+        }
+
+        resp.json()
+            .await
+            .context("error receiving/parsing response")
+    }
 }
 
 pub fn get_default_test_config() -> ConfigurationInner {


### PR DESCRIPTION
Add tests for filtering by msg channels and endpoint header validation/sending
