### PR TITLE
Gracefully handle non-text endpoint response bodies

### DIFF
--- a/server/svix-server/src/worker.rs
+++ b/server/svix-server/src/worker.rs
@@ -191,7 +191,10 @@ async fn dispatch(
             };
             let http_error = res.error_for_status_ref().err();
 
-            let bytes = res.bytes().await.unwrap();
+            let bytes = res
+                .bytes()
+                .await
+                .expect("Could not read endpoint response body");
             let body = bytes_to_string(bytes);
 
             let attempt = messageattempt::ActiveModel {


### PR DESCRIPTION
If parsing a message attempt's response body as a string fails, then base64 encode the response body bytes, and persist that.