### PR TITLE
Destructure self in ModelIn impls to avoid forgotten members

### DIFF
--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -59,9 +59,15 @@ impl ModelIn for ApplicationIn {
     type ActiveModel = application::ActiveModel;
 
     fn update_model(self, model: &mut Self::ActiveModel) {
-        model.name = Set(self.name);
-        model.rate_limit = Set(self.rate_limit.map(|x| x.into()));
-        model.uid = Set(self.uid);
+        let ApplicationIn {
+            name,
+            rate_limit,
+            uid,
+        } = self;
+
+        model.name = Set(name);
+        model.rate_limit = Set(rate_limit.map(|x| x.into()));
+        model.uid = Set(uid);
     }
 }
 

--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -157,14 +157,26 @@ impl ModelIn for EndpointIn {
     type ActiveModel = endpoint::ActiveModel;
 
     fn update_model(self, model: &mut Self::ActiveModel) {
-        model.description = Set(self.description);
-        model.rate_limit = Set(self.rate_limit.map(|x| x.into()));
-        model.uid = Set(self.uid);
-        model.url = Set(self.url);
-        model.version = Set(self.version.into());
-        model.disabled = Set(self.disabled);
-        model.event_types_ids = Set(self.event_types_ids);
-        model.channels = Set(self.channels);
+        let EndpointIn {
+            description,
+            rate_limit,
+            uid,
+            url,
+            version,
+            disabled,
+            event_types_ids,
+            channels,
+            key: _,
+        } = self;
+
+        model.description = Set(description);
+        model.rate_limit = Set(rate_limit.map(|x| x.into()));
+        model.uid = Set(uid);
+        model.url = Set(url);
+        model.version = Set(version.into());
+        model.disabled = Set(disabled);
+        model.event_types_ids = Set(event_types_ids);
+        model.channels = Set(channels);
     }
 }
 
@@ -347,7 +359,8 @@ impl ModelIn for EndpointHeadersIn {
     type ActiveModel = endpoint::ActiveModel;
 
     fn update_model(self, model: &mut Self::ActiveModel) {
-        model.headers = Set(Some(self.headers));
+        let EndpointHeadersIn { headers } = self;
+        model.headers = Set(Some(headers));
     }
 }
 
@@ -393,8 +406,10 @@ impl ModelIn for EndpointHeadersPatchIn {
     type ActiveModel = endpoint::ActiveModel;
 
     fn update_model(self, model: &mut Self::ActiveModel) {
+        let EndpointHeadersPatchIn { headers } = self;
+
         model.headers = if let Some(Some(mut hdrs)) = model.headers.take() {
-            for (k, v) in self.headers.0 {
+            for (k, v) in headers.0 {
                 if let Some(v) = v {
                     hdrs.0.insert(k, v);
                 } else {
@@ -403,8 +418,7 @@ impl ModelIn for EndpointHeadersPatchIn {
             }
             Set(Some(hdrs))
         } else {
-            let headers: HashMap<String, String> = self
-                .headers
+            let headers: HashMap<String, String> = headers
                 .0
                 .into_iter()
                 .filter_map(|(k, v)| v.map(|v| (k, v)))

--- a/server/svix-server/src/v1/endpoints/event_type.rs
+++ b/server/svix-server/src/v1/endpoints/event_type.rs
@@ -48,10 +48,17 @@ impl ModelIn for EventTypeIn {
     type ActiveModel = eventtype::ActiveModel;
 
     fn update_model(self, model: &mut Self::ActiveModel) {
-        model.name = Set(self.name);
-        model.description = Set(self.description);
-        model.deleted = Set(self.deleted);
-        model.schemas = Set(self.schemas);
+        let EventTypeIn {
+            name,
+            description,
+            deleted,
+            schemas,
+        } = self;
+
+        model.name = Set(name);
+        model.description = Set(description);
+        model.deleted = Set(deleted);
+        model.schemas = Set(schemas);
     }
 }
 
@@ -70,9 +77,15 @@ impl ModelIn for EventTypeUpdate {
     type ActiveModel = eventtype::ActiveModel;
 
     fn update_model(self, model: &mut Self::ActiveModel) {
-        model.description = Set(self.description);
-        model.deleted = Set(self.deleted);
-        model.schemas = Set(self.schemas);
+        let EventTypeUpdate {
+            description,
+            deleted,
+            schemas,
+        } = self;
+
+        model.description = Set(description);
+        model.deleted = Set(deleted);
+        model.schemas = Set(schemas);
     }
 }
 

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -73,13 +73,21 @@ impl ModelIn for MessageIn {
     type ActiveModel = message::ActiveModel;
 
     fn update_model(self, model: &mut message::ActiveModel) {
-        let expiration = Utc::now() + Duration::days(self.payload_retention_period);
+        let MessageIn {
+            uid,
+            payload,
+            event_type,
+            channels,
+            payload_retention_period,
+        } = self;
 
-        model.uid = Set(self.uid);
-        model.payload = Set(Some(self.payload));
-        model.event_type = Set(self.event_type);
+        let expiration = Utc::now() + Duration::days(payload_retention_period);
+
+        model.uid = Set(uid);
+        model.payload = Set(Some(payload));
+        model.event_type = Set(event_type);
         model.expiration = Set(expiration.with_timezone(&Utc).into());
-        model.channels = Set(self.channels);
+        model.channels = Set(channels);
     }
 }
 


### PR DESCRIPTION
Destructures the `self` type into its members inside `ModelIn` implementations where it should be very explicit if a field is to be ignored when updating the database model.