### PR TITLE
Server: fix caching dependencies for docker builds

### DIFF
--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,5 +1,7 @@
 # will have compiled files and executables
 target/
+# We don't want it to bust our docker build cache
+Cargo.lock
 
 /tmp
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -8,13 +8,20 @@ RUN set -ex ; \
         mkdir -p /home/appuser ;\
         chown -R appuser: /home/appuser
 
-USER appuser
-
 WORKDIR /app
-COPY . .
 
-WORKDIR /app/svix-server
-RUN cargo install --path .
+# Hack to enable docker caching
+COPY Cargo.toml .
+COPY svix-server_derive svix-server_derive
+COPY svix-server/Cargo.toml svix-server/
+RUN set -ex ;\
+        mkdir svix-server/src ;\
+        echo 'fn main() { println!("Dummy!"); }' > svix-server/src/main.rs ;\
+        cargo build --release ;\
+        rm -rf svix-server/src
+
+COPY . .
+RUN cargo build --release --frozen
 
 # Production
 FROM debian:11.2-slim AS prod
@@ -35,7 +42,7 @@ USER appuser
 EXPOSE 8080
 
 COPY ./wait-for /usr/local/bin/wait-for
-COPY --from=build /usr/local/cargo/bin/svix-server /usr/local/bin/svix-server
+COPY --from=build /app/target/release/svix-server /usr/local/bin/svix-server
 
 # Ignoring this lint, because it's an embedded shell script
 # hadolint ignore=DL3025


### PR DESCRIPTION
The problem is that in order to build deps we need the full source tree.
This fix just adds a dummy source tree so that we can build and cache
the deps before doing a full build.

This is still an incomplete solution. It caches all of the deps, but it
still doesn't cache the building of the main binary. So it's 10x better
than what we have now, but there's still 10x more to go.

One day Cargo will hopefully fix it:
https://github.com/rust-lang/cargo/issues/2644

Solution from:
https://stackoverflow.com/questions/58473606/cache-rust-dependencies-with-docker-build