### PR TITLE
Server: Fix validation errors

### DIFF
--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
-use std::borrow::Cow;
-
 use crate::{
     core::{
         security::{
@@ -18,9 +16,9 @@ use crate::{
             patch_field_non_nullable, patch_field_nullable, UnrequiredField,
             UnrequiredNullableField,
         },
-        validate_no_control_characters, validate_no_control_characters_unrequired, EmptyResponse,
-        ListResponse, ModelIn, ModelOut, Pagination, PaginationLimit, ValidatedJson,
-        ValidatedQuery,
+        validate_no_control_characters, validate_no_control_characters_unrequired,
+        validation_error, EmptyResponse, ListResponse, ModelIn, ModelOut, Pagination,
+        PaginationLimit, ValidatedJson, ValidatedQuery,
     },
 };
 use axum::{
@@ -116,11 +114,10 @@ fn validate_name_length_patch(
         UnrequiredField::Absent => Ok(()),
         UnrequiredField::Some(s) => {
             if s.is_empty() {
-                let mut error = ValidationError::new("length");
-                error.message = Some(Cow::from(
-                    "Application names must be at least one character",
-                ));
-                Err(error)
+                Err(validation_error(
+                    Some("length"),
+                    Some("Application names must be at least one character"),
+                ))
             } else {
                 Ok(())
             }
@@ -137,11 +134,10 @@ fn validate_rate_limit_patch(
             if *rate_limit > 0 {
                 Ok(())
             } else {
-                let mut error = ValidationError::new("range");
-                error.message = Some(Cow::from(
-                    "Application rate limits must be at least 1 if set",
-                ));
-                Err(error)
+                Err(validation_error(
+                    Some("range"),
+                    Some("Application rate limits must be at least 1 if set"),
+                ))
             }
         }
     }

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -14,8 +14,9 @@ use crate::{
     error::{Error, HttpError, Result},
     queue::{MessageTaskBatch, TaskQueueProducer},
     v1::utils::{
-        apply_pagination, iterator_from_before_or_after, ListResponse, MessageListFetchOptions,
-        ModelIn, ModelOut, PaginationLimit, ReversibleIterator, ValidatedJson, ValidatedQuery,
+        apply_pagination, iterator_from_before_or_after, validation_error, ListResponse,
+        MessageListFetchOptions, ModelIn, ModelOut, PaginationLimit, ReversibleIterator,
+        ValidatedJson, ValidatedQuery,
     },
 };
 use axum::{
@@ -41,8 +42,9 @@ pub fn validate_channels_msg(
 ) -> std::result::Result<(), ValidationError> {
     let len = channels.0.len();
     if !(1..=5).contains(&len) {
-        Err(ValidationError::new(
-            "Channels must have at least 1 and at most 5 items, or be set to null.",
+        Err(validation_error(
+            Some("channels"),
+            Some("Channels must have at least 1 and at most 5 items, or be set to null."),
         ))
     } else {
         Ok(())


### PR DESCRIPTION
Previously many of our custom validation errors were passing messages
as error codes, which caused them not to be shown by our current
validation error handling. Fixed this and added method to simplify
proper instantiation of validation errors.
