### PR TITLE
OpenAPI Schema: don't mark msg payloads as nullable

### DIFF
--- a/javascript/src/openapi/models/AnyType.ts
+++ b/javascript/src/openapi/models/AnyType.ts
@@ -1,1 +1,0 @@
-export type AnyType = any;

--- a/openapi.json
+++ b/openapi.json
@@ -675,9 +675,6 @@
                         "type": "string"
                     },
                     "payload": {
-                        "additionalProperties": {
-                            "nullable": true
-                        },
                         "example": {
                             "email": "test@example.com",
                             "username": "test_user"
@@ -1152,9 +1149,6 @@
             "EventTypeExampleOut": {
                 "properties": {
                     "example": {
-                        "additionalProperties": {
-                            "nullable": true
-                        },
                         "example": {
                             "data": {
                                 "email": "test@example.com",
@@ -2306,9 +2300,6 @@
                         "type": "string"
                     },
                     "payload": {
-                        "additionalProperties": {
-                            "nullable": true
-                        },
                         "example": {
                             "email": "test@example.com",
                             "username": "test_user"
@@ -2377,9 +2368,6 @@
                         "type": "string"
                     },
                     "payload": {
-                        "additionalProperties": {
-                            "nullable": true
-                        },
                         "example": {
                             "email": "test@example.com",
                             "username": "test_user"

--- a/python/templates/model.py.jinja
+++ b/python/templates/model.py.jinja
@@ -38,7 +38,7 @@ class {{ class_name }}({{"Exception" if is_exception}}):
     status_code: int
     def __init__(self, response: Dict[str, str], status_code: int):
         self.status_code = status_code
-        super({{class_name}}, self).__init__(response) 
+        super({{class_name}}, self).__init__(response)
     {%else%}
     """{% if model.title %}{{ model.title | wordwrap(116) }}
 
@@ -75,6 +75,7 @@ class {{ class_name }}({{"Exception" if is_exception}}):
     {% if model.additional_properties %}
     additional_properties: Dict[str, {{ additional_property_type }}] = attr.ib(init=False, factory=dict)
     {% endif %}
+
 {% macro _to_dict(multipart=False) %}
 {% for property in model.required_properties + model.optional_properties %}
 {% import "property_templates/" + property.template as prop_template %}
@@ -98,7 +99,7 @@ field_dict: Dict[str, Any] = {}
 {% endif %}
 {% if prop_template and prop_template.transform %}
 for prop_name, prop in self.additional_properties.items():
-    {{ prop_template.transform(model.additional_properties, "prop", "field_dict[prop_name]", multipart=multipart) | indent(4) }}
+    {{ prop_template.transform(model.additional_properties, "prop", "field_dict[prop_name]", multipart=multipart, declare_type=false) | indent(4) }}
 {% elif multipart %}
 field_dict.update({
     key: (None, str(value).encode(), "text/plain")
@@ -196,5 +197,5 @@ return field_dict
     def __contains__(self, key: str) -> bool:
         return key in self.additional_properties
     {% endif %}
-    {%endif%}
+    {% endif %}
 {% endif %}


### PR DESCRIPTION
This is a fix to the change introduced in 05f3f8a5c628a4fe1a1f5655606377e9731dc3fc.
It was an overzealous change where we accidentally changed the null of
the payload where we shouldn't have.

This PR also fixes the Python and JavaScript libs to match this fix.