### PR TITLE
Server: wait-for db before attempting to run migrations

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -62,7 +62,7 @@ jobs:
         SVIX_CACHE_TYPE: "memory"
       with:
         command: run
-        args: --manifest-path server/Cargo.toml -- migrate
+        args: --manifest-path server/Cargo.toml -- --wait-for 15 migrate
 
     - name: Run tests
       working-directory: ./server


### PR DESCRIPTION
We need to wait for the db to be ready before attempting to connect to
it. This applies both to the "run migrations" command, and to the run
parameter.