### PR TITLE
JavaScript: change the utf8 encoder to the default node one

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "@stablelib/base64": "^1.0.0",
-    "@stablelib/utf8": "^1.0.0",
     "es6-promise": "^4.2.4",
     "fast-sha256": "^1.3.0",
     "svix-fetch": "^3.0.0",

--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -49,7 +49,6 @@ import {
 } from "./openapi/index";
 export * from "./openapi/models/all";
 export * from "./openapi/apis/exception";
-import * as utf8 from "@stablelib/utf8";
 import * as base64 from "@stablelib/base64";
 import * as sha256 from "fast-sha256";
 
@@ -672,7 +671,8 @@ export class Webhook {
   }
 
   public sign(msgId: string, timestamp: Date, payload: string): string {
-    const toSign = utf8.encode(`${msgId}.${timestamp.getTime() / 1000}.${payload}`);
+    const encoder = new TextEncoder();
+    const toSign = encoder.encode(`${msgId}.${timestamp.getTime() / 1000}.${payload}`);
     const expectedSignature = base64.encode(sha256.hmac(this.key, toSign));
     return `v1,${expectedSignature}`;
   }

--- a/javascript/yarn.lock
+++ b/javascript/yarn.lock
@@ -575,11 +575,6 @@
   resolved "https://registry.yarnpkg.com/@stablelib/base64/-/base64-1.0.0.tgz#e08ba78078c731cbbb244530b1750659c52ba7cb"
   integrity sha512-s/wTc/3+vYSalh4gfayJrupzhT7SDBqNtiYOeEMlkSDqL/8cExh5FAeTzLpmYq+7BLLv36EjBL5xrb0bUHWJWQ==
 
-"@stablelib/utf8@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@stablelib/utf8/-/utf8-1.0.0.tgz#7c0c039b6d154da50326003ea92777ddc8f5db2c"
-  integrity sha512-Y8QWrK4T0yW0HMFfSI3ZaMHKV37q27hX5ilsmKV358x01mzYfj5fwIf2LjzTlF+UIemHEXSlSN9XJnv1ML4znQ==
-
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"


### PR DESCRIPTION
The TextEncoder API is supported both by Node and by web APIs, so we
should have used it in the first place though we didn't know it was
incomplete.

Essentially the problem is that we used a lib that doesn't support the
full extended utf8 (6 byte) range so it was barfing.

Here's a utf8 sequence that triggers the use (when encoded as string):

```
Uint8Array(21) [
  226, 143, 176, 240, 159,
  154, 180, 240, 159, 143,
  187, 226, 128, 141, 226,
  153, 130, 239, 184, 143,
   32
]
```

Initially reported on Slack:
https://svixcommunity.slack.com/archives/C022BJ2EBHV/p1659020835781289

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
