### PR TITLE
Preserve header key capitalization

### DIFF
--- a/server/svix-server/src/core/types.rs
+++ b/server/svix-server/src/core/types.rs
@@ -579,14 +579,14 @@ impl Validate for EndpointHeaders {
             if let Err(_e) = http::header::HeaderValue::try_from(v) {
                 errors.add(ALL_ERROR, ValidationError::new("Invalid Header Value."));
             }
-            if Self::FORBIDDEN_KEYS.contains(&k.as_str()) {
+            if Self::FORBIDDEN_KEYS.contains(&k.to_lowercase().as_str()) {
                 errors.add(
                     ALL_ERROR,
                     ValidationError::new("Header uses a forbidden key."),
                 );
             }
             Self::FORBIDDEN_PREFIXES.iter().for_each(|p| {
-                if k.starts_with(p) {
+                if k.to_lowercase().starts_with(p) {
                     errors.add(
                         ALL_ERROR,
                         ValidationError::new("Header starts with a forbidden prefix."),
@@ -726,17 +726,11 @@ mod tests {
         let endpoint_headers = EndpointHeaders(hdr_map);
         assert!(endpoint_headers.validate().is_err());
 
-        let hdr_map = HashMap::from([(
-            EndpointHeaders::FORBIDDEN_KEYS[0].to_owned(),
-            "true".to_owned(),
-        )]);
+        let hdr_map = HashMap::from([("User-Agent".to_string(), "true".to_owned())]);
         let endpoint_headers = EndpointHeaders(hdr_map);
         assert!(endpoint_headers.validate().is_err());
 
-        let hdr_map = HashMap::from([(
-            EndpointHeaders::FORBIDDEN_PREFIXES[0].to_owned(),
-            "true".to_owned(),
-        )]);
+        let hdr_map = HashMap::from([("User-Agent".to_string(), "true".to_owned())]);
         let endpoint_headers = EndpointHeaders(hdr_map);
         assert!(endpoint_headers.validate().is_err());
     }

--- a/server/svix-server/src/core/types.rs
+++ b/server/svix-server/src/core/types.rs
@@ -573,20 +573,21 @@ impl Validate for EndpointHeaders {
     fn validate(&self) -> std::result::Result<(), ValidationErrors> {
         let mut errors = ValidationErrors::new();
         self.0.iter().for_each(|(k, v)| {
+            let k = &k.to_lowercase();
             if let Err(_e) = http::header::HeaderName::try_from(k) {
                 errors.add(ALL_ERROR, ValidationError::new("Invalid Header Name."));
             }
             if let Err(_e) = http::header::HeaderValue::try_from(v) {
                 errors.add(ALL_ERROR, ValidationError::new("Invalid Header Value."));
             }
-            if Self::FORBIDDEN_KEYS.contains(&k.to_lowercase().as_str()) {
+            if Self::FORBIDDEN_KEYS.contains(&k.as_str()) {
                 errors.add(
                     ALL_ERROR,
                     ValidationError::new("Header uses a forbidden key."),
                 );
             }
             Self::FORBIDDEN_PREFIXES.iter().for_each(|p| {
-                if k.to_lowercase().starts_with(p) {
+                if k.starts_with(p) {
                     errors.add(
                         ALL_ERROR,
                         ValidationError::new("Header starts with a forbidden prefix."),
@@ -730,7 +731,7 @@ mod tests {
         let endpoint_headers = EndpointHeaders(hdr_map);
         assert!(endpoint_headers.validate().is_err());
 
-        let hdr_map = HashMap::from([("User-Agent".to_string(), "true".to_owned())]);
+        let hdr_map = HashMap::from([("X-Amz-".to_string(), "true".to_owned())]);
         let endpoint_headers = EndpointHeaders(hdr_map);
         assert!(endpoint_headers.validate().is_err());
     }

--- a/server/svix-server/src/core/types.rs
+++ b/server/svix-server/src/core/types.rs
@@ -564,9 +564,7 @@ impl<'de> Deserialize<'de> for EndpointHeaders {
         D: serde::Deserializer<'de>,
     {
         HashMap::deserialize(deserializer)
-            .map(|x: HashMap<String, String>| {
-                x.into_iter().map(|(k, v)| (k.to_lowercase(), v)).collect()
-            })
+            .map(|x: HashMap<String, String>| x.into_iter().map(|(k, v)| (k, v)).collect())
             .map(EndpointHeaders)
     }
 }
@@ -741,23 +739,6 @@ mod tests {
         )]);
         let endpoint_headers = EndpointHeaders(hdr_map);
         assert!(endpoint_headers.validate().is_err());
-    }
-
-    #[test]
-    fn test_endpoint_headers_deserialization() {
-        let js = serde_json::json!(
-        {
-            "NOT_UPPER_CASE": "TRUE",
-            "is_lower_case": "true"
-        });
-        let eph: EndpointHeaders = serde_json::from_value(js).unwrap();
-        assert_eq!(
-            HashMap::from([
-                ("not_upper_case".to_owned(), "TRUE".to_owned()),
-                ("is_lower_case".to_owned(), "true".to_owned()),
-            ]),
-            eph.0
-        );
     }
 
     #[test]

--- a/server/svix-server/tests/e2e_endpoint.rs
+++ b/server/svix-server/tests/e2e_endpoint.rs
@@ -1219,7 +1219,6 @@ async fn test_endpoint_header_key_capitalization() {
         .unwrap();
 
     for k in headers.headers.0.keys() {
-        println!("{}, {:?}", k, retrieved_headers.headers);
         assert!(retrieved_headers.headers.contains_key(k));
     }
 }


### PR DESCRIPTION
Preserves the capitalization of header keys, removes a unit test that enforced lowercasing of keys, and adds an integration test that validates key capitalization is persisted as received.