### PR TITLE
Ruby library: fix region detection

### DIFF
--- a/ruby/lib/svix/svix.rb
+++ b/ruby/lib/svix/svix.rb
@@ -5,7 +5,7 @@ module Svix
         attr_accessor :debug
         attr_accessor :server_url
 
-        def initialize(debug = false, server_url = "https://api.svix.com")
+        def initialize(debug = false, server_url = nil)
             @debug=debug
             @server_url=server_url
         end
@@ -22,7 +22,6 @@ module Svix
 
         def initialize(auth_token, options = SvixOptions.new)
 
-            regional_url = nil
             region = auth_token.split(".").last
             if region == "us"
                 regional_url = "https://api.us.svix.com"
@@ -30,6 +29,8 @@ module Svix
                 regional_url = "https://api.eu.svix.com"
             elsif region == "in"
                 regional_url = "https://api.in.svix.com"
+            else
+                regional_url = "https://api.svix.com"
             end
 
             uri = URI(options.server_url || regional_url)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Region detection fails to detect region automatically
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Swap the places of the operands around the || operator. That way if the region is detectable using AUTH_TOKEN it will use that, otherwise it will use default url.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
