### PR TITLE
Implement support for a log_format cfg var and JSON formatted logs

### DIFF
--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -35,7 +35,7 @@ regex = "1.5.5"
 lazy_static = "1.4.0"
 figment = { version = "0.10", features = ["toml", "env", "test"] }
 tracing = "0.1.29"
-tracing-subscriber = { version="0.3", features = ["env-filter"] }
+tracing-subscriber = { version="0.3", features = ["env-filter", "json"] }
 validator = { version = "0.14.0", features = ["derive"] }
 jwt-simple = "0.10.8"
 chrono = { version="0.4.19", features = ["serde"] }

--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -10,6 +10,8 @@ listen_address = "0.0.0.0:8071"
 
 # The log level to run the service with. Supported: info, debug, trace
 log_level = "info"
+# The log format that all output will follow. Supported: default, json
+log_format = "default"
 
 # The wanted retry schedule in seconds. Each value is the time to wait between retries.
 retry_schedule = [5,300,1800,7200,18000,36000,36000]

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -69,6 +69,8 @@ pub struct ConfigurationInner {
     pub jwt_secret: Keys,
     /// The log level to run the service with. Supported: info, debug, trace
     pub log_level: LogLevel,
+    /// The log format that all output will follow. Supported: default, json
+    pub log_format: LogFormat,
     /// The wanted retry schedule in seconds. Each value is the time to wait between retries.
     #[serde(deserialize_with = "deserialize_retry_schedule")]
     pub retry_schedule: Vec<Duration>,
@@ -104,6 +106,13 @@ pub enum LogLevel {
     Info,
     Debug,
     Trace,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LogFormat {
+    Default,
+    Json,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -63,7 +63,15 @@ async fn main() {
         );
     }
 
-    tracing_subscriber::fmt::init();
+    match cfg.log_format {
+        cfg::LogFormat::Default => {
+            tracing_subscriber::fmt::init();
+        }
+        cfg::LogFormat::Json => {
+            let fmt = tracing_subscriber::fmt::format().json();
+            tracing_subscriber::fmt().event_format(fmt).init();
+        }
+    };
 
     if args.run_migrations {
         db::run_migrations(&cfg).await;


### PR DESCRIPTION
Fixes #492 by creating a new configuration variable `log_format` with the options `default` and `json`. When in JSON mode, all logs are formatted as JSON strings. While in default mode, nothing has changed and the `tracing_subscriber` `Full` logs are used.