### PR TITLE
Release Docker tags with version numbers on GitHub release

### DIFF
--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -74,11 +74,16 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Derive Version Numbers
+        run: |
+          echo "MAJOR_MINOR=$(echo ${{ github.event.release.tag_name }} | sed -E 's/v([0-9]+)\.([0-9]+)\.([0-9]+)/v\1.\2/')" >> $GITHUB_ENV
+          echo "MAJOR=$(echo ${{ github.event.release.tag_name }} | sed -E 's/v([0-9]+)\.([0-9]+)\.([0-9]+)/v\1/')" >> $GITHUB_ENV
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
           context: ./server
           file: ./server/Dockerfile
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/svix-server:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/svix-server:latest,${{ secrets.DOCKERHUB_USERNAME }}/svix-server:${{ github.event.release.tag_name }},${{ secrets.DOCKERHUB_USERNAME }}/svix-server:${{ env.MAJOR_MINOR }},${{ secrets.DOCKERHUB_USERNAME }}/svix-server:${{ env.MAJOR }}
           platforms: linux/amd64

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -76,8 +76,9 @@ jobs:
 
       - name: Derive Version Numbers
         run: |
-          echo REPO="${{ secrets.DOCKERHUB_USERNAME }}/svix-server" >> "$GITHUB_ENV"
-          echo "DOCKER_TAGS=$(echo "${{ github.event.release.tag_name }}" | sed -E 's/v([0-9]+)\.([0-9]+)\.([0-9]+)/"${{ env.REPO }}":latest,"${{ env.REPO }}":v\1.\2.\3"${{ env.REPO }}":v\1.\2,"${{ env.REPO }}":/v\1')" >> "$GITHUB_ENV"
+          export REPO="${{ secrets.DOCKERHUB_USERNAME }}/svix-server" >> "$GITHUB_ENV"
+          echo DOCKER_TAGS=$(echo "${{ github.event.release.tag_name }}" | sed -E "s/v([0-9]+)\.([0-9]+)\.([0-9]+)/${REPO}:latest,${REPO}:v\1.\2.\3${REPO}:v\1.\2,${REPO}:/v\1')" >> "$GITHUB_ENV"
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -76,8 +76,9 @@ jobs:
 
       - name: Derive Version Numbers
         run: |
-          echo "MAJOR_MINOR=$(echo ${{ github.event.release.tag_name }} | sed -E 's/v([0-9]+)\.([0-9]+)\.([0-9]+)/v\1.\2/')" >> $GITHUB_ENV
-          echo "MAJOR=$(echo ${{ github.event.release.tag_name }} | sed -E 's/v([0-9]+)\.([0-9]+)\.([0-9]+)/v\1/')" >> $GITHUB_ENV
+          echo "MAJOR_MINOR=$(echo "${{ github.event.release.tag_name }}" | sed -E 's/v([0-9]+)\.([0-9]+)\.([0-9]+)/v\1.\2/')" >> $GITHUB_ENV
+          echo "MAJOR=$(echo "${{ github.event.release.tag_name }}" | sed -E 's/v([0-9]+)\.([0-9]+)\.([0-9]+)/v\1/')" >> $GITHUB_ENV
+          echo REPO="${{ secrets.DOCKERHUB_USERNAME }}/svix-server" >> $GITHUB_ENV
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
@@ -85,5 +86,5 @@ jobs:
           context: ./server
           file: ./server/Dockerfile
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/svix-server:latest,${{ secrets.DOCKERHUB_USERNAME }}/svix-server:${{ github.event.release.tag_name }},${{ secrets.DOCKERHUB_USERNAME }}/svix-server:${{ env.MAJOR_MINOR }},${{ secrets.DOCKERHUB_USERNAME }}/svix-server:${{ env.MAJOR }}
+          tags: ${{ env.REPO }}:latest,${{ env.REPO }}:${{ github.event.release.tag_name }},${{ env.REPO }}:${{ env.MAJOR_MINOR }},${{ env.REPO }}:${{ env.MAJOR }}
           platforms: linux/amd64

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Derive Version Numbers
         run: |
           export REPO="${{ secrets.DOCKERHUB_USERNAME }}/svix-server" >> "$GITHUB_ENV"
-          echo DOCKER_TAGS=$(echo "${{ github.event.release.tag_name }}" | sed -E "s/v([0-9]+)\.([0-9]+)\.([0-9]+)/${REPO}:latest,${REPO}:v\1.\2.\3${REPO}:v\1.\2,${REPO}:/v\1')" >> "$GITHUB_ENV"
+          echo DOCKER_TAGS=$(echo "${{ github.event.release.tag_name }}" | sed -E "s/v([0-9]+)\.([0-9]+)\.([0-9]+)/${REPO}:latest,${REPO}:v\1.\2.\3${REPO}:v\1.\2,${REPO}:/v\1") >> "$GITHUB_ENV"
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -76,15 +76,13 @@ jobs:
 
       - name: Derive Version Numbers
         run: |
-          echo "MAJOR_MINOR=$(echo "${{ github.event.release.tag_name }}" | sed -E 's/v([0-9]+)\.([0-9]+)\.([0-9]+)/v\1.\2/')" >> $GITHUB_ENV
-          echo "MAJOR=$(echo "${{ github.event.release.tag_name }}" | sed -E 's/v([0-9]+)\.([0-9]+)\.([0-9]+)/v\1/')" >> $GITHUB_ENV
-          echo REPO="${{ secrets.DOCKERHUB_USERNAME }}/svix-server" >> $GITHUB_ENV
-
+          echo REPO="${{ secrets.DOCKERHUB_USERNAME }}/svix-server" >> "$GITHUB_ENV"
+          echo "DOCKER_TAGS=$(echo "${{ github.event.release.tag_name }}" | sed -E 's/v([0-9]+)\.([0-9]+)\.([0-9]+)/"${{ env.REPO }}":latest,"${{ env.REPO }}":v\1.\2.\3"${{ env.REPO }}":v\1.\2,"${{ env.REPO }}":/v\1')" >> "$GITHUB_ENV"
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
           context: ./server
           file: ./server/Dockerfile
           push: true
-          tags: ${{ env.REPO }}:latest,${{ env.REPO }}:${{ github.event.release.tag_name }},${{ env.REPO }}:${{ env.MAJOR_MINOR }},${{ env.REPO }}:${{ env.MAJOR }}
+          tags: ${{ env.DOCKER_TAGS }}
           platforms: linux/amd64

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -76,8 +76,8 @@ jobs:
 
       - name: Derive Version Numbers
         run: |
-          export REPO="${{ secrets.DOCKERHUB_USERNAME }}/svix-server" >> "$GITHUB_ENV"
-          echo DOCKER_TAGS=$(echo "${{ github.event.release.tag_name }}" | sed -E "s/v([0-9]+)\.([0-9]+)\.([0-9]+)/${REPO}:latest,${REPO}:v\1.\2.\3${REPO}:v\1.\2,${REPO}:/v\1") >> "$GITHUB_ENV"
+          export REPO="${{ secrets.DOCKERHUB_USERNAME }}/svix-server"
+          echo DOCKER_TAGS=$(echo "${{ github.event.release.tag_name }}" | sed -E "s/v([0-9]+)\.([0-9]+)\.([0-9]+)/${REPO}:latest,${REPO}:v\1.\2.\3,${REPO}:v\1.\2,${REPO}:v\1/") >> "$GITHUB_ENV"
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Derive Version Numbers
         run: |
           export REPO="${{ secrets.DOCKERHUB_USERNAME }}/svix-server"
-          echo DOCKER_TAGS=$(echo "${{ github.event.release.tag_name }}" | sed -E "s#v([0-9]+)\.([0-9]+)\.([0-9]+)#${REPO}:latest,${REPO}:v\1.\2.\3,${REPO}:v\1.\2,${REPO}:v\1#") >> "$GITHUB_ENV"
+          echo DOCKER_TAGS="$(echo "${{ github.event.release.tag_name }}" | sed -E "s#v([0-9]+)\.([0-9]+)\.([0-9]+)#${REPO}:latest,${REPO}:v\1.\2.\3,${REPO}:v\1.\2,${REPO}:v\1#")" >> "$GITHUB_ENV"
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Derive Version Numbers
         run: |
           export REPO="${{ secrets.DOCKERHUB_USERNAME }}/svix-server"
-          echo DOCKER_TAGS=$(echo "${{ github.event.release.tag_name }}" | sed -E "s/v([0-9]+)\.([0-9]+)\.([0-9]+)/${REPO}:latest,${REPO}:v\1.\2.\3,${REPO}:v\1.\2,${REPO}:v\1/") >> "$GITHUB_ENV"
+          echo DOCKER_TAGS=$(echo "${{ github.event.release.tag_name }}" | sed -E "s#v([0-9]+)\.([0-9]+)\.([0-9]+)#${REPO}:latest,${REPO}:v\1.\2.\3,${REPO}:v\1.\2,${REPO}:v\1#") >> "$GITHUB_ENV"
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2


### PR DESCRIPTION
On a release to GitHub, in CI, it will now push to multiple tags for Docker Hub. This includes the full version number, trimming to MAJOR.MINOR and trimming to just MAJOR.