### PR TITLE
Server: clarify the error message to show migrations have ran.

### DIFF
--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -94,13 +94,13 @@ async fn main() {
 
     if args.run_migrations {
         db::run_migrations(&cfg).await;
-        println!("Migrations run");
+        tracing::debug!("Migrations: success");
     }
 
     match args.command {
         Some(Commands::Migrate) => {
             db::run_migrations(&cfg).await;
-            println!("Migrations run");
+            println!("Migrations: success");
             exit(0);
         }
         Some(Commands::Jwt {


### PR DESCRIPTION
It was very confusing before and confused both myself and a customer
when we were trying to figure out why migrations are failing, when
in fact they were not.