### PR TITLE
Rust: TaskQueueReceive Receive to ReceiveAll

### DIFF
--- a/server/svix-server/src/queue/memory.rs
+++ b/server/svix-server/src/queue/memory.rs
@@ -62,10 +62,10 @@ pub struct MemoryQueueConsumer {
 
 #[async_trait]
 impl TaskQueueReceive for MemoryQueueConsumer {
-    async fn receive(&mut self) -> Result<TaskQueueDelivery> {
+    async fn receive_all(&mut self) -> Result<Vec<TaskQueueDelivery>> {
         if let Some(delivery) = self.rx.recv().await {
             tracing::trace!("MemoryQueue: event recv <");
-            Ok(delivery)
+            Ok(vec![delivery])
         } else {
             Err(Error::Queue("Failed to fetch from queue".to_owned()))
         }

--- a/server/svix-server/src/queue/mod.rs
+++ b/server/svix-server/src/queue/mod.rs
@@ -207,7 +207,7 @@ mod tests {
     async fn test_ack() {
         let (tx_mem, mut rx_mem) = memory::new_pair().await;
         assert!(tx_mem
-            .send(mock_message("1".to_owned()), None)
+            .send(mock_message("test".to_owned()), None)
             .await
             .is_ok());
 
@@ -219,7 +219,7 @@ mod tests {
             .nth(0)
             .unwrap();
 
-        assert_eq!(recv.task, mock_message("1".to_owned()));
+        assert_eq!(recv.task, mock_message("test".to_owned()));
 
         assert!(tx_mem.ack(recv).await.is_ok());
 
@@ -239,7 +239,7 @@ mod tests {
     async fn test_nack() {
         let (tx_mem, mut rx_mem) = memory::new_pair().await;
         assert!(tx_mem
-            .send(mock_message("1".to_owned()), None)
+            .send(mock_message("test".to_owned()), None)
             .await
             .is_ok());
 
@@ -250,7 +250,7 @@ mod tests {
             .into_iter()
             .nth(0)
             .unwrap();
-        assert_eq!(&recv.task, &mock_message("1".to_owned()));
+        assert_eq!(&recv.task, &mock_message("test".to_owned()));
 
         assert!(tx_mem.nack(recv).await.is_ok());
 

--- a/server/svix-server/src/queue/redis.rs
+++ b/server/svix-server/src/queue/redis.rs
@@ -215,7 +215,7 @@ pub struct RedisQueueConsumer {
 
 #[async_trait]
 impl TaskQueueReceive for RedisQueueConsumer {
-    async fn receive(&mut self) -> Result<TaskQueueDelivery> {
+    async fn receive_all(&mut self) -> Result<Vec<TaskQueueDelivery>> {
         let mut pool = self.pool.get().await.unwrap();
         let mut cmd = redis::cmd("BLMOVE");
         cmd.arg(MAIN)
@@ -228,7 +228,7 @@ impl TaskQueueReceive for RedisQueueConsumer {
             .await
             .map_err(|x| Error::Queue(x.to_string()))?;
         tracing::trace!("RedisQueue: event recv <");
-        Ok(from_redis_key(&key))
+        Ok(vec![from_redis_key(&key)])
     }
 }
 


### PR DESCRIPTION
This modifies queue receivers to potentially return batches instead
of single messages.