### PR TITLE
Add soft and hard caps to pagination limits

### DIFF
--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -90,7 +90,7 @@ async fn list_applications(
     pagination: ValidatedQuery<Pagination<ApplicationId>>,
     permissions: Permissions,
 ) -> Result<Json<ListResponse<ApplicationOut>>> {
-    let limit = pagination.limit;
+    let limit = pagination.capped_limit();
     let iterator = pagination.iterator.clone();
 
     let mut query = application::Entity::secure_find(permissions.org_id)

--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -5,8 +5,8 @@ use crate::{
     core::types::{ApplicationId, ApplicationIdOrUid, ApplicationUid},
     error::{HttpError, Result},
     v1::utils::{
-        validate_no_control_characters, EmptyResponse, ListLimit, ListResponse, ModelIn, ModelOut,
-        ValidatedJson, ValidatedQuery,
+        validate_no_control_characters, EmptyResponse, ListResponse, ModelIn, ModelOut,
+        PaginationLimit, ValidatedJson, ValidatedQuery,
     },
 };
 use axum::{
@@ -90,7 +90,7 @@ async fn list_applications(
     pagination: ValidatedQuery<Pagination<ApplicationId>>,
     permissions: Permissions,
 ) -> Result<Json<ListResponse<ApplicationOut>>> {
-    let ListLimit(limit) = pagination.limit;
+    let PaginationLimit(limit) = pagination.limit;
     let iterator = pagination.iterator.clone();
 
     let mut query = application::Entity::secure_find(permissions.org_id)

--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -5,7 +5,7 @@ use crate::{
     core::types::{ApplicationId, ApplicationIdOrUid, ApplicationUid},
     error::{HttpError, Result},
     v1::utils::{
-        validate_no_control_characters, EmptyResponse, ListResponse, ModelIn, ModelOut,
+        validate_no_control_characters, EmptyResponse, ListLimit, ListResponse, ModelIn, ModelOut,
         ValidatedJson, ValidatedQuery,
     },
 };
@@ -90,7 +90,7 @@ async fn list_applications(
     pagination: ValidatedQuery<Pagination<ApplicationId>>,
     permissions: Permissions,
 ) -> Result<Json<ListResponse<ApplicationOut>>> {
-    let limit = pagination.capped_limit();
+    let ListLimit(limit) = pagination.limit;
     let iterator = pagination.iterator.clone();
 
     let mut query = application::Entity::secure_find(permissions.org_id)

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -16,8 +16,8 @@ use crate::{
     v1::{
         endpoints::message::MessageOut,
         utils::{
-            apply_pagination, iterator_from_before_or_after, EmptyResponse, ListLimit,
-            ListResponse, MessageListFetchOptions, ModelOut, ReversibleIterator, ValidatedQuery,
+            apply_pagination, iterator_from_before_or_after, EmptyResponse, ListResponse,
+            MessageListFetchOptions, ModelOut, PaginationLimit, ReversibleIterator, ValidatedQuery,
         },
     },
 };
@@ -129,7 +129,7 @@ async fn list_attempted_messages(
         app,
     }: AuthenticatedApplication,
 ) -> Result<Json<ListResponse<AttemptedMessageOut>>> {
-    let ListLimit(limit) = pagination.limit;
+    let PaginationLimit(limit) = pagination.limit;
     let endp = endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endp_id)
         .one(db)
         .await?
@@ -302,7 +302,7 @@ async fn list_attempts_by_endpoint(
         app,
     }: AuthenticatedApplication,
 ) -> Result<Json<ListResponse<MessageAttemptOut>>> {
-    let ListLimit(limit) = pagination.limit;
+    let PaginationLimit(limit) = pagination.limit;
     // Confirm endpoint ID belongs to the given application
     let endp = endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endp_id)
         .one(db)
@@ -374,7 +374,7 @@ async fn list_attempts_by_msg(
         app,
     }: AuthenticatedApplication,
 ) -> Result<Json<ListResponse<MessageAttemptOut>>> {
-    let ListLimit(limit) = pagination.limit;
+    let PaginationLimit(limit) = pagination.limit;
     // Confirm message ID belongs to the given application
     if message::Entity::secure_find_by_id(app.id.clone(), msg_id.clone())
         .one(db)
@@ -463,7 +463,7 @@ async fn list_attempted_destinations(
         app,
     }: AuthenticatedApplication,
 ) -> Result<Json<ListResponse<MessageEndpointOut>>> {
-    let ListLimit(limit) = pagination.limit;
+    let PaginationLimit(limit) = pagination.limit;
     let iterator = pagination.iterator.take();
 
     // Confirm message ID belongs to the given application while fetching the ID in case a UID was
@@ -573,7 +573,7 @@ async fn list_messageattempts(
         app,
     }: AuthenticatedApplication,
 ) -> Result<Json<ListResponse<MessageAttemptOut>>> {
-    let ListLimit(limit) = pagination.limit;
+    let PaginationLimit(limit) = pagination.limit;
     let msg = message::Entity::secure_find_by_id_or_uid(app.id.clone(), msg_id)
         .one(db)
         .await?

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -16,8 +16,8 @@ use crate::{
     v1::{
         endpoints::message::MessageOut,
         utils::{
-            apply_pagination, iterator_from_before_or_after, EmptyResponse, ListResponse,
-            MessageListFetchOptions, ModelOut, ReversibleIterator, ValidatedQuery,
+            apply_pagination, iterator_from_before_or_after, EmptyResponse, ListLimit,
+            ListResponse, MessageListFetchOptions, ModelOut, ReversibleIterator, ValidatedQuery,
         },
     },
 };
@@ -129,7 +129,7 @@ async fn list_attempted_messages(
         app,
     }: AuthenticatedApplication,
 ) -> Result<Json<ListResponse<AttemptedMessageOut>>> {
-    let limit = pagination.capped_limit();
+    let ListLimit(limit) = pagination.limit;
     let endp = endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endp_id)
         .one(db)
         .await?
@@ -302,7 +302,7 @@ async fn list_attempts_by_endpoint(
         app,
     }: AuthenticatedApplication,
 ) -> Result<Json<ListResponse<MessageAttemptOut>>> {
-    let limit = pagination.capped_limit();
+    let ListLimit(limit) = pagination.limit;
     // Confirm endpoint ID belongs to the given application
     let endp = endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endp_id)
         .one(db)
@@ -374,7 +374,7 @@ async fn list_attempts_by_msg(
         app,
     }: AuthenticatedApplication,
 ) -> Result<Json<ListResponse<MessageAttemptOut>>> {
-    let limit = pagination.capped_limit();
+    let ListLimit(limit) = pagination.limit;
     // Confirm message ID belongs to the given application
     if message::Entity::secure_find_by_id(app.id.clone(), msg_id.clone())
         .one(db)
@@ -463,7 +463,7 @@ async fn list_attempted_destinations(
         app,
     }: AuthenticatedApplication,
 ) -> Result<Json<ListResponse<MessageEndpointOut>>> {
-    let limit = pagination.capped_limit();
+    let ListLimit(limit) = pagination.limit;
     let iterator = pagination.iterator.take();
 
     // Confirm message ID belongs to the given application while fetching the ID in case a UID was
@@ -573,7 +573,7 @@ async fn list_messageattempts(
         app,
     }: AuthenticatedApplication,
 ) -> Result<Json<ListResponse<MessageAttemptOut>>> {
-    let limit = pagination.capped_limit();
+    let ListLimit(limit) = pagination.limit;
     let msg = message::Entity::secure_find_by_id_or_uid(app.id.clone(), msg_id)
         .one(db)
         .await?

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -129,6 +129,7 @@ async fn list_attempted_messages(
         app,
     }: AuthenticatedApplication,
 ) -> Result<Json<ListResponse<AttemptedMessageOut>>> {
+    let limit = pagination.capped_limit();
     let endp = endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endp_id)
         .one(db)
         .await?
@@ -172,7 +173,7 @@ async fn list_attempted_messages(
     let dests_and_msgs = apply_pagination(
         dests_and_msgs,
         messagedestination::Column::Id,
-        pagination.limit,
+        limit,
         iterator,
     );
 
@@ -202,7 +203,7 @@ async fn list_attempted_messages(
 
     Ok(Json(AttemptedMessageOut::list_response(
         out,
-        pagination.limit as usize,
+        limit as usize,
         is_prev,
     )))
 }
@@ -301,6 +302,7 @@ async fn list_attempts_by_endpoint(
         app,
     }: AuthenticatedApplication,
 ) -> Result<Json<ListResponse<MessageAttemptOut>>> {
+    let limit = pagination.capped_limit();
     // Confirm endpoint ID belongs to the given application
     let endp = endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endp_id)
         .one(db)
@@ -317,12 +319,7 @@ async fn list_attempts_by_endpoint(
 
     let iterator = iterator_from_before_or_after(pagination.iterator, before, after);
     let is_prev = matches!(iterator, Some(ReversibleIterator::Prev(_)));
-    let query = apply_pagination(
-        query,
-        messageattempt::Column::Id,
-        pagination.limit,
-        iterator,
-    );
+    let query = apply_pagination(query, messageattempt::Column::Id, limit, iterator);
 
     let out = if is_prev {
         query
@@ -338,7 +335,7 @@ async fn list_attempts_by_endpoint(
 
     Ok(Json(MessageAttemptOut::list_response(
         out,
-        pagination.limit as usize,
+        limit as usize,
         is_prev,
     )))
 }
@@ -377,6 +374,7 @@ async fn list_attempts_by_msg(
         app,
     }: AuthenticatedApplication,
 ) -> Result<Json<ListResponse<MessageAttemptOut>>> {
+    let limit = pagination.capped_limit();
     // Confirm message ID belongs to the given application
     if message::Entity::secure_find_by_id(app.id.clone(), msg_id.clone())
         .one(db)
@@ -409,12 +407,7 @@ async fn list_attempts_by_msg(
 
     let iterator = iterator_from_before_or_after(pagination.iterator, before, after);
     let is_prev = matches!(iterator, Some(ReversibleIterator::Prev(_)));
-    let query = apply_pagination(
-        query,
-        messageattempt::Column::Id,
-        pagination.limit,
-        iterator,
-    );
+    let query = apply_pagination(query, messageattempt::Column::Id, limit, iterator);
     let out = if is_prev {
         query
             .all(db)
@@ -429,7 +422,7 @@ async fn list_attempts_by_msg(
 
     Ok(Json(MessageAttemptOut::list_response(
         out,
-        pagination.limit as usize,
+        limit as usize,
         is_prev,
     )))
 }
@@ -470,7 +463,7 @@ async fn list_attempted_destinations(
         app,
     }: AuthenticatedApplication,
 ) -> Result<Json<ListResponse<MessageEndpointOut>>> {
-    let limit = pagination.limit;
+    let limit = pagination.capped_limit();
     let iterator = pagination.iterator.take();
 
     // Confirm message ID belongs to the given application while fetching the ID in case a UID was
@@ -580,6 +573,7 @@ async fn list_messageattempts(
         app,
     }: AuthenticatedApplication,
 ) -> Result<Json<ListResponse<MessageAttemptOut>>> {
+    let limit = pagination.capped_limit();
     let msg = message::Entity::secure_find_by_id_or_uid(app.id.clone(), msg_id)
         .one(db)
         .await?
@@ -609,12 +603,7 @@ async fn list_messageattempts(
 
     let iterator = iterator_from_before_or_after(pagination.iterator, before, after);
     let is_prev = matches!(iterator, Some(ReversibleIterator::Prev(_)));
-    let query = apply_pagination(
-        query,
-        messageattempt::Column::Id,
-        pagination.limit,
-        iterator,
-    );
+    let query = apply_pagination(query, messageattempt::Column::Id, limit, iterator);
     let out = if is_prev {
         query
             .all(db)
@@ -629,7 +618,7 @@ async fn list_messageattempts(
 
     Ok(Json(MessageAttemptOut::list_response(
         out,
-        pagination.limit as usize,
+        limit as usize,
         false,
     )))
 }

--- a/server/svix-server/src/v1/endpoints/endpoint/crud.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/crud.rs
@@ -33,7 +33,7 @@ pub(super) async fn list_endpoints(
         app,
     }: AuthenticatedApplication,
 ) -> Result<Json<ListResponse<EndpointOut>>> {
-    let limit = pagination.limit;
+    let limit = pagination.capped_limit();
     let iterator = pagination.iterator.clone();
 
     let mut query = endpoint::Entity::secure_find(app.id)

--- a/server/svix-server/src/v1/endpoints/endpoint/crud.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/crud.rs
@@ -20,7 +20,7 @@ use crate::{
     db::models::{endpoint, eventtype},
     error::{HttpError, Result, ValidationErrorItem},
     v1::utils::{
-        EmptyResponse, ListLimit, ListResponse, ModelIn, ModelOut, Pagination, ValidatedJson,
+        EmptyResponse, ListResponse, ModelIn, ModelOut, Pagination, PaginationLimit, ValidatedJson,
         ValidatedQuery,
     },
 };
@@ -34,7 +34,7 @@ pub(super) async fn list_endpoints(
         app,
     }: AuthenticatedApplication,
 ) -> Result<Json<ListResponse<EndpointOut>>> {
-    let ListLimit(limit) = pagination.limit;
+    let PaginationLimit(limit) = pagination.limit;
     let iterator = pagination.iterator.clone();
 
     let mut query = endpoint::Entity::secure_find(app.id)

--- a/server/svix-server/src/v1/endpoints/endpoint/crud.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/crud.rs
@@ -20,7 +20,8 @@ use crate::{
     db::models::{endpoint, eventtype},
     error::{HttpError, Result, ValidationErrorItem},
     v1::utils::{
-        EmptyResponse, ListResponse, ModelIn, ModelOut, Pagination, ValidatedJson, ValidatedQuery,
+        EmptyResponse, ListLimit, ListResponse, ModelIn, ModelOut, Pagination, ValidatedJson,
+        ValidatedQuery,
     },
 };
 use hack::EventTypeNameResult;
@@ -33,7 +34,7 @@ pub(super) async fn list_endpoints(
         app,
     }: AuthenticatedApplication,
 ) -> Result<Json<ListResponse<EndpointOut>>> {
-    let limit = pagination.capped_limit();
+    let ListLimit(limit) = pagination.limit;
     let iterator = pagination.iterator.clone();
 
     let mut query = endpoint::Entity::secure_find(app.id)

--- a/server/svix-server/src/v1/endpoints/event_type.rs
+++ b/server/svix-server/src/v1/endpoints/event_type.rs
@@ -5,8 +5,8 @@ use crate::{
     core::types::EventTypeName,
     error::{HttpError, Result},
     v1::utils::{
-        api_not_implemented, validate_no_control_characters, EmptyResponse, ListLimit,
-        ListResponse, ModelIn, ModelOut, ValidatedJson, ValidatedQuery,
+        api_not_implemented, validate_no_control_characters, EmptyResponse, ListResponse, ModelIn,
+        ModelOut, PaginationLimit, ValidatedJson, ValidatedQuery,
     },
 };
 use axum::{
@@ -121,7 +121,7 @@ async fn list_event_types(
     fetch_options: ValidatedQuery<ListFetchOptions>,
     permissions: Permissions,
 ) -> Result<Json<ListResponse<EventTypeOut>>> {
-    let ListLimit(limit) = pagination.limit;
+    let PaginationLimit(limit) = pagination.limit;
     let iterator = pagination.iterator.clone();
 
     let mut query = eventtype::Entity::secure_find(permissions.org_id)

--- a/server/svix-server/src/v1/endpoints/event_type.rs
+++ b/server/svix-server/src/v1/endpoints/event_type.rs
@@ -121,7 +121,7 @@ async fn list_event_types(
     fetch_options: ValidatedQuery<ListFetchOptions>,
     permissions: Permissions,
 ) -> Result<Json<ListResponse<EventTypeOut>>> {
-    let limit = pagination.limit;
+    let limit = pagination.capped_limit();
     let iterator = pagination.iterator.clone();
 
     let mut query = eventtype::Entity::secure_find(permissions.org_id)

--- a/server/svix-server/src/v1/endpoints/event_type.rs
+++ b/server/svix-server/src/v1/endpoints/event_type.rs
@@ -5,8 +5,8 @@ use crate::{
     core::types::EventTypeName,
     error::{HttpError, Result},
     v1::utils::{
-        api_not_implemented, validate_no_control_characters, EmptyResponse, ListResponse, ModelIn,
-        ModelOut, ValidatedJson, ValidatedQuery,
+        api_not_implemented, validate_no_control_characters, EmptyResponse, ListLimit,
+        ListResponse, ModelIn, ModelOut, ValidatedJson, ValidatedQuery,
     },
 };
 use axum::{
@@ -121,7 +121,7 @@ async fn list_event_types(
     fetch_options: ValidatedQuery<ListFetchOptions>,
     permissions: Permissions,
 ) -> Result<Json<ListResponse<EventTypeOut>>> {
-    let limit = pagination.capped_limit();
+    let ListLimit(limit) = pagination.limit;
     let iterator = pagination.iterator.clone();
 
     let mut query = eventtype::Entity::secure_find(permissions.org_id)

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -14,9 +14,8 @@ use crate::{
     error::{Error, HttpError, Result},
     queue::{MessageTaskBatch, TaskQueueProducer},
     v1::utils::{
-        apply_pagination, iterator_from_before_or_after, ListLimit, ListResponse,
-        MessageListFetchOptions, ModelIn, ModelOut, ReversibleIterator, ValidatedJson,
-        ValidatedQuery,
+        apply_pagination, iterator_from_before_or_after, ListResponse, MessageListFetchOptions,
+        ModelIn, ModelOut, PaginationLimit, ReversibleIterator, ValidatedJson, ValidatedQuery,
     },
 };
 use axum::{
@@ -154,7 +153,7 @@ async fn list_messages(
         app,
     }: AuthenticatedApplication,
 ) -> Result<Json<ListResponse<MessageOut>>> {
-    let ListLimit(limit) = pagination.limit;
+    let PaginationLimit(limit) = pagination.limit;
 
     let mut query = message::Entity::secure_find(app.id);
 

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -153,7 +153,7 @@ async fn list_messages(
         app,
     }: AuthenticatedApplication,
 ) -> Result<Json<ListResponse<MessageOut>>> {
-    let limit = pagination.limit;
+    let limit = pagination.capped_limit();
 
     let mut query = message::Entity::secure_find(app.id);
 
@@ -168,7 +168,7 @@ async fn list_messages(
     let iterator = iterator_from_before_or_after(pagination.iterator, list_filter.before, after);
     let is_prev = matches!(iterator, Some(ReversibleIterator::Prev(_)));
 
-    let query = apply_pagination(query, message::Column::Id, pagination.limit, iterator);
+    let query = apply_pagination(query, message::Column::Id, limit, iterator);
     let into = |x: message::Model| {
         if with_content {
             x.into()

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -14,8 +14,9 @@ use crate::{
     error::{Error, HttpError, Result},
     queue::{MessageTaskBatch, TaskQueueProducer},
     v1::utils::{
-        apply_pagination, iterator_from_before_or_after, ListResponse, MessageListFetchOptions,
-        ModelIn, ModelOut, ReversibleIterator, ValidatedJson, ValidatedQuery,
+        apply_pagination, iterator_from_before_or_after, ListLimit, ListResponse,
+        MessageListFetchOptions, ModelIn, ModelOut, ReversibleIterator, ValidatedJson,
+        ValidatedQuery,
     },
 };
 use axum::{
@@ -153,7 +154,7 @@ async fn list_messages(
         app,
     }: AuthenticatedApplication,
 ) -> Result<Json<ListResponse<MessageOut>>> {
-    let limit = pagination.capped_limit();
+    let ListLimit(limit) = pagination.limit;
 
     let mut query = message::Entity::secure_find(app.id);
 

--- a/server/svix-server/tests/utils/common_calls.rs
+++ b/server/svix-server/tests/utils/common_calls.rs
@@ -181,7 +181,7 @@ pub async fn common_test_list<
     assert!(!list.done);
 
     let list = client
-        .get::<ListResponse<ModelOut>>(&format!("{}?limit=500", path), StatusCode::OK)
+        .get::<ListResponse<ModelOut>>(&format!("{}?limit=50", path), StatusCode::OK)
         .await
         .unwrap();
 

--- a/server/svix-server/tests/utils/common_calls.rs
+++ b/server/svix-server/tests/utils/common_calls.rs
@@ -223,7 +223,34 @@ pub async fn common_test_list<
         .await
         .unwrap();
 
-    Ok(())
+    // Test Limits
+    for i in 10..300 {
+        let _: ModelOut = client
+            .post(path, create_model(i), StatusCode::CREATED)
+            .await
+            .unwrap();
+    }
+
+    // If limits are hard, it will be a 422 UNPROCESSABLE_ENTITY response, otherwise it'll be capped to 250
+    if client
+        .get::<IgnoredResponse>(
+            &format!("{}?limit=300", path),
+            StatusCode::UNPROCESSABLE_ENTITY,
+        )
+        .await
+        .is_ok()
+        || client
+            .get::<ListResponse<ModelOut>>(&format!("{}?limit=300", path), StatusCode::OK)
+            .await
+            .unwrap()
+            .data
+            .len()
+            == 250
+    {
+        Ok(())
+    } else {
+        panic!("Error with soft/hard caps to pagination limits")
+    }
 }
 
 pub async fn recover_webhooks(client: &TestClient, since: DateTime<Utc>, url: &str) {

--- a/server/svix-server/tests/utils/common_calls.rs
+++ b/server/svix-server/tests/utils/common_calls.rs
@@ -223,15 +223,17 @@ pub async fn common_test_list<
         .await
         .unwrap();
 
-    // Test Limits
-    for i in 10..300 {
+    // Test limits -- ten models were created previously and the default hard/soft cap is 250 so
+    // 10..251 is the sane range here.
+    for i in 10..251 {
         let _: ModelOut = client
             .post(path, create_model(i), StatusCode::CREATED)
             .await
             .unwrap();
     }
 
-    // If limits are hard, it will be a 422 UNPROCESSABLE_ENTITY response, otherwise it'll be capped to 250
+    // If limits are hard, it will be a 422 UNPROCESSABLE_ENTITY response, otherwise it'll be capped
+    // to 250
     if client
         .get::<IgnoredResponse>(
             &format!("{}?limit=300", path),


### PR DESCRIPTION
Adds soft and hard caps to the limit for pagination. This is configured via a constant in the `v1::utils` module.

With soft caps no error is returned exceeding the cap, but list responses will use the cap instead of an exceeding value. With hard caps a 422 error is returned if the given limit exceeds the cap.