### PR TITLE
Lists: don't output prev_iterator when not supported.

### DIFF
--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -101,10 +101,9 @@ async fn list_applications(
         query = query.filter(application::Column::Id.gt(iterator))
     }
 
-    Ok(Json(ApplicationOut::list_response(
+    Ok(Json(ApplicationOut::list_response_no_prev(
         query.all(db).await?.into_iter().map(|x| x.into()).collect(),
         limit as usize,
-        false,
     )))
 }
 

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -495,7 +495,7 @@ async fn list_attempted_destinations(
         query = query.filter(messagedestination::Column::EndpId.lt(iterator));
     }
 
-    Ok(Json(MessageEndpointOut::list_response(
+    Ok(Json(MessageEndpointOut::list_response_no_prev(
         query
             .all(db)
             .await?
@@ -510,7 +510,6 @@ async fn list_attempted_destinations(
             )
             .collect::<Result<_>>()?,
         limit as usize,
-        false,
     )))
 }
 

--- a/server/svix-server/src/v1/endpoints/endpoint/crud.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/crud.rs
@@ -44,10 +44,9 @@ pub(super) async fn list_endpoints(
         query = query.filter(endpoint::Column::Id.gt(iterator))
     }
 
-    Ok(Json(EndpointOut::list_response(
+    Ok(Json(EndpointOut::list_response_no_prev(
         query.all(db).await?.into_iter().map(|x| x.into()).collect(),
         limit as usize,
-        false,
     )))
 }
 

--- a/server/svix-server/src/v1/endpoints/event_type.rs
+++ b/server/svix-server/src/v1/endpoints/event_type.rs
@@ -136,7 +136,7 @@ async fn list_event_types(
         query = query.filter(eventtype::Column::Name.gt(iterator));
     }
 
-    Ok(Json(EventTypeOut::list_response(
+    Ok(Json(EventTypeOut::list_response_no_prev(
         query
             .all(db)
             .await?
@@ -150,7 +150,6 @@ async fn list_event_types(
             })
             .collect(),
         limit as usize,
-        false,
     )))
 }
 

--- a/server/svix-server/src/v1/utils.rs
+++ b/server/svix-server/src/v1/utils.rs
@@ -122,14 +122,14 @@ pub trait ModelIn {
     fn update_model(self, model: &mut Self::ActiveModel);
 }
 
-pub trait ModelOut {
+pub trait ModelOut: Clone {
     fn id_copy(&self) -> String;
 
-    fn list_response<T: ModelOut + Clone>(
-        mut data: Vec<T>,
+    fn list_response(
+        mut data: Vec<Self>,
         limit: usize,
         is_prev_iter: bool,
-    ) -> ListResponse<T> {
+    ) -> ListResponse<Self> {
         let done = data.len() <= limit;
 
         if data.len() > limit {


### PR DESCRIPTION
We don't currently support a prev iterator in all the routes so
we shouldn't be returning a prev iterator there.