### PR TITLE
Add support for disabling endpoints on repeated failure

### DIFF
--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -70,6 +70,15 @@ whitelabel_headers = false
 # If true, only allow https endpoints, otherwise also allow http.
 endpoint_https_only = false
 
+# How long of a period to wait after the first dispatch failure to disable an endpoint. If a message
+# is successfully sent during this time, then the endpoint will not disable. Measured in hours.
+dispatch_disable_grace_period = 12
+
+# How long of a period to wait after a first failure has been cached to remove the record. If a
+# consistently failing endpoint is called only once within this period, then it will never be
+# disabled. Measured in hours.
+dispatch_disable_expiration_period = 36
+
 # How long to wait when making a request (in seconds)
 worker_request_timeout = 30
 

--- a/server/svix-server/tests/worker.rs
+++ b/server/svix-server/tests/worker.rs
@@ -1,16 +1,20 @@
 //! Test module for worker functionality that depends on external networking and test utilities.
 //! As such they are included with integration tests for organizational purposes.
-use std::{net::TcpListener, sync::Arc};
+use std::{net::TcpListener, sync::Arc, time::Duration};
 
 use axum::extract::Extension;
 use http::StatusCode;
-use svix_server::v1::{endpoints::attempt::MessageAttemptOut, utils::ListResponse};
+use svix_server::v1::{
+    endpoints::{attempt::MessageAttemptOut, endpoint::EndpointOut},
+    utils::ListResponse,
+};
 use tokio::sync::Mutex;
 
 mod utils;
 use utils::{
     common_calls::{create_test_app, create_test_endpoint, create_test_message},
-    run_with_retries, start_svix_server, ResponseStatusCode,
+    get_default_test_config, run_with_retries, start_svix_server, start_svix_server_with_cfg,
+    ResponseStatusCode,
 };
 
 /// Runs a full Axum server with two endoints. The first endpoint redirects to the second endpoint
@@ -113,4 +117,217 @@ async fn test_no_redirects_policy() {
     assert!(!*receiver.has_been_visited.lock().await);
 
     receiver.jh.abort();
+}
+
+/// This tests that endpoints are successfully disabled after the retry schedule is exhausted
+/// multiple times without intermittent success over a period exceeding the grace period. So the
+/// tests don't take too long, thes grace period and expiration period will be reconfigured to be
+/// on the order of seconds
+#[tokio::test]
+async fn test_endpoint_disable_on_repeated_failure() {
+    let mut cfg = get_default_test_config();
+
+    if !matches!(cfg.cache_type, svix_server::cfg::CacheType::None) {
+        cfg.retry_schedule = vec![];
+        cfg.dispatch_disable_grace_period = Duration::from_secs(1);
+        cfg.dispatch_disable_expiration_period = Duration::from_secs(5);
+
+        let (client, _jh) = start_svix_server_with_cfg(&cfg);
+
+        let app_id = create_test_app(&client, "app").await.unwrap().id;
+        let ep_id = create_test_endpoint(&client, &app_id, "http://bad.url/")
+            .await
+            .unwrap()
+            .id;
+
+        let _msg_id = create_test_message(&client, &app_id, serde_json::json!({}))
+            .await
+            .unwrap()
+            .id;
+
+        tokio::time::sleep(Duration::from_millis(1200)).await;
+
+        let _msg_id = create_test_message(&client, &app_id, serde_json::json!({}))
+            .await
+            .unwrap()
+            .id;
+
+        run_with_retries(|| async {
+            let ep: EndpointOut = client
+                .get(
+                    &format!("api/v1/app/{}/endpoint/{}/", app_id, ep_id),
+                    StatusCode::OK,
+                )
+                .await
+                .unwrap();
+
+            if !ep.disabled {
+                anyhow::bail!("Endpoint not disabled")
+            } else {
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+    }
+}
+
+/// This tests that if a consistently failing endpoint is only tried after the expiration period
+/// has been exceeded, that it will not be disabled.
+#[tokio::test]
+async fn test_endpoint_disable_expiration_duration() {
+    let mut cfg = get_default_test_config();
+
+    if !matches!(cfg.cache_type, svix_server::cfg::CacheType::None) {
+        cfg.retry_schedule = vec![];
+        cfg.dispatch_disable_grace_period = Duration::from_secs(2);
+        cfg.dispatch_disable_expiration_period = Duration::from_secs(1);
+
+        let (client, _jh) = start_svix_server_with_cfg(&cfg);
+
+        let app_id = create_test_app(&client, "app").await.unwrap().id;
+        let ep_id = create_test_endpoint(&client, &app_id, "http://bad.url/")
+            .await
+            .unwrap()
+            .id;
+
+        let _msg_id = create_test_message(&client, &app_id, serde_json::json!({}))
+            .await
+            .unwrap()
+            .id;
+
+        tokio::time::sleep(Duration::from_millis(1200)).await;
+
+        let _msg_id = create_test_message(&client, &app_id, serde_json::json!({}))
+            .await
+            .unwrap()
+            .id;
+
+        // Cannot run with retries as it's not disabled by default and we are checking that it remains
+        // not disabled. So another sleep is required here.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let ep: EndpointOut = client
+            .get(
+                &format!("api/v1/app/{}/endpoint/{}/", app_id, ep_id),
+                StatusCode::OK,
+            )
+            .await
+            .unwrap();
+
+        assert!(!ep.disabled);
+    }
+}
+
+/// Because the endpoint disabling system requires failures, we need a test receiver that fails
+/// some of the time, but not all of the time, such as to be able to test that a successful response
+/// after a failure clears the cache for that endpoint.
+struct SporadicallyFailingReceiver {
+    pub base_uri: String,
+    pub jh: tokio::task::JoinHandle<()>,
+}
+
+impl SporadicallyFailingReceiver {
+    pub fn start(resp_with: (http::StatusCode, http::StatusCode)) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let base_uri = format!("http://{}", listener.local_addr().unwrap());
+
+        let count = Arc::new(Mutex::new(0u8));
+
+        let routes = axum::Router::new()
+            .route(
+                "/",
+                axum::routing::post(sporadically_failing_route).get(sporadically_failing_route),
+            )
+            .layer(Extension(count))
+            .layer(Extension(resp_with))
+            .into_make_service();
+
+        let jh = tokio::spawn(async move {
+            axum::Server::from_tcp(listener)
+                .unwrap()
+                .serve(routes)
+                .await
+                .unwrap();
+        });
+
+        SporadicallyFailingReceiver { base_uri, jh }
+    }
+}
+
+async fn sporadically_failing_route(
+    Extension(count): Extension<Arc<Mutex<u8>>>,
+    Extension((resp_ok, resp_fail)): Extension<(StatusCode, StatusCode)>,
+) -> StatusCode {
+    let mut count = count.lock().await;
+    *count += 1;
+
+    if *count % 2 == 0 {
+        resp_ok
+    } else {
+        resp_fail
+    }
+}
+
+/// This tetss that if an endpoint succceeds, that its record is cleared in the cache and it is not
+/// disabled after the grace period following a failure.
+#[tokio::test]
+async fn test_endpoint_disable_on_sporadic_failure() {
+    let mut cfg = get_default_test_config();
+
+    if !matches!(cfg.cache_type, svix_server::cfg::CacheType::None) {
+        let receiver =
+            SporadicallyFailingReceiver::start((StatusCode::OK, StatusCode::INTERNAL_SERVER_ERROR));
+
+        cfg.retry_schedule = vec![];
+        cfg.dispatch_disable_grace_period = Duration::from_secs(1);
+        cfg.dispatch_disable_expiration_period = Duration::from_secs(3);
+
+        let (client, _jh) = start_svix_server_with_cfg(&cfg);
+
+        let app_id = create_test_app(&client, "app").await.unwrap().id;
+        let ep_id = create_test_endpoint(&client, &app_id, &receiver.base_uri)
+            .await
+            .unwrap()
+            .id;
+
+        // Fails
+        let _msg_id = create_test_message(&client, &app_id, serde_json::json!({}))
+            .await
+            .unwrap()
+            .id;
+
+        // Sleep here to make sure the failure has been processed *before* the successful response clears
+        // the key. Otherwise the set may happen after the clear and the endpoint will be disabled after
+        // the second failure
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Succeeds
+        let _msg_id = create_test_message(&client, &app_id, serde_json::json!({}))
+            .await
+            .unwrap()
+            .id;
+
+        tokio::time::sleep(Duration::from_millis(1200)).await;
+
+        // Fails
+        let _msg_id = create_test_message(&client, &app_id, serde_json::json!({}))
+            .await
+            .unwrap()
+            .id;
+
+        // Cannot run with retries as it's not disabled by default and we are checking that it remains
+        // not disabled. So another sleep is required here.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let ep: EndpointOut = client
+            .get(
+                &format!("api/v1/app/{}/endpoint/{}/", app_id, ep_id),
+                StatusCode::OK,
+            )
+            .await
+            .unwrap();
+
+        assert!(!ep.disabled);
+
+        receiver.jh.abort();
+    }
 }


### PR DESCRIPTION
If a given endpoint has only failed for a duration exceeding the configured
grace period, then this PR will disable the endpoint such as to avoid flooding
the queue with tasks to endpoints which only ever fail.