### PR TITLE
Server: add support for CORS and pre-flight requests.

### DIFF
--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -24,7 +24,7 @@ base64 = "0.13.0"
 hyper = { version = "0.14.16", features = ["full"] }
 tokio = { version = "1.15.0", features = ["full"] }
 tower = "0.4.11"
-tower-http = { version = "0.2.0", features = ["trace"] }
+tower-http = { version = "0.2.0", features = ["trace", "cors"] }
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"
 serde_urlencoded = "0.7.1"

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -12,6 +12,7 @@ use std::{
     str::FromStr,
 };
 use tower::ServiceBuilder;
+use tower_http::cors::{Any, CorsLayer};
 use tower_http::trace::TraceLayer;
 
 use crate::{
@@ -78,6 +79,13 @@ pub async fn run_with_prefix(
                 cache: cache.clone(),
                 service,
             }),
+        )
+        .layer(
+            CorsLayer::new()
+                .allow_credentials(true)
+                .allow_origin(Any)
+                .allow_methods(Any)
+                .allow_headers(Any),
         )
         .layer(TraceLayer::new_for_http().on_request(()))
         .layer(Extension(pool.clone()))


### PR DESCRIPTION
This is needed in order to allow calls from the browser.
The Svix API should be accessible from the browser because
we provide client-side tokens that should be used directly
from the frontend.

This fixes the frontend to work.