### PR TITLE
Make corrections to JSON log format

### DIFF
--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -68,7 +68,7 @@ async fn main() {
             tracing_subscriber::fmt::init();
         }
         cfg::LogFormat::Json => {
-            let fmt = tracing_subscriber::fmt::format().json();
+            let fmt = tracing_subscriber::fmt::format().json().flatten_event(true);
             let filter = tracing_subscriber::EnvFilter::from_default_env();
 
             tracing_subscriber::fmt()

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -69,7 +69,12 @@ async fn main() {
         }
         cfg::LogFormat::Json => {
             let fmt = tracing_subscriber::fmt::format().json();
-            tracing_subscriber::fmt().event_format(fmt).init();
+            let filter = tracing_subscriber::EnvFilter::from_default_env();
+
+            tracing_subscriber::fmt()
+                .event_format(fmt)
+                .with_env_filter(filter)
+                .init();
         }
     };
 


### PR DESCRIPTION
Corrects the JSON log format to add the `EnvFilter` and to flatten events.

Follow up to #496 