### PR TITLE
Explicitly allow Unicode-DFS-2016 license in deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -27,10 +27,11 @@ allow = [
     "Apache-2.0",
     "BSD-2-Clause",
     "BSD-3-Clause",
-	"ISC",
+    "ISC",
     "MIT",
-	"MPL-2.0",
+    "MPL-2.0",
     "OpenSSL",
+    "Unicode-DFS-2016",
 ]
 deny = []
 copyleft = "deny"


### PR DESCRIPTION
An indirect dependency of ours recently included this license with the project. This adds that license to those explicitly allowed in the cargo-deny configuration. 