### PR TITLE
Queue: pass the configuration as reference.

### DIFF
--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -58,7 +58,7 @@ pub async fn run(cfg: Configuration, listener: Option<TcpListener>) {
     };
 
     tracing::debug!("Queue type: {:?}", cfg.queue_type);
-    let (queue_tx, queue_rx) = queue::new_pair(cfg.clone(), None).await;
+    let (queue_tx, queue_rx) = queue::new_pair(&cfg, None).await;
 
     // build our application with a route
     let app = Router::new()

--- a/server/svix-server/src/queue/mod.rs
+++ b/server/svix-server/src/queue/mod.rs
@@ -15,7 +15,7 @@ pub mod memory;
 pub mod redis;
 
 pub async fn new_pair(
-    cfg: Configuration,
+    cfg: &Configuration,
     prefix: Option<&str>,
 ) -> (TaskQueueProducer, TaskQueueConsumer) {
     let redis_dsn = || {

--- a/server/svix-server/tests/queue.rs
+++ b/server/svix-server/tests/queue.rs
@@ -51,8 +51,7 @@ async fn test_many_queue_consumers() {
     // Make 20 producers and 20 consumers using the same configuration
     let mut producers_and_consumers: Vec<(TaskQueueProducer, TaskQueueConsumer)> = Vec::new();
     for _ in 0..20 {
-        producers_and_consumers
-            .push(new_pair(cfg.clone(), Some("test_many_queue_consumers_")).await);
+        producers_and_consumers.push(new_pair(&cfg, Some("test_many_queue_consumers_")).await);
     }
 
     // Add 50 test messages with unique message IDs to each producer for a total of 1000 unique


### PR DESCRIPTION
We don't need ownership of the configuration so don't try and take it.
No need to clone it this way (even though it's an arc), and it just
makes how we want to use it more explicit.