### PR TITLE
Implement basic OpenTelemetry support

### DIFF
--- a/OpenTelemetry.md
+++ b/OpenTelemetry.md
@@ -1,0 +1,10 @@
+# OpenTelemetry Configuration
+Svix supports sending tracing information to the OpenTelemetry collector at a configured address. This can be used to interface with many services such as DataDog or Sentry.
+
+To set this up you can follow these steps:
+
+1. Set up an account with any service which supports receiving logs from the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/). Note some services (such as DataDog) require use of specific forks of the OpenTelemetry Collector which include "exporters" for their services. The most popular is the [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib).
+2. Install, configure, and (re)start the OpenTelemetry Collector, noting the gRPC address it is configured to bind to. Ensure that your external service has been integrated properly by consulting their documentation for OpenTelemetry Collector exporters.
+3. Configure the Svix server including the `opentelemetry_address` field to point towards the gRPC address configured above.
+4. Optionally configure the `opentelemetry_sample_ration` in the Svix server configuration. If not set, all traces will be sent to the external service.
+5. Ensure the OpenTelemetry Collector is running, start the Svix server, and watch the tracing information be received.

--- a/OpenTelemetry.md
+++ b/OpenTelemetry.md
@@ -6,5 +6,5 @@ To set this up you can follow these steps:
 1. Set up an account with any service which supports receiving logs from the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/). Note some services (such as DataDog) require use of specific forks of the OpenTelemetry Collector which include "exporters" for their services. The most popular is the [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib).
 2. Install, configure, and (re)start the OpenTelemetry Collector, noting the gRPC address it is configured to bind to. Ensure that your external service has been integrated properly by consulting their documentation for OpenTelemetry Collector exporters.
 3. Configure the Svix server including the `opentelemetry_address` field to point towards the gRPC address configured above.
-4. Optionally configure the `opentelemetry_sample_ration` in the Svix server configuration. If not set, all traces will be sent to the external service.
+4. Optionally configure the `opentelemetry_sample_ratio` in the Svix server configuration. If not set, all traces will be sent to the external service.
 5. Ensure the OpenTelemetry Collector is running, start the Svix server, and watch the tracing information be received.

--- a/README.md
+++ b/README.md
@@ -226,6 +226,12 @@ SVIX_REDIS_DSN = "redis://redis:6379"
 SVIX_QUEUE_TYPE = "redis"
 ```
 
+### OpenTelemetry
+
+You may send tracing information to the OpenTelemetry Collector which allows forwarding trace events to a number of external services.
+
+You can see more in [these instructions](./OpenTelemetry.md)
+
 ### Connection Pool Size
 
 There are two configuration variables `db_pool_max_size` and `redis_pool_max_size` which control the maximum allowed size of the connection pool for PostgreSQL and Redis respectively.

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ SVIX_QUEUE_TYPE = "redis"
 
 ### OpenTelemetry
 
-You may send tracing information to the OpenTelemetry Collector which allows forwarding trace events to a number of external services.
+You may send tracing information to the OpenTelemetry Collector which allows forwarding trace events to a number of external applications/services such as DataDog, Jaeger, NewRelic, Prometheus, Sentry, Signoz, and Zipkin.
 
 You can see more in [these instructions](./OpenTelemetry.md)
 

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -435,6 +435,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +717,12 @@ dependencies = [
  "uncased",
  "version_check",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
 name = "fnv"
@@ -1098,6 +1114,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,6 +1383,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
 name = "nom"
 version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,6 +1509,57 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "opentelemetry"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "js-sys",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project",
+ "rand",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449048140ee61e28f57abe6e9975eedc1f3a29855c7407bd6c12b18578863379"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1a6ca9de4c8b00aa7f1a153bd76cb263287155cec642680d79d98706f3d28a"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-util",
+ "http",
+ "opentelemetry",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tonic-build",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -1620,6 +1705,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "petgraph"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1752,6 +1847,59 @@ dependencies = [
  "syn",
  "version_check",
  "yansi",
+]
+
+[[package]]
+name = "prost"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
+dependencies = [
+ "bytes",
+ "heck 0.3.3",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "regex",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+dependencies = [
+ "bytes",
+ "prost",
 ]
 
 [[package]]
@@ -2619,6 +2767,9 @@ dependencies = [
  "jwt-simple",
  "lazy_static",
  "num_enum",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-otlp",
  "redis",
  "redis_cluster_async",
  "regex",
@@ -2638,6 +2789,7 @@ dependencies = [
  "tower",
  "tower-http 0.2.5",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
  "validator",
@@ -2834,6 +2986,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2915,6 +3077,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.6.10",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
+dependencies = [
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2922,9 +3127,13 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project",
  "pin-project-lite",
+ "rand",
+ "slab",
  "tokio",
+ "tokio-util 0.7.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3015,6 +3224,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3023,6 +3242,20 @@ dependencies = [
  "lazy_static",
  "log",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93600c803bb15e2a32bd376001b8625587f268fe887669b5ac86af524637c242"
+dependencies = [
+ "once_cell",
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3387,6 +3620,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
 dependencies = [
  "webpki 0.22.0",
+]
+
+[[package]]
+name = "which"
+version = "4.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
 ]
 
 [[package]]

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -25,7 +25,7 @@ base64 = "0.13.0"
 hyper = { version = "0.14.16", features = ["full"] }
 tokio = { version = "1.15.0", features = ["full"] }
 tower = "0.4.11"
-tower-http = { version = "0.2.0", features = ["trace", "cors"] }
+tower-http = { version = "0.2.0", features = ["trace", "cors", "request-id"] }
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"
 serde_urlencoded = "0.7.1"
@@ -39,6 +39,7 @@ tracing = "0.1.35"
 tracing-subscriber = { version="0.3", features = ["env-filter", "json"] }
 tracing-opentelemetry = "0.17.3"
 opentelemetry = { version= "0.17", features = ["rt-tokio"] }
+opentelemetry-http = "0.6.0"
 opentelemetry-otlp = { version = "0.10" }
 validator = { version = "0.14.0", features = ["derive"] }
 jwt-simple = "0.10.8"

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -35,8 +35,11 @@ enum_dispatch = "0.3.8"
 regex = "1.5.5"
 lazy_static = "1.4.0"
 figment = { version = "0.10", features = ["toml", "env", "test"] }
-tracing = "0.1.29"
+tracing = "0.1.35"
 tracing-subscriber = { version="0.3", features = ["env-filter", "json"] }
+tracing-opentelemetry = "0.17.3"
+opentelemetry = { version= "0.17", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.10" }
 validator = { version = "0.14.0", features = ["derive"] }
 jwt-simple = "0.10.8"
 chrono = { version="0.4.19", features = ["serde"] }

--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -19,6 +19,13 @@ log_level = "info"
 # The log format that all output will follow. Supported: default, json
 log_format = "default"
 
+# The OpenTelemetry address to send trace information to. Disabled when omitted/null.
+# opentelemetry_address = "http://localhost:4317"
+
+# The ratio at which to sample spans when sending to OpenTelemetry. When not given it defaults to
+# always sending. If the OpenTelemetry address is not set, this will do nothing.
+# opentelemetry_sample_ratio = 1.0
+
 # The wanted retry schedule in seconds. Each value is the time to wait between retries.
 retry_schedule = [5,300,1800,7200,18000,36000,36000]
 

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -72,10 +72,17 @@ pub struct ConfigurationInner {
     /// The JWT secret for authentication - should be secret and securely generated
     #[serde(deserialize_with = "deserialize_jwt_secret")]
     pub jwt_secret: Keys,
+
     /// The log level to run the service with. Supported: info, debug, trace
     pub log_level: LogLevel,
     /// The log format that all output will follow. Supported: default, json
     pub log_format: LogFormat,
+    /// The OpenTelemetry address to send events to if given.
+    pub opentelemetry_address: Option<String>,
+    /// The ratio at which to sample spans when sending to OpenTelemetry. When not given it defaults
+    /// to always sending. If the OpenTelemetry address is not set, this will do nothing.
+    pub opentelemetry_sample_ratio: Option<f64>,
+
     /// The wanted retry schedule in seconds. Each value is the time to wait between retries.
     #[serde(deserialize_with = "deserialize_retry_schedule")]
     pub retry_schedule: Vec<Duration>,

--- a/server/svix-server/src/core/mod.rs
+++ b/server/svix-server/src/core/mod.rs
@@ -5,6 +5,7 @@ pub mod cache;
 pub mod idempotency;
 pub mod message_app;
 pub mod operational_webhooks;
+pub mod otel_spans;
 pub mod security;
 pub mod types;
 

--- a/server/svix-server/src/core/otel_spans.rs
+++ b/server/svix-server/src/core/otel_spans.rs
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: © 2022 Svix Authors
+// SPDX-License-Identifier: MIT
+
+//! Module defining utilities for crating `tracing` spans compatable with OpenTelemetry's
+//! conventions.
+use std::{borrow::Cow, net::SocketAddr};
+
+use axum::extract::{ConnectInfo, MatchedPath};
+use http::{header, uri::Scheme, Method, Version};
+use opentelemetry::trace::TraceContextExt;
+use tower_http::{
+    classify::ServerErrorsFailureClass,
+    request_id::RequestId,
+    trace::{MakeSpan, OnFailure, OnResponse},
+};
+use tracing::field::Empty;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+/// An implementor of [`MakeSpan`] which creates `tracing` spans populated with information about
+/// the request received by an `axum` web server.
+#[derive(Clone, Copy)]
+pub struct AxumOtelSpanCreator;
+
+impl<B> MakeSpan<B> for AxumOtelSpanCreator {
+    fn make_span(&mut self, request: &http::Request<B>) -> tracing::Span {
+        let user_agent = request
+            .headers()
+            .get(header::USER_AGENT)
+            .map_or("", |header| header.to_str().unwrap_or(""));
+
+        let host = request
+            .headers()
+            .get(header::HOST)
+            .map_or("", |header| header.to_str().unwrap_or(""));
+
+        let scheme = request.uri().scheme().map_or_else(
+            || "HTTP".into(),
+            |scheme| -> Cow<'static, str> {
+                if scheme == &Scheme::HTTP {
+                    "http".into()
+                } else if scheme == &Scheme::HTTPS {
+                    "https".into()
+                } else {
+                    scheme.to_string().into()
+                }
+            },
+        );
+
+        let http_route = if let Some(matched_path) = request.extensions().get::<MatchedPath>() {
+            matched_path.as_str().to_owned()
+        } else {
+            request.uri().path().to_owned()
+        };
+
+        let client_ip: Cow<'static, str> = request
+            .extensions()
+            .get::<ConnectInfo<SocketAddr>>()
+            .map(|ConnectInfo(ip)| Cow::from(ip.to_string()))
+            .unwrap_or_default();
+
+        let request_id = request
+            .extensions()
+            .get::<RequestId>()
+            .and_then(|id| id.header_value().to_str().ok())
+            .unwrap_or_default();
+
+        let remote_context = opentelemetry::global::get_text_map_propagator(|p| {
+            p.extract(&opentelemetry_http::HeaderExtractor(request.headers()))
+        });
+        let remote_span = remote_context.span();
+        let span_context = remote_span.span_context();
+        let trace_id = span_context
+            .is_valid()
+            .then(|| Cow::from(span_context.trace_id().to_string()))
+            .unwrap_or_default();
+
+        let flavor: Cow<'static, str> = match request.version() {
+            Version::HTTP_09 => "0.9".into(),
+            Version::HTTP_10 => "1.0".into(),
+            Version::HTTP_11 => "1.1".into(),
+            Version::HTTP_2 => "2.0".into(),
+            Version::HTTP_3 => "3.0".into(),
+            other => format!("{:?}", other).into(),
+        };
+
+        let method: Cow<'static, str> = match request.method() {
+            &Method::CONNECT => "CONNECT".into(),
+            &Method::DELETE => "DELETE".into(),
+            &Method::GET => "GET".into(),
+            &Method::OPTIONS => "OPTIONS".into(),
+            &Method::PATCH => "PATCH".into(),
+            &Method::POST => "POST".into(),
+            &Method::PUT => "PUT".into(),
+            &Method::TRACE => "TRACE".into(),
+            other => other.to_string().into(),
+        };
+
+        let span = tracing::info_span!(
+            "HTTP request",
+            grpc.code = Empty,
+            http.client_ip = %client_ip,
+            http.flavor = %flavor,
+            http.host = %host,
+            http.method = %method,
+            http.route = %http_route,
+            http.scheme = %scheme,
+            http.status_code = Empty,
+            http.target = %request.uri().path_and_query().map_or("", |p| p.as_str()),
+            http.user_agent = %user_agent,
+            otel.kind = "server",
+            otel.status_code = Empty,
+            request_id = %request_id,
+            trace_id = %trace_id,
+        );
+
+        span.set_parent(remote_context);
+
+        span
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct AxumOtelOnResponse;
+
+impl<B> OnResponse<B> for AxumOtelOnResponse {
+    fn on_response(
+        self,
+        response: &http::Response<B>,
+        _latency: std::time::Duration,
+        span: &tracing::Span,
+    ) {
+        let status = response.status().as_u16().to_string();
+        span.record("http.status_code", &tracing::field::display(status));
+        span.record("otel.status_code", &"OK");
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct AxumOtelOnFailure;
+
+impl OnFailure<ServerErrorsFailureClass> for AxumOtelOnFailure {
+    fn on_failure(
+        &mut self,
+        failure_classification: ServerErrorsFailureClass,
+        _latency: std::time::Duration,
+        span: &tracing::Span,
+    ) {
+        match failure_classification {
+            ServerErrorsFailureClass::StatusCode(status) if status.is_server_error() => {
+                span.record("otel.status_code", &"ERROR");
+            }
+            _ => {}
+        }
+    }
+}

--- a/server/svix-server/src/core/otel_spans.rs
+++ b/server/svix-server/src/core/otel_spans.rs
@@ -126,12 +126,18 @@ impl<B> OnResponse<B> for AxumOtelOnResponse {
     fn on_response(
         self,
         response: &http::Response<B>,
-        _latency: std::time::Duration,
+        latency: std::time::Duration,
         span: &tracing::Span,
     ) {
         let status = response.status().as_u16().to_string();
         span.record("http.status_code", &tracing::field::display(status));
         span.record("otel.status_code", &"OK");
+
+        tracing::debug!(
+            "finished processing request latency={} ms status={}",
+            latency.as_millis(),
+            response.status().as_u16(),
+        );
     }
 }
 

--- a/server/svix-server/src/db/mod.rs
+++ b/server/svix-server/src/db/mod.rs
@@ -10,6 +10,7 @@ pub mod models;
 
 static MIGRATIONS: sqlx::migrate::Migrator = sqlx::migrate!();
 
+#[tracing::instrument(level = "trace")]
 async fn connect(cfg: &Configuration) -> sqlx::Pool<sqlx::Postgres> {
     tracing::debug!("DB: Initializing pool");
     if DbBackend::Postgres.is_prefix_of(&cfg.db_dsn) {
@@ -23,10 +24,12 @@ async fn connect(cfg: &Configuration) -> sqlx::Pool<sqlx::Postgres> {
     }
 }
 
+#[tracing::instrument(level = "trace")]
 pub async fn init_db(cfg: &Configuration) -> DatabaseConnection {
     SqlxPostgresConnector::from_sqlx_postgres_pool(connect(cfg).await)
 }
 
+#[tracing::instrument(level = "trace")]
 pub async fn run_migrations(cfg: &Configuration) {
     let db = connect(cfg).await;
     MIGRATIONS.run(&db).await.unwrap();

--- a/server/svix-server/src/db/mod.rs
+++ b/server/svix-server/src/db/mod.rs
@@ -10,7 +10,6 @@ pub mod models;
 
 static MIGRATIONS: sqlx::migrate::Migrator = sqlx::migrate!();
 
-#[tracing::instrument(level = "trace")]
 async fn connect(cfg: &Configuration) -> sqlx::Pool<sqlx::Postgres> {
     tracing::debug!("DB: Initializing pool");
     if DbBackend::Postgres.is_prefix_of(&cfg.db_dsn) {
@@ -24,12 +23,10 @@ async fn connect(cfg: &Configuration) -> sqlx::Pool<sqlx::Postgres> {
     }
 }
 
-#[tracing::instrument(level = "trace")]
 pub async fn init_db(cfg: &Configuration) -> DatabaseConnection {
     SqlxPostgresConnector::from_sqlx_postgres_pool(connect(cfg).await)
 }
 
-#[tracing::instrument(level = "trace")]
 pub async fn run_migrations(cfg: &Configuration) {
     let db = connect(cfg).await;
     MIGRATIONS.run(&db).await.unwrap();

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -35,12 +35,14 @@ pub mod redis;
 pub mod v1;
 pub mod worker;
 
+#[tracing::instrument(name = "app_start", level = "trace")]
 pub async fn run(cfg: Configuration, listener: Option<TcpListener>) {
     run_with_prefix(None, cfg, listener).await
 }
 
 // Made public for the purpose of E2E testing in which a queue prefix is necessary to avoid tests
 // consuming from each others' queues
+#[tracing::instrument(level = "trace")]
 pub async fn run_with_prefix(
     prefix: Option<String>,
     cfg: Configuration,
@@ -103,6 +105,8 @@ pub async fn run_with_prefix(
 
     let with_api = cfg.api_enabled;
     let with_worker = cfg.worker_enabled;
+
+	tracing::info!("Service Starting");
 
     let listen_address =
         SocketAddr::from_str(&cfg.listen_address).expect("Error parsing server listen address");

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -38,14 +38,13 @@ pub mod redis;
 pub mod v1;
 pub mod worker;
 
-#[tracing::instrument(name = "app_start", level = "trace")]
+#[tracing::instrument(name = "app_start", level = "trace", skip_all)]
 pub async fn run(cfg: Configuration, listener: Option<TcpListener>) {
     run_with_prefix(None, cfg, listener).await
 }
 
 // Made public for the purpose of E2E testing in which a queue prefix is necessary to avoid tests
 // consuming from each others' queues
-#[tracing::instrument(level = "trace")]
 pub async fn run_with_prefix(
     prefix: Option<String>,
     cfg: Configuration,
@@ -102,7 +101,6 @@ pub async fn run_with_prefix(
         .layer(
             TraceLayer::new_for_http()
                 .make_span_with(AxumOtelSpanCreator)
-                .on_request(())
                 .on_response(AxumOtelOnResponse)
                 .on_failure(AxumOtelOnFailure),
         )

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -111,7 +111,7 @@ async fn main() {
                 opentelemetry::sdk::trace::config()
                     .with_sampler(
                         cfg.opentelemetry_sample_ratio
-                            .map(|rate| opentelemetry::sdk::trace::Sampler::TraceIdRatioBased(rate))
+                            .map(opentelemetry::sdk::trace::Sampler::TraceIdRatioBased)
                             .unwrap_or(opentelemetry::sdk::trace::Sampler::AlwaysOn),
                     )
                     .with_resource(opentelemetry::sdk::Resource::new(vec![

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -114,7 +114,7 @@ async fn main() {
     match cfg.log_format {
         cfg::LogFormat::Default => {
             let stdout_layer = tracing_subscriber::fmt::layer();
-            let _ = tracing_subscriber::Registry::default()
+            tracing_subscriber::Registry::default()
                 .with(otel_layer)
                 .with(stdout_layer)
                 .with(tracing_subscriber::EnvFilter::from_default_env())
@@ -128,7 +128,7 @@ async fn main() {
                 .event_format(fmt)
                 .fmt_fields(json_fields);
 
-            let _ = tracing_subscriber::Registry::default()
+            tracing_subscriber::Registry::default()
                 .with(otel_layer)
                 .with(stdout_layer)
                 .with(tracing_subscriber::EnvFilter::from_default_env())


### PR DESCRIPTION
This PR integrates OpenTelemetry support and creates middleware for Axum that ensures that the spans created for each request follow OpenTelemetry conventions.

Fixes #344 