### PR TITLE
Kotlin: fix compilation of kotlin lib.

### DIFF
--- a/kotlin/lib/src/main/kotlin/Webhook.kt
+++ b/kotlin/lib/src/main/kotlin/Webhook.kt
@@ -11,7 +11,7 @@ import java.util.Base64
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
-class Webhook(secret: String) {
+class Webhook {
     private val key: ByteArray
 
     @Throws(WebhookVerificationException::class)
@@ -101,10 +101,11 @@ class Webhook(secret: String) {
     }
 
     constructor(secret: String) {
-        if (secret.startsWith(SECRET_PREFIX)) {
-            secret = secret.substring(SECRET_PREFIX.length)
+        var sec = secret
+        if (sec.startsWith(SECRET_PREFIX)) {
+            sec = sec.substring(SECRET_PREFIX.length)
         }
-        key = Base64.getDecoder().decode(secret)
+        key = Base64.getDecoder().decode(sec)
     }
 
     constructor(secret: ByteArray) {


### PR DESCRIPTION
There were two issues, the first one was that we were using
the primary constructor on the class and it was conflicting
with our secondary ones. The second was that we were trying
to re-assign a val, which we can't do in kotlin.