### PR TITLE
Update clap version to latest in Cargo.toml

### DIFF
--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -18,7 +18,7 @@ svix-ksuid = "^0.5.1"
 dotenv = "0.15.0"
 getrandom = "0.2.4"
 hmac-sha256 = "1"
-clap = { version = "3.0.10", features = ["derive"] }
+clap = { version = "3.2.1", features = ["derive"] }
 axum = { version = "0.5.1", features = ["headers"] }
 base64 = "0.13.0"
 hyper = { version = "0.14.16", features = ["full"] }


### PR DESCRIPTION
Ensures that the latest version of clap is used for the workaround in #505 to work.