### PR TITLE
Consolidate configuration validation to the cfg module

### DIFF
--- a/server/svix-server/src/queue/mod.rs
+++ b/server/svix-server/src/queue/mod.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use svix_ksuid::*;
 
 use crate::{
-    cfg::{Configuration, QueueType},
+    cfg::{Configuration, QueueBackend},
     core::{
         run_with_retries::run_with_retries,
         types::{ApplicationId, EndpointId, MessageAttemptTriggerType, MessageId},
@@ -31,23 +31,16 @@ pub async fn new_pair(
     cfg: &Configuration,
     prefix: Option<&str>,
 ) -> (TaskQueueProducer, TaskQueueConsumer) {
-    let redis_dsn = || {
-        cfg.redis_dsn
-            .as_ref()
-            .expect("Redis DSN not found")
-            .as_str()
-    };
-
-    match cfg.queue_type {
-        QueueType::Redis => {
-            let pool = crate::redis::new_redis_pool(redis_dsn(), cfg).await;
+    match cfg.queue_backend() {
+        QueueBackend::Redis(dsn) => {
+            let pool = crate::redis::new_redis_pool(dsn, cfg).await;
             redis::new_pair(pool, prefix).await
         }
-        QueueType::RedisCluster => {
-            let pool = crate::redis::new_redis_pool_clustered(redis_dsn(), cfg).await;
+        QueueBackend::RedisCluster(dsn) => {
+            let pool = crate::redis::new_redis_pool_clustered(dsn, cfg).await;
             redis::new_pair(pool, prefix).await
         }
-        QueueType::Memory => memory::new_pair().await,
+        QueueBackend::Memory => memory::new_pair().await,
     }
 }
 


### PR DESCRIPTION
Makes miscellaneous improvements to the `ConfigurationInner` validation to provide clearer error messages and avoid validation code scattered elsewhere in the codebase.

The main change is to the Redis DSN validation and the associated helper methods for fetching the key value store backend used by both the queue and the cache.

This also changes the type of the `listen_address` from a `String` to a `SocketAddr` such as to avoid parsing it elsewhere in the code.