### PR TITLE
Update libraries to automatically detect region from API key

### DIFF
--- a/go/svix.go
+++ b/go/svix.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+	"strings"
 
 	"github.com/svix/svix-webhooks/go/internal/openapi"
 	"github.com/svix/svix-webhooks/go/internal/version"
@@ -45,6 +46,21 @@ func New(token string, options *SvixOptions) *Svix {
 	conf.Scheme = "https"
 	conf.Host = "api.svix.com"
 	conf.HTTPClient = defaultHTTPClient
+
+	var tokenParts = strings.Split(s, ".")
+	if len(tokenParts) == 2 {
+		var region = tokenParts[1]
+		if region == "us" {
+			conf.Host = "api.us.svix.com"
+		}
+		if region == "eu" {
+			conf.Host = "api.eu.svix.com"
+		}
+		if region == "in" {
+			conf.Host = "api.in.svix.com"
+		}
+	}
+
 	if options != nil {
 		conf.Debug = options.Debug
 		if options.ServerUrl != nil {

--- a/java/lib/src/main/java/com/svix/Svix.java
+++ b/java/lib/src/main/java/com/svix/Svix.java
@@ -20,6 +20,21 @@ public final class Svix {
 
 	public Svix(final String token, final SvixOptions options) {
 		ApiClient apiClient = Configuration.getDefaultApiClient();
+
+		String[] tokenParts = token.split("\\.");
+		if (tokenParts.length == 2) {
+			String region = tokenParts[1];
+			if (region.equals("us")) {
+				apiClient.setBasePath("https://api.us.svix.com");
+			}
+			if (region.equals("eu")) {
+				apiClient.setBasePath("https://api.eu.svix.com");
+			}
+			if (region.equals("in")) {
+				apiClient.setBasePath("https://api.in.svix.com");
+			}
+		}
+
 		apiClient.setBasePath(options.getServerUrl());
 		apiClient.setUserAgent(String.format("svix-libs/%s/java", Svix.VERSION));
 

--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -72,6 +72,12 @@ export interface SvixOptions {
   serverUrl?: string;
 }
 
+const REGIONS = [
+  { region: "us", url: "https://api.us.svix.com" },
+  { region: "eu", url: "https://api.eu.svix.com" },
+  { region: "in", url: "https://api.in.svix.com" },
+];
+
 export class Svix {
   public readonly _configuration: Configuration;
   public readonly authentication: Authentication;
@@ -83,7 +89,8 @@ export class Svix {
   public readonly messageAttempt: MessageAttempt;
 
   public constructor(token: string, options: SvixOptions = {}) {
-    const baseUrl: string = options.serverUrl ?? "https://api.svix.com";
+    const regionalUrl = REGIONS.find((x) => x.region === token.split(".")[1])?.url;
+    const baseUrl: string = options.serverUrl ?? regionalUrl ?? "https://api.svix.com";
 
     const baseServer = new ServerConfiguration<any>(baseUrl, {});
 


### PR DESCRIPTION
Updates libraries to automatically detect the appropriate region from the API key, and set the correct Svix server base URL. Backwards-compat. Base URL inference works like this:

1. Is an explicit base URL provided? Use that. If not,
2. Does the API key indicate its corresponding region? Use that region's URL. If not,
3. Fallback on current behavior.

Fixes #3471.