### PR TITLE
WIP: demonstrate error tracing

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -9,6 +9,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aead"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +81,9 @@ name = "anyhow"
 version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9a8f622bcf6ff3df478e9deba3e03e4e04b300f8e6a139e192c05fa3490afc7"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arrayvec"
@@ -193,6 +211,21 @@ dependencies = [
  "http",
  "http-body",
  "mime",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
 ]
 
 [[package]]
@@ -941,6 +974,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+
+[[package]]
 name = "group"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,6 +1497,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1601,6 +1649,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2312,6 +2369,12 @@ dependencies = [
  "num-traits",
  "serde",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc_version"

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -62,6 +62,5 @@ futures = "0.3"
 redis_cluster_async = { git = "https://github.com/redis-rs/redis-cluster-async.git", rev = "e6fe168" }
 url = "2.2.2"
 rand = "0.8.5"
+anyhow = { version = "1.0.64", features = ["backtrace"] }
 
-[dev-dependencies]
-anyhow = "1.0.56"

--- a/server/svix-server/src/core/cryptography.rs
+++ b/server/svix-server/src/core/cryptography.rs
@@ -20,14 +20,13 @@ impl AsymmetricKey {
     }
 
     pub fn from_slice(bytes: &[u8]) -> Result<Self> {
-        Ok(AsymmetricKey(KeyPair::from_slice(bytes).map_err(|_| {
-            Error::Generic("Failed parsing key.".to_string())
-        })?))
+        Ok(AsymmetricKey(
+            KeyPair::from_slice(bytes).map_err(|_| Error::generic("Failed parsing key."))?,
+        ))
     }
 
     pub fn from_base64(b64: &str) -> Result<Self> {
-        let bytes =
-            base64::decode(b64).map_err(|_| Error::Generic("Failed parsing base64".to_string()))?;
+        let bytes = base64::decode(b64).map_err(|_| Error::generic("Failed parsing base64"))?;
 
         Self::from_slice(bytes.as_slice())
     }
@@ -74,7 +73,7 @@ impl Encryption {
             let nonce = XNonce::from_slice(&nonce);
             let mut ciphertext = cipher
                 .encrypt(nonce, data)
-                .map_err(|_| crate::error::Error::Generic("Encryption failed".to_string()))?;
+                .map_err(|_| crate::error::Error::generic("Encryption failed"))?;
             let mut ret = nonce.to_vec();
             ret.append(&mut ciphertext);
             Ok(ret)
@@ -90,7 +89,7 @@ impl Encryption {
             let ciphertext = &ciphertext[Self::NONCE_SIZE..];
             cipher
                 .decrypt(XNonce::from_slice(nonce), ciphertext)
-                .map_err(|_| crate::error::Error::Generic("Encryption failed".to_string()))
+                .map_err(|_| crate::error::Error::generic("Encryption failed"))
         } else {
             Ok(ciphertext.to_vec())
         }

--- a/server/svix-server/src/core/idempotency.rs
+++ b/server/svix-server/src/core/idempotency.rs
@@ -286,7 +286,7 @@ async fn lock_loop(
             // Start value has expired
             Ok(None) => return Ok(None),
 
-            Err(e) => return Err(Error::Database(e.to_string())),
+            Err(e) => return Err(Error::Database(e.into())),
         }
     }
 }

--- a/server/svix-server/src/core/message_app.rs
+++ b/server/svix-server/src/core/message_app.rs
@@ -55,9 +55,7 @@ impl CreateMessageApp {
                 .rate_limit
                 .map(|v| v.try_into())
                 .transpose()
-                .map_err(|_| {
-                    Error::Validation("Application rate limit out of bounds".to_owned())
-                })?,
+                .map_err(|_| Error::validation("Application rate limit out of bounds"))?,
             endpoints,
             deleted: app.deleted,
         })
@@ -189,7 +187,7 @@ impl TryFrom<endpoint::Model> for CreateMessageEndpoint {
                 .rate_limit
                 .map(|v| v.try_into())
                 .transpose()
-                .map_err(|_| Error::Validation("Endpoint rate limit out of bounds".to_owned()))?,
+                .map_err(|_| Error::validation("Endpoint rate limit out of bounds"))?,
             first_failure_at: m.first_failure_at,
             headers: m.headers,
             disabled: m.disabled,

--- a/server/svix-server/src/core/types.rs
+++ b/server/svix-server/src/core/types.rs
@@ -471,7 +471,7 @@ impl EndpointSecretMarker {
         let encrypted = (v & Self::ENCRYPTED_FLAG) != 0;
         let v = v & !Self::ENCRYPTED_FLAG;
         let type_ = EndpointSecretType::try_from(v)
-            .map_err(|_| crate::error::Error::Generic("Invalid marker value".to_string()))?;
+            .map_err(|_| crate::error::Error::generic("Invalid marker value"))?;
 
         Ok(Self { type_, encrypted })
     }
@@ -542,9 +542,7 @@ impl EndpointSecretInternal {
     fn from_vec(v: Vec<u8>) -> crate::error::Result<Self> {
         // Legacy had exact size
         match v.len() {
-            0..=Self::KEY_SIZE_MINUS_ONE => {
-                Err(crate::error::Error::Generic("Value too small".to_string()))
-            }
+            0..=Self::KEY_SIZE_MINUS_ONE => Err(crate::error::Error::generic("Value too small")),
             Self::KEY_SIZE => Ok(Self {
                 marker: EndpointSecretMarker {
                     type_: EndpointSecretType::Hmac256,
@@ -608,8 +606,8 @@ impl EndpointSecretInternal {
             if encryption.enabled() {
                 encryption.decrypt(&self.key)?
             } else {
-                return Err(crate::error::Error::Generic(
-                    "main_secret unset, can't decrypt key".to_string(),
+                return Err(crate::error::Error::generic(
+                    "main_secret unset, can't decrypt key",
                 ));
             }
         } else {

--- a/server/svix-server/src/error.rs
+++ b/server/svix-server/src/error.rs
@@ -86,6 +86,13 @@ impl From<DbErr> for Error {
     }
 }
 
+impl From<anyhow::Error> for Error {
+    fn from(e: anyhow::Error) -> Self {
+        tracing::error!("context trace: {:#}", e);
+        Error::Http(HttpError::internal_server_errer(None, None))
+    }
+}
+
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
         match self {

--- a/server/svix-server/src/queue/memory.rs
+++ b/server/svix-server/src/queue/memory.rs
@@ -66,7 +66,7 @@ impl TaskQueueReceive for MemoryQueueConsumer {
                     tracing::trace!("MemoryQueue: event recv <");
                     Ok(vec![delivery])
                 } else {
-                    Err(Error::Queue("Failed to fetch from queue".to_owned()))
+                    Err(Error::queue("Failed to fetch from queue"))
                 }
             }
         }

--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -21,7 +21,6 @@ use crate::{
         PaginationLimit, ValidatedJson, ValidatedQuery,
     },
 };
-use anyhow::Context;
 use axum::{
     extract::{Extension, Path},
     routing::{get, post},
@@ -184,7 +183,7 @@ async fn list_applications(
     pagination: ValidatedQuery<Pagination<ApplicationId>>,
     AuthenticatedOrganization { permissions }: AuthenticatedOrganization,
 ) -> Result<Json<ListResponse<ApplicationOut>>> {
-    fallible().with_context(|| "fallible thing happened")?;
+    fallible()?;
 
     let PaginationLimit(limit) = pagination.limit;
     let iterator = pagination.iterator.clone();

--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -21,6 +21,7 @@ use crate::{
         PaginationLimit, ValidatedJson, ValidatedQuery,
     },
 };
+use anyhow::Context;
 use axum::{
     extract::{Extension, Path},
     routing::{get, post},
@@ -173,11 +174,18 @@ impl From<application::Model> for ApplicationOut {
     }
 }
 
+// TODO GABRIEL REMOVE
+fn fallible() -> std::result::Result<(), DbErr> {
+    Err(DbErr::Custom("some internal server error happened".into()))
+}
+
 async fn list_applications(
     Extension(ref db): Extension<DatabaseConnection>,
     pagination: ValidatedQuery<Pagination<ApplicationId>>,
     AuthenticatedOrganization { permissions }: AuthenticatedOrganization,
 ) -> Result<Json<ListResponse<ApplicationOut>>> {
+    fallible().with_context(|| "fallible thing happened")?;
+
     let PaginationLimit(limit) = pagination.limit;
     let iterator = pagination.iterator.clone();
 

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -178,9 +178,8 @@ async fn list_attempted_messages(
     );
 
     let into = |(dest, msg): (messagedestination::Model, Option<message::Model>)| {
-        let msg = msg.ok_or_else(|| {
-            Error::Database("No associated message with messagedestination".to_owned())
-        })?;
+        let msg =
+            msg.ok_or_else(|| Error::database("No associated message with messagedestination"))?;
         Ok(AttemptedMessageOut::from_dest_and_msg(dest, msg))
     };
 
@@ -496,7 +495,7 @@ async fn list_attempted_destinations(
             .map(
                 |(dest, endp): (messagedestination::Model, Option<endpoint::Model>)| {
                     let endp = endp.ok_or_else(|| {
-                        Error::Database("No associated endpoint with messagedestination".to_owned())
+                        Error::database("No associated endpoint with messagedestination")
                     })?;
                     Ok(MessageEndpointOut::from_dest_and_endp(dest, endp))
                 },

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -19,6 +19,7 @@ use crate::{
         ValidatedJson, ValidatedQuery,
     },
 };
+use anyhow::anyhow;
 use axum::{
     extract::{Extension, Path},
     routing::{get, post},
@@ -236,7 +237,7 @@ async fn create_message(
     )
     .await?
     // Should never happen since you're giving it an existing Application, but just in case
-    .ok_or_else(|| Error::Generic(format!("Application doesn't exist: {}", app.id)))?;
+    .ok_or_else(|| Error::Generic(anyhow!("Application doesn't exist: {}", app.id)))?;
 
     let msg = message::ActiveModel {
         app_id: Set(app.id.clone()),


### PR DESCRIPTION
WORK IN PROGRESS

I added a forced server error to `GET /app` to demonstrate what internal server errors look like to the end user and as logs.

What the response looks like
```
{
    "code": "server_error",
    "detail": "Internal Server Error"
}
```

What the logs look like for the relevant error
```
2022-09-09T16:23:37.746415Z ERROR HTTP request{http.client_ip= http.flavor=1.1 http.host=localhost:8071 http.method=GET http.route=/api/v1/app/ http.scheme=HTTP http.target=/api/v1/app/?limit=50 http.user_agent=PostmanRuntime/7.29.2 otel.kind="server" request_id=2EXSpPDDfrsz9owScGI8q46o7fV trace_id=}: svix_server::error: context trace: fallible thing happened: Custom Error: some internal server error happened
```

specifically the error trace
```
svix_server::error: context trace: fallible thing happened: Custom Error: some internal server error happened
```


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
