### PR TITLE
Build/release ARM64 Docker images on release

### DIFF
--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -65,9 +65,6 @@ jobs:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v2
 
-      - name: Setup Buildx
-        uses: docker/setup-buildx-action@v2
-
       - name: Login Docker
         uses: docker/login-action@v1
         with:
@@ -75,7 +72,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2


### PR DESCRIPTION
In CI, on the publish of a release, this will now automatically build and push ARM64 builds to Docker Hub to on the latest tag.