### PR TITLE
Server: support accepting msg payload also as "data".

### DIFF
--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -57,6 +57,7 @@ pub struct MessageIn {
     pub uid: Option<MessageUid>,
     #[validate]
     pub event_type: EventTypeName,
+    #[serde(alias = "payload", alias = "data")]
     pub payload: serde_json::Value,
     #[validate(custom = "validate_channels_msg")]
     #[validate]


### PR DESCRIPTION
We support this on api.svix.com due to backwards compatibility, may as
well have it here too.