### PR TITLE
Enable running tests in parallel

### DIFF
--- a/server/run-tests.sh
+++ b/server/run-tests.sh
@@ -2,7 +2,7 @@
 
 # Run tests with various configurations:
 
-TEST_COMMAND="cargo test --all --all-features --all-targets -- --test-threads=1"
+TEST_COMMAND="cargo test --all --all-features --all-targets"
 
 # Common variables:
 export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres"

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -33,6 +33,16 @@ pub mod v1;
 pub mod worker;
 
 pub async fn run(cfg: Configuration, listener: Option<TcpListener>) {
+    run_with_prefix(None, cfg, listener).await
+}
+
+// Made public for the purpose of E2E testing in which a queue prefix is necessary to avoid tests
+// consuming from each others' queues
+pub async fn run_with_prefix(
+    prefix: Option<String>,
+    cfg: Configuration,
+    listener: Option<TcpListener>,
+) {
     let pool = init_db(&cfg).await;
 
     let redis_dsn = || {
@@ -57,7 +67,7 @@ pub async fn run(cfg: Configuration, listener: Option<TcpListener>) {
     };
 
     tracing::debug!("Queue type: {:?}", cfg.queue_type);
-    let (queue_tx, queue_rx) = queue::new_pair(&cfg, None).await;
+    let (queue_tx, queue_rx) = queue::new_pair(&cfg, prefix.as_deref()).await;
 
     // build our application with a route
     let app = Router::new()

--- a/server/svix-server/tests/utils/mod.rs
+++ b/server/svix-server/tests/utils/mod.rs
@@ -8,11 +8,11 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-
 use reqwest::{Client, RequestBuilder, StatusCode};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tokio::sync::mpsc;
 
+use svix_ksuid::KsuidLike;
 use svix_server::{
     cfg::ConfigurationInner,
     core::{
@@ -232,7 +232,11 @@ pub fn start_svix_server_with_cfg(
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let base_uri = format!("http://{}", listener.local_addr().unwrap());
 
-    let jh = tokio::spawn(svix_server::run(cfg, Some(listener)));
+    let jh = tokio::spawn(svix_server::run_with_prefix(
+        Some(svix_ksuid::Ksuid::new(None, None).to_string()),
+        cfg,
+        Some(listener),
+    ));
 
     (TestClient::new(base_uri, &token), jh)
 }


### PR DESCRIPTION
Previously tests could not run in parallel because multiple Redis queues would steal tasks from each other. This adds a unique prefix to test queue keys allowing them to run in parallel.