### PR TITLE
Server: add support for encrypting webhook secrets

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
+name = "aead"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,6 +317,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chacha20"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b72a433d0cf2aef113ba70f62634c56fddb0f244e6377185c56a7cadbd8f91"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+ "zeroize",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b84ed6d1d5f7aa9bdde921a5090e0ca4d934d250ea3b402a5fab3a994e28a2a"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +353,15 @@ dependencies = [
  "serde",
  "time 0.1.44",
  "winapi",
+]
+
+[[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1882,6 +1925,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
+name = "poly1305"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2889,6 +2943,7 @@ dependencies = [
  "bb8-redis",
  "blake2",
  "bytes",
+ "chacha20poly1305",
  "chrono",
  "clap",
  "dotenv",
@@ -3549,6 +3604,16 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "universal-hash"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -133,9 +133,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d590cacd53140ff87cc2e192eb22fc3dc23c5b3f93b0d4f020677f98e8c629"
+checksum = "c2cc6e8e8c993cb61a005fab8c1e5093a29199b7253b05a6883999312935c1ff"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -198,9 +198,9 @@ checksum = "a17bd29f7c70f32e9387f4d4acfa5ea7b7749ef784fb78cf382df97069337b8c"
 
 [[package]]
 name = "base-x"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc19a4937b4fbd3fe3379793130e42060d10627a360f2127802b10b87e7baf74"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
 name = "base16ct"
@@ -323,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.6"
+version = "3.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1fe12880bae935d142c8702d500c63a4e8634b6c3c57ad72bf978fc7b6249a"
+checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
 dependencies = [
  "atty",
  "bitflags",
@@ -340,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.6"
+version = "3.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6db9e867166a43a53f7199b5e4d1f522a1e5bd626654be263c999ce59df39a"
+checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87eba3c8c7f42ef17f6c659fc7416d0f4758cd3e58861ee63c5fa4a4dde649e4"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff1f980957787286a554052d03c7aee98d99cc32e09f6d45f0a814133c87978"
+checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -505,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "5999502d32b9c48d492abe66392408144895020ec4709e549e840799f3bb74c0"
 dependencies = [
  "generic-array",
  "typenum",
@@ -637,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "elliptic-curve"
@@ -736,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fnv"
@@ -1040,18 +1040,18 @@ checksum = "d103cfecf6edf3f7d1dc7c5ab64e99488c0f8d11786e43b40873e66e8489d014"
 
 [[package]]
 name = "hmac-sha256"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f465fee748ff957af8a35a4045b39ba50495d136a10cd330167afbd4b1960e"
+checksum = "fd29dbba58ee5314f3ec570066d78a3f4772bf45b322efcf2ce2a43af69a4d85"
 dependencies = [
  "digest 0.9.0",
 ]
 
 [[package]]
 name = "hmac-sha512"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2ce076d8070f292037093a825343f6341fe0ce873268c2477e2f49abd57b10"
+checksum = "a928b002dff1780b7fa21056991d395770ab9359154b8c1724c4d0511dad0a65"
 dependencies = [
  "digest 0.9.0",
 ]
@@ -1305,9 +1305,9 @@ checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
@@ -1549,9 +1549,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "ac8b1a9b2518dc799a2271eff1688707eb315f0d4697aa6b0871369ca4c4da55"
 
 [[package]]
 name = "opaque-debug"
@@ -1810,18 +1810,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2478,18 +2478,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "1578c6245786b9d168c5447eeacfb96856573ca56c9d68fdcf394be134882a47"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "023e9b1467aef8a10fb88f25611870ada9800ef7e22afce356bb0d2387b6f27c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2498,9 +2498,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
  "itoa 1.0.2",
  "ryu",
@@ -2614,9 +2614,9 @@ checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "socket2"
@@ -3351,9 +3351,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
+checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3362,9 +3362,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709595b8878a4965ce5e87ebf880a7d39c9afc6837721b21a5a816a8117d921"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3393,9 +3393,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.17.3"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93600c803bb15e2a32bd376001b8625587f268fe887669b5ac86af524637c242"
+checksum = "fbbe89715c1dbbb790059e2565353978564924ee85017b5fff365c872ff6721f"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -3417,13 +3417,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.11"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
+checksum = "3a713421342a5a666b7577783721d3117f1b69a393df803ee17bb73b1e122a59"
 dependencies = [
  "ansi_term",
- "lazy_static",
  "matchers",
+ "once_cell",
  "regex",
  "serde",
  "serde_json",
@@ -3525,9 +3525,9 @@ checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
 dependencies = [
  "tinyvec",
 ]

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -52,6 +52,7 @@ redis = { version = "0.21.5", features = ["tokio-comp", "tokio-native-tls-comp",
 thiserror = "1.0.30"
 bytes = "1.1.0"
 blake2 = "0.10.4"
+chacha20poly1305 = "0.9.0"
 # sea orm
 sea-orm = { version = "0.7.1", features = [ "sqlx-postgres", "runtime-tokio-rustls", "macros" ], default-features = false }
 sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "postgres", "migrate" ] }

--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -11,6 +11,10 @@ listen_address = "0.0.0.0:8071"
 # For a list of supported events please refer to: https://api.svix.com/docs#tag/Webhooks
 # operational_webhook_address = "http://127.0.0.1:8071"
 
+# The main secret used by Svix. Used for client-side encryption of sensitive data, etc.
+# IMPORTANT: Once set, it can't be changed.
+# main_secret = "kPafCtH7KC351nWXQb2pEGa6IRW3OsYpzQJldB8X"
+
 # The JWT secret for authentication - should be secret and securely generated
 # jwt_secret = "8KjzRXrKkd9YFcNyqLSIY8JwiaCeRc6WK4UkMnSW"
 

--- a/server/svix-server/src/core/cryptography.rs
+++ b/server/svix-server/src/core/cryptography.rs
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: © 2022 Svix Authors
+// SPDX-License-Identifier: MIT
+
+use std::fmt::Debug;
+
+use chacha20poly1305::aead::{Aead, NewAead};
+use chacha20poly1305::{Key, XChaCha20Poly1305, XNonce};
+use ed25519_compact::*;
+use rand::Rng;
+
+use crate::error::{Error, Result};
+
+// Asymmetric Signature keys
+#[derive(Clone, Eq)]
+pub struct AsymmetricKey(pub KeyPair);
+
+impl AsymmetricKey {
+    pub fn generate() -> AsymmetricKey {
+        AsymmetricKey(KeyPair::from_seed(Seed::generate()))
+    }
+
+    pub fn from_slice(bytes: &[u8]) -> Result<Self> {
+        Ok(AsymmetricKey(KeyPair::from_slice(bytes).map_err(|_| {
+            Error::Generic("Failed parsing key.".to_string())
+        })?))
+    }
+
+    pub fn from_base64(b64: &str) -> Result<Self> {
+        let bytes =
+            base64::decode(b64).map_err(|_| Error::Generic("Failed parsing base64".to_string()))?;
+
+        Self::from_slice(bytes.as_slice())
+    }
+
+    pub fn pubkey(&self) -> &[u8] {
+        &self.0.pk[..]
+    }
+}
+
+impl Debug for AsymmetricKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "<AsymmetricKey sk=*** pk={}>",
+            base64::encode(self.0.pk.as_slice())
+        )
+    }
+}
+
+impl PartialEq for AsymmetricKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_slice() == other.0.as_slice()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Encryption(Option<Key>);
+
+impl Encryption {
+    const NONCE_SIZE: usize = 24;
+
+    pub fn new_noop() -> Self {
+        Self(None)
+    }
+
+    pub fn new(key: [u8; 32]) -> Self {
+        Self(Some(Key::from_slice(&key).to_owned()))
+    }
+
+    pub fn encrypt(&self, data: &[u8]) -> crate::error::Result<Vec<u8>> {
+        if let Some(main_key) = self.0.as_ref() {
+            let cipher = XChaCha20Poly1305::new(main_key);
+            let nonce: [u8; Self::NONCE_SIZE] = rand::thread_rng().gen();
+            let nonce = XNonce::from_slice(&nonce);
+            let mut ciphertext = cipher
+                .encrypt(nonce, data)
+                .map_err(|_| crate::error::Error::Generic("Encryption failed".to_string()))?;
+            let mut ret = nonce.to_vec();
+            ret.append(&mut ciphertext);
+            Ok(ret)
+        } else {
+            Ok(data.to_vec())
+        }
+    }
+
+    pub fn decrypt(&self, ciphertext: &[u8]) -> crate::error::Result<Vec<u8>> {
+        if let Some(main_key) = self.0.as_ref() {
+            let cipher = XChaCha20Poly1305::new(main_key);
+            let nonce = &ciphertext[..Self::NONCE_SIZE];
+            let ciphertext = &ciphertext[Self::NONCE_SIZE..];
+            cipher
+                .decrypt(XNonce::from_slice(nonce), ciphertext)
+                .map_err(|_| crate::error::Error::Generic("Encryption failed".to_string()))
+        } else {
+            Ok(ciphertext.to_vec())
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.0.is_some()
+    }
+}
+
+impl Default for Encryption {
+    fn default() -> Self {
+        Self::new_noop()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encryption() {
+        let clear = b"hello world";
+        let encryption = Encryption::new([1; 32]);
+        let ciphertext = encryption.encrypt(clear).unwrap();
+        let clear2 = encryption.decrypt(&ciphertext).unwrap();
+        assert_eq!(&clear[..], &clear2[..]);
+    }
+}

--- a/server/svix-server/src/core/mod.rs
+++ b/server/svix-server/src/core/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 pub mod cache;
+pub mod cryptography;
 pub mod idempotency;
 pub mod message_app;
 pub mod operational_webhooks;

--- a/server/svix-server/src/core/security.rs
+++ b/server/svix-server/src/core/security.rs
@@ -8,7 +8,6 @@ use axum::{
     extract::{Extension, FromRequest, Path, RequestParts, TypedHeader},
     headers::{authorization::Bearer, Authorization},
 };
-use ed25519_compact::*;
 
 use jwt_simple::prelude::*;
 use sea_orm::DatabaseConnection;
@@ -288,48 +287,5 @@ impl Keys {
         Self {
             key: HS256Key::from_bytes(secret),
         }
-    }
-}
-
-// Asymmetric Signature keys
-#[derive(Clone, Eq)]
-pub struct AsymmetricKey(pub KeyPair);
-
-impl AsymmetricKey {
-    pub fn generate() -> AsymmetricKey {
-        AsymmetricKey(KeyPair::from_seed(Seed::generate()))
-    }
-
-    pub fn from_slice(bytes: &[u8]) -> Result<AsymmetricKey> {
-        Ok(AsymmetricKey(KeyPair::from_slice(bytes).map_err(|_| {
-            Error::Generic("Failed parsing key.".to_string())
-        })?))
-    }
-
-    pub fn from_base64(b64: &str) -> Result<AsymmetricKey> {
-        let bytes =
-            base64::decode(b64).map_err(|_| Error::Generic("Failed parsing base64".to_string()))?;
-
-        Self::from_slice(bytes.as_slice())
-    }
-
-    pub fn pubkey(&self) -> &[u8] {
-        &self.0.pk[..]
-    }
-}
-
-impl Debug for AsymmetricKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "<AsymmetricKey sk=*** pk={}>",
-            base64::encode(self.0.pk.as_slice())
-        )
-    }
-}
-
-impl PartialEq for AsymmetricKey {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.as_slice() == other.0.as_slice()
     }
 }

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -185,9 +185,10 @@ async fn main() {
         }
         Some(Commands::AsymmetricKey { command }) => match command {
             AsymmetricKeyCommands::Generate => {
-                let secret = EndpointSecretInternal::generate_asymmetric()
+                let secret = EndpointSecretInternal::generate_asymmetric(&cfg.encryption)
                     .unwrap()
-                    .into_endpoint_secret();
+                    .into_endpoint_secret(&cfg.encryption)
+                    .unwrap();
                 println!("Secret key: {}", secret.serialize_secret_key());
                 println!("Public key: {}", secret.serialize_public_key());
                 exit(0);

--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -9,8 +9,8 @@ use crate::{
     core::{
         security::AuthenticatedApplication,
         types::{
-            ApplicationIdOrUid, BaseId, EndpointId, EndpointIdOrUid, EndpointSecretInternal,
-            EndpointUid, EventChannelSet, EventTypeNameSet, MessageEndpointId, MessageStatus,
+            ApplicationIdOrUid, BaseId, EndpointId, EndpointIdOrUid, EndpointUid, EventChannelSet,
+            EventTypeNameSet, MessageEndpointId, MessageStatus,
         },
     },
     db::models::messagedestination,
@@ -131,9 +131,6 @@ impl ModelIn for EndpointIn {
         model.disabled = Set(self.disabled);
         model.event_types_ids = Set(self.event_types_ids);
         model.channels = Set(self.channels);
-        if let Some(key) = self.key {
-            model.key = Set(EndpointSecretInternal::from_endpoint_secret(key));
-        }
     }
 }
 

--- a/server/svix-server/tests/utils/mod.rs
+++ b/server/svix-server/tests/utils/mod.rs
@@ -233,9 +233,16 @@ pub fn start_svix_server() -> (TestClient, tokio::task::JoinHandle<()>) {
 pub fn start_svix_server_with_cfg(
     cfg: &ConfigurationInner,
 ) -> (TestClient, tokio::task::JoinHandle<()>) {
+    start_svix_server_with_cfg_and_org_id(cfg, OrganizationId::new(None, None))
+}
+
+pub fn start_svix_server_with_cfg_and_org_id(
+    cfg: &ConfigurationInner,
+    org_id: OrganizationId,
+) -> (TestClient, tokio::task::JoinHandle<()>) {
     let cfg = Arc::new(cfg.clone());
 
-    let token = generate_org_token(&cfg.jwt_secret, OrganizationId::new(None, None)).unwrap();
+    let token = generate_org_token(&cfg.jwt_secret, org_id).unwrap();
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let base_uri = format!("http://{}", listener.local_addr().unwrap());
 


### PR DESCRIPTION
Webhook secrets are used for signing the webhook messages and they are
stored in the main database and cache. Normally they are stored there in
the clear, which means that people with access to the database could
potentially retrieve them and forge webhook messages.

With this change, we are adding support for an optional secret key that
can be used to encrypt the webhook secrets.

This change is fully backwards compatible when encryption is turned off,
and you can also change from non-encrypted to encrypted whenever you
want and everything will continue to work.

Changing the encryption key, or moving from encrypted to non-encrypted
is not supported, as without the key you won't be able to view endpoint
secrets. We could potentially add a script that migrates the database
from one to the other in the future if needed, but it's probably a very
rare requirement.