### PR TITLE
Server: set the default region to self_hosted.

### DIFF
--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -253,7 +253,7 @@ pub struct InternalConfig {
 }
 
 fn default_region() -> String {
-    "eu".to_owned()
+    "self_hosted".to_owned()
 }
 
 fn default_app_portal_url() -> String {


### PR DESCRIPTION
The default region shouldn't be the EU, but rather self_hosted, so we are
explicit about the region being used rather than claiming to be in the
EU. This was causing issues with the app portal not being able to
detect the token is for a self hosted install.

First step towards fixing #576