### PR TITLE
fix: Endpoint spelling in some error messages and comments

### DIFF
--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -103,7 +103,7 @@ impl AttemptedMessageOut {
 }
 
 /// Additional parameters (besides pagination) in the query string for the "List Attempted Messages"
-/// enpoint.
+/// endpoint.
 #[derive(Debug, Deserialize, Validate)]
 pub struct ListAttemptedMessagesQueryParameters {
     #[validate]
@@ -209,7 +209,7 @@ async fn list_attempted_messages(
 }
 
 /// Additional parameters (besides pagination) in the query string for the "List Attempts by
-/// Endpoint" enpoint.
+/// Endpoint" endpoint.
 #[derive(Debug, Deserialize, Validate)]
 pub struct ListAttemptsByEndpointQueryParameters {
     status: Option<MessageStatus>,

--- a/server/svix-server/src/v1/endpoints/endpoint/crud.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/crud.rs
@@ -241,7 +241,7 @@ fn validate_endpoint_url(url: &str, https_only: bool) -> Result<()> {
             } else {
                 Err(HttpError::unprocessable_entity(vec![ValidationErrorItem {
                     loc: vec!["body".to_owned(), "url".to_owned()],
-                    msg: "Enpoint URL schemes must be https when endpoint_https_only is set."
+                    msg: "Endpoint URL schemes must be https when endpoint_https_only is set."
                         .to_owned(),
                     ty: "value_error".to_owned(),
                 }])

--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -70,7 +70,7 @@ pub fn validate_url(val: &str) -> std::result::Result<(), ValidationError> {
                 Ok(())
             } else {
                 Err(ValidationError::new(
-                    "Enpoint URL schemes must be http or https",
+                    "Endpoint URL schemes must be http or https",
                 ))
             }
         }

--- a/server/svix-server/tests/worker.rs
+++ b/server/svix-server/tests/worker.rs
@@ -109,7 +109,7 @@ async fn test_no_redirects_policy() {
     .await
     .unwrap();
 
-    // Assert that the second enpoint has not been visited
+    // Assert that the second endpoint has not been visited
     assert!(!*receiver.has_been_visited.lock().await);
 
     receiver.jh.abort();


### PR DESCRIPTION
## Motivation

I noticed an error message I had received contained a typo, which looks to have been copy-pasted a couple times around the repository.

## Solution

Fixed typos.
