### PR TITLE
Allow enabling logging information on PostgreSQL requests

### DIFF
--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -35,6 +35,10 @@ log_format = "default"
 # always sending. If the OpenTelemetry address is not set, this will do nothing.
 # opentelemetry_sample_ratio = 1.0
 
+# Whether to enable the logging of the databses at the configured log level. This may be useful for
+# analyzing their response times.
+db_tracing = false
+
 # The wanted retry schedule in seconds. Each value is the time to wait between retries.
 retry_schedule = [5,300,1800,7200,18000,36000,36000]
 

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -118,6 +118,9 @@ pub struct ConfigurationInner {
     /// The ratio at which to sample spans when sending to OpenTelemetry. When not given it defaults
     /// to always sending. If the OpenTelemetry address is not set, this will do nothing.
     pub opentelemetry_sample_ratio: Option<f64>,
+    /// Whether to enable the logging of the databases at the configured log level. This may be
+    /// useful for analyzing their response times.
+    pub db_tracing: bool,
 
     /// The wanted retry schedule in seconds. Each value is the time to wait between retries.
     #[serde(deserialize_with = "deserialize_retry_schedule")]

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -97,14 +97,17 @@ async fn main() {
     let cfg = cfg::load().expect("Error loading configuration");
 
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var(
-            "RUST_LOG",
-            format!(
-                "{crate}={level},tower_http={level}",
-                crate = CRATE_NAME,
-                level = cfg.log_level.to_string()
-            ),
-        );
+        let level = cfg.log_level.to_string();
+        let mut var = vec![
+            format!("{crate}={level}", crate = CRATE_NAME),
+            format!("tower_http={level}"),
+        ];
+
+        if cfg.db_tracing {
+            var.push(format!("sqlx={level}"));
+        }
+
+        std::env::set_var("RUST_LOG", var.join(","));
     }
 
     let otel_layer = cfg.opentelemetry_address.as_ref().map(|addr| {


### PR DESCRIPTION
Partial fix to the additional request in https://github.com/svix/svix-webhooks/issues/631 which asks for increased logging on PostgreSQL and Redis requests. These changes enables the tracing of SQLx behind a configuration flag.