### PR TITLE
Allow overriding redis_dsn for separate queue and cache DSNs

### DIFF
--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -45,7 +45,9 @@ db_dsn = "postgresql://postgres:postgres@pgbouncer/postgres"
 # Higher values can significantly increase performance if your database can handle it.
 db_pool_max_size = 20
 
-# The DSN for redis (can be left empty if not using redis)
+# The defualt DSN for redis. `queue_dsn` and `cache_dsn` with take precedence over this value.
+# (can be left empty if not using redis or if Redis is configured through the queue and/or cache
+# specific DSNs)
 redis_dsn = "redis://redis:6379"
 
 # The maximum number of connections for the Redis pool. Minimum value of 10
@@ -53,16 +55,22 @@ redis_dsn = "redis://redis:6379"
 redis_pool_max_size = 20
 
 # What kind of message queue to use. Supported: memory, redis, rediscluster
-# Redis backends must have a redis_dsn configured, and it's highly recommended to enable persistence in redis so that
-# a server restart doesn't wipe the queue.
+# Redis backends must have a redis_dsn or queue_dsn configured, and it's highly recommended to
+# enable persistence in redis so that a server restart doesn't wipe the queue.
 queue_type = "redis"
 
+# The DSN for the Redis-backed queue. Overrides `redis_dsn`. (can be left empty if not using redis)
+# queue_dsn = "redis://redis:6379"
+
 # What kind of cache to use. Supported: memory, redis, rediscluster, none.
-# Redis backends must have a redis_dsn configured.
+# Redis backends must have a redis_dsn or cache_dsn configured.
 # The memory backend is recommended if you only have one instance running (not including workers). If you have
 # multiple API servers running, please use the redis backend or some functionality, (e.g. Idempotency)
 # may fail to work correctly.
 cache_type = "memory"
+
+# The DSN for the Redis-backed cache. Overrides `redis_dsn`. (can be left empty if not using redis)
+# cache_dsn = "redis://redis:6379"
 
 # If true, headers are prefixed with `Webhook-`, otherwise with `Svix-` (default).
 whitelabel_headers = false


### PR DESCRIPTION
This adds two configuration values, `redis_dsn` and `cache_dsn` which both will override the default `redis_dsn` when set. This is such that you can use separate Redis instances/clusters for the cache and queue.