### PR TITLE
Update idempotency key lock time from 20s to 5s

### DIFF
--- a/server/svix-server/src/core/idempotency.rs
+++ b/server/svix-server/src/core/idempotency.rs
@@ -31,7 +31,7 @@ const fn expiry_default() -> Duration {
 
 /// Returns the default expiry period for the starting lock
 const fn expiry_starting() -> Duration {
-    Duration::from_secs(20)
+    Duration::from_secs(5)
 }
 
 /// Returns the duration to sleep before retrying to find a [`SerializedResponse::Finished`] in the


### PR DESCRIPTION
It was deemed that a 20 second lock on the `expiry_starting` constant was too long, to the point of potentially causing issue. This change reduces that lock time to 5 seconds.