### PR TITLE
Idempotency: add the service first to fix logging.

### DIFF
--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -73,13 +73,13 @@ pub async fn run(cfg: Configuration, listener: Option<TcpListener>) {
     // build our application with a route
     let app = Router::new()
         .nest("/api/v1", v1::router())
-        .layer(TraceLayer::new_for_http().on_request(()))
         .layer(
             ServiceBuilder::new().layer_fn(|service| IdempotencyService {
                 cache: cache.clone(),
                 service,
             }),
         )
+        .layer(TraceLayer::new_for_http().on_request(()))
         .layer(Extension(pool.clone()))
         .layer(Extension(queue_tx.clone()))
         .layer(Extension(cfg.clone()))


### PR DESCRIPTION
The first service added is the last invoked, and we want the logging
service to be called even with the idempotency short-circuits invocation
and doesn't actually process the request in the API.