### PR TITLE
Server: make the application portal URL configurable.

### DIFF
--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -115,10 +115,18 @@ pub struct InternalConfig {
     /// The region to use in the Svix URL given in th dashboard access endpoint
     #[serde(default = "default_region")]
     pub region: String,
+
+    /// The base url to use for the app portal
+    #[serde(default = "default_app_portal_url")]
+    pub app_portal_url: String,
 }
 
 fn default_region() -> String {
     "eu".to_owned()
+}
+
+fn default_app_portal_url() -> String {
+    "https://app.svix.com".to_owned()
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/server/svix-server/src/v1/endpoints/auth.rs
+++ b/server/svix-server/src/v1/endpoints/auth.rs
@@ -14,8 +14,6 @@ pub struct DashboardAccessOut {
     pub token: String,
 }
 
-const SVIX_URL: &str = "https://app.svix.com";
-
 async fn dashboard_access(
     Extension(cfg): Extension<Configuration>,
     AuthenticatedOrganizationWithApplication { permissions, app }: AuthenticatedOrganizationWithApplication,
@@ -32,7 +30,7 @@ async fn dashboard_access(
     let login_key = base64::encode(&login_key);
 
     // Included for API compatibility, but this URL will not be useful
-    let url = format!("{}/login#key={}", SVIX_URL, login_key);
+    let url = format!("{}/login#key={}", &cfg.internal.app_portal_url, login_key);
 
     Ok(Json(DashboardAccessOut { url, token }))
 }


### PR DESCRIPTION
This shouldn't be used for now, and is only used for internal purposes.
In the future we may want to expose it in the configuration to make it
easy to implement custom application portals.

We just don't want to do it yet to not force us to have the URL structure
a de-facto API.