### PR TITLE
Remove the codeball automatic code reviewer.

### DIFF
--- a/.github/workflows/codeball.yml
+++ b/.github/workflows/codeball.yml
@@ -1,9 +1,0 @@
-on: [pull_request]
-
-jobs:
-  codeball_job:
-    runs-on: ubuntu-latest
-    name: Run Codeball
-    steps:
-      - name: Codeball AI Actions
-        uses: sturdy-dev/codeball-action@v1


### PR DESCRIPTION
We don't want it to automatically approve and interfere with
our current workflows. I was told it was less intrusive but
I guess it's not the case.