### PR TITLE
Server: use the `rand` crate rather than `getrandom`

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2895,7 +2895,6 @@ dependencies = [
  "enum_dispatch",
  "figment",
  "futures",
- "getrandom",
  "hmac-sha256",
  "http",
  "hyper",

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -17,7 +17,6 @@ svix-server_derive = { path = "../svix-server_derive" }
 svix = "0.60"
 svix-ksuid = "^0.5.1"
 dotenv = "0.15.0"
-getrandom = "0.2.4"
 hmac-sha256 = "1"
 clap = { version = "3.2.1", features = ["derive"] }
 axum = { version = "0.5.1", features = ["headers"] }

--- a/server/svix-server/src/core/types.rs
+++ b/server/svix-server/src/core/types.rs
@@ -6,6 +6,7 @@ use std::collections::{HashMap, HashSet};
 use chrono::{DateTime, Utc};
 use lazy_static::lazy_static;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
+use rand::Rng;
 use regex::Regex;
 use sea_orm::{
     entity::prelude::*,
@@ -429,8 +430,7 @@ impl EndpointSecret {
     const KEY_SIZE: usize = 24;
 
     pub fn generate() -> crate::error::Result<Self> {
-        let mut buf = [0u8; Self::KEY_SIZE];
-        getrandom::getrandom(&mut buf)?;
+        let buf: [u8; Self::KEY_SIZE] = rand::thread_rng().gen();
         Ok(Self(buf.to_vec()))
     }
 }

--- a/server/svix-server/src/error.rs
+++ b/server/svix-server/src/error.rs
@@ -71,12 +71,6 @@ impl From<redis::RedisError> for Error {
     }
 }
 
-impl From<getrandom::Error> for Error {
-    fn from(err: getrandom::Error) -> Error {
-        Error::Generic(err.to_string())
-    }
-}
-
 impl From<DbErr> for Error {
     fn from(err: DbErr) -> Error {
         if let DbErr::Query(ref err_str) = err {


### PR DESCRIPTION
The `rand` crate is more high-level, more efficient, faster, and unlike
getrandom, it can't fail.

Fixes #527