### PR TITLE
Server CI: treat warnings as errors and fix them.

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -35,7 +35,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: --manifest-path server/Cargo.toml --all --all-targets --all-features
+        args: --manifest-path server/Cargo.toml --all --all-targets --all-features -- -D warnings
 
     - name: rustfmt
       uses: actions-rs/cargo@v1

--- a/server/svix-server/src/queue/mod.rs
+++ b/server/svix-server/src/queue/mod.rs
@@ -216,7 +216,7 @@ mod tests {
             .await
             .unwrap()
             .into_iter()
-            .nth(0)
+            .next()
             .unwrap();
 
         assert_eq!(recv.task, mock_message("test".to_owned()));
@@ -248,7 +248,7 @@ mod tests {
             .await
             .unwrap()
             .into_iter()
-            .nth(0)
+            .next()
             .unwrap();
         assert_eq!(&recv.task, &mock_message("test".to_owned()));
 


### PR DESCRIPTION
We missed a couple of cargo warnings because of it.