### PR TITLE
Python: update httpx and openapi-python-client.

### DIFF
--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -24,8 +24,6 @@ certifi==2021.10.8
     # via
     #   httpcore
     #   httpx
-charset-normalizer==2.0.12
-    # via httpx
 click==8.0.1
     # via
     #   black
@@ -42,10 +40,12 @@ flake8-print==4.0.0
     # via -r requirements.in/development.txt
 h11==0.12.0
     # via httpcore
-httpcore==0.14.7
+httpcore==0.15.0
     # via httpx
-httpx==0.22.0
-    # via openapi-python-client
+httpx==0.23.0
+    # via
+    #   -r requirements.in/development.txt
+    #   openapi-python-client
 idna==3.3
     # via
     #   anyio
@@ -68,7 +68,7 @@ mypy-extensions==0.4.3
     # via
     #   black
     #   mypy
-openapi-python-client==0.11.1
+openapi-python-client==0.11.3
     # via -r requirements.in/development.txt
 packaging==20.9
     # via pytest

--- a/python/requirements.in/development.txt
+++ b/python/requirements.in/development.txt
@@ -7,4 +7,5 @@ pep8-naming
 mypy
 pip-tools
 pytest
-openapi-python-client
+httpx>=0.23.0
+openapi-python-client>=0.11.3

--- a/python/setup.py
+++ b/python/setup.py
@@ -31,7 +31,7 @@ PKG_DIR = os.path.abspath(os.path.dirname(__file__))
 META_PATH = os.path.join(PKG_DIR, PKG_NAME, "__init__.py")
 META_CONTENTS = read_file(META_PATH)
 PKG_REQUIRES = [
-    "httpx >=0.15.4,<0.23.0",
+    "httpx >=0.23.0",
     "attrs >=21.3.0",
     "python-dateutil",
     "Deprecated",
@@ -119,4 +119,3 @@ setup(
     long_description=PKG_README,
     long_description_content_type="text/markdown",
 )
-


### PR DESCRIPTION
httpx had a CVE: CVE-2021-41945
We were not affected by it because it uses code paths that we don't use,
though being a dependency we were still forcing an old version which is
not good.

We would have updated it before, but openapi-python-client was blocking
us. They just relesaed a version.