### PR TITLE
Upsert behavior on PUT methods

### DIFF
--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -9,7 +9,7 @@ use crate::{
             AuthenticatedApplication, AuthenticatedOrganization,
             AuthenticatedOrganizationWithApplication,
         },
-        types::{ApplicationId, ApplicationUid},
+        types::{ApplicationId, ApplicationIdOrUid, ApplicationUid},
     },
     db::models::application,
     error::{HttpError, Result},
@@ -24,7 +24,7 @@ use crate::{
     },
 };
 use axum::{
-    extract::Extension,
+    extract::{Extension, Path},
     routing::{get, post},
     Json, Router,
 };
@@ -249,16 +249,34 @@ async fn get_application(
 async fn update_application(
     Extension(ref db): Extension<DatabaseConnection>,
     ValidatedJson(data): ValidatedJson<ApplicationIn>,
-    AuthenticatedOrganizationWithApplication {
-        permissions: _,
-        app,
-    }: AuthenticatedOrganizationWithApplication,
-) -> Result<Json<ApplicationOut>> {
-    let mut app: application::ActiveModel = app.into();
-    data.update_model(&mut app);
+    Path(app_id): Path<ApplicationIdOrUid>,
+    AuthenticatedOrganization { permissions }: AuthenticatedOrganization,
+) -> Result<(StatusCode, Json<ApplicationOut>)> {
+    let app = application::Entity::secure_find_by_id_or_uid(permissions.org_id.clone(), app_id)
+        .one(db)
+        .await?;
 
-    let ret = app.update(db).await?;
-    Ok(Json(ret.into()))
+    let (status_code, ret) = match app {
+        Some(app) => {
+            let mut app: application::ActiveModel = app.into();
+            data.update_model(&mut app);
+            let ret = app.update(db).await?;
+
+            (StatusCode::OK, ret)
+        }
+        None => {
+            let ret = application::ActiveModel {
+                org_id: Set(permissions.org_id.clone()),
+                ..data.into()
+            }
+            .insert(db)
+            .await?;
+
+            (StatusCode::CREATED, ret)
+        }
+    };
+
+    Ok((status_code, Json(ret.into())))
 }
 
 async fn patch_application(

--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -256,13 +256,13 @@ async fn update_application(
         .one(db)
         .await?;
 
-    let (status_code, ret) = match app {
+    match app {
         Some(app) => {
             let mut app: application::ActiveModel = app.into();
             data.update_model(&mut app);
             let ret = app.update(db).await?;
 
-            (StatusCode::OK, ret)
+            Ok((StatusCode::OK, Json(ret.into())))
         }
         None => {
             let ret = application::ActiveModel {
@@ -272,11 +272,9 @@ async fn update_application(
             .insert(db)
             .await?;
 
-            (StatusCode::CREATED, ret)
+            Ok((StatusCode::CREATED, Json(ret.into())))
         }
-    };
-
-    Ok((status_code, Json(ret.into())))
+    }
 }
 
 async fn patch_application(

--- a/server/svix-server/src/v1/endpoints/event_type.rs
+++ b/server/svix-server/src/v1/endpoints/event_type.rs
@@ -258,17 +258,32 @@ async fn update_event_type(
     Path(evtype_name): Path<EventTypeName>,
     ValidatedJson(data): ValidatedJson<EventTypeUpdate>,
     AuthenticatedOrganization { permissions }: AuthenticatedOrganization,
-) -> Result<Json<EventTypeOut>> {
+) -> Result<(StatusCode, Json<EventTypeOut>)> {
     let evtype = eventtype::Entity::secure_find_by_name(permissions.org_id.clone(), evtype_name)
         .one(db)
-        .await?
-        .ok_or_else(|| HttpError::not_found(None, None))?;
+        .await?;
 
-    let mut evtype: eventtype::ActiveModel = evtype.into();
-    data.update_model(&mut evtype);
+    let (status_code, ret) = match evtype {
+        Some(evtype) => {
+            let mut evtype: eventtype::ActiveModel = evtype.into();
+            data.update_model(&mut evtype);
+            let ret = evtype.update(db).await?;
 
-    let ret = evtype.update(db).await?;
-    Ok(Json(ret.into()))
+            (StatusCode::OK, ret)
+        }
+        None => {
+            let ret = eventtype::ActiveModel {
+                org_id: Set(permissions.org_id.clone()),
+                ..data.into()
+            }
+            .insert(db)
+            .await?;
+
+            (StatusCode::CREATED, ret)
+        }
+    };
+
+    Ok((status_code, Json(ret.into())))
 }
 
 async fn patch_event_type(

--- a/server/svix-server/src/v1/endpoints/event_type.rs
+++ b/server/svix-server/src/v1/endpoints/event_type.rs
@@ -259,9 +259,10 @@ async fn update_event_type(
     ValidatedJson(data): ValidatedJson<EventTypeUpdate>,
     AuthenticatedOrganization { permissions }: AuthenticatedOrganization,
 ) -> Result<(StatusCode, Json<EventTypeOut>)> {
-    let evtype = eventtype::Entity::secure_find_by_name(permissions.org_id.clone(), evtype_name)
-        .one(db)
-        .await?;
+    let evtype =
+        eventtype::Entity::secure_find_by_name(permissions.org_id.clone(), evtype_name.clone())
+            .one(db)
+            .await?;
 
     let (status_code, ret) = match evtype {
         Some(evtype) => {
@@ -274,6 +275,7 @@ async fn update_event_type(
         None => {
             let ret = eventtype::ActiveModel {
                 org_id: Set(permissions.org_id.clone()),
+                name: Set(evtype_name),
                 ..data.into()
             }
             .insert(db)

--- a/server/svix-server/src/v1/endpoints/event_type.rs
+++ b/server/svix-server/src/v1/endpoints/event_type.rs
@@ -264,13 +264,13 @@ async fn update_event_type(
             .one(db)
             .await?;
 
-    let (status_code, ret) = match evtype {
+    match evtype {
         Some(evtype) => {
             let mut evtype: eventtype::ActiveModel = evtype.into();
             data.update_model(&mut evtype);
             let ret = evtype.update(db).await?;
 
-            (StatusCode::OK, ret)
+            Ok((StatusCode::OK, Json(ret.into())))
         }
         None => {
             let ret = eventtype::ActiveModel {
@@ -281,11 +281,9 @@ async fn update_event_type(
             .insert(db)
             .await?;
 
-            (StatusCode::CREATED, ret)
+            Ok((StatusCode::CREATED, Json(ret.into())))
         }
-    };
-
-    Ok((status_code, Json(ret.into())))
+    }
 }
 
 async fn patch_event_type(

--- a/server/svix-server/tests/e2e_application.rs
+++ b/server/svix-server/tests/e2e_application.rs
@@ -30,6 +30,16 @@ async fn test_patch() {
         .await
         .unwrap();
 
+    // Test that PUT with an invalid ID creates an application
+    let _: ApplicationOut = client
+        .put(
+            "api/v1/app/fake-id/",
+            application_in("first_name"),
+            StatusCode::CREATED,
+        )
+        .await
+        .unwrap();
+
     // Test that name may be set while the rest are omitted
     let _: ApplicationOut = client
         .patch(

--- a/server/svix-server/tests/e2e_endpoint.rs
+++ b/server/svix-server/tests/e2e_endpoint.rs
@@ -538,6 +538,16 @@ async fn test_crud() {
         .unwrap();
     assert_eq!(app_1_ep_1.url, EP_URI_APP_1_EP_1_VER_2);
 
+    // Test that PUT with an invalid ID creates an endpoint
+    let _: EndpointOut = client
+        .put(
+            &format!("api/v1/app/{}/endpoint/fake-id/", app_1),
+            endpoint_in(EP_URI_APP_1_EP_1_VER_2),
+            StatusCode::CREATED,
+        )
+        .await
+        .unwrap();
+
     // CONFIRM UPDATE
     assert_eq!(
         get_endpoint(&client, &app_1, &app_1_ep_1_id).await.unwrap(),

--- a/server/svix-server/tests/e2e_endpoint.rs
+++ b/server/svix-server/tests/e2e_endpoint.rs
@@ -539,7 +539,7 @@ async fn test_crud() {
     assert_eq!(app_1_ep_1.url, EP_URI_APP_1_EP_1_VER_2);
 
     // Test that PUT with an invalid ID creates an endpoint
-    let _: EndpointOut = client
+    let app_1_ep_3: EndpointOut = client
         .put(
             &format!("api/v1/app/{}/endpoint/fake-id/", app_1),
             endpoint_in(EP_URI_APP_1_EP_1_VER_2),
@@ -559,9 +559,10 @@ async fn test_crud() {
         .get(&format!("api/v1/app/{}/endpoint/", &app_1), StatusCode::OK)
         .await
         .unwrap();
-    assert_eq!(list_app_1.data.len(), 2);
+    assert_eq!(list_app_1.data.len(), 3);
     assert!(list_app_1.data.contains(&app_1_ep_1));
     assert!(list_app_1.data.contains(&app_1_ep_2));
+    assert!(list_app_1.data.contains(&app_1_ep_3));
 
     let list_app_2: ListResponse<EndpointOut> = client
         .get(&format!("api/v1/app/{}/endpoint/", &app_2), StatusCode::OK)

--- a/server/svix-server/tests/e2e_event_type.rs
+++ b/server/svix-server/tests/e2e_event_type.rs
@@ -28,6 +28,16 @@ async fn test_patch() {
         .await
         .unwrap();
 
+    // Test that PUT with invalid ID creates an event type
+    let _: EventTypeOut = client
+        .put(
+            "api/v1/event-type/fake-id",
+            event_type_in("test-event-type", serde_json::json!({"test": "value"})).unwrap(),
+            StatusCode::CREATED,
+        )
+        .await
+        .unwrap();
+
     // Test that description may be set while the rest are omitted
     let _: EventTypeOut = client
         .patch(


### PR DESCRIPTION
This PR enables support for creation of entities during PUT requests if the provided ID did not match an existing record. Affected entities are Application, Endpoint, and Event Type. PUT requests against those entities will now return 200 to indicate the record existed and was modified, or 201 to indicate the record was created.

Closes #603.