### PR TITLE
Config: parse retry_schedule as an array not string

### DIFF
--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -33,7 +33,7 @@ num_enum = "0.5.6"
 enum_dispatch = "0.3.8"
 regex = "1.5.5"
 lazy_static = "1.4.0"
-figment = { version = "0.10", features = ["toml", "env"] }
+figment = { version = "0.10", features = ["toml", "env", "test"] }
 tracing = "0.1.29"
 tracing-subscriber = { version="0.3", features = ["env-filter"] }
 validator = { version = "0.14.0", features = ["derive"] }

--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -12,7 +12,7 @@ listen_address = "0.0.0.0:8071"
 log_level = "info"
 
 # The wanted retry schedule in seconds. Each value is the time to wait between retries.
-retry_schedule = "5,300,1800,7200,18000,36000,36000"
+retry_schedule = [5,300,1800,7200,18000,36000,36000]
 
 # The DSN for the database. Only postgres is currently supported.
 db_dsn = "postgresql://postgres:postgres@pgbouncer/postgres"


### PR DESCRIPTION
This was a mistake that we did when initially creating it.

This change tries to first parse it as an array, and if fails, it falls
back to the previous string parsing behavior.

Fixes #480 and #481