### PR TITLE
test that serde’s JSON serializations are compact

### DIFF
--- a/server/svix-server/src/core/mod.rs
+++ b/server/svix-server/src/core/mod.rs
@@ -5,3 +5,29 @@ pub mod cache;
 pub mod message_app;
 pub mod security;
 pub mod types;
+
+#[cfg(test)]
+mod tests {
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    struct TestStruct {
+        field1: String,
+        field2: i32,
+    }
+
+    // demonstrates that JSON serialized by serde_json is in "compact-mode"
+    // i.e. that it has no spaces and is comparable to JSON.stringify in Javascript
+    #[test]
+    fn test_json_is_compact() {
+        let test_struct = TestStruct {
+            field1: String::from("test"),
+            field2: 42,
+        };
+
+        let serialized_json = serde_json::to_string(&test_struct).unwrap();
+        let desired_json = r#"{"field1":"test","field2":42}"#;
+
+        assert_eq!(serialized_json, desired_json);
+    }
+}


### PR DESCRIPTION
By default, serde_json serializes into "compact" JSON strings, i.e. strings with no extra spaces - comparable to output from JSON.stringify. This test simply demonstrates that this is the case.