### PR TITLE
Fix clippy warning caused by clap derive macro

### DIFF
--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -21,7 +21,7 @@ struct Args {
     #[clap(subcommand)]
     command: Option<Commands>,
     /// Run database migrations before starting
-    #[clap(long)]
+    #[clap(long, value_parser)]
     run_migrations: bool,
 }
 


### PR DESCRIPTION
A deprecated function was being called in the clap macro due to changes in their API. The issue is described here https://github.com/clap-rs/clap/issues/3822.