### PR TITLE
Add log event on graceful shutdown start

### DIFF
--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -68,6 +68,7 @@ async fn graceful_shutdown_handler() {
         _ = sigterm => {},
     }
 
+    tracing::info!("Received shutdown signal. Shutting down gracefully...");
     SHUTTING_DOWN.store(true, Ordering::SeqCst)
 }
 


### PR DESCRIPTION
Adds a message stating that the server is shutting down gracefully on receiving SIGTERM/SIGINT.