### PR TITLE
Additional testing

### DIFF
--- a/server/svix-server/tests/e2e_attempt.rs
+++ b/server/svix-server/tests/e2e_attempt.rs
@@ -94,9 +94,9 @@ async fn test_list_attempted_messages() {
             }
 
             // Assert order
-            assert_eq!(list.data[0].msg, msg_3);
-            assert_eq!(list.data[1].msg, msg_2);
-            assert_eq!(list.data[2].msg, msg_1);
+            if list.data[0].msg != msg_3 || list.data[1].msg != msg_2 || list.data[2].msg != msg_1 {
+                anyhow::bail!("test order failed");
+            }
         }
 
         Ok(())


### PR DESCRIPTION
Adds testing that uses a small test server to verify message delivery, redelivery, and accurate response recording.

Not formally part of this PR but worth mentioning that along with #446, we have verified through manual testing that background worker loops will recover from both standalone Redis connection failures and Postgres connection failures.

TODO: manually test Redis Cluster connection failures. Local environment issues, will update once confirmed or provide a patch in this PR.