### PR TITLE
Server: update tower-http and fix CORS.

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tower",
- "tower-http 0.3.4",
+ "tower-http",
  "tower-layer",
  "tower-service",
 ]
@@ -2414,7 +2414,7 @@ dependencies = [
  "time 0.2.27",
  "tracing",
  "url",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -2441,7 +2441,7 @@ dependencies = [
  "sea-query-derive",
  "serde_json",
  "time 0.2.27",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -2779,7 +2779,7 @@ dependencies = [
  "time 0.2.27",
  "tokio-stream",
  "url",
- "uuid",
+ "uuid 0.8.2",
  "webpki 0.21.4",
  "webpki-roots 0.21.1",
  "whoami",
@@ -2979,7 +2979,7 @@ dependencies = [
  "time 0.3.11",
  "tokio",
  "tower",
- "tower-http 0.2.5",
+ "tower-http",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -3343,25 +3343,6 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba3f3efabf7fb41fae8534fc20a817013dd1c12cb45441efb6c82e6556b4cd8"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-range-header",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c530c8675c1dbf98facee631536fa116b5fb6382d7dd6dc1b118d970eafe3ba"
@@ -3377,6 +3358,8 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
+ "uuid 1.1.2",
 ]
 
 [[package]]
@@ -3641,6 +3624,15 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom",
  "serde",
+]
+
+[[package]]
+name = "uuid"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -25,7 +25,7 @@ base64 = "0.13.0"
 hyper = { version = "0.14.16", features = ["full"] }
 tokio = { version = "1.15.0", features = ["full"] }
 tower = "0.4.11"
-tower-http = { version = "0.2.0", features = ["trace", "cors", "request-id"] }
+tower-http = { version = "0.3.4", features = ["trace", "cors", "request-id"] }
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"
 serde_urlencoded = "0.7.1"

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -10,9 +10,10 @@ use cfg::CacheType;
 use std::{
     net::{SocketAddr, TcpListener},
     str::FromStr,
+    time::Duration,
 };
 use tower::ServiceBuilder;
-use tower_http::cors::{Any, CorsLayer};
+use tower_http::cors::{AllowHeaders, Any, CorsLayer};
 use tower_http::trace::TraceLayer;
 
 use crate::{
@@ -93,10 +94,10 @@ pub async fn run_with_prefix(
         )
         .layer(
             CorsLayer::new()
-                .allow_credentials(true)
                 .allow_origin(Any)
                 .allow_methods(Any)
-                .allow_headers(Any),
+                .allow_headers(AllowHeaders::mirror_request())
+                .max_age(Duration::from_secs(600)),
         )
         .layer(
             TraceLayer::new_for_http()


### PR DESCRIPTION
We updated tower-http which then complained about bad CORS. So we fixed
the CORS settings and also added the missing CORS cache directive
(max_age).

The main issue was mixing wildcard origin and allow_creds.
It's not actually needed, because we can just explicitly allow the
`Authorization` header which is a better idea anyway because we don't
need creds as we don't support cookie authentication.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin

Thanks to @svix-daniel for finding this issue and figuring it out.