### PR TITLE
Remove redundant default config and improve its docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ There are three ways to configure `svix-server`: environment vars, `.env` file, 
 ### Configuration file
 
 You can put a file called `config.toml` in the current working directory of `svix-server` and it will automatically pick it up.
-You can take a look at the example file for more information and a full list of supported settings: [config.toml](./server/svix-server/config.example.toml).
+You can take a look at the example file for more information and a full list of supported settings: [config.toml](./server/svix-server/config.default.toml).
 
 Here's a quick example of the most important configurations:
 

--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -1,6 +1,6 @@
-# Example configuration file
+# Default configuration file
 # Values here can also be set by setting the appropriate env var, e.g. SVIX_DB_DSN for db_dsn
-# The values shown below are the default values
+# The values shown below are the default values. Values commented out are not set but recommended.
 
 # The address to listen on
 listen_address = "0.0.0.0:8071"
@@ -20,10 +20,13 @@ db_dsn = "postgresql://postgres:postgres@pgbouncer/postgres"
 # The DSN for redis (can be left empty if not using redis)
 redis_dsn = "redis://redis:6379"
 
-# What kind of message queue to use. Supported: memory, redis (must have redis_dsn configured), rediscluster (add multiple hosts to redis_dsn separated by commas).
+# What kind of message queue to use. Supported: memory, redis, rediscluster
+# Redis backends must have a redis_dsn configured, and it's highly recommended to enable persistence in redis so that
+# a server restart doesn't wipe the queue.
 queue_type = "redis"
 
-# What kind of cache to use. Supported: memory, redis (must have redis_dsn configured), none.
+# What kind of cache to use. Supported: memory, redis, rediscluster, none.
+# Redis backends must have a redis_dsn configured.
 # The memory backend is recommended if you only have one instance running (not including workers). If you have
 # multiple API servers running, please use the redis backend or some functionality, (e.g. Idempotency)
 # may fail to work correctly.

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -37,50 +37,7 @@ where
         .collect())
 }
 
-const DEFAULTS: &str = r#"
-# Default configuration file
-# Values here can also be set by setting the appropriate env var, e.g. SVIX_DB_DSN for db_dsn
-# The values shown below are the default values. Values commented out are not set but recommended.
-
-# The address to listen on
-listen_address = "0.0.0.0:8071"
-
-# The JWT secret for authentication - should be secret and securely generated
-# jwt_secret = "8KjzRXrKkd9YFcNyqLSIY8JwiaCeRc6WK4UkMnSW"
-
-# The log level to run the service with. Supported: info, debug, trace
-log_level = "info"
-
-# The wanted retry schedule in seconds. Each value is the time to wait between retries.
-retry_schedule = "5,300,1800,7200,18000,36000,36000"
-
-# The DSN for the database. Only postgres is currently supported.
-# db_dsn = "postgresql://postgres:postgres@pgbouncer/postgres"
-
-# The DSN for redis (can be left empty if not using redis)
-# redis_dsn = "redis://redis:6379"
-
-# What kind of message queue to use. Supported: memory, redis (must have redis_dsn configured).
-queue_type = "redis"
-
-# What kind of cache to use. Supported: memory, redis (must have redis_dsn configured), none.
-# The memory backend is recommended if you only have one instance running (not including workers). If you have
-# multiple API servers running, please use the redis backend or some functionality, (e.g. Idempotency)
-# may fail to work correctly.
-cache_type = "memory"
-
-# If true, headers are prefixed with `Webhook-`, otherwise with `Svix-` (default).
-whitelabel_headers = false
-
-# How long to wait when making a request (in seconds)
-worker_request_timeout = 30
-
-# Should this instance run the API
-api_enabled = true
-
-# Should this instance run the message worker
-worker_enabled = true
-"#;
+const DEFAULTS: &str = include_str!("../config.default.toml");
 
 pub type Configuration = Arc<ConfigurationInner>;
 


### PR DESCRIPTION
There's no reason why to have two default configurations when rust
supports embedding files at compile time.

I also added missing documentation regarding the redis queue.