### PR TITLE
Remove updated_at from static entities

### DIFF
--- a/server/svix-server/migrations/20220506181355_remove_updated_at_from_static_entities.down.sql
+++ b/server/svix-server/migrations/20220506181355_remove_updated_at_from_static_entities.down.sql
@@ -1,0 +1,3 @@
+-- rollback makes updated_at inaccurate but preserves SeaORM type integrity
+ALTER TABLE message ADD COLUMN updated_at timestamp with time zone NOT NULL DEFAULT now();
+ALTER TABLE messageattempt ADD COLUMN updated_at timestamp with time zone NOT NULL DEFAULT now();

--- a/server/svix-server/migrations/20220506181355_remove_updated_at_from_static_entities.up.sql
+++ b/server/svix-server/migrations/20220506181355_remove_updated_at_from_static_entities.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE message DROP COLUMN updated_at;
+ALTER TABLE messageattempt DROP COLUMN updated_at;

--- a/server/svix-server/src/db/models/message.rs
+++ b/server/svix-server/src/db/models/message.rs
@@ -15,7 +15,6 @@ pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub id: MessageId,
     pub created_at: DateTimeWithTimeZone,
-    pub updated_at: DateTimeWithTimeZone,
     pub org_id: OrganizationId,
     pub app_id: ApplicationId,
     pub event_type: EventTypeName,
@@ -58,14 +57,8 @@ impl ActiveModelBehavior for ActiveModel {
         Self {
             id: Set(MessageId::new(timestamp.into(), None)),
             created_at: Set(timestamp.into()),
-            updated_at: Set(timestamp.into()),
             ..ActiveModelTrait::default()
         }
-    }
-
-    fn before_save(mut self, _insert: bool) -> Result<Self, DbErr> {
-        self.updated_at = Set(Utc::now().into());
-        Ok(self)
     }
 }
 

--- a/server/svix-server/src/db/models/messageattempt.rs
+++ b/server/svix-server/src/db/models/messageattempt.rs
@@ -16,7 +16,6 @@ pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub id: MessageAttemptId,
     pub created_at: DateTimeWithTimeZone,
-    pub updated_at: DateTimeWithTimeZone,
     pub msg_id: MessageId,
     pub msg_dest_id: MessageEndpointId,
     pub endp_id: EndpointId,
@@ -53,14 +52,8 @@ impl ActiveModelBehavior for ActiveModel {
         Self {
             id: Set(MessageAttemptId::new(timestamp.into(), None)),
             created_at: Set(timestamp.into()),
-            updated_at: Set(timestamp.into()),
             ..ActiveModelTrait::default()
         }
-    }
-
-    fn before_save(mut self, _insert: bool) -> Result<Self, DbErr> {
-        self.updated_at = Set(Utc::now().into());
-        Ok(self)
     }
 }
 


### PR DESCRIPTION
Removes the updated_at timestamp columns from tables where rows are virtually immutable.

Requires migration: `cargo sqlx migrate run`