### PR TITLE
Validate URL scheme is http or https for EndpointIn

### DIFF
--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -53,6 +53,7 @@ http = "0.2"
 time = { version = "0.3.9", features = [ "std" ]}
 futures = "0.3"
 redis_cluster_async = { git = "https://github.com/redis-rs/redis-cluster-async.git", rev = "e6fe168" }
+url = "2.2.2"
 
 [dev-dependencies]
 anyhow = "1.0.56"


### PR DESCRIPTION
Fixes #478 by validating that the scheme for URLs in any EndpointIn received is http or https.