### PR TITLE
Ensure tracing spans are always recorded

### DIFF
--- a/server/svix-server/src/core/otel_spans.rs
+++ b/server/svix-server/src/core/otel_spans.rs
@@ -96,7 +96,7 @@ impl<B> MakeSpan<B> for AxumOtelSpanCreator {
             other => other.to_string().into(),
         };
 
-        let span = tracing::info_span!(
+        let span = tracing::error_span!(
             "HTTP request",
             grpc.code = Empty,
             http.client_ip = %client_ip,

--- a/server/svix-server/src/worker.rs
+++ b/server/svix-server/src/worker.rs
@@ -234,6 +234,7 @@ struct DispatchExtraIds<'a> {
         endp_id = msg_task.endpoint_id.0.as_str(),
         msg_id = msg_task.msg_id.0.as_str()
     )
+    level = "error"
 )]
 async fn dispatch(
     WorkerContext {
@@ -531,7 +532,7 @@ fn bytes_to_string(bytes: bytes::Bytes) -> String {
 }
 
 /// Manages preparation and execution of a QueueTask type
-#[tracing::instrument(skip_all, fields(task_id = worker_context.task_id))]
+#[tracing::instrument(skip_all, fields(task_id = worker_context.task_id), level = "error")]
 async fn process_task(worker_context: WorkerContext<'_>, queue_task: Arc<QueueTask>) -> Result<()> {
     let WorkerContext { db, cache, .. }: WorkerContext<'_> = worker_context;
 


### PR DESCRIPTION
While we only officially support `info`, `debug`, and `trace` log levels via the configuration, these changes ensure that request and worker spans are entered even if the log level is set to `warn` or `error` via an environment variable override.

Note that, by an error level span, that means that the span is created and entered for every log level, not that it only appears for errors.