### PR TITLE
C#: expose the missing getters for making it useful

### DIFF
--- a/csharp/Svix/Abstractions/ISvixClient.cs
+++ b/csharp/Svix/Abstractions/ISvixClient.cs
@@ -8,6 +8,18 @@ namespace Svix.Abstractions
     {
         public IApplication Application { get; }
 
+        public IAuthentication Authentication { get; }
+
+        public IEndpoint Endpoint { get; }
+
+        public IEventType EventType { get; }
+
+        public IIntegration Integration { get; }
+
+        public IMessage Message { get; }
+
+        public IMessageAttempt MessageAttempt { get; }
+
         public IHealth Health { get; }
 
         public ILogger Logger { get; }


### PR DESCRIPTION
We were not exposing many needed getters, including the ones for getting
the message creator (and many others).

Without them being exposed, you can't actually interact with the API.
This fixes it.

Fixes #485