### PR TITLE
Change default cache type to memory and improve its docs.

### DIFF
--- a/server/svix-server/config.example.toml
+++ b/server/svix-server/config.example.toml
@@ -24,7 +24,10 @@ redis_dsn = "redis://redis:6379"
 queue_type = "redis"
 
 # What kind of cache to use. Supported: memory, redis (must have redis_dsn configured), none.
-cache_type = "redis"
+# The memory backend is recommended if you only have one instance running (not including workers). If you have
+# multiple API servers running, please use the redis backend or some functionality, (e.g. Idempotency)
+# may fail to work correctly.
+cache_type = "memory"
 
 # If true, headers are prefixed with `Webhook-`, otherwise with `Svix-` (default).
 whitelabel_headers = false

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -64,7 +64,10 @@ retry_schedule = "5,300,1800,7200,18000,36000,36000"
 queue_type = "redis"
 
 # What kind of cache to use. Supported: memory, redis (must have redis_dsn configured), none.
-cache_type = "redis"
+# The memory backend is recommended if you only have one instance running (not including workers). If you have
+# multiple API servers running, please use the redis backend or some functionality, (e.g. Idempotency)
+# may fail to work correctly.
+cache_type = "memory"
 
 # If true, headers are prefixed with `Webhook-`, otherwise with `Svix-` (default).
 whitelabel_headers = false


### PR DESCRIPTION
It's faster than redis (duh), and it makes things simpler when using
a redis for the queue as the cache can be ephemeral and the queue
shouldn't be.