### PR TITLE
Rust: Refactor `test_recovery_expected_retry_counts` integration test

### DIFF
--- a/server/svix-server/tests/e2e_endpoint.rs
+++ b/server/svix-server/tests/e2e_endpoint.rs
@@ -7,13 +7,13 @@ use std::{
 };
 
 use anyhow::Result;
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 use reqwest::StatusCode;
 
 use svix_server::{
     core::types::{
-        ApplicationId, EndpointHeaders, EndpointId, EndpointSecret, EndpointUid, EventChannel,
-        EventChannelSet, EventTypeName, EventTypeNameSet, ExpiringSigningKeys,
+        ApplicationId, EndpointHeaders, EndpointSecret, EndpointUid, EventChannel, EventChannelSet,
+        EventTypeName, EventTypeNameSet, ExpiringSigningKeys,
     },
     v1::{
         endpoints::{
@@ -31,12 +31,11 @@ use svix_server::{
 
 mod utils;
 
-use tokio::time::sleep;
 use utils::{
     common_calls::{
         common_test_list, create_test_app, create_test_endpoint, create_test_message,
         delete_test_app, endpoint_in, event_type_in, get_msg_attempt_list_and_assert_count,
-        post_endpoint, put_endpoint, recover_webhooks, wait_for_msg_retries,
+        post_endpoint, put_endpoint, recover_webhooks,
     },
     get_default_test_config, start_svix_server, start_svix_server_with_cfg, IgnoredResponse,
     TestClient, TestReceiver,
@@ -425,20 +424,17 @@ async fn test_recovery_should_fail_if_start_time_too_old() {
         .unwrap();
 }
 
-async fn create_failed_message_attempts() -> (
-    TestClient,
-    ApplicationId,
-    EndpointId,
-    MessageOut,
-    MessageOut,
-    usize,
-    [DateTime<Utc>; 3],
-) {
+#[tokio::test]
+async fn test_recovery_expected_retry_counts() {
     let mut cfg = get_default_test_config();
+
     cfg.retry_schedule = (0..2)
         .into_iter()
         .map(|_| Duration::from_millis(1))
         .collect();
+
+    // total attempts for a failed message should be 1 (first attempt) + length of retry_schedule:
+    let base_attempt_cnt = 1 + &cfg.retry_schedule.len();
 
     let (client, _jh) = start_svix_server_with_cfg(&cfg);
 
@@ -451,81 +447,43 @@ async fn create_failed_message_attempts() -> (
         .unwrap()
         .id;
 
-    let before_msg_1 = Utc::now();
+    let before_msg = Utc::now();
 
-    let msg_1 = create_test_message(&client, &app_id, serde_json::json!({"test": "data1"}))
+    let msg = create_test_message(&client, &app_id, serde_json::json!({"test": "data1"}))
         .await
         .unwrap();
 
-    wait_for_msg_retries(&cfg.retry_schedule).await;
-
-    let before_msg_2 = Utc::now();
-
-    let msg_2 = create_test_message(&client, &app_id, serde_json::json!({"test": "data2"}))
+    get_msg_attempt_list_and_assert_count(&client, &app_id, &msg.id, base_attempt_cnt)
         .await
         .unwrap();
 
-    wait_for_msg_retries(&cfg.retry_schedule).await;
+    let after_msg = Utc::now();
 
-    let after_msg_2 = Utc::now();
+    // recovery time after msg -- should be no additional attempts
+    recover_webhooks(
+        &client,
+        after_msg,
+        &format!("api/v1/app/{}/endpoint/{}/recover/", app_id, endp_id),
+    )
+    .await;
+
+    get_msg_attempt_list_and_assert_count(&client, &app_id, &msg.id, base_attempt_cnt)
+        .await
+        .unwrap();
+
+    // recovery time before msg -- should be 1 additional attempt
+    recover_webhooks(
+        &client,
+        before_msg,
+        &format!("api/v1/app/{}/endpoint/{}/recover/", app_id, endp_id),
+    )
+    .await;
+
+    get_msg_attempt_list_and_assert_count(&client, &app_id, &msg.id, base_attempt_cnt + 1)
+        .await
+        .unwrap();
 
     receiver.jh.abort();
-
-    (
-        client,
-        app_id,
-        endp_id,
-        msg_1,
-        msg_2,
-        cfg.retry_schedule.len() + 1,
-        [before_msg_1, before_msg_2, after_msg_2],
-    )
-}
-
-#[tokio::test]
-async fn test_recovery_expected_retry_counts() {
-    sleep(Duration::from_millis(50)).await;
-
-    for (i, (msg_1_retry_cnt, msg2_retry_cnt)) in [
-        // expected number of additional retry attempts for (msg1, msg2) if recover `since` is before msg 1:
-        (1, 1),
-        // expected values if recover `since` is before msg 2:
-        (0, 1),
-        // expected values if recover `since` is after msg 2:
-        (0, 0),
-    ]
-    .iter()
-    .enumerate()
-    {
-        let (client, app_id, endp_id, msg_1, msg_2, base_attempt_cnt, times) =
-            create_failed_message_attempts().await;
-
-        recover_webhooks(
-            &client,
-            times[i],
-            &format!("api/v1/app/{}/endpoint/{}/recover/", app_id, endp_id),
-        )
-        .await;
-
-        sleep(Duration::from_millis(50)).await;
-
-        get_msg_attempt_list_and_assert_count(
-            &client,
-            &app_id,
-            &msg_1.id,
-            base_attempt_cnt + msg_1_retry_cnt,
-        )
-        .await
-        .unwrap();
-        get_msg_attempt_list_and_assert_count(
-            &client,
-            &app_id,
-            &msg_2.id,
-            base_attempt_cnt + msg2_retry_cnt,
-        )
-        .await
-        .unwrap();
-    }
 }
 
 #[tokio::test]

--- a/server/svix-server/tests/utils/common_calls.rs
+++ b/server/svix-server/tests/utils/common_calls.rs
@@ -21,7 +21,6 @@ use svix_server::{
         utils::ListResponse,
     },
 };
-use tokio::time::sleep;
 
 use super::{run_with_retries, IgnoredResponse, TestClient};
 
@@ -225,14 +224,6 @@ pub async fn common_test_list<
         .unwrap();
 
     Ok(())
-}
-
-pub async fn wait_for_msg_retries(retry_schedule: &[Duration]) {
-    for i in retry_schedule {
-        sleep(*i).await;
-    }
-    // Give attempts buffer time to complete:
-    sleep(Duration::from_millis(50)).await;
 }
 
 pub async fn recover_webhooks(client: &TestClient, since: DateTime<Utc>, url: &str) {

--- a/server/svix-server/tests/utils/mod.rs
+++ b/server/svix-server/tests/utils/mod.rs
@@ -264,7 +264,7 @@ where
     F: Future<Output = Result<O>>,
     C: Fn() -> F,
 {
-    for attempt in 0..20 {
+    for attempt in 0..50 {
         let out = f().await;
         if out.is_ok() {
             return out;


### PR DESCRIPTION
This should improve test stability by validating the number of msg
attempts before recording `since` times rather than simply sleeping
for an assumed-to-be-sufficient duration
