### PR TITLE
Reenable CI builds against Rust Beta channel

### DIFF
--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable]
+        rust: [stable, beta]
     steps:
     - uses: actions/checkout@master
 

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable]
+        rust: [stable, beta]
     steps:
     - uses: actions/checkout@master
     - uses: actions-rs/toolchain@v1

--- a/rust/src/webhooks.rs
+++ b/rust/src/webhooks.rs
@@ -91,7 +91,7 @@ impl Webhook {
                     .fold(0, |acc, (a, b)| acc | (a ^ b))
                     == 0
             })
-            .then(|| ())
+            .then_some(())
             .ok_or(WebhookError::InvalidSignature)
     }
 

--- a/server/svix-server/src/queue/redis.rs
+++ b/server/svix-server/src/queue/redis.rs
@@ -454,7 +454,7 @@ fn to_redis_key(delivery: &TaskQueueDelivery) -> String {
 fn from_redis_key(key: &str) -> TaskQueueDelivery {
     // Get the first delimiter -> it has to have the |
     let pos = key.find('|').unwrap();
-    let id = (&key[..pos]).to_string();
+    let id = key[..pos].to_string();
     let task = serde_json::from_str(&key[pos + 1..]).unwrap();
     TaskQueueDelivery { id, task }
 }


### PR DESCRIPTION
This PR reverts the changes made in #615, in which we disabled CI builds against Rust Beta due to a bug on that channel.