### PR TITLE
Introduce svix.NullableString utility

### DIFF
--- a/go/svix.go
+++ b/go/svix.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"time"
 	"strings"
+	"time"
 
 	"github.com/svix/svix-webhooks/go/internal/openapi"
 	"github.com/svix/svix-webhooks/go/internal/version"
@@ -36,6 +36,9 @@ var defaultHTTPClient = &http.Client{
 
 func String(s string) *string {
 	return &s
+}
+func NullableString(s string) *openapi.NullableString {
+	return openapi.NewNullableString(&s)
 }
 func Int32(i int32) *int32 {
 	return &i


### PR DESCRIPTION
## Motivation

The MessageIn struct has an EventId field of type `openapi.NullableString`. The `openapi.NullableString` is defined in an internal package, so it's impossible to be imported by the end developer.


## Solution


This PR introduces the `svix.NullableString` public utility to generate an `openapi.NullableString` struct to be used as an `EventId`.
