### PR TITLE
Swap validation and HTTP error variants in error conversion code

### DIFF
--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -52,12 +52,12 @@ impl<T> From<crate::apis::Error<T>> for Error {
         match err {
             crate::apis::Error::ResponseError(e) => {
                 if e.status == status::StatusCode::UNPROCESSABLE_ENTITY {
-                    Error::Http(HttpErrorContent {
+                    Error::Validation(HttpErrorContent {
                         status: e.status,
                         payload: serde_json::from_str(&e.content).ok(),
                     })
                 } else {
-                    Error::Validation(HttpErrorContent {
+                    Error::Http(HttpErrorContent {
                         status: e.status,
                         payload: serde_json::from_str(&e.content).ok(),
                     })


### PR DESCRIPTION
This fixes a bug in the Rust lib where validation errors are returned on any HTTP status but unprocessable entity and HTTP errors are only returned on unprocessable entity responses by swapping the variants in the conversion from another error type.