### PR TITLE
Fix clippy lints for beta Rust version

### DIFF
--- a/server/svix-server/src/core/cache/redis.rs
+++ b/server/svix-server/src/core/cache/redis.rs
@@ -129,14 +129,8 @@ mod tests {
 
     async fn get_pool(redis_dsn: &str, cfg: &crate::cfg::Configuration) -> RedisPool {
         match cfg.cache_type {
-            CacheType::RedisCluster => {
-                let mgr = crate::redis::new_redis_pool_clustered(redis_dsn, cfg).await;
-                mgr
-            }
-            _ => {
-                let mgr = crate::redis::new_redis_pool(redis_dsn, cfg).await;
-                mgr
-            }
+            CacheType::RedisCluster => crate::redis::new_redis_pool_clustered(redis_dsn, cfg).await,
+            _ => crate::redis::new_redis_pool(redis_dsn, cfg).await,
         }
     }
 

--- a/server/svix-server/src/core/security.rs
+++ b/server/svix-server/src/core/security.rs
@@ -42,7 +42,7 @@ pub struct Permissions {
     pub app_id: Option<ApplicationId>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum KeyType {
     Organization,
     Application,

--- a/server/svix-server/src/core/types.rs
+++ b/server/svix-server/src/core/types.rs
@@ -330,7 +330,7 @@ macro_rules! create_all_id_types {
         }
 
         // Id or uid
-        #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+        #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
         pub struct $name_id_or_uid(pub String);
 
         impl From<$name_id_or_uid> for $name_uid {
@@ -410,7 +410,7 @@ impl Validate for EventTypeNameSet {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExpiringSigningKeys(pub Vec<ExpiringSigningKey>);
 json_wrapper!(ExpiringSigningKeys);
 
@@ -419,7 +419,7 @@ impl ExpiringSigningKeys {
     pub const OLD_KEY_EXPIRY_HOURS: i64 = 24;
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EndpointSecret(pub Vec<u8>);
 impl EndpointSecret {
     const PREFIX: &'static str = "whsec_";
@@ -519,7 +519,7 @@ impl ValueType for EndpointSecret {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExpiringSigningKey {
     #[serde(rename = "signingKey")]
     pub key: EndpointSecret,
@@ -574,7 +574,7 @@ fn validate_header_key(k: &str, errors: &mut ValidationErrors) {
     })
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Default)]
 pub struct EndpointHeaders(pub HashMap<String, String>);
 json_wrapper!(EndpointHeaders);
 
@@ -606,7 +606,7 @@ impl Validate for EndpointHeaders {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Default)]
 pub struct EndpointHeadersPatch(pub HashMap<String, Option<String>>);
 json_wrapper!(EndpointHeadersPatch);
 
@@ -636,7 +636,7 @@ impl Validate for EndpointHeadersPatch {
 }
 
 #[repr(i16)]
-#[derive(Clone, Debug, Copy, PartialEq, IntoPrimitive, TryFromPrimitive)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
 pub enum MessageAttemptTriggerType {
     Scheduled = 0,
     Manual = 1,
@@ -652,7 +652,7 @@ pub enum MessageStatus {
 }
 
 #[repr(i16)]
-#[derive(Clone, Debug, Copy, PartialEq, IntoPrimitive, TryFromPrimitive)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
 pub enum StatusCodeClass {
     CodeNone = 0,
     Code1xx = 100,

--- a/server/svix-server/src/db/models/application.rs
+++ b/server/svix-server/src/db/models/application.rs
@@ -8,7 +8,7 @@ use chrono::Utc;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{entity::prelude::*, Condition};
 
-#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "application")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]

--- a/server/svix-server/src/db/models/endpoint.rs
+++ b/server/svix-server/src/db/models/endpoint.rs
@@ -9,7 +9,7 @@ use chrono::Utc;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{entity::prelude::*, Condition};
 
-#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "endpoint")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]

--- a/server/svix-server/src/db/models/eventtype.rs
+++ b/server/svix-server/src/db/models/eventtype.rs
@@ -6,7 +6,7 @@ use chrono::Utc;
 use sea_orm::entity::prelude::*;
 use sea_orm::ActiveValue::Set;
 
-#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "eventtype")]
 pub struct Model {
     pub created_at: DateTimeWithTimeZone,

--- a/server/svix-server/src/db/models/message.rs
+++ b/server/svix-server/src/db/models/message.rs
@@ -9,7 +9,7 @@ use chrono::Utc;
 use sea_orm::ActiveValue::Set;
 use sea_orm::{entity::prelude::*, Condition};
 
-#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "message")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]

--- a/server/svix-server/src/db/models/messageattempt.rs
+++ b/server/svix-server/src/db/models/messageattempt.rs
@@ -10,7 +10,7 @@ use crate::core::types::{
     MessageStatus,
 };
 
-#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "messageattempt")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]

--- a/server/svix-server/src/db/models/messagedestination.rs
+++ b/server/svix-server/src/db/models/messagedestination.rs
@@ -7,7 +7,7 @@ use sea_orm::ActiveValue::Set;
 
 use crate::core::types::{BaseId, EndpointId, MessageEndpointId, MessageId, MessageStatus};
 
-#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "messagedestination")]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]

--- a/server/svix-server/src/error.rs
+++ b/server/svix-server/src/error.rs
@@ -109,7 +109,7 @@ pub enum HttpErrorBody {
     Validation { detail: Vec<ValidationErrorItem> },
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 /// Validation errors have their own schema to provide context for invalid requests eg. mismatched
 /// types and out of bounds values. There may be any number of these per 422 UNPROCESSABLE ENTITY
 /// error.

--- a/server/svix-server/src/queue/mod.rs
+++ b/server/svix-server/src/queue/mod.rs
@@ -38,7 +38,7 @@ pub async fn new_pair(
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MessageTask {
     pub msg_id: MessageId,
@@ -65,7 +65,7 @@ impl MessageTask {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MessageTaskBatch {
     pub msg_id: MessageId,
@@ -87,7 +87,7 @@ impl MessageTaskBatch {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "type")]
 pub enum QueueTask {

--- a/server/svix-server/src/queue/redis.rs
+++ b/server/svix-server/src/queue/redis.rs
@@ -609,19 +609,13 @@ pub mod tests {
     pub async fn get_pool(cfg: Configuration) -> RedisPool {
         match cfg.cache_type {
             CacheType::RedisCluster => {
-                let mgr = crate::redis::new_redis_pool_clustered(
+                crate::redis::new_redis_pool_clustered(
                     cfg.redis_dsn.as_ref().unwrap().as_str(),
                     &cfg,
                 )
-                .await;
-                mgr
+                .await
             }
-            _ => {
-                let mgr =
-                    crate::redis::new_redis_pool(cfg.redis_dsn.as_ref().unwrap().as_str(), &cfg)
-                        .await;
-                mgr
-            }
+            _ => crate::redis::new_redis_pool(cfg.redis_dsn.as_ref().unwrap().as_str(), &cfg).await,
         }
     }
 

--- a/server/svix-server/src/redis/mod.rs
+++ b/server/svix-server/src/redis/mod.rs
@@ -297,14 +297,8 @@ mod tests {
 
     async fn get_pool(redis_dsn: &str, cfg: &Configuration) -> RedisPool {
         match cfg.cache_type {
-            CacheType::RedisCluster => {
-                let mgr = crate::redis::new_redis_pool_clustered(redis_dsn, cfg).await;
-                mgr
-            }
-            _ => {
-                let mgr = crate::redis::new_redis_pool(redis_dsn, cfg).await;
-                mgr
-            }
+            CacheType::RedisCluster => crate::redis::new_redis_pool_clustered(redis_dsn, cfg).await,
+            _ => crate::redis::new_redis_pool(redis_dsn, cfg).await,
         }
     }
 

--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 use svix_server_derive::{ModelIn, ModelOut};
 use validator::Validate;
 
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, Validate, ModelIn)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Validate, ModelIn)]
 #[serde(rename_all = "camelCase")]
 pub struct ApplicationIn {
     #[validate(
@@ -58,7 +58,7 @@ impl ModelIn for ApplicationIn {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, ModelOut)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, ModelOut)]
 #[serde(rename_all = "camelCase")]
 pub struct ApplicationOut {
     // FIXME: Do we want to use serde(flatten) or just duplicate the keys?

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -38,7 +38,7 @@ use validator::Validate;
 use crate::db::models::messageattempt;
 use crate::v1::utils::Pagination;
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, ModelOut)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, ModelOut)]
 #[serde(rename_all = "camelCase")]
 pub struct MessageAttemptOut {
     pub response: String,
@@ -73,7 +73,7 @@ impl From<messageattempt::Model> for MessageAttemptOut {
 
 /// A model containing information on a given message plus additional fields on the last attempt for
 /// that message.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AttemptedMessageOut {
     #[serde(flatten)]
@@ -429,7 +429,7 @@ async fn list_attempts_by_msg(
 
 /// A type combining information from [`messagedestination::Model`]s and [`endpoint::Model`]s to
 /// output information on attempted destinations
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MessageEndpointOut {
     #[serde(flatten)]

--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -79,7 +79,7 @@ pub fn validate_url(val: &str) -> std::result::Result<(), ValidationError> {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, Validate, ModelIn)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Validate, ModelIn)]
 #[serde(rename_all = "camelCase")]
 pub struct EndpointIn {
     #[serde(default)]
@@ -137,7 +137,7 @@ impl ModelIn for EndpointIn {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, ModelOut)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, ModelOut)]
 #[serde(rename_all = "camelCase")]
 pub struct EndpointOut {
     pub description: String,
@@ -176,7 +176,7 @@ impl From<endpoint::Model> for EndpointOut {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Validate, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Validate, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EndpointSecretRotateIn {
     #[validate]
@@ -184,19 +184,19 @@ pub struct EndpointSecretRotateIn {
     key: Option<EndpointSecret>,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EndpointSecretOut {
     pub key: EndpointSecret,
 }
 
-#[derive(Clone, Debug, PartialEq, Validate, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Validate, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RecoverIn {
     pub since: DateTime<Utc>,
 }
 
-#[derive(Clone, Debug, PartialEq, Validate, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Validate, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EndpointHeadersIn {
     #[validate]
@@ -211,7 +211,7 @@ impl ModelIn for EndpointHeadersIn {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct EndpointHeadersOut {
     pub headers: HashMap<String, String>,
@@ -242,7 +242,7 @@ impl From<EndpointHeaders> for EndpointHeadersOut {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Validate, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Validate, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EndpointHeadersPatchIn {
     #[validate]

--- a/server/svix-server/src/v1/endpoints/event_type.rs
+++ b/server/svix-server/src/v1/endpoints/event_type.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 use svix_server_derive::{ModelIn, ModelOut};
 use validator::Validate;
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Validate, ModelIn)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, ModelIn)]
 #[serde(rename_all = "camelCase")]
 pub struct EventTypeIn {
     pub name: EventTypeName,
@@ -70,7 +70,7 @@ impl ModelIn for EventTypeUpdate {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, ModelOut)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, ModelOut)]
 #[serde(rename_all = "camelCase")]
 pub struct EventTypeOut {
     pub name: EventTypeName,

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -49,7 +49,7 @@ pub fn validate_channels_msg(
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, Validate, ModelIn)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Validate, ModelIn)]
 #[serde(rename_all = "camelCase")]
 pub struct MessageIn {
     #[validate]
@@ -82,7 +82,7 @@ impl ModelIn for MessageIn {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, ModelOut)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, ModelOut)]
 #[serde(rename_all = "camelCase")]
 pub struct MessageOut {
     #[serde(rename = "eventId")]

--- a/server/svix-server/src/v1/utils.rs
+++ b/server/svix-server/src/v1/utils.rs
@@ -74,7 +74,7 @@ impl Validate for PaginationLimit {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ReversibleIterator<T: Validate> {
     Normal(T),
     Prev(T),

--- a/server/svix-server/src/worker.rs
+++ b/server/svix-server/src/worker.rs
@@ -338,7 +338,7 @@ async fn dispatch(
 }
 
 fn bytes_to_string(bytes: bytes::Bytes) -> String {
-    match std::str::from_utf8(&bytes.to_vec()) {
+    match std::str::from_utf8(&bytes) {
         Ok(v) => v.to_owned(),
         Err(_) => base64::encode(&bytes),
     }

--- a/server/svix-server/tests/queue.rs
+++ b/server/svix-server/tests/queue.rs
@@ -19,14 +19,9 @@ use svix_server::{
 pub async fn get_pool(cfg: Configuration) -> RedisPool {
     match cfg.cache_type {
         CacheType::RedisCluster => {
-            let mgr =
-                new_redis_pool_clustered(cfg.redis_dsn.as_ref().unwrap().as_str(), &cfg).await;
-            mgr
+            new_redis_pool_clustered(cfg.redis_dsn.as_ref().unwrap().as_str(), &cfg).await
         }
-        _ => {
-            let mgr = new_redis_pool(cfg.redis_dsn.as_ref().unwrap().as_str(), &cfg).await;
-            mgr
-        }
+        _ => new_redis_pool(cfg.redis_dsn.as_ref().unwrap().as_str(), &cfg).await,
     }
 }
 


### PR DESCRIPTION
Currently new Clippy lints in the beta Rust version used in CI are causing runs to fail. This PR fixes these lints.