### PR TITLE
Implement Dashboard Access Endpoint

### DIFF
--- a/server/svix-server/src/core/idempotency.rs
+++ b/server/svix-server/src/core/idempotency.rs
@@ -371,7 +371,7 @@ mod tests {
     use super::IdempotencyService;
     use crate::core::{
         cache,
-        security::generate_token,
+        security::generate_org_token,
         types::{BaseId, OrganizationId},
     };
 
@@ -445,7 +445,7 @@ mod tests {
         // Generate a new token so that keys are unique
         dotenv::dotenv().ok();
         let cfg = crate::cfg::load().unwrap();
-        let token = generate_token(&cfg.jwt_secret, OrganizationId::new(None, None), None)
+        let token = generate_org_token(&cfg.jwt_secret, OrganizationId::new(None, None))
             .unwrap()
             .to_string();
 
@@ -548,7 +548,7 @@ mod tests {
         dotenv::dotenv().ok();
         let cfg = crate::cfg::load().unwrap();
 
-        let token = generate_token(&cfg.jwt_secret, OrganizationId::new(None, None), None)
+        let token = generate_org_token(&cfg.jwt_secret, OrganizationId::new(None, None))
             .unwrap()
             .to_string();
 
@@ -638,7 +638,7 @@ mod tests {
         // Generate a new token so that keys are unique
         dotenv::dotenv().ok();
         let cfg = crate::cfg::load().unwrap();
-        let token = generate_token(&cfg.jwt_secret, OrganizationId::new(None, None), None)
+        let token = generate_org_token(&cfg.jwt_secret, OrganizationId::new(None, None))
             .unwrap()
             .to_string();
 

--- a/server/svix-server/src/core/idempotency.rs
+++ b/server/svix-server/src/core/idempotency.rs
@@ -445,7 +445,7 @@ mod tests {
         // Generate a new token so that keys are unique
         dotenv::dotenv().ok();
         let cfg = crate::cfg::load().unwrap();
-        let token = generate_token(&cfg.jwt_secret, OrganizationId::new(None, None))
+        let token = generate_token(&cfg.jwt_secret, OrganizationId::new(None, None), None)
             .unwrap()
             .to_string();
 
@@ -548,7 +548,7 @@ mod tests {
         dotenv::dotenv().ok();
         let cfg = crate::cfg::load().unwrap();
 
-        let token = generate_token(&cfg.jwt_secret, OrganizationId::new(None, None))
+        let token = generate_token(&cfg.jwt_secret, OrganizationId::new(None, None), None)
             .unwrap()
             .to_string();
 
@@ -638,7 +638,7 @@ mod tests {
         // Generate a new token so that keys are unique
         dotenv::dotenv().ok();
         let cfg = crate::cfg::load().unwrap();
-        let token = generate_token(&cfg.jwt_secret, OrganizationId::new(None, None))
+        let token = generate_token(&cfg.jwt_secret, OrganizationId::new(None, None), None)
             .unwrap()
             .to_string();
 

--- a/server/svix-server/src/core/security.rs
+++ b/server/svix-server/src/core/security.rs
@@ -209,32 +209,29 @@ where
     }
 }
 
-pub fn generate_token(
+pub fn generate_org_token(keys: &Keys, org_id: OrganizationId) -> Result<String> {
+    let claims = Claims::with_custom_claims(
+        CustomClaim { organization: None },
+        Duration::from_hours(24 * 365 * 10),
+    )
+    .with_issuer(env!("CARGO_PKG_NAME"))
+    .with_subject(org_id.0);
+    Ok(keys.key.authenticate(claims).unwrap())
+}
+
+pub fn generate_app_token(
     keys: &Keys,
     org_id: OrganizationId,
-    app_id: Option<ApplicationId>,
+    app_id: ApplicationId,
 ) -> Result<String> {
-    // If there is an app ID to encode, the the org is under the organization custom claim and the
-    // application is the subject
-    let claims = if let Some(app_id) = app_id {
-        Claims::with_custom_claims(
-            CustomClaim {
-                organization: Some(org_id.0),
-            },
-            Duration::from_hours(24 * 28),
-        )
-        .with_issuer(env!("CARGO_PKG_NAME"))
-        .with_subject(app_id.0)
-    }
-    // With no app ID to encode, the org field is blank while the sub is the organization ID
-    else {
-        Claims::with_custom_claims(
-            CustomClaim { organization: None },
-            Duration::from_hours(24 * 365 * 10),
-        )
-        .with_issuer(env!("CARGO_PKG_NAME"))
-        .with_subject(org_id.0)
-    };
+    let claims = Claims::with_custom_claims(
+        CustomClaim {
+            organization: Some(org_id.0),
+        },
+        Duration::from_hours(24 * 28),
+    )
+    .with_issuer(env!("CARGO_PKG_NAME"))
+    .with_subject(app_id.0);
     Ok(keys.key.authenticate(claims).unwrap())
 }
 

--- a/server/svix-server/src/core/security.rs
+++ b/server/svix-server/src/core/security.rs
@@ -233,6 +233,20 @@ where
         .one(db)
         .await?
         .ok_or_else(|| HttpError::not_found(None, None))?;
+
+        if let Some(permitted_app_id) = &permissions.app_id {
+            if permitted_app_id != &app.id {
+                return Err(HttpError::unauthorized(
+                    None,
+                    Some(
+                        "You are only permitted to perform operations under the Application type"
+                            .to_owned(),
+                    ),
+                )
+                .into());
+            }
+        }
+
         Ok(AuthenticatedApplication { permissions, app })
     }
 }

--- a/server/svix-server/src/core/security.rs
+++ b/server/svix-server/src/core/security.rs
@@ -141,15 +141,18 @@ where
 
     async fn from_request(req: &mut RequestParts<B>) -> Result<Self> {
         let permissions = Permissions::from_request(req).await?;
-        if permissions.type_ == KeyType::Application {
-            return Err(HttpError::unauthorized(
-                None,
-                Some(
-                    "You are only permitted to perform operations under the Application type"
-                        .to_owned(),
-                ),
-            )
-            .into());
+        match permissions.type_ {
+            KeyType::Organization => {}
+            KeyType::Application => {
+                return Err(HttpError::unauthorized(
+                    None,
+                    Some(
+                        "You are only permitted to perform operations under the Application type"
+                            .to_owned(),
+                    ),
+                )
+                .into());
+            }
         }
 
         Ok(AuthenticatedOrganization { permissions })
@@ -176,15 +179,18 @@ where
     async fn from_request(req: &mut RequestParts<B>) -> Result<Self> {
         let permissions = Permissions::from_request(req).await?;
 
-        if permissions.type_ == KeyType::Application {
-            return Err(HttpError::unauthorized(
-                None,
-                Some(
-                    "You are only permitted to perform operations under the Application type"
-                        .to_owned(),
-                ),
-            )
-            .into());
+        match permissions.type_ {
+            KeyType::Organization => {}
+            KeyType::Application => {
+                return Err(HttpError::unauthorized(
+                    None,
+                    Some(
+                        "You are only permitted to perform operations under the Application type"
+                            .to_owned(),
+                    ),
+                )
+                .into());
+            }
         }
 
         let Path(ApplicationPathParams { app_id }) =

--- a/server/svix-server/src/core/security.rs
+++ b/server/svix-server/src/core/security.rs
@@ -144,14 +144,7 @@ where
         match permissions.type_ {
             KeyType::Organization => {}
             KeyType::Application => {
-                return Err(HttpError::unauthorized(
-                    None,
-                    Some(
-                        "You are only permitted to perform operations under the Application type"
-                            .to_owned(),
-                    ),
-                )
-                .into());
+                return Err(HttpError::permission_denied(None, None).into());
             }
         }
 
@@ -182,14 +175,7 @@ where
         match permissions.type_ {
             KeyType::Organization => {}
             KeyType::Application => {
-                return Err(HttpError::unauthorized(
-                    None,
-                    Some(
-                        "You are only permitted to perform operations under the Application type"
-                            .to_owned(),
-                    ),
-                )
-                .into());
+                return Err(HttpError::unauthorized(None, None).into());
             }
         }
 
@@ -242,14 +228,7 @@ where
 
         if let Some(permitted_app_id) = &permissions.app_id {
             if permitted_app_id != &app.id {
-                return Err(HttpError::unauthorized(
-                    None,
-                    Some(
-                        "You are only permitted to perform operations under the Application type"
-                            .to_owned(),
-                    ),
-                )
-                .into());
+                return Err(HttpError::not_found(None, None).into());
             }
         }
 
@@ -257,12 +236,14 @@ where
     }
 }
 
+const JWT_ISSUER: &str = env!("CARGO_PKG_NAME");
+
 pub fn generate_org_token(keys: &Keys, org_id: OrganizationId) -> Result<String> {
     let claims = Claims::with_custom_claims(
         CustomClaim { organization: None },
         Duration::from_hours(24 * 365 * 10),
     )
-    .with_issuer(env!("CARGO_PKG_NAME"))
+    .with_issuer(JWT_ISSUER)
     .with_subject(org_id.0);
     Ok(keys.key.authenticate(claims).unwrap())
 }
@@ -278,7 +259,7 @@ pub fn generate_app_token(
         },
         Duration::from_hours(24 * 28),
     )
-    .with_issuer(env!("CARGO_PKG_NAME"))
+    .with_issuer(JWT_ISSUER)
     .with_subject(app_id.0);
     Ok(keys.key.authenticate(claims).unwrap())
 }

--- a/server/svix-server/src/core/security.rs
+++ b/server/svix-server/src/core/security.rs
@@ -175,7 +175,7 @@ where
         match permissions.type_ {
             KeyType::Organization => {}
             KeyType::Application => {
-                return Err(HttpError::unauthorized(None, None).into());
+                return Err(HttpError::permission_denied(None, None).into());
             }
         }
 

--- a/server/svix-server/src/core/security.rs
+++ b/server/svix-server/src/core/security.rs
@@ -164,13 +164,13 @@ struct ApplicationPathParams {
     app_id: ApplicationIdOrUid,
 }
 
-pub struct OrganizationAuthenticatedApplication {
+pub struct AuthenticatedOrganizationWithApplication {
     pub permissions: Permissions,
     pub app: application::Model,
 }
 
 #[async_trait]
-impl<B> FromRequest<B> for OrganizationAuthenticatedApplication
+impl<B> FromRequest<B> for AuthenticatedOrganizationWithApplication
 where
     B: Send,
 {
@@ -207,7 +207,7 @@ where
         .one(db)
         .await?
         .ok_or_else(|| HttpError::not_found(None, None))?;
-        Ok(OrganizationAuthenticatedApplication { permissions, app })
+        Ok(AuthenticatedOrganizationWithApplication { permissions, app })
     }
 }
 

--- a/server/svix-server/src/error.rs
+++ b/server/svix-server/src/error.rs
@@ -166,11 +166,11 @@ impl HttpError {
     }
 
     pub fn permission_denied(code: Option<String>, detail: Option<String>) -> Self {
-		Self::new_standard(
-    		StatusCode::FORBIDDEN,
-    		code.unwrap_or_else(|| "insufficient access".to_owned()),
-    		detail.unwrap_or_else(|| "Insufficient access for the given operation.".to_owned()),
-		)
+        Self::new_standard(
+            StatusCode::FORBIDDEN,
+            code.unwrap_or_else(|| "insufficient access".to_owned()),
+            detail.unwrap_or_else(|| "Insufficient access for the given operation.".to_owned()),
+        )
     }
 
     pub fn conflict(code: Option<String>, detail: Option<String>) -> Self {

--- a/server/svix-server/src/error.rs
+++ b/server/svix-server/src/error.rs
@@ -165,6 +165,14 @@ impl HttpError {
         )
     }
 
+    pub fn permission_denied(code: Option<String>, detail: Option<String>) -> Self {
+		Self::new_standard(
+    		StatusCode::FORBIDDEN,
+    		code.unwrap_or_else(|| "insufficient access".to_owned()),
+    		detail.unwrap_or_else(|| "Insufficient access for the given operation.".to_owned()),
+		)
+    }
+
     pub fn conflict(code: Option<String>, detail: Option<String>) -> Self {
         Self::new_standard(
             StatusCode::CONFLICT,

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -7,7 +7,7 @@
 use dotenv::dotenv;
 use std::process::exit;
 
-use svix_server::core::security::{default_org_id, generate_token};
+use svix_server::core::security::{default_org_id, generate_org_token};
 
 use svix_server::{cfg, db, run};
 
@@ -78,8 +78,8 @@ async fn main() {
         command: JwtCommands::Generate,
     }) = &args.command
     {
-        let token = generate_token(&cfg.jwt_secret, default_org_id(), None)
-            .expect("Error generating token");
+        let token =
+            generate_org_token(&cfg.jwt_secret, default_org_id()).expect("Error generating token");
         println!("Token (Bearer): {}", token);
         exit(0);
     }

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -78,8 +78,8 @@ async fn main() {
         command: JwtCommands::Generate,
     }) = &args.command
     {
-        let token =
-            generate_token(&cfg.jwt_secret, default_org_id()).expect("Error generating token");
+        let token = generate_token(&cfg.jwt_secret, default_org_id(), None)
+            .expect("Error generating token");
         println!("Token (Bearer): {}", token);
         exit(0);
     }

--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -3,7 +3,10 @@
 
 use crate::{
     core::{
-        security::{AuthenticatedApplication, AuthenticatedOrganization},
+        security::{
+            AuthenticatedApplication, AuthenticatedOrganization,
+            OrganizationAuthenticatedApplication,
+        },
         types::{ApplicationId, ApplicationIdOrUid, ApplicationUid},
     },
     db::models::application,
@@ -157,15 +160,13 @@ async fn get_application(
 
 async fn update_application(
     Extension(ref db): Extension<DatabaseConnection>,
-    Path(app_id): Path<ApplicationIdOrUid>,
+    Path(_app_id): Path<ApplicationIdOrUid>,
     ValidatedJson(data): ValidatedJson<ApplicationIn>,
-    AuthenticatedOrganization { permissions }: AuthenticatedOrganization,
+    OrganizationAuthenticatedApplication {
+        permissions: _,
+        app,
+    }: OrganizationAuthenticatedApplication,
 ) -> Result<Json<ApplicationOut>> {
-    let app = application::Entity::secure_find_by_id_or_uid(permissions.org_id.clone(), app_id)
-        .one(db)
-        .await?
-        .ok_or_else(|| HttpError::not_found(None, None))?;
-
     let mut app: application::ActiveModel = app.into();
     data.update_model(&mut app);
 

--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -7,7 +7,7 @@ use crate::{
             AuthenticatedApplication, AuthenticatedOrganization,
             AuthenticatedOrganizationWithApplication,
         },
-        types::{ApplicationId, ApplicationIdOrUid, ApplicationUid},
+        types::{ApplicationId, ApplicationUid},
     },
     db::models::application,
     error::{HttpError, Result},
@@ -17,7 +17,7 @@ use crate::{
     },
 };
 use axum::{
-    extract::{Extension, Path},
+    extract::Extension,
     routing::{get, post},
     Json, Router,
 };

--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -5,7 +5,7 @@ use crate::{
     core::{
         security::{
             AuthenticatedApplication, AuthenticatedOrganization,
-            OrganizationAuthenticatedApplication,
+            AuthenticatedOrganizationWithApplication,
         },
         types::{ApplicationId, ApplicationIdOrUid, ApplicationUid},
     },
@@ -162,10 +162,10 @@ async fn update_application(
     Extension(ref db): Extension<DatabaseConnection>,
     Path(_app_id): Path<ApplicationIdOrUid>,
     ValidatedJson(data): ValidatedJson<ApplicationIn>,
-    OrganizationAuthenticatedApplication {
+    AuthenticatedOrganizationWithApplication {
         permissions: _,
         app,
-    }: OrganizationAuthenticatedApplication,
+    }: AuthenticatedOrganizationWithApplication,
 ) -> Result<Json<ApplicationOut>> {
     let mut app: application::ActiveModel = app.into();
     data.update_model(&mut app);

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     core::{
-        security::{AuthenticatedApplication, AuthenticatedOrganizationWithApplication},
+        security::AuthenticatedApplication,
         types::{
             ApplicationIdOrUid, EndpointId, EndpointIdOrUid, EventChannel, EventTypeNameSet,
             MessageAttemptId, MessageAttemptTriggerType, MessageEndpointId, MessageId,

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     core::{
-        security::{AuthenticatedApplication, AuthenticatedOrganization},
+        security::{AuthenticatedApplication, OrganizationAuthenticatedApplication},
         types::{
             ApplicationIdOrUid, EndpointId, EndpointIdOrUid, EventChannel, EventTypeNameSet,
             MessageAttemptId, MessageAttemptTriggerType, MessageEndpointId, MessageId,
@@ -652,10 +652,10 @@ async fn resend_webhook(
     Extension(ref db): Extension<DatabaseConnection>,
     Extension(queue_tx): Extension<TaskQueueProducer>,
     Path((_app_id, msg_id, endp_id)): Path<(ApplicationIdOrUid, MessageIdOrUid, EndpointIdOrUid)>,
-    AuthenticatedOrganization {
+    OrganizationAuthenticatedApplication {
         permissions: _,
         app,
-    }: AuthenticatedOrganization,
+    }: OrganizationAuthenticatedApplication,
 ) -> Result<(StatusCode, Json<EmptyResponse>)> {
     let msg = message::Entity::secure_find_by_id_or_uid(app.id.clone(), msg_id)
         .one(db)

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -652,10 +652,10 @@ async fn resend_webhook(
     Extension(ref db): Extension<DatabaseConnection>,
     Extension(queue_tx): Extension<TaskQueueProducer>,
     Path((_app_id, msg_id, endp_id)): Path<(ApplicationIdOrUid, MessageIdOrUid, EndpointIdOrUid)>,
-    AuthenticatedOrganizationWithApplication {
+    AuthenticatedApplication {
         permissions: _,
         app,
-    }: AuthenticatedOrganizationWithApplication,
+    }: AuthenticatedApplication,
 ) -> Result<(StatusCode, Json<EmptyResponse>)> {
     let msg = message::Entity::secure_find_by_id_or_uid(app.id.clone(), msg_id)
         .one(db)

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     core::{
-        security::{AuthenticatedApplication, OrganizationAuthenticatedApplication},
+        security::{AuthenticatedApplication, AuthenticatedOrganizationWithApplication},
         types::{
             ApplicationIdOrUid, EndpointId, EndpointIdOrUid, EventChannel, EventTypeNameSet,
             MessageAttemptId, MessageAttemptTriggerType, MessageEndpointId, MessageId,
@@ -652,10 +652,10 @@ async fn resend_webhook(
     Extension(ref db): Extension<DatabaseConnection>,
     Extension(queue_tx): Extension<TaskQueueProducer>,
     Path((_app_id, msg_id, endp_id)): Path<(ApplicationIdOrUid, MessageIdOrUid, EndpointIdOrUid)>,
-    OrganizationAuthenticatedApplication {
+    AuthenticatedOrganizationWithApplication {
         permissions: _,
         app,
-    }: OrganizationAuthenticatedApplication,
+    }: AuthenticatedOrganizationWithApplication,
 ) -> Result<(StatusCode, Json<EmptyResponse>)> {
     let msg = message::Entity::secure_find_by_id_or_uid(app.id.clone(), msg_id)
         .one(db)

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     core::{
-        security::AuthenticatedApplication,
+        security::{AuthenticatedApplication, AuthenticatedOrganization},
         types::{
             ApplicationIdOrUid, EndpointId, EndpointIdOrUid, EventChannel, EventTypeNameSet,
             MessageAttemptId, MessageAttemptTriggerType, MessageEndpointId, MessageId,
@@ -652,10 +652,10 @@ async fn resend_webhook(
     Extension(ref db): Extension<DatabaseConnection>,
     Extension(queue_tx): Extension<TaskQueueProducer>,
     Path((_app_id, msg_id, endp_id)): Path<(ApplicationIdOrUid, MessageIdOrUid, EndpointIdOrUid)>,
-    AuthenticatedApplication {
+    AuthenticatedOrganization {
         permissions: _,
         app,
-    }: AuthenticatedApplication,
+    }: AuthenticatedOrganization,
 ) -> Result<(StatusCode, Json<EmptyResponse>)> {
     let msg = message::Entity::secure_find_by_id_or_uid(app.id.clone(), msg_id)
         .one(db)

--- a/server/svix-server/src/v1/endpoints/auth.rs
+++ b/server/svix-server/src/v1/endpoints/auth.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     cfg::Configuration,
     core::{
-        security::{generate_token, AuthenticatedOrganization},
+        security::{generate_app_token, AuthenticatedOrganization},
         types::ApplicationIdOrUid,
     },
     error::{HttpError, Result},
@@ -22,7 +22,7 @@ async fn dashboard_access(
     Path(_app_id): Path<ApplicationIdOrUid>,
     AuthenticatedOrganization { permissions, app }: AuthenticatedOrganization,
 ) -> Result<Json<DashboardAccessOut>> {
-    let token = generate_token(&cfg.jwt_secret, permissions.org_id, Some(app.id.clone()))?;
+    let token = generate_app_token(&cfg.jwt_secret, permissions.org_id, app.id.clone())?;
 
     let login_key = serde_json::to_vec(&serde_json::json!({
         "appId": app.id,

--- a/server/svix-server/src/v1/endpoints/auth.rs
+++ b/server/svix-server/src/v1/endpoints/auth.rs
@@ -1,0 +1,45 @@
+use axum::{extract::Path, routing::post, Extension, Json, Router};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    cfg::Configuration,
+    core::{
+        security::{generate_token, AuthenticatedOrganization},
+        types::ApplicationIdOrUid,
+    },
+    error::{HttpError, Result},
+    v1::utils::api_not_implemented,
+};
+
+#[derive(Deserialize, Serialize)]
+struct DashboardAccessOut {
+    url: String,
+    token: String,
+}
+
+async fn dashboard_access(
+    Extension(cfg): Extension<Configuration>,
+    Path(_app_id): Path<ApplicationIdOrUid>,
+    AuthenticatedOrganization { permissions, app }: AuthenticatedOrganization,
+) -> Result<Json<DashboardAccessOut>> {
+    let token = generate_token(&cfg.jwt_secret, permissions.org_id, Some(app.id.clone()))?;
+
+    let login_key = serde_json::to_vec(&serde_json::json!({
+        "appId": app.id,
+        "token": token,
+        "region": "eu"
+    }))
+    .map_err(|_| HttpError::internal_server_errer(None, None))?;
+
+    let login_key = base64::encode(&login_key);
+
+    let url = format!("https://app.svix.com/login#key={}", login_key);
+
+    Ok(Json(DashboardAccessOut { url, token }))
+}
+
+pub fn router() -> Router {
+    Router::new()
+        .route("/auth/dashboard-access/:app_id/", post(dashboard_access))
+        .route("/auth/logout/", post(api_not_implemented))
+}

--- a/server/svix-server/src/v1/endpoints/auth.rs
+++ b/server/svix-server/src/v1/endpoints/auth.rs
@@ -1,11 +1,10 @@
-use axum::{extract::Path, routing::post, Extension, Json, Router};
+use axum::{routing::post, Extension, Json, Router};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     cfg::Configuration,
     core::{
         security::{generate_app_token, AuthenticatedOrganizationWithApplication},
-        types::ApplicationIdOrUid,
     },
     error::{HttpError, Result},
     v1::utils::api_not_implemented,

--- a/server/svix-server/src/v1/endpoints/auth.rs
+++ b/server/svix-server/src/v1/endpoints/auth.rs
@@ -12,9 +12,9 @@ use crate::{
 };
 
 #[derive(Deserialize, Serialize)]
-struct DashboardAccessOut {
-    url: String,
-    token: String,
+pub struct DashboardAccessOut {
+    pub url: String,
+    pub token: String,
 }
 
 const SVIX_URL: &str = "https://app.svix.com";

--- a/server/svix-server/src/v1/endpoints/auth.rs
+++ b/server/svix-server/src/v1/endpoints/auth.rs
@@ -25,6 +25,7 @@ async fn dashboard_access(
     let login_key = serde_json::to_vec(&serde_json::json!({
         "appId": app.id,
         "token": token,
+        // Region is unused
         "region": "eu"
     }))
     .map_err(|_| HttpError::internal_server_errer(None, None))?;

--- a/server/svix-server/src/v1/endpoints/auth.rs
+++ b/server/svix-server/src/v1/endpoints/auth.rs
@@ -17,6 +17,8 @@ struct DashboardAccessOut {
     token: String,
 }
 
+const SVIX_URL: &str = "https://app.svix.com";
+
 async fn dashboard_access(
     Extension(cfg): Extension<Configuration>,
     Path(_app_id): Path<ApplicationIdOrUid>,
@@ -33,7 +35,8 @@ async fn dashboard_access(
 
     let login_key = base64::encode(&login_key);
 
-    let url = format!("https://app.svix.com/login#key={}", login_key);
+    // Included for API compatibility, but this URL will not be useful
+    let url = format!("{}/login#key={}", SVIX_URL, login_key);
 
     Ok(Json(DashboardAccessOut { url, token }))
 }

--- a/server/svix-server/src/v1/endpoints/auth.rs
+++ b/server/svix-server/src/v1/endpoints/auth.rs
@@ -21,7 +21,6 @@ const SVIX_URL: &str = "https://app.svix.com";
 
 async fn dashboard_access(
     Extension(cfg): Extension<Configuration>,
-    Path(_app_id): Path<ApplicationIdOrUid>,
     AuthenticatedOrganizationWithApplication { permissions, app }: AuthenticatedOrganizationWithApplication,
 ) -> Result<Json<DashboardAccessOut>> {
     let token = generate_app_token(&cfg.jwt_secret, permissions.org_id, app.id.clone())?;

--- a/server/svix-server/src/v1/endpoints/auth.rs
+++ b/server/svix-server/src/v1/endpoints/auth.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     cfg::Configuration,
     core::{
-        security::{generate_app_token, AuthenticatedOrganization},
+        security::{generate_app_token, OrganizationAuthenticatedApplication},
         types::ApplicationIdOrUid,
     },
     error::{HttpError, Result},
@@ -20,7 +20,7 @@ struct DashboardAccessOut {
 async fn dashboard_access(
     Extension(cfg): Extension<Configuration>,
     Path(_app_id): Path<ApplicationIdOrUid>,
-    AuthenticatedOrganization { permissions, app }: AuthenticatedOrganization,
+    OrganizationAuthenticatedApplication { permissions, app }: OrganizationAuthenticatedApplication,
 ) -> Result<Json<DashboardAccessOut>> {
     let token = generate_app_token(&cfg.jwt_secret, permissions.org_id, app.id.clone())?;
 

--- a/server/svix-server/src/v1/endpoints/auth.rs
+++ b/server/svix-server/src/v1/endpoints/auth.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     cfg::Configuration,
     core::{
-        security::{generate_app_token, OrganizationAuthenticatedApplication},
+        security::{generate_app_token, AuthenticatedOrganizationWithApplication},
         types::ApplicationIdOrUid,
     },
     error::{HttpError, Result},
@@ -22,7 +22,7 @@ const SVIX_URL: &str = "https://app.svix.com";
 async fn dashboard_access(
     Extension(cfg): Extension<Configuration>,
     Path(_app_id): Path<ApplicationIdOrUid>,
-    OrganizationAuthenticatedApplication { permissions, app }: OrganizationAuthenticatedApplication,
+    AuthenticatedOrganizationWithApplication { permissions, app }: AuthenticatedOrganizationWithApplication,
 ) -> Result<Json<DashboardAccessOut>> {
     let token = generate_app_token(&cfg.jwt_secret, permissions.org_id, app.id.clone())?;
 

--- a/server/svix-server/src/v1/endpoints/auth.rs
+++ b/server/svix-server/src/v1/endpoints/auth.rs
@@ -3,9 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     cfg::Configuration,
-    core::{
-        security::{generate_app_token, AuthenticatedOrganizationWithApplication},
-    },
+    core::security::{generate_app_token, AuthenticatedOrganizationWithApplication},
     error::{HttpError, Result},
     v1::utils::api_not_implemented,
 };

--- a/server/svix-server/src/v1/endpoints/event_type.rs
+++ b/server/svix-server/src/v1/endpoints/event_type.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 use crate::{
-    core::types::EventTypeName,
+    core::{security::KeyType, types::EventTypeName},
     error::{HttpError, Result},
     v1::utils::{
         api_not_implemented, validate_no_control_characters, EmptyResponse, ListResponse, ModelIn,
@@ -158,6 +158,14 @@ async fn create_event_type(
     ValidatedJson(data): ValidatedJson<EventTypeIn>,
     permissions: Permissions,
 ) -> Result<(StatusCode, Json<EventTypeOut>)> {
+    if permissions.type_ == KeyType::Application {
+        return Err(HttpError::unauthorized(
+            None,
+            Some("You require organization level authentication for this endpoint".to_owned()),
+        )
+        .into());
+    }
+
     let evtype =
         eventtype::Entity::secure_find_by_name(permissions.org_id.clone(), data.name.to_owned())
             .one(db)
@@ -193,6 +201,14 @@ async fn get_event_type(
     Path(evtype_name): Path<EventTypeName>,
     permissions: Permissions,
 ) -> Result<Json<EventTypeOut>> {
+    if permissions.type_ == KeyType::Application {
+        return Err(HttpError::unauthorized(
+            None,
+            Some("You require organization level authentication for this endpoint".to_owned()),
+        )
+        .into());
+    }
+
     let evtype = eventtype::Entity::secure_find_by_name(permissions.org_id, evtype_name)
         .one(db)
         .await?
@@ -206,6 +222,14 @@ async fn update_event_type(
     ValidatedJson(data): ValidatedJson<EventTypeUpdate>,
     permissions: Permissions,
 ) -> Result<Json<EventTypeOut>> {
+    if permissions.type_ == KeyType::Application {
+        return Err(HttpError::unauthorized(
+            None,
+            Some("You require organization level authentication for this endpoint".to_owned()),
+        )
+        .into());
+    }
+
     let evtype = eventtype::Entity::secure_find_by_name(permissions.org_id.clone(), evtype_name)
         .one(db)
         .await?
@@ -223,6 +247,14 @@ async fn delete_event_type(
     Path(evtype_name): Path<EventTypeName>,
     permissions: Permissions,
 ) -> Result<(StatusCode, Json<EmptyResponse>)> {
+    if permissions.type_ == KeyType::Application {
+        return Err(HttpError::unauthorized(
+            None,
+            Some("You require organization level authentication for this endpoint".to_owned()),
+        )
+        .into());
+    }
+
     let evtype = eventtype::Entity::secure_find_by_name(permissions.org_id, evtype_name)
         .one(db)
         .await?

--- a/server/svix-server/src/v1/endpoints/event_type.rs
+++ b/server/svix-server/src/v1/endpoints/event_type.rs
@@ -2,11 +2,15 @@
 // SPDX-License-Identifier: MIT
 
 use crate::{
-    core::{security::KeyType, types::EventTypeName},
+    core::{
+        security::{AuthenticatedOrganization, Permissions},
+        types::EventTypeName,
+    },
+    db::models::eventtype,
     error::{HttpError, Result},
     v1::utils::{
         api_not_implemented, validate_no_control_characters, EmptyResponse, ListResponse, ModelIn,
-        ModelOut, PaginationLimit, ValidatedJson, ValidatedQuery,
+        ModelOut, Pagination, PaginationLimit, ValidatedJson, ValidatedQuery,
     },
 };
 use axum::{
@@ -21,10 +25,6 @@ use sea_orm::{ActiveModelTrait, DatabaseConnection, QuerySelect};
 use serde::{Deserialize, Serialize};
 use svix_server_derive::{ModelIn, ModelOut};
 use validator::Validate;
-
-use crate::core::security::Permissions;
-use crate::db::models::eventtype;
-use crate::v1::utils::Pagination;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Validate, ModelIn)]
 #[serde(rename_all = "camelCase")]
@@ -156,16 +156,8 @@ async fn list_event_types(
 async fn create_event_type(
     Extension(ref db): Extension<DatabaseConnection>,
     ValidatedJson(data): ValidatedJson<EventTypeIn>,
-    permissions: Permissions,
+    AuthenticatedOrganization { permissions }: AuthenticatedOrganization,
 ) -> Result<(StatusCode, Json<EventTypeOut>)> {
-    if permissions.type_ == KeyType::Application {
-        return Err(HttpError::unauthorized(
-            None,
-            Some("You require organization level authentication for this endpoint".to_owned()),
-        )
-        .into());
-    }
-
     let evtype =
         eventtype::Entity::secure_find_by_name(permissions.org_id.clone(), data.name.to_owned())
             .one(db)
@@ -199,16 +191,8 @@ async fn create_event_type(
 async fn get_event_type(
     Extension(ref db): Extension<DatabaseConnection>,
     Path(evtype_name): Path<EventTypeName>,
-    permissions: Permissions,
+    AuthenticatedOrganization { permissions }: AuthenticatedOrganization,
 ) -> Result<Json<EventTypeOut>> {
-    if permissions.type_ == KeyType::Application {
-        return Err(HttpError::unauthorized(
-            None,
-            Some("You require organization level authentication for this endpoint".to_owned()),
-        )
-        .into());
-    }
-
     let evtype = eventtype::Entity::secure_find_by_name(permissions.org_id, evtype_name)
         .one(db)
         .await?
@@ -220,16 +204,8 @@ async fn update_event_type(
     Extension(ref db): Extension<DatabaseConnection>,
     Path(evtype_name): Path<EventTypeName>,
     ValidatedJson(data): ValidatedJson<EventTypeUpdate>,
-    permissions: Permissions,
+    AuthenticatedOrganization { permissions }: AuthenticatedOrganization,
 ) -> Result<Json<EventTypeOut>> {
-    if permissions.type_ == KeyType::Application {
-        return Err(HttpError::unauthorized(
-            None,
-            Some("You require organization level authentication for this endpoint".to_owned()),
-        )
-        .into());
-    }
-
     let evtype = eventtype::Entity::secure_find_by_name(permissions.org_id.clone(), evtype_name)
         .one(db)
         .await?
@@ -245,16 +221,8 @@ async fn update_event_type(
 async fn delete_event_type(
     Extension(ref db): Extension<DatabaseConnection>,
     Path(evtype_name): Path<EventTypeName>,
-    permissions: Permissions,
+    AuthenticatedOrganization { permissions }: AuthenticatedOrganization,
 ) -> Result<(StatusCode, Json<EmptyResponse>)> {
-    if permissions.type_ == KeyType::Application {
-        return Err(HttpError::unauthorized(
-            None,
-            Some("You require organization level authentication for this endpoint".to_owned()),
-        )
-        .into());
-    }
-
     let evtype = eventtype::Entity::secure_find_by_name(permissions.org_id, evtype_name)
         .one(db)
         .await?

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -5,7 +5,7 @@ use crate::{
     cache::Cache,
     core::{
         message_app::CreateMessageApp,
-        security::{AuthenticatedApplication, OrganizationAuthenticatedApplication},
+        security::{AuthenticatedApplication, AuthenticatedOrganizationWithApplication},
         types::{
             ApplicationIdOrUid, EventChannel, EventChannelSet, EventTypeName, EventTypeNameSet,
             MessageAttemptTriggerType, MessageId, MessageIdOrUid, MessageUid,
@@ -200,7 +200,7 @@ async fn create_message(
         CreateMessageQueryParams,
     >,
     ValidatedJson(data): ValidatedJson<MessageIn>,
-    OrganizationAuthenticatedApplication { permissions, app }: OrganizationAuthenticatedApplication,
+    AuthenticatedOrganizationWithApplication { permissions, app }: AuthenticatedOrganizationWithApplication,
 ) -> Result<(StatusCode, Json<MessageOut>)> {
     let create_message_app = CreateMessageApp::layered_fetch(
         cache,

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -5,7 +5,7 @@ use crate::{
     cache::Cache,
     core::{
         message_app::CreateMessageApp,
-        security::{AuthenticatedApplication, AuthenticatedOrganization},
+        security::{AuthenticatedApplication, OrganizationAuthenticatedApplication},
         types::{
             ApplicationIdOrUid, EventChannel, EventChannelSet, EventTypeName, EventTypeNameSet,
             MessageAttemptTriggerType, MessageId, MessageIdOrUid, MessageUid,
@@ -200,7 +200,7 @@ async fn create_message(
         CreateMessageQueryParams,
     >,
     ValidatedJson(data): ValidatedJson<MessageIn>,
-    AuthenticatedOrganization { permissions, app }: AuthenticatedOrganization,
+    OrganizationAuthenticatedApplication { permissions, app }: OrganizationAuthenticatedApplication,
 ) -> Result<(StatusCode, Json<MessageOut>)> {
     let create_message_app = CreateMessageApp::layered_fetch(
         cache,

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -5,7 +5,7 @@ use crate::{
     cache::Cache,
     core::{
         message_app::CreateMessageApp,
-        security::AuthenticatedApplication,
+        security::{AuthenticatedApplication, AuthenticatedOrganization},
         types::{
             ApplicationIdOrUid, EventChannel, EventChannelSet, EventTypeName, EventTypeNameSet,
             MessageAttemptTriggerType, MessageId, MessageIdOrUid, MessageUid,
@@ -200,7 +200,7 @@ async fn create_message(
         CreateMessageQueryParams,
     >,
     ValidatedJson(data): ValidatedJson<MessageIn>,
-    AuthenticatedApplication { permissions, app }: AuthenticatedApplication,
+    AuthenticatedOrganization { permissions, app }: AuthenticatedOrganization,
 ) -> Result<(StatusCode, Json<MessageOut>)> {
     let create_message_app = CreateMessageApp::layered_fetch(
         cache,

--- a/server/svix-server/src/v1/endpoints/mod.rs
+++ b/server/svix-server/src/v1/endpoints/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
+pub mod auth;
 pub mod application;
 pub mod attempt;
 pub mod endpoint;

--- a/server/svix-server/src/v1/endpoints/mod.rs
+++ b/server/svix-server/src/v1/endpoints/mod.rs
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
-pub mod auth;
 pub mod application;
 pub mod attempt;
+pub mod auth;
 pub mod endpoint;
 pub mod event_type;
 pub mod health;

--- a/server/svix-server/src/v1/mod.rs
+++ b/server/svix-server/src/v1/mod.rs
@@ -9,7 +9,7 @@ pub mod utils;
 pub fn router() -> Router {
     let ret = Router::new()
         .merge(endpoints::health::router())
-        .merge(auth::router())
+        .merge(endpoints::auth::router())
         .merge(endpoints::application::router())
         .merge(endpoints::endpoint::router())
         .merge(endpoints::event_type::router())
@@ -21,18 +21,6 @@ pub fn router() -> Router {
         return ret.merge(development::router());
     }
     ret
-}
-
-mod auth {
-    use axum::{routing::post, Router};
-
-    use super::utils::api_not_implemented;
-
-    pub fn router() -> Router {
-        Router::new()
-            .route("/auth/dashboard-access/:app_id/", post(api_not_implemented))
-            .route("/auth/logout/", post(api_not_implemented))
-    }
 }
 
 #[cfg(debug_assertions)]

--- a/server/svix-server/tests/e2e_auth.rs
+++ b/server/svix-server/tests/e2e_auth.rs
@@ -85,10 +85,7 @@ async fn test_restricted_application_access() {
 
     // READ should succeed when accessing the app_id the token is auhtorized for but no others
     let _: IgnoredResponse = client
-        .get(
-            &format!("api/v1/app/{}", app_id_2),
-            StatusCode::NOT_FOUND,
-        )
+        .get(&format!("api/v1/app/{}", app_id_2), StatusCode::NOT_FOUND)
         .await
         .unwrap();
     let _: ApplicationOut = client

--- a/server/svix-server/tests/e2e_auth.rs
+++ b/server/svix-server/tests/e2e_auth.rs
@@ -1,0 +1,98 @@
+//! Module that test the dashboard-access endpoint and associated JWT tokens. This module will test
+//! that the tokens returned by the endpoint have restricted functionality and that the response
+//! from the endpoint is valid in the process.
+
+use reqwest::StatusCode;
+
+use svix_server::{
+    core::types::ApplicationId,
+    v1::endpoints::{application::ApplicationOut, auth::DashboardAccessOut},
+};
+
+mod utils;
+use utils::{common_calls::application_in, start_svix_server, IgnoredResponse, TestClient};
+
+/// Accesses the dashboard-access endpoint and returns a new [`TestClient`] with an auth header set
+/// to the returned token.
+async fn dashboard_access(org_client: &TestClient, application_id: &ApplicationId) -> TestClient {
+    let resp: DashboardAccessOut = org_client
+        .post(
+            &format!("api/v1/auth/dashboard-access/{}/", application_id),
+            (),
+            StatusCode::OK,
+        )
+        .await
+        .unwrap();
+
+    let mut app_client = org_client.clone();
+    app_client.set_auth_header(resp.token);
+
+    app_client
+}
+
+#[tokio::test]
+/// Users with application-level tokens should only be allowed to read the information related to
+/// their one application. All other endpoints should error.
+async fn test_restricted_application_access() {
+    let (client, _jh) = start_svix_server();
+
+    let app_id: ApplicationId = client
+        .post::<_, ApplicationOut>(
+            "api/v1/app/",
+            application_in("TEST_APP_NAME"),
+            StatusCode::CREATED,
+        )
+        .await
+        .unwrap()
+        .id;
+    let app_id_2: ApplicationId = client
+        .post::<_, ApplicationOut>(
+            "api/v1/app/",
+            application_in("TEST_APP_NAME_2"),
+            StatusCode::CREATED,
+        )
+        .await
+        .unwrap()
+        .id;
+
+    let client = dashboard_access(&client, &app_id).await;
+
+    // CREATE, UPDATE, DELETE, and LIST ops
+    let _: IgnoredResponse = client
+        .post(
+            "api/v1/app/",
+            application_in("TEST_APP_NAME"),
+            StatusCode::UNAUTHORIZED,
+        )
+        .await
+        .unwrap();
+    let _: IgnoredResponse = client
+        .put(
+            &format!("api/v1/app/{}", app_id),
+            application_in("TEST_APP_NAME"),
+            StatusCode::UNAUTHORIZED,
+        )
+        .await
+        .unwrap();
+    let _: IgnoredResponse = client
+        .delete(&format!("api/v1/app/{}", app_id), StatusCode::UNAUTHORIZED)
+        .await
+        .unwrap();
+    let _: IgnoredResponse = client
+        .get("api/v1/app/", StatusCode::UNAUTHORIZED)
+        .await
+        .unwrap();
+
+    // READ should succeed when accessing the app_id the token is auhtorized for but no others
+    let _: IgnoredResponse = client
+        .get(
+            &format!("api/v1/app/{}", app_id_2),
+            StatusCode::UNAUTHORIZED,
+        )
+        .await
+        .unwrap();
+    let _: ApplicationOut = client
+        .get(&format!("api/v1/app/{}", app_id), StatusCode::OK)
+        .await
+        .unwrap();
+}

--- a/server/svix-server/tests/e2e_auth.rs
+++ b/server/svix-server/tests/e2e_auth.rs
@@ -62,7 +62,7 @@ async fn test_restricted_application_access() {
         .post(
             "api/v1/app/",
             application_in("TEST_APP_NAME"),
-            StatusCode::UNAUTHORIZED,
+            StatusCode::FORBIDDEN,
         )
         .await
         .unwrap();
@@ -70,16 +70,16 @@ async fn test_restricted_application_access() {
         .put(
             &format!("api/v1/app/{}", app_id),
             application_in("TEST_APP_NAME"),
-            StatusCode::UNAUTHORIZED,
+            StatusCode::FORBIDDEN,
         )
         .await
         .unwrap();
     let _: IgnoredResponse = client
-        .delete(&format!("api/v1/app/{}", app_id), StatusCode::UNAUTHORIZED)
+        .delete(&format!("api/v1/app/{}", app_id), StatusCode::FORBIDDEN)
         .await
         .unwrap();
     let _: IgnoredResponse = client
-        .get("api/v1/app/", StatusCode::UNAUTHORIZED)
+        .get("api/v1/app/", StatusCode::FORBIDDEN)
         .await
         .unwrap();
 
@@ -87,7 +87,7 @@ async fn test_restricted_application_access() {
     let _: IgnoredResponse = client
         .get(
             &format!("api/v1/app/{}", app_id_2),
-            StatusCode::UNAUTHORIZED,
+            StatusCode::NOT_FOUND,
         )
         .await
         .unwrap();

--- a/server/svix-server/tests/utils/mod.rs
+++ b/server/svix-server/tests/utils/mod.rs
@@ -228,7 +228,7 @@ pub fn start_svix_server_with_cfg(
 ) -> (TestClient, tokio::task::JoinHandle<()>) {
     let cfg = Arc::new(cfg.clone());
 
-    let token = generate_token(&cfg.jwt_secret, OrganizationId::new(None, None)).unwrap();
+    let token = generate_token(&cfg.jwt_secret, OrganizationId::new(None, None), None).unwrap();
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let base_uri = format!("http://{}", listener.local_addr().unwrap());
 

--- a/server/svix-server/tests/utils/mod.rs
+++ b/server/svix-server/tests/utils/mod.rs
@@ -33,9 +33,9 @@ pub struct TestClient {
 }
 
 impl TestClient {
-	pub fn set_auth_header(&mut self, auth_header: String) {
-		self.auth_header = format!("Bearer {}", auth_header);
-	}
+    pub fn set_auth_header(&mut self, auth_header: String) {
+        self.auth_header = format!("Bearer {}", auth_header);
+    }
 }
 
 /// This struct accepts any JSON response and just ignores it.

--- a/server/svix-server/tests/utils/mod.rs
+++ b/server/svix-server/tests/utils/mod.rs
@@ -25,10 +25,17 @@ use http::HeaderMap;
 
 pub mod common_calls;
 
+#[derive(Clone)]
 pub struct TestClient {
     base_uri: String,
     auth_header: String,
     client: Client,
+}
+
+impl TestClient {
+	pub fn set_auth_header(&mut self, auth_header: String) {
+		self.auth_header = format!("Bearer {}", auth_header);
+	}
 }
 
 /// This struct accepts any JSON response and just ignores it.

--- a/server/svix-server/tests/utils/mod.rs
+++ b/server/svix-server/tests/utils/mod.rs
@@ -16,7 +16,7 @@ use svix_ksuid::KsuidLike;
 use svix_server::{
     cfg::ConfigurationInner,
     core::{
-        security::generate_token,
+        security::generate_org_token,
         types::{BaseId, OrganizationId},
     },
 };
@@ -228,7 +228,7 @@ pub fn start_svix_server_with_cfg(
 ) -> (TestClient, tokio::task::JoinHandle<()>) {
     let cfg = Arc::new(cfg.clone());
 
-    let token = generate_token(&cfg.jwt_secret, OrganizationId::new(None, None), None).unwrap();
+    let token = generate_org_token(&cfg.jwt_secret, OrganizationId::new(None, None)).unwrap();
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let base_uri = format!("http://{}", listener.local_addr().unwrap());
 


### PR DESCRIPTION
Implements the `/auth/dashboard-access/:app_id/` endpoint and associated permissions changes. This makes it so there are tokens valid only for some endpoints. This is meant so that someone using the Svix service may create a token for the owner of an application under their organization to perform limited operations on what falls under the scope of that application.