### PR TITLE
Add cfg for max pool connections to DBs

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ SVIX_QUEUE_TYPE = "redis"
 
 There are two configuration variables `db_pool_max_size` and `redis_pool_max_size` which control the maximum allowed size of the connection pool for PostgreSQL and Redis respectively.
 
-They default to a max size of 20, but increasing this value can significantly increase performance if your database can handle it.
+They default to a max size of 20, but higher values can significantly increase performance if your database can handle it.
 
 ## Authentication
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,12 @@ SVIX_REDIS_DSN = "redis://redis:6379"
 SVIX_QUEUE_TYPE = "redis"
 ```
 
+### Connection Pool Size
+
+There are two configuration variables `db_pool_max_size` and `redis_pool_max_size` which control the maximum allowed size of the connection pool for PostgreSQL and Redis respectively.
+
+They default to a max size of 20, but increasing this value can significantly increase performance if your database can handle it.
+
 ## Authentication
 
 Use valid JWTs generated with the correct secret as `Bearer`.

--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -19,14 +19,16 @@ retry_schedule = [5,300,1800,7200,18000,36000,36000]
 # The DSN for the database. Only postgres is currently supported.
 db_dsn = "postgresql://postgres:postgres@pgbouncer/postgres"
 
-# The maximum number of connections for the PostgreSQL pool. Minimum value is 10
-db_pool_max_connections = 10
+# The maximum number of connections for the PostgreSQL pool. Minimum value is 10.
+# Increasing this may improve performance in the event there are enough concurrent requests.
+db_pool_max_size = 20
 
 # The DSN for redis (can be left empty if not using redis)
 redis_dsn = "redis://redis:6379"
 
 # The maximum number of connections for the Redis pool. Minimum value of 10
-redis_pool_max_connections = 10
+# Increasing this may improve performance in the event there are enough concurrent requests.
+redis_pool_max_size = 20
 
 # What kind of message queue to use. Supported: memory, redis, rediscluster
 # Redis backends must have a redis_dsn configured, and it's highly recommended to enable persistence in redis so that

--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -19,8 +19,14 @@ retry_schedule = [5,300,1800,7200,18000,36000,36000]
 # The DSN for the database. Only postgres is currently supported.
 db_dsn = "postgresql://postgres:postgres@pgbouncer/postgres"
 
+# The maximum number of connections for the PostgreSQL pool. Minimum value is 10
+db_pool_max_connections = 10
+
 # The DSN for redis (can be left empty if not using redis)
 redis_dsn = "redis://redis:6379"
+
+# The maximum number of connections for the Redis pool. Minimum value of 10
+redis_pool_max_connections = 10
 
 # What kind of message queue to use. Supported: memory, redis, rediscluster
 # Redis backends must have a redis_dsn configured, and it's highly recommended to enable persistence in redis so that
@@ -39,12 +45,6 @@ whitelabel_headers = false
 
 # How long to wait when making a request (in seconds)
 worker_request_timeout = 30
-
-# The maximum number of connections for the PostgreSQL pool. Minimum value of 10, defaults to 100
-db_pool_max_connections = 100
-
-# The maximum number of connections for the Redis pool. Minimum value of 10, defaults to 100
-redis_pool_max_connections = 100
 
 # Should this instance run the API
 api_enabled = true

--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -20,14 +20,14 @@ retry_schedule = [5,300,1800,7200,18000,36000,36000]
 db_dsn = "postgresql://postgres:postgres@pgbouncer/postgres"
 
 # The maximum number of connections for the PostgreSQL pool. Minimum value is 10.
-# Increasing this may improve performance in the event there are enough concurrent requests.
+# Higher values can significantly increase performance if your database can handle it.
 db_pool_max_size = 20
 
 # The DSN for redis (can be left empty if not using redis)
 redis_dsn = "redis://redis:6379"
 
 # The maximum number of connections for the Redis pool. Minimum value of 10
-# Increasing this may improve performance in the event there are enough concurrent requests.
+# Higher values can significantly increase performance if your database can handle it.
 redis_pool_max_size = 20
 
 # What kind of message queue to use. Supported: memory, redis, rediscluster

--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -40,6 +40,12 @@ whitelabel_headers = false
 # How long to wait when making a request (in seconds)
 worker_request_timeout = 30
 
+# The maximum number of connections for the PostgreSQL pool. Minimum value of 10, defaults to 100
+db_pool_max_connections = 100
+
+# The maximum number of connections for the Redis pool. Minimum value of 10, defaults to 100
+redis_pool_max_connections = 100
+
 # Should this instance run the API
 api_enabled = true
 

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -77,8 +77,15 @@ pub struct ConfigurationInner {
 
     /// The DSN for the database. Only postgres is currently supported.
     pub db_dsn: String,
+    // The maximum number of connections for the PostgreSQL pool
+    #[validate(range(min = 10))]
+    pub db_pool_max_connections: u16,
+
     /// The DSN for redis (can be left empty if not using redis)
     pub redis_dsn: Option<String>,
+    /// The maximum number of connections for the Redis pool
+    #[validate(range(min = 10))]
+    pub redis_pool_max_connections: u16,
 
     /// What kind of message queue to use. Supported: memory, redis (must have redis_dsn configured).
     pub queue_type: QueueType,
@@ -93,24 +100,11 @@ pub struct ConfigurationInner {
     #[validate(range(min = 1, max = 30))]
     pub worker_request_timeout: u16,
 
-    // The maximum number of connections for the PostgreSQL pool
-    #[validate(range(min = 10))]
-    #[serde(default = "default_max_connections")]
-    pub db_pool_max_connections: u16,
-    /// The maximum number of connections for the Redis pool
-    #[validate(range(min = 10))]
-    #[serde(default = "default_max_connections")]
-    pub redis_pool_max_connections: u16,
-
     // Execution mode
     /// Should this instance run the API
     pub api_enabled: bool,
     /// Should this instance run the message worker
     pub worker_enabled: bool,
-}
-
-const fn default_max_connections() -> u16 {
-    100
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -93,11 +93,24 @@ pub struct ConfigurationInner {
     #[validate(range(min = 1, max = 30))]
     pub worker_request_timeout: u16,
 
+    // The maximum number of connections for the PostgreSQL pool
+    #[validate(range(min = 10))]
+    #[serde(default = "default_max_connections")]
+    pub db_pool_max_connections: u16,
+    /// The maximum number of connections for the Redis pool
+    #[validate(range(min = 10))]
+    #[serde(default = "default_max_connections")]
+    pub redis_pool_max_connections: u16,
+
     // Execution mode
     /// Should this instance run the API
     pub api_enabled: bool,
     /// Should this instance run the message worker
     pub worker_enabled: bool,
+}
+
+const fn default_max_connections() -> u16 {
+    100
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -79,13 +79,13 @@ pub struct ConfigurationInner {
     pub db_dsn: String,
     // The maximum number of connections for the PostgreSQL pool
     #[validate(range(min = 10))]
-    pub db_pool_max_connections: u16,
+    pub db_pool_max_size: u16,
 
     /// The DSN for redis (can be left empty if not using redis)
     pub redis_dsn: Option<String>,
     /// The maximum number of connections for the Redis pool
     #[validate(range(min = 10))]
-    pub redis_pool_max_connections: u16,
+    pub redis_pool_max_size: u16,
 
     /// What kind of message queue to use. Supported: memory, redis (must have redis_dsn configured).
     pub queue_type: QueueType,

--- a/server/svix-server/src/core/cache/redis.rs
+++ b/server/svix-server/src/core/cache/redis.rs
@@ -114,11 +114,11 @@ mod tests {
     async fn get_pool(redis_dsn: &str, cache_type: &crate::cfg::CacheType) -> RedisPool {
         match cache_type {
             CacheType::RedisCluster => {
-                let mgr = crate::redis::new_redis_pool_clustered(redis_dsn).await;
+                let mgr = crate::redis::new_redis_pool_clustered(redis_dsn, 10).await;
                 mgr
             }
             _ => {
-                let mgr = crate::redis::new_redis_pool(redis_dsn).await;
+                let mgr = crate::redis::new_redis_pool(redis_dsn, 10).await;
                 mgr
             }
         }

--- a/server/svix-server/src/core/cache/redis.rs
+++ b/server/svix-server/src/core/cache/redis.rs
@@ -111,14 +111,14 @@ mod tests {
         }
     }
 
-    async fn get_pool(redis_dsn: &str, cache_type: &crate::cfg::CacheType) -> RedisPool {
-        match cache_type {
+    async fn get_pool(redis_dsn: &str, cfg: &crate::cfg::Configuration) -> RedisPool {
+        match cfg.cache_type {
             CacheType::RedisCluster => {
-                let mgr = crate::redis::new_redis_pool_clustered(redis_dsn, 10).await;
+                let mgr = crate::redis::new_redis_pool_clustered(redis_dsn, cfg).await;
                 mgr
             }
             _ => {
-                let mgr = crate::redis::new_redis_pool(redis_dsn, 10).await;
+                let mgr = crate::redis::new_redis_pool(redis_dsn, cfg).await;
                 mgr
             }
         }
@@ -129,7 +129,7 @@ mod tests {
         dotenv::dotenv().ok();
         let cfg = crate::cfg::load().unwrap();
 
-        let redis_pool = get_pool(cfg.redis_dsn.as_ref().unwrap().as_str(), &cfg.cache_type).await;
+        let redis_pool = get_pool(cfg.redis_dsn.as_ref().unwrap().as_str(), &cfg).await;
         let cache = super::new(redis_pool);
 
         let (first_key, first_val_a, first_val_b) =
@@ -182,7 +182,7 @@ mod tests {
         dotenv::dotenv().ok();
         let cfg = crate::cfg::load().unwrap();
 
-        let redis_pool = get_pool(cfg.redis_dsn.as_ref().unwrap().as_str(), &cfg.cache_type).await;
+        let redis_pool = get_pool(cfg.redis_dsn.as_ref().unwrap().as_str(), &cfg).await;
         let cache = super::new(redis_pool);
 
         let key = TestKeyA::new("key".to_owned());
@@ -200,7 +200,7 @@ mod tests {
         dotenv::dotenv().ok();
         let cfg = crate::cfg::load().unwrap();
 
-        let redis_pool = get_pool(cfg.redis_dsn.as_ref().unwrap().as_str(), &cfg.cache_type).await;
+        let redis_pool = get_pool(cfg.redis_dsn.as_ref().unwrap().as_str(), &cfg).await;
         let cache = super::new(redis_pool);
 
         let key = TestKeyA::new("nx_status_test_key".to_owned());

--- a/server/svix-server/src/db/mod.rs
+++ b/server/svix-server/src/db/mod.rs
@@ -14,6 +14,7 @@ async fn connect(cfg: &Configuration) -> sqlx::Pool<sqlx::Postgres> {
     tracing::debug!("DB: Initializing pool");
     if DbBackend::Postgres.is_prefix_of(&cfg.db_dsn) {
         PgPoolOptions::new()
+            .max_connections(cfg.db_pool_max_connections.into())
             .connect(&cfg.db_dsn)
             .await
             .expect("Error connectiong to Postgres")

--- a/server/svix-server/src/db/mod.rs
+++ b/server/svix-server/src/db/mod.rs
@@ -14,7 +14,7 @@ async fn connect(cfg: &Configuration) -> sqlx::Pool<sqlx::Postgres> {
     tracing::debug!("DB: Initializing pool");
     if DbBackend::Postgres.is_prefix_of(&cfg.db_dsn) {
         PgPoolOptions::new()
-            .max_connections(cfg.db_pool_max_connections.into())
+            .max_connections(cfg.db_pool_max_size.into())
             .connect(&cfg.db_dsn)
             .await
             .expect("Error connectiong to Postgres")

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -55,14 +55,11 @@ pub async fn run_with_prefix(
     tracing::debug!("Cache type: {:?}", cfg.cache_type);
     let cache = match cfg.cache_type {
         CacheType::Redis => {
-            let mgr =
-                crate::redis::new_redis_pool(redis_dsn(), cfg.redis_pool_max_connections).await;
+            let mgr = crate::redis::new_redis_pool(redis_dsn(), &cfg).await;
             cache::redis::new(mgr)
         }
         CacheType::RedisCluster => {
-            let mgr =
-                crate::redis::new_redis_pool_clustered(redis_dsn(), cfg.redis_pool_max_connections)
-                    .await;
+            let mgr = crate::redis::new_redis_pool_clustered(redis_dsn(), &cfg).await;
             cache::redis::new(mgr)
         }
         CacheType::Memory => cache::memory::new(),

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -55,11 +55,14 @@ pub async fn run_with_prefix(
     tracing::debug!("Cache type: {:?}", cfg.cache_type);
     let cache = match cfg.cache_type {
         CacheType::Redis => {
-            let mgr = crate::redis::new_redis_pool(redis_dsn()).await;
+            let mgr =
+                crate::redis::new_redis_pool(redis_dsn(), cfg.redis_pool_max_connections).await;
             cache::redis::new(mgr)
         }
         CacheType::RedisCluster => {
-            let mgr = crate::redis::new_redis_pool_clustered(redis_dsn()).await;
+            let mgr =
+                crate::redis::new_redis_pool_clustered(redis_dsn(), cfg.redis_pool_max_connections)
+                    .await;
             cache::redis::new(mgr)
         }
         CacheType::Memory => cache::memory::new(),

--- a/server/svix-server/src/queue/mod.rs
+++ b/server/svix-server/src/queue/mod.rs
@@ -27,11 +27,14 @@ pub async fn new_pair(
 
     match cfg.queue_type {
         QueueType::Redis => {
-            let pool = crate::redis::new_redis_pool(redis_dsn()).await;
+            let pool =
+                crate::redis::new_redis_pool(redis_dsn(), cfg.redis_pool_max_connections).await;
             redis::new_pair(pool, prefix).await
         }
         QueueType::RedisCluster => {
-            let pool = crate::redis::new_redis_pool_clustered(redis_dsn()).await;
+            let pool =
+                crate::redis::new_redis_pool_clustered(redis_dsn(), cfg.redis_pool_max_connections)
+                    .await;
             redis::new_pair(pool, prefix).await
         }
         QueueType::Memory => memory::new_pair().await,

--- a/server/svix-server/src/queue/mod.rs
+++ b/server/svix-server/src/queue/mod.rs
@@ -27,14 +27,11 @@ pub async fn new_pair(
 
     match cfg.queue_type {
         QueueType::Redis => {
-            let pool =
-                crate::redis::new_redis_pool(redis_dsn(), cfg.redis_pool_max_connections).await;
+            let pool = crate::redis::new_redis_pool(redis_dsn(), cfg).await;
             redis::new_pair(pool, prefix).await
         }
         QueueType::RedisCluster => {
-            let pool =
-                crate::redis::new_redis_pool_clustered(redis_dsn(), cfg.redis_pool_max_connections)
-                    .await;
+            let pool = crate::redis::new_redis_pool_clustered(redis_dsn(), cfg).await;
             redis::new_pair(pool, prefix).await
         }
         QueueType::Memory => memory::new_pair().await,

--- a/server/svix-server/src/queue/redis.rs
+++ b/server/svix-server/src/queue/redis.rs
@@ -611,13 +611,15 @@ pub mod tests {
             CacheType::RedisCluster => {
                 let mgr = crate::redis::new_redis_pool_clustered(
                     cfg.redis_dsn.as_ref().unwrap().as_str(),
+                    10,
                 )
                 .await;
                 mgr
             }
             _ => {
                 let mgr =
-                    crate::redis::new_redis_pool(cfg.redis_dsn.as_ref().unwrap().as_str()).await;
+                    crate::redis::new_redis_pool(cfg.redis_dsn.as_ref().unwrap().as_str(), 10)
+                        .await;
                 mgr
             }
         }

--- a/server/svix-server/src/queue/redis.rs
+++ b/server/svix-server/src/queue/redis.rs
@@ -611,14 +611,14 @@ pub mod tests {
             CacheType::RedisCluster => {
                 let mgr = crate::redis::new_redis_pool_clustered(
                     cfg.redis_dsn.as_ref().unwrap().as_str(),
-                    10,
+                    &cfg,
                 )
                 .await;
                 mgr
             }
             _ => {
                 let mgr =
-                    crate::redis::new_redis_pool(cfg.redis_dsn.as_ref().unwrap().as_str(), 10)
+                    crate::redis::new_redis_pool(cfg.redis_dsn.as_ref().unwrap().as_str(), &cfg)
                         .await;
                 mgr
             }

--- a/server/svix-server/src/redis/mod.rs
+++ b/server/svix-server/src/redis/mod.rs
@@ -282,11 +282,11 @@ async fn new_redis_pool_helper(
 }
 
 pub async fn new_redis_pool_clustered(redis_dsn: &str, cfg: &Configuration) -> RedisPool {
-    new_redis_pool_helper(redis_dsn, true, cfg.redis_pool_max_connections).await
+    new_redis_pool_helper(redis_dsn, true, cfg.redis_pool_max_size).await
 }
 
 pub async fn new_redis_pool(redis_dsn: &str, cfg: &Configuration) -> RedisPool {
-    new_redis_pool_helper(redis_dsn, false, cfg.redis_pool_max_connections).await
+    new_redis_pool_helper(redis_dsn, false, cfg.redis_pool_max_size).await
 }
 
 #[cfg(test)]

--- a/server/svix-server/tests/queue.rs
+++ b/server/svix-server/tests/queue.rs
@@ -19,11 +19,11 @@ use svix_server::{
 pub async fn get_pool(cfg: Configuration) -> RedisPool {
     match cfg.cache_type {
         CacheType::RedisCluster => {
-            let mgr = new_redis_pool_clustered(cfg.redis_dsn.as_ref().unwrap().as_str()).await;
+            let mgr = new_redis_pool_clustered(cfg.redis_dsn.as_ref().unwrap().as_str(), 10).await;
             mgr
         }
         _ => {
-            let mgr = new_redis_pool(cfg.redis_dsn.as_ref().unwrap().as_str()).await;
+            let mgr = new_redis_pool(cfg.redis_dsn.as_ref().unwrap().as_str(), 10).await;
             mgr
         }
     }

--- a/server/svix-server/tests/queue.rs
+++ b/server/svix-server/tests/queue.rs
@@ -19,11 +19,12 @@ use svix_server::{
 pub async fn get_pool(cfg: Configuration) -> RedisPool {
     match cfg.cache_type {
         CacheType::RedisCluster => {
-            let mgr = new_redis_pool_clustered(cfg.redis_dsn.as_ref().unwrap().as_str(), 10).await;
+            let mgr =
+                new_redis_pool_clustered(cfg.redis_dsn.as_ref().unwrap().as_str(), &cfg).await;
             mgr
         }
         _ => {
-            let mgr = new_redis_pool(cfg.redis_dsn.as_ref().unwrap().as_str(), 10).await;
+            let mgr = new_redis_pool(cfg.redis_dsn.as_ref().unwrap().as_str(), &cfg).await;
             mgr
         }
     }


### PR DESCRIPTION
Adds two configuration variables, `db_pool_max_size` and `redis_pool_max_size`.

They both control the maximum connections created in the connection pool for Postgres and Redis respectively.

They default to 20 maximum connections and have a minimum value of 10.

Fixes #490 