### PR TITLE
Fix logging configuration in production builds.

### DIFF
--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -52,7 +52,7 @@ async fn main() {
     let args = Args::parse();
     let cfg = cfg::load().expect("Error loading configuration");
 
-    if cfg!(debug_assertions) && std::env::var_os("RUST_LOG").is_none() {
+    if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var(
             "RUST_LOG",
             format!(


### PR DESCRIPTION
At some point a check to only enable logging for debug builds snuck into
the code. This means that logging configuration variables were only
being respected in debug builds and not in production.

The issue was reported on Slack:
https://svixcommunity.slack.com/archives/C022THZCJQ3/p1653606219172509