### PR TITLE
Temporarily disable CI builds against the Rust Beta channel

### DIFF
--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, beta]
+        rust: [stable]
     steps:
     - uses: actions/checkout@master
 

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, beta]
+        rust: [stable]
     steps:
     - uses: actions/checkout@master
     - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
rust-lang/rust#100215 on the Rust Beta channel is causing CI builds to fail. This PR temporarily disables CI against the Rust Beta channel, with the expectation that it will be reenabled once the issue has been resolved.