### PR TITLE
Send operational webhooks from worker and endpoint API

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,16 @@ Example valid JWT for the secret `x` (so you can see the structure):
 }
 ```
 
+## Operational (incoming) webhooks
+
+Operational webhooks are webhooks that you can subscribe to in order to get notified of important events occurring on the svix-server. The list of supported events is available in [the webhooks section of the API reference](https://api.svix.com/docs#tag/Webhooks).
+
+The operational webhooks utilize Svix, and are controlled by a special account with the following ID: `org_00000000000SvixManagement00`.
+To turn operational webhooks on, set the `operational_webhook_address` config to point to your Svix server, and create a JWT for the special account.
+Once those are set, create an `Application` with the `uid` set to the `org_id` you're interested in, and add `Endpoint`s for all of the events you'd like to subscribe to.
+
+For example, for the default account, just create an app with the `uid` set to `org_23rb8YdGqMT0qIzpgGwdXfHirMu`.
+
 
 # Differences to the Svix hosted service
 

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -14,6 +14,7 @@ publish = false
 [dependencies]
 svix-server_derive = { path = "../svix-server_derive" }
 
+svix = "0.60"
 svix-ksuid = "^0.5.1"
 dotenv = "0.15.0"
 getrandom = "0.2.4"
@@ -57,4 +58,3 @@ url = "2.2.2"
 
 [dev-dependencies]
 anyhow = "1.0.56"
-svix = "0"

--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -5,6 +5,12 @@
 # The address to listen on
 listen_address = "0.0.0.0:8071"
 
+# The address of the Svix server to use for sending operational webhooks (disabled when omitted/null)
+# Operational webhooks (otherwise known as "incoming webhooks"), are webhooks
+# send from the Svix server to you, to let you know when some events happen.
+# For a list of supported events please refer to: https://api.svix.com/docs#tag/Webhooks
+# operational_webhook_address = "http://127.0.0.1:8071"
+
 # The JWT secret for authentication - should be secret and securely generated
 # jwt_secret = "8KjzRXrKkd9YFcNyqLSIY8JwiaCeRc6WK4UkMnSW"
 

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -64,6 +64,11 @@ pub type Configuration = Arc<ConfigurationInner>;
 pub struct ConfigurationInner {
     /// The address to listen on
     pub listen_address: String,
+
+    /// The address to send operational webhooks to. When None, operational webhooks will not be
+    /// sent. When Some, the API server with the given URL will be used to send operational webhooks.
+    pub operational_webhook_address: Option<String>,
+
     /// The JWT secret for authentication - should be secret and securely generated
     #[serde(deserialize_with = "deserialize_jwt_secret")]
     pub jwt_secret: Keys,

--- a/server/svix-server/src/core/message_app.rs
+++ b/server/svix-server/src/core/message_app.rs
@@ -105,7 +105,7 @@ impl CreateMessageApp {
     }
 
     pub fn filtered_endpoints(
-        self,
+        &self,
         trigger_type: MessageAttemptTriggerType,
         msg: &message::Model,
     ) -> Vec<CreateMessageEndpoint> {

--- a/server/svix-server/src/core/mod.rs
+++ b/server/svix-server/src/core/mod.rs
@@ -4,6 +4,7 @@
 pub mod cache;
 pub mod idempotency;
 pub mod message_app;
+pub mod operational_webhooks;
 pub mod security;
 pub mod types;
 

--- a/server/svix-server/src/core/operational_webhooks.rs
+++ b/server/svix-server/src/core/operational_webhooks.rs
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: © 2022 Svix Authors
+// SPDX-License-Identifier: MIT
+
+//! Module defining an interface for sending webhook events about the service.
+
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use http::StatusCode;
+use serde::Serialize;
+use svix::api::{MessageIn, Svix, SvixOptions};
+
+use super::{
+    security::{generate_management_token, Keys},
+    types::{
+        ApplicationId, ApplicationUid, EndpointId, EndpointUid, MessageAttemptId, MessageId,
+        MessageUid, OrganizationId,
+    },
+};
+use crate::{
+    db::models::messageattempt,
+    error::{HttpError, Result},
+};
+
+/// Sent when an endpoint has been automatically disabled after continuous failures.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EndpointDisabledEvent<'a> {
+    pub app_id: &'a ApplicationId,
+    pub app_uid: Option<&'a ApplicationUid>,
+    pub endpoint_id: &'a EndpointId,
+    pub endpoint_uid: Option<&'a EndpointUid>,
+    pub fail_since: DateTime<Utc>,
+}
+
+/// Sent when an endpoint is created, updated, or deleted
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EndpointEvent<'a> {
+    pub app_id: &'a ApplicationId,
+    pub app_uid: Option<&'a ApplicationUid>,
+    pub endpoint_id: &'a EndpointId,
+    pub endpoint_uid: Option<&'a EndpointUid>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MessageAttempetLast<'a> {
+    pub id: &'a MessageAttemptId,
+    pub response_status_code: i16,
+    pub timestamp: DateTime<Utc>,
+}
+
+impl<'a> From<&'a messageattempt::Model> for MessageAttempetLast<'a> {
+    fn from(attempt: &'a messageattempt::Model) -> Self {
+        Self {
+            id: &attempt.id,
+            response_status_code: attempt.response_status_code,
+            timestamp: attempt.created_at.into(),
+        }
+    }
+}
+
+/// Sent when a message delivery has failed (all of the retry attempts have been exhausted) as a
+/// "message.attempt.exhausted" type or after it's failed four times as a "message.attempt.failing"
+/// event.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MessageAttemptEvent<'a> {
+    pub app_id: &'a ApplicationId,
+    pub app_uid: Option<&'a ApplicationUid>,
+    pub msg_id: &'a MessageId,
+    pub msg_event_id: Option<&'a MessageUid>,
+    pub endpoint_id: &'a EndpointId,
+    pub last_attempt: MessageAttempetLast<'a>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", content = "data")]
+pub enum OperationalWebhook<'a> {
+    #[serde(rename = "endpoint.disabled")]
+    EndpointDisabled(EndpointDisabledEvent<'a>),
+    #[serde(rename = "endpoint.created")]
+    EndpointCreated(EndpointEvent<'a>),
+    #[serde(rename = "endpoint.updated")]
+    EndpointUpdated(EndpointEvent<'a>),
+    #[serde(rename = "endpoint.deleted")]
+    EndpointDeleted(EndpointEvent<'a>),
+    #[serde(rename = "message.attempt.exhausted")]
+    MessageAttemptExhausted(MessageAttemptEvent<'a>),
+    #[serde(rename = "message.attempt.failing")]
+    MessageAttemptFailing(MessageAttemptEvent<'a>),
+}
+
+pub type OperationalWebhookSender = Arc<OperationalWebhookSenderInner>;
+
+pub struct OperationalWebhookSenderInner {
+    keys: Keys,
+    url: Option<String>,
+}
+
+impl OperationalWebhookSenderInner {
+    pub fn new(keys: Keys, url: Option<String>) -> Arc<Self> {
+        Arc::new(Self { keys, url })
+    }
+
+    pub async fn send_operational_webhook(
+        &self,
+        recipient_org_id: &OrganizationId,
+        payload: OperationalWebhook<'_>,
+    ) -> Result<()> {
+        let url = match self.url.as_ref() {
+            Some(url) => url,
+            None => return Ok(()),
+        };
+
+        let op_webhook_token =
+            generate_management_token(&self.keys).expect("Error generating Svix Management token");
+        let svix_api = Svix::new(
+            op_webhook_token,
+            Some(SvixOptions {
+                server_url: Some(url.to_string()),
+                debug: false,
+            }),
+        );
+
+        let payload = serde_json::to_value(&payload)
+            .map_err(|_| HttpError::internal_server_errer(None, None))?;
+
+        // Get the event type from the type field
+        let event_type: String = payload
+            .get("type")
+            .ok_or_else(|| HttpError::internal_server_errer(None, None))?
+            .as_str()
+            .ok_or_else(|| HttpError::internal_server_errer(None, None))?
+            .to_string();
+
+        let recipient_org_id = recipient_org_id.to_string();
+
+        tokio::spawn(async move {
+            // This sends a webhook under the Svix management organization. This organization contains
+            // applications which are each a regular organization. The recipient's OrganizationId is the
+            // app UID to use.
+            let resp = svix_api
+                .message()
+                .create(
+                    recipient_org_id.clone(),
+                    MessageIn {
+                        event_type,
+                        payload,
+                        ..MessageIn::default()
+                    },
+                    None,
+                )
+                .await;
+
+            match resp {
+                Ok(_) => {}
+                // Ignore 404s because not every org will have an associated application
+                Err(svix::error::Error::Http(svix::error::HttpErrorContent {
+                    status: StatusCode::NOT_FOUND,
+                    ..
+                })) => {
+                    tracing::warn!(
+                        "Operational webhooks are enabled but no listener set for {}",
+                        recipient_org_id,
+                    );
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "Failed sending operational webhook for {} {}",
+                        recipient_org_id,
+                        e.to_string()
+                    );
+                }
+            }
+        });
+
+        Ok(())
+    }
+}

--- a/server/svix-server/src/core/security.rs
+++ b/server/svix-server/src/core/security.rs
@@ -26,6 +26,11 @@ pub fn default_org_id() -> OrganizationId {
     OrganizationId("org_23rb8YdGqMT0qIzpgGwdXfHirMu".to_owned())
 }
 
+/// The default org_id we use (useful for generating JWTs when testing).
+pub fn management_org_id() -> OrganizationId {
+    OrganizationId("org_00000000000SvixManagement00".to_owned())
+}
+
 fn to_internal_server_error(x: impl Display) -> HttpError {
     tracing::error!("Error: {}", x);
     HttpError::internal_server_errer(None, None)
@@ -245,6 +250,14 @@ pub fn generate_org_token(keys: &Keys, org_id: OrganizationId) -> Result<String>
     )
     .with_issuer(JWT_ISSUER)
     .with_subject(org_id.0);
+    Ok(keys.key.authenticate(claims).unwrap())
+}
+
+pub fn generate_management_token(keys: &Keys) -> Result<String> {
+    let claims =
+        Claims::with_custom_claims(CustomClaim { organization: None }, Duration::from_mins(10))
+            .with_issuer(JWT_ISSUER)
+            .with_subject(management_org_id());
     Ok(keys.key.authenticate(claims).unwrap())
 }
 

--- a/server/svix-server/tests/e2e_operational_webhooks.rs
+++ b/server/svix-server/tests/e2e_operational_webhooks.rs
@@ -1,0 +1,403 @@
+// SPDX-FileCopyrightText: © 2022 Svix Authors
+// SPDX-License-Identifier: MIT
+
+use std::{net::TcpListener, sync::Arc, time::Duration};
+
+use chrono::{DateTime, Utc};
+use http::StatusCode;
+
+use serde::Deserialize;
+use svix_ksuid::KsuidLike;
+use svix_server::{
+    cfg::ConfigurationInner,
+    core::{
+        security::{generate_org_token, management_org_id},
+        types::{
+            ApplicationId, ApplicationUid, BaseId, EndpointId, EndpointUid, MessageAttemptId,
+            MessageId, MessageUid, OrganizationId,
+        },
+    },
+    v1::endpoints::{
+        application::{ApplicationIn, ApplicationOut},
+        endpoint::{EndpointIn, EndpointOut},
+    },
+};
+
+mod utils;
+use utils::{
+    common_calls::{create_test_app, create_test_endpoint, create_test_message},
+    get_default_test_config, IgnoredResponse, TestClient, TestReceiver,
+};
+
+/// Sent when an endpoint has been automatically disabled after continuous failures.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EndpointDisabledEvent {
+    pub app_id: ApplicationId,
+    pub app_uid: Option<ApplicationUid>,
+    pub endpoint_id: EndpointId,
+    pub endpoint_uid: Option<EndpointUid>,
+    pub fail_since: DateTime<Utc>,
+}
+
+/// Sent when an endpoint is created, updated, or deleted
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EndpointEvent {
+    pub app_id: ApplicationId,
+    pub app_uid: Option<ApplicationUid>,
+    pub endpoint_id: EndpointId,
+    pub endpoint_uid: Option<EndpointUid>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MessageAttempetLast {
+    pub id: MessageAttemptId,
+    pub response_status_code: i16,
+    pub timestamp: DateTime<Utc>,
+}
+
+/// Sent when a message delivery has failed (all of the retry attempts have been exhausted) as a
+/// "message.attempt.exhausted" type or after it's failed four times as a "message.attempt.failing"
+/// event.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MessageAttemptEvent {
+    pub app_id: ApplicationId,
+    pub app_uid: Option<ApplicationUid>,
+    pub msg_id: MessageId,
+    pub msg_event_id: Option<MessageUid>,
+    pub endpoint_id: EndpointId,
+    pub last_attempt: MessageAttempetLast,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", content = "data")]
+pub enum OperationalWebhookTest {
+    #[serde(rename = "endpoint.disabled")]
+    EndpointDisabled(EndpointDisabledEvent),
+    #[serde(rename = "endpoint.created")]
+    EndpointCreated(EndpointEvent),
+    #[serde(rename = "endpoint.updated")]
+    EndpointUpdated(EndpointEvent),
+    #[serde(rename = "endpoint.deleted")]
+    EndpointDeleted(EndpointEvent),
+    #[serde(rename = "message.attempt.exhausted")]
+    MessageAttemptExhausted(MessageAttemptEvent),
+    #[serde(rename = "message.attempt.failing")]
+    MessageAttemptFailing(MessageAttemptEvent),
+}
+
+/// Operational webhooks are dispatched by a special organization, so this function returns two
+/// [`TestClient`]s, one with the Svix Management org token, and one with a random org token.
+///
+/// Additionally it returns the [`OrganizationId`] of the random  organization such that it may be
+/// included as an application of the of the Operational webhooks organization.
+fn start_svix_server_with_operational_webhooks(
+    mut cfg: ConfigurationInner,
+) -> (
+    TestClient,
+    TestClient,
+    OrganizationId,
+    tokio::task::JoinHandle<()>,
+) {
+    let op_webhook_jwt = generate_org_token(&cfg.jwt_secret, management_org_id()).unwrap();
+
+    let org_id = OrganizationId::new(None, None);
+    let regular_jwt = generate_org_token(&cfg.jwt_secret, org_id.clone()).unwrap();
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let base_url = format!("http://{}", listener.local_addr().unwrap());
+
+    cfg.operational_webhook_address = Some(base_url.clone());
+    let cfg = Arc::new(cfg);
+
+    let jh = tokio::spawn(svix_server::run_with_prefix(
+        Some(svix_ksuid::Ksuid::new(None, None).to_string()),
+        cfg,
+        Some(listener),
+    ));
+
+    (
+        TestClient::new(base_url.clone(), &regular_jwt),
+        TestClient::new(base_url, &op_webhook_jwt),
+        org_id,
+        jh,
+    )
+}
+
+#[tokio::test]
+async fn test_endpoint_create_update_and_delete() {
+    let cfg = get_default_test_config();
+
+    let (client_regular, client_op, org_id, _jh) = start_svix_server_with_operational_webhooks(cfg);
+
+    // Setup operational webhook Application and Endpoint
+    let op_webhook_app: ApplicationOut = client_op
+        .post(
+            "api/v1/app/",
+            ApplicationIn {
+                name: "TestOperationalWebhookApplication".to_owned(),
+                rate_limit: None,
+                uid: Some(ApplicationUid(org_id.to_string())),
+            },
+            StatusCode::CREATED,
+        )
+        .await
+        .unwrap();
+
+    let mut receiver = TestReceiver::start(StatusCode::OK);
+
+    let _op_webhook_endp: EndpointOut = client_op
+        .post(
+            &format!("api/v1/app/{}/endpoint/", op_webhook_app.id),
+            EndpointIn {
+                description: "TestOperationalWebhookEndpoint".to_owned(),
+                url: receiver.endpoint.clone(),
+                version: 1,
+                ..Default::default()
+            },
+            StatusCode::CREATED,
+        )
+        .await
+        .unwrap();
+
+    // Setup regular Application and Endpoint
+    let regular_app = create_test_app(&client_regular, "TestOperationalWebhookApplicationRegular")
+        .await
+        .unwrap();
+    let regular_endp = create_test_endpoint(&client_regular, &regular_app.id, "http://junk.url")
+        .await
+        .unwrap();
+
+    let op_webhook_out = receiver.data_recv.recv().await.unwrap();
+    assert_eq!(
+        op_webhook_out.get("type").unwrap().as_str().unwrap(),
+        "endpoint.created"
+    );
+    let op_webhook_out: OperationalWebhookTest = serde_json::from_value(op_webhook_out).unwrap();
+
+    match op_webhook_out {
+        OperationalWebhookTest::EndpointCreated(EndpointEvent {
+            app_id,
+            app_uid,
+            endpoint_id,
+            endpoint_uid,
+        }) => {
+            assert_eq!(app_id, regular_app.id);
+            assert_eq!(app_uid, regular_app.uid);
+            assert_eq!(endpoint_id, regular_endp.id);
+            assert_eq!(endpoint_uid, regular_endp.uid);
+        }
+        _ => panic!("Got wrong type"),
+    };
+
+    // Update endpoint
+    let regular_endp: EndpointOut = client_regular
+        .put(
+            &format!(
+                "api/v1/app/{}/endpoint/{}/",
+                regular_app.id, regular_endp.id
+            ),
+            EndpointIn {
+                description: "Updated description".to_owned(),
+                url: receiver.endpoint,
+                version: 2,
+                ..Default::default()
+            },
+            StatusCode::OK,
+        )
+        .await
+        .unwrap();
+
+    let op_webhook_out = receiver.data_recv.recv().await.unwrap();
+    assert_eq!(
+        op_webhook_out.get("type").unwrap().as_str().unwrap(),
+        "endpoint.updated"
+    );
+    let op_webhook_out: OperationalWebhookTest = serde_json::from_value(op_webhook_out).unwrap();
+
+    match op_webhook_out {
+        OperationalWebhookTest::EndpointUpdated(EndpointEvent {
+            app_id,
+            app_uid,
+            endpoint_id,
+            endpoint_uid,
+        }) => {
+            assert_eq!(app_id, regular_app.id);
+            assert_eq!(app_uid, regular_app.uid);
+            assert_eq!(endpoint_id, regular_endp.id);
+            assert_eq!(endpoint_uid, regular_endp.uid);
+        }
+        _ => panic!("Got wrong type"),
+    };
+
+    // And finally delete the endpoint
+    let _: IgnoredResponse = client_regular
+        .delete(
+            &format!(
+                "api/v1/app/{}/endpoint/{}/",
+                regular_app.id, regular_endp.id
+            ),
+            StatusCode::NO_CONTENT,
+        )
+        .await
+        .unwrap();
+
+    let op_webhook_out = receiver.data_recv.recv().await.unwrap();
+    assert_eq!(
+        op_webhook_out.get("type").unwrap().as_str().unwrap(),
+        "endpoint.deleted"
+    );
+    let op_webhook_out: OperationalWebhookTest = serde_json::from_value(op_webhook_out).unwrap();
+
+    match op_webhook_out {
+        OperationalWebhookTest::EndpointDeleted(EndpointEvent {
+            app_id,
+            app_uid,
+            endpoint_id,
+            endpoint_uid,
+        }) => {
+            assert_eq!(app_id, regular_app.id);
+            assert_eq!(app_uid, regular_app.uid);
+            assert_eq!(endpoint_id, regular_endp.id);
+            assert_eq!(endpoint_uid, regular_endp.uid);
+        }
+        _ => panic!("Got wrong type"),
+    };
+}
+
+#[tokio::test]
+async fn test_message_attempt_operational_webhooks() {
+    let mut cfg = get_default_test_config();
+
+    cfg.retry_schedule = (0..5)
+        .into_iter()
+        .map(|_| Duration::from_millis(1))
+        .collect();
+
+    let (client_regular, client_op, org_id, _jh) = start_svix_server_with_operational_webhooks(cfg);
+
+    // Setup operational webhook Application and Endpoint
+    let op_webhook_app: ApplicationOut = client_op
+        .post(
+            "api/v1/app/",
+            ApplicationIn {
+                name: "TestOperationalWebhookApplication".to_owned(),
+                rate_limit: None,
+                uid: Some(ApplicationUid(org_id.to_string())),
+            },
+            StatusCode::CREATED,
+        )
+        .await
+        .unwrap();
+
+    let mut receiver = TestReceiver::start(StatusCode::OK);
+
+    let _op_webhook_endp: EndpointOut = client_op
+        .post(
+            &format!("api/v1/app/{}/endpoint/", op_webhook_app.id),
+            EndpointIn {
+                description: "TestOperationalWebhookEndpoint".to_owned(),
+                url: receiver.endpoint.clone(),
+                version: 1,
+                ..Default::default()
+            },
+            StatusCode::CREATED,
+        )
+        .await
+        .unwrap();
+
+    // Setup regular Application and Endpoint
+    let regular_app = create_test_app(&client_regular, "TestOperationalWebhookApplicationRegular")
+        .await
+        .unwrap();
+    let regular_endp = create_test_endpoint(&client_regular, &regular_app.id, "http://junk.url")
+        .await
+        .unwrap();
+
+    // Receive the EndpointCreatedEvent so it's not in the data_recv queue
+    let op_webhook_out = receiver.data_recv.recv().await.unwrap();
+    assert_eq!(
+        op_webhook_out.get("type").unwrap().as_str().unwrap(),
+        "endpoint.created"
+    );
+    let op_webhook_out: OperationalWebhookTest = serde_json::from_value(op_webhook_out).unwrap();
+
+    match op_webhook_out {
+        OperationalWebhookTest::EndpointCreated(EndpointEvent {
+            app_id,
+            app_uid,
+            endpoint_id,
+            endpoint_uid,
+        }) => {
+            assert_eq!(app_id, regular_app.id);
+            assert_eq!(app_uid, regular_app.uid);
+            assert_eq!(endpoint_id, regular_endp.id);
+            assert_eq!(endpoint_uid, regular_endp.uid);
+        }
+        _ => panic!("Got wrong type"),
+    };
+
+    // Create a message
+    let regular_msg = create_test_message(
+        &client_regular,
+        &regular_app.id,
+        serde_json::json!({"test": "data"}),
+    )
+    .await
+    .unwrap();
+
+    // Wait a little to ensure they've been processed
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    // Assert first the MessageAttemptFailingEvent was received then the MessageAttemptExhaustedEvent
+    let op_webhook_out = receiver.data_recv.recv().await.unwrap();
+    assert_eq!(
+        op_webhook_out.get("type").unwrap().as_str().unwrap(),
+        "message.attempt.failing"
+    );
+    let op_webhook_out: OperationalWebhookTest = serde_json::from_value(op_webhook_out).unwrap();
+
+    if let OperationalWebhookTest::MessageAttemptFailing(MessageAttemptEvent {
+        app_id,
+        app_uid,
+        msg_id,
+        endpoint_id,
+        // Rest aren't practical to test
+        ..
+    }) = op_webhook_out
+    {
+        assert_eq!(app_id, regular_app.id);
+        assert_eq!(app_uid, regular_app.uid);
+        assert_eq!(msg_id, regular_msg.id);
+        assert_eq!(endpoint_id, regular_endp.id);
+    } else {
+        panic!("Invalid type for op_webhook_out")
+    }
+
+    let op_webhook_out = receiver.data_recv.recv().await.unwrap();
+    assert_eq!(
+        op_webhook_out.get("type").unwrap().as_str().unwrap(),
+        "message.attempt.exhausted"
+    );
+    let op_webhook_out: OperationalWebhookTest = serde_json::from_value(op_webhook_out).unwrap();
+
+    if let OperationalWebhookTest::MessageAttemptExhausted(MessageAttemptEvent {
+        app_id,
+        app_uid,
+        msg_id,
+        endpoint_id,
+        // Rest aren't practical to test
+        ..
+    }) = op_webhook_out
+    {
+        assert_eq!(app_id, regular_app.id);
+        assert_eq!(app_uid, regular_app.uid);
+        assert_eq!(msg_id, regular_msg.id);
+        assert_eq!(endpoint_id, regular_endp.id);
+    } else {
+        panic!("Invalid type for op_webhook_out")
+    }
+}


### PR DESCRIPTION
Sends "operational webhooks" about the status of endpoints and messages as per the models defined here: https://api.svix.com/docs#tag/Webhooks. 