### PR TITLE
Rename HealthStatusVariants to lowercase via serde

### DIFF
--- a/server/svix-server/src/v1/endpoints/health.rs
+++ b/server/svix-server/src/v1/endpoints/health.rs
@@ -17,6 +17,7 @@ async fn ping() -> StatusCode {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum HealthStatusVariant {
     Ok,
     Error,


### PR DESCRIPTION
Fixes #489 by renaming `Ok` and `Error` variants to `ok` and `error` in serialized output. 