### PR TITLE
Server CI: change --frozen to --locked due to git dep

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -41,7 +41,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: build
-        args: --manifest-path server/Cargo.toml --all --frozen
+        args: --manifest-path server/Cargo.toml --all --locked
 
     - name: Clippy
       uses: actions-rs/cargo@v1


### PR DESCRIPTION
Because of the git dependency that we have, we need --locked to be
passed, not --frozen. Because we do want to let it access the internet
to check the git repo is fine, but still not actually make any
modifications to the lock file.

This fixes the build in some scenarios.