### PR TITLE
Patch typo in python lib

### DIFF
--- a/python/svix/api.py
+++ b/python/svix/api.py
@@ -820,7 +820,7 @@ class ClientBase:
         if region == "us":
             regional_url = "https://api.us.svix.com"
         elif region == "eu":
-            regional_url = "https://api.ei.svix.com"
+            regional_url = "https://api.eu.svix.com"
         elif region == "in":
             regional_url = "https://api.in.svix.com"
 


### PR DESCRIPTION
Our Python lib had a typo in the European region server URL. This PR
fixes that typo.

Closes #620.