### PR TITLE
Fix incorrect phrasing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ When verifying the message you should also ensure that the timestamp is recent e
 # Differences to the Svix hosted service
 
 One of our main goals with open sourcing the Svix dispatcher is ease of use. The hosted Svix service, however, is quite complex due to our scale and the infrastructure it requires. This complexity is not useful for the vast majority of people and would make this project much harder to use and much more limited.
-This is why this code has been adjusted before being released, and some of the features, optimizations, and behaviors supported by the hosted dispatcher are not yet available in this repo. With that being said, other than some known incompatibilities, the internal Svix test suite passes. This makes them are already mostly compatible, and we are working hard on bringing them to full feature parity.
+This is why this code has been adjusted before being released, and some of the features, optimizations, and behaviors supported by the hosted dispatcher are not yet available in this repo. With that being said, other than some known incompatibilities, the internal Svix test suite passes. This means they are already mostly compatible, and we are working hard on bringing them to full feature parity.
 
 
 # Development


### PR DESCRIPTION
Simply fixes some nonsensical grammar in the README.