### PR TITLE
Server: enable redis persistence in example docker-compose.

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -32,6 +32,11 @@ services:
       MAX_CLIENT_CONN: 500
   redis:
     image: "redis:6.2-alpine"
+    # Enable persistence
+    command: "--save 60 500 --appendonly yes --appendfsync everysec"
+    volumes:
+      - "redis-data:/data"
 
 volumes:
   postgres-data:
+  redis-data:


### PR DESCRIPTION
While this file was not originally intended for production use, it can
definitely be used for that. Additionally, production use or not, people
will take inspiration from it, so it's better to be explicit about the
fact that redis should be persisted when used as the queue mechanism.

Fixes #404