### PR TITLE
--run-migrations option flag

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -45,4 +45,4 @@ CMD \
         wait-for -t 15 pgbouncer:5432 -- echo "Postgres ready" ; \
         wait-for -t 15 redis:6379 -- echo "Redis ready" ; \
     fi ; \
-    svix-server
+    svix-server --run-migrations

--- a/server/svix-server/src/db/mod.rs
+++ b/server/svix-server/src/db/mod.rs
@@ -22,19 +22,11 @@ async fn connect(cfg: &Configuration) -> sqlx::Pool<sqlx::Postgres> {
     }
 }
 
-#[cfg(not(debug_assertions))]
-pub async fn init_db(cfg: &Configuration) -> DatabaseConnection {
-    init_db_and_run_migrations(cfg).await
-}
-
-#[cfg(debug_assertions)]
 pub async fn init_db(cfg: &Configuration) -> DatabaseConnection {
     SqlxPostgresConnector::from_sqlx_postgres_pool(connect(cfg).await)
 }
 
-pub async fn init_db_and_run_migrations(cfg: &Configuration) -> DatabaseConnection {
+pub async fn run_migrations(cfg: &Configuration) {
     let db = connect(cfg).await;
     MIGRATIONS.run(&db).await.unwrap();
-
-    SqlxPostgresConnector::from_sqlx_postgres_pool(db)
 }

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -13,6 +13,7 @@ use svix_server::{cfg, db, run};
 
 const CRATE_NAME: &str = env!("CARGO_CRATE_NAME");
 
+use crate::cfg::Configuration;
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
@@ -20,6 +21,9 @@ use clap::{Parser, Subcommand};
 struct Args {
     #[clap(subcommand)]
     command: Option<Commands>,
+    /// Run database migrations before starting
+    #[clap(long)]
+    run_migrations: bool,
 }
 
 #[derive(Subcommand)]
@@ -30,7 +34,7 @@ enum Commands {
         #[clap(subcommand)]
         command: JwtCommands,
     },
-
+    /// Run database migrations and exit
     #[clap()]
     Migrate,
 }
@@ -62,9 +66,17 @@ async fn main() {
 
     tracing_subscriber::fmt::init();
 
-    if let Some(Commands::Migrate) = &args.command {
-        let _ = db::init_db_and_run_migrations(&cfg).await;
+    async fn run_migrations(cfg: &Configuration) {
+        db::init_db_and_run_migrations(cfg).await;
         println!("Migrations run");
+    }
+
+    if args.run_migrations {
+        run_migrations(&cfg).await;
+    }
+
+    if let Some(Commands::Migrate) = &args.command {
+        run_migrations(&cfg).await;
         exit(0);
     } else if let Some(Commands::Jwt {
         command: JwtCommands::Generate,

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -71,7 +71,7 @@ async fn main() {
     }
 
     if let Some(Commands::Migrate) = &args.command {
-        let _ = db::run_migrations(&cfg).await;
+        db::run_migrations(&cfg).await;
         println!("Migrations run");
         exit(0);
     } else if let Some(Commands::Jwt {

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -66,12 +66,12 @@ async fn main() {
     tracing_subscriber::fmt::init();
 
     if args.run_migrations {
-        db::init_db_and_run_migrations(&cfg).await;
+        db::run_migrations(&cfg).await;
         println!("Migrations run");
     }
 
     if let Some(Commands::Migrate) = &args.command {
-        let _ = db::init_db_and_run_migrations(&cfg).await;
+        let _ = db::run_migrations(&cfg).await;
         println!("Migrations run");
         exit(0);
     } else if let Some(Commands::Jwt {

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -13,7 +13,6 @@ use svix_server::{cfg, db, run};
 
 const CRATE_NAME: &str = env!("CARGO_CRATE_NAME");
 
-use crate::cfg::Configuration;
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
@@ -66,17 +65,14 @@ async fn main() {
 
     tracing_subscriber::fmt::init();
 
-    async fn run_migrations(cfg: &Configuration) {
-        db::init_db_and_run_migrations(cfg).await;
+    if args.run_migrations {
+        db::init_db_and_run_migrations(&cfg).await;
         println!("Migrations run");
     }
 
-    if args.run_migrations {
-        run_migrations(&cfg).await;
-    }
-
     if let Some(Commands::Migrate) = &args.command {
-        run_migrations(&cfg).await;
+        db::init_db_and_run_migrations(&cfg).await;
+        println!("Migrations run");
         exit(0);
     } else if let Some(Commands::Jwt {
         command: JwtCommands::Generate,

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -71,7 +71,7 @@ async fn main() {
     }
 
     if let Some(Commands::Migrate) = &args.command {
-        db::init_db_and_run_migrations(&cfg).await;
+        let _ = db::init_db_and_run_migrations(&cfg).await;
         println!("Migrations run");
         exit(0);
     } else if let Some(Commands::Jwt {


### PR DESCRIPTION
Adds a new `--run-migrations` option flag that will run any database
migrations before server startup. Includes this flag in the
Dockerfile CMD.

The existing subcommand, `migrate`, is still supported and unchanged;
it will continue to run migrations and then exit.