### PR TITLE
CSharp lib - make logger optional when Creating SvixClient

### DIFF
--- a/csharp/Svix.Tests/EndpointTests.cs
+++ b/csharp/Svix.Tests/EndpointTests.cs
@@ -249,7 +249,7 @@ namespace Svix.Tests
 
             var lHeaderKey = "MyHeaderKey";
             var lHeaderValue = "MyHeaderValue";
-            var lHeaders = new EndpointHeadersIn(new Dictionary<string, string>
+            var lHeaders = new EndpointHeadersPatchIn(new Dictionary<string, string>
             {
                 { lHeaderKey, lHeaderValue }
             });
@@ -274,7 +274,7 @@ namespace Svix.Tests
 
             var lHeaderKey = "MyHeaderKey";
             var lHeaderValue = "MyHeaderValue";
-            var lHeaders = new EndpointHeadersIn(new Dictionary<string, string>
+            var lHeaders = new EndpointHeadersPatchIn(new Dictionary<string, string>
             {
                 { lHeaderKey, lHeaderValue }
             });

--- a/csharp/Svix.Tests/SvixClientTests.cs
+++ b/csharp/Svix.Tests/SvixClientTests.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.Logging.Abstractions;
+using Svix.Models;
+using Xunit;
+
+namespace Svix.Tests
+{
+    public class SvixClientTests
+    {
+        [Fact]
+        public void Constructor_WhenCalled_DoesNotNeedLogger()
+        {
+            var sut = new SvixClient("", new SvixOptions("http://some.url"));
+
+            Assert.NotNull(sut);
+        }
+
+        [Fact]
+        public void Constructor_WhenCalled_AcceptsLogger()
+        {
+            var sut = new SvixClient("", new SvixOptions("http://some.url"), new NullLogger<SvixClient>());
+
+            Assert.NotNull(sut);
+        }
+    }
+}

--- a/csharp/Svix/SvixClient.cs
+++ b/csharp/Svix/SvixClient.cs
@@ -60,7 +60,7 @@ namespace Svix
             MessageAttempt = new MessageAttempt(this, messageAttemptApi ?? new MessageAttemptApi(Config));
         }
 
-        public SvixClient(string token, ISvixOptions options, ILogger<SvixClient> logger = null)
+        public SvixClient(string token, ISvixOptions options, ILogger<SvixClient> logger)
             : this(token, options, logger, healthApi: null, applicationApi: null)
         {
             // empty


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
This makes the logger optional when creating the SvixClient.

See #624 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Just by removing the null default value on the logger in the constructor makes it behave as I think was intended, that is the logger should be optional.

I also changed a test to make the code compile. I think it is due to the version of openapi-generator has been bumped since the code was checked in.