### PR TITLE
Add file/line information to main error type with macros

### DIFF
--- a/server/svix-server/src/core/cryptography.rs
+++ b/server/svix-server/src/core/cryptography.rs
@@ -8,7 +8,8 @@ use chacha20poly1305::{Key, XChaCha20Poly1305, XNonce};
 use ed25519_compact::*;
 use rand::Rng;
 
-use crate::error::{Error, Result};
+use crate::err_generic;
+use crate::error::Result;
 
 // Asymmetric Signature keys
 #[derive(Clone, Eq)]
@@ -20,14 +21,13 @@ impl AsymmetricKey {
     }
 
     pub fn from_slice(bytes: &[u8]) -> Result<Self> {
-        Ok(AsymmetricKey(KeyPair::from_slice(bytes).map_err(|_| {
-            Error::Generic("Failed parsing key.".to_string())
-        })?))
+        Ok(AsymmetricKey(
+            KeyPair::from_slice(bytes).map_err(|_| err_generic!("Failed parsing key."))?,
+        ))
     }
 
     pub fn from_base64(b64: &str) -> Result<Self> {
-        let bytes =
-            base64::decode(b64).map_err(|_| Error::Generic("Failed parsing base64".to_string()))?;
+        let bytes = base64::decode(b64).map_err(|_| err_generic!("Failed parsing base64"))?;
 
         Self::from_slice(bytes.as_slice())
     }
@@ -74,7 +74,7 @@ impl Encryption {
             let nonce = XNonce::from_slice(&nonce);
             let mut ciphertext = cipher
                 .encrypt(nonce, data)
-                .map_err(|_| crate::error::Error::Generic("Encryption failed".to_string()))?;
+                .map_err(|_| err_generic!("Encryption failed"))?;
             let mut ret = nonce.to_vec();
             ret.append(&mut ciphertext);
             Ok(ret)
@@ -90,7 +90,7 @@ impl Encryption {
             let ciphertext = &ciphertext[Self::NONCE_SIZE..];
             cipher
                 .decrypt(XNonce::from_slice(nonce), ciphertext)
-                .map_err(|_| crate::error::Error::Generic("Encryption failed".to_string()))
+                .map_err(|_| err_generic!("Encryption failed"))
         } else {
             Ok(ciphertext.to_vec())
         }

--- a/server/svix-server/src/core/idempotency.rs
+++ b/server/svix-server/src/core/idempotency.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 use tower::Service;
 
 use super::cache::{kv_def, Cache, CacheBehavior, CacheKey, CacheValue};
-use crate::error::Error;
+use crate::{err_database, error::Error};
 
 /// Returns the default exipry period for cached responses
 const fn expiry_default() -> Duration {
@@ -286,7 +286,7 @@ async fn lock_loop(
             // Start value has expired
             Ok(None) => return Ok(None),
 
-            Err(e) => return Err(Error::Database(e.to_string())),
+            Err(e) => return Err(err_database!(e)),
         }
     }
 }

--- a/server/svix-server/src/core/security.rs
+++ b/server/svix-server/src/core/security.rs
@@ -15,6 +15,7 @@ use validator::Validate;
 
 use crate::{
     cfg::Configuration,
+    ctx,
     db::models::application,
     error::{Error, HttpError, Result},
 };
@@ -191,12 +192,14 @@ where
         let Extension(ref db) = Extension::<DatabaseConnection>::from_request(req)
             .await
             .map_err(to_internal_server_error)?;
-        let app = application::Entity::secure_find_by_id_or_uid(
-            permissions.org_id.clone(),
-            app_id.to_owned(),
-        )
-        .one(db)
-        .await?
+        let app = ctx!(
+            application::Entity::secure_find_by_id_or_uid(
+                permissions.org_id.clone(),
+                app_id.to_owned(),
+            )
+            .one(db)
+            .await
+        )?
         .ok_or_else(|| HttpError::not_found(None, None))?;
         Ok(AuthenticatedOrganizationWithApplication { permissions, app })
     }
@@ -223,12 +226,14 @@ where
         let Extension(ref db) = Extension::<DatabaseConnection>::from_request(req)
             .await
             .map_err(to_internal_server_error)?;
-        let app = application::Entity::secure_find_by_id_or_uid(
-            permissions.org_id.clone(),
-            app_id.to_owned(),
-        )
-        .one(db)
-        .await?
+        let app = ctx!(
+            application::Entity::secure_find_by_id_or_uid(
+                permissions.org_id.clone(),
+                app_id.to_owned(),
+            )
+            .one(db)
+            .await
+        )?
         .ok_or_else(|| HttpError::not_found(None, None))?;
 
         if let Some(permitted_app_id) = &permissions.app_id {

--- a/server/svix-server/src/queue/memory.rs
+++ b/server/svix-server/src/queue/memory.rs
@@ -4,7 +4,7 @@ use axum::async_trait;
 use chrono::Utc;
 use tokio::{sync::mpsc, time::sleep};
 
-use crate::error::{Error, Result};
+use crate::{err_queue, error::Result};
 
 use super::{
     QueueTask, TaskQueueConsumer, TaskQueueDelivery, TaskQueueProducer, TaskQueueReceive,
@@ -66,7 +66,7 @@ impl TaskQueueReceive for MemoryQueueConsumer {
                     tracing::trace!("MemoryQueue: event recv <");
                     Ok(vec![delivery])
                 } else {
-                    Err(Error::Queue("Failed to fetch from queue".to_owned()))
+                    Err(err_queue!("Failed to fetch from queue"))
                 }
             }
         }

--- a/server/svix-server/src/queue/mod.rs
+++ b/server/svix-server/src/queue/mod.rs
@@ -11,7 +11,7 @@ use crate::{
         run_with_retries::run_with_retries,
         types::{ApplicationId, EndpointId, MessageAttemptTriggerType, MessageId},
     },
-    error::{Error, Result},
+    error::{Error, ErrorType, Result},
 };
 
 pub mod memory;
@@ -24,7 +24,7 @@ const RETRY_SCHEDULE: &[Duration] = &[
 ];
 
 fn should_retry(err: &Error) -> bool {
-    matches!(err, Error::Queue(_))
+    matches!(err.typ, ErrorType::Queue(_))
 }
 
 pub async fn new_pair(

--- a/server/svix-server/src/queue/redis.rs
+++ b/server/svix-server/src/queue/redis.rs
@@ -39,7 +39,8 @@ use redis::{
 use tokio::time::sleep;
 
 use crate::{
-    error::{Error, Result},
+    ctx, err_generic,
+    error::Result,
     redis::{PoolLike, PooledConnection, PooledConnectionLike, RedisPool},
 };
 
@@ -131,7 +132,7 @@ async fn background_task_pending(
     main_queue_name: String,
     pending_duration: i64,
 ) -> Result<()> {
-    let mut pool = pool.get().await?;
+    let mut pool = ctx!(pool.get().await)?;
 
     // Every iteration checks whether the processing queue has items that should be picked back up,
     // claiming them in the process
@@ -144,7 +145,7 @@ async fn background_task_pending(
         .arg("COUNT")
         .arg(PENDING_BATCH_SIZE);
 
-    let StreamAutoclaimReply { ids } = pool.query_async(cmd).await?;
+    let StreamAutoclaimReply { ids } = ctx!(pool.query_async(cmd).await)?;
 
     if !ids.is_empty() {
         let mut pipe = redis::pipe();
@@ -166,16 +167,17 @@ async fn background_task_pending(
             );
         }
 
-        let _: () = pool.query_async_pipeline(pipe).await?;
+        let _: () = ctx!(pool.query_async_pipeline(pipe).await)?;
 
         // Acknowledge all the stale ones so the pending queue is cleared
-        let _: () = pool
-            .query_async(Cmd::xack(
+        let _: () = ctx!(
+            pool.query_async(Cmd::xack(
                 &main_queue_name,
                 WORKERS_GROUP,
                 &ids.iter().map(|wrapped| &wrapped.id).collect::<Vec<_>>(),
             ))
-            .await?;
+            .await
+        )?;
     } else {
         // Wait for half a second before attempting to fetch again if nothing was found
         sleep(Duration::from_millis(500)).await;
@@ -192,7 +194,7 @@ async fn background_task_delayed(
 ) -> Result<()> {
     let batch_size: isize = 50;
 
-    let mut pool = pool.get().await?;
+    let mut pool = ctx!(pool.get().await)?;
 
     // There is a lock on the delayed queue processing to avoid race conditions. So first try to
     // acquire the lock should it not already exist. The lock expires after five seconds in case a
@@ -204,14 +206,15 @@ async fn background_task_delayed(
         .arg("PX")
         .arg(5000);
     // WIll be Some("OK") when set or None when not set
-    let resp: Option<String> = pool.query_async(cmd).await?;
+    let resp: Option<String> = ctx!(pool.query_async(cmd).await)?;
 
     if resp.as_deref() == Some("OK") {
         // First look for delayed keys whose time is up and add them to the main qunue
         let timestamp = Utc::now().timestamp();
-        let keys: Vec<String> = pool
-            .zrangebyscore_limit(&delayed_queue_name, 0isize, timestamp, 0isize, batch_size)
-            .await?;
+        let keys: Vec<String> = ctx!(
+            pool.zrangebyscore_limit(&delayed_queue_name, 0isize, timestamp, 0isize, batch_size)
+                .await
+        )?;
 
         if !keys.is_empty() {
             let tasks: Vec<&str> = keys
@@ -230,18 +233,16 @@ async fn background_task_delayed(
                     &[(QUEUE_KV_KEY, task)],
                 );
             }
-            let _: () = pool.query_async_pipeline(pipe).await?;
+            let _: () = ctx!(pool.query_async_pipeline(pipe).await)?;
 
             // Then remove the tasks from the delayed queue so they aren't resent
-            let _: () = pool
-                .query_async(Cmd::zrem(&delayed_queue_name, keys))
-                .await?;
+            let _: () = ctx!(pool.query_async(Cmd::zrem(&delayed_queue_name, keys)).await)?;
 
             // Make sure to release the lock after done processing
-            let _: () = pool.del(delayed_lock).await?;
+            let _: () = ctx!(pool.del(delayed_lock).await)?;
         } else {
             // Make sure to release the lock before sleeping
-            let _: () = pool.del(delayed_lock).await?;
+            let _: () = ctx!(pool.del(delayed_lock).await)?;
             // Wait for half a second before attempting to fetch again if nothing was found
             sleep(Duration::from_millis(500)).await;
         }
@@ -462,13 +463,13 @@ fn from_redis_key(key: &str) -> TaskQueueDelivery {
 #[async_trait]
 impl TaskQueueSend for RedisQueueProducer {
     async fn send(&self, task: Arc<QueueTask>, delay: Option<Duration>) -> Result<()> {
-        let mut pool = self.pool.get().await?;
+        let mut pool = ctx!(self.pool.get().await)?;
 
         // If there's a delay, compute the timestamp at which the delay is up
         let timestamp = delay.map(|delay| -> Result<_> {
             Ok(Utc::now()
                 + chrono::Duration::from_std(delay)
-                    .map_err(|_| Error::Generic("Duration out of bounds".to_owned()))?)
+                    .map_err(|_| err_generic!("Duration out of bounds"))?)
         });
 
         if let Some(timestamp) = timestamp {
@@ -477,22 +478,24 @@ impl TaskQueueSend for RedisQueueProducer {
             // delivery
             let delivery = TaskQueueDelivery::from_arc(task.clone(), Some(timestamp));
             let key = to_redis_key(&delivery);
-            let _: () = pool
-                .zadd(&self.delayed_queue_name, key, timestamp.timestamp())
-                .await?;
+            let _: () = ctx!(
+                pool.zadd(&self.delayed_queue_name, key, timestamp.timestamp())
+                    .await
+            )?;
         } else {
             // If there is no delay simply XADD the task to the MAIN queue
-            let _: () = pool
-                .query_async(Cmd::xadd(
+            let _: () = ctx!(
+                pool.query_async(Cmd::xadd(
                     &self.main_queue_name,
                     GENERATE_STREAM_ID,
                     &[(
                         QUEUE_KV_KEY,
                         serde_json::to_string(&*task)
-                            .map_err(|e| Error::Generic(format!("serialization error: {}", e)))?,
+                            .map_err(|e| err_generic!("serialization error: {}", e))?,
                     )],
                 ))
-                .await?;
+                .await
+            )?;
         }
         tracing::trace!("RedisQueue: event sent > (delay: {:?})", delay);
         Ok(())
@@ -500,21 +503,22 @@ impl TaskQueueSend for RedisQueueProducer {
 
     /// ACKing the delivery, XACKs the message in the queue so it will no longer be retried
     async fn ack(&self, delivery: &TaskQueueDelivery) -> Result<()> {
-        let mut pool = self.pool.get().await?;
-        let processed: u8 = pool
-            .query_async(Cmd::xack(
+        let mut pool = ctx!(self.pool.get().await)?;
+        let processed: u8 = ctx!(
+            pool.query_async(Cmd::xack(
                 &self.main_queue_name,
                 WORKERS_GROUP,
                 &[delivery.id.as_str()],
             ))
-            .await?;
+            .await
+        )?;
         if processed != 1 {
             tracing::warn!(
                 "Expected to remove 1 from the list, removed {} for {}|{}",
                 processed,
                 delivery.id,
                 serde_json::to_string(&delivery.task)
-                    .map_err(|e| Error::Generic(format!("serialization error: {}", e)))?
+                    .map_err(|e| err_generic!("serialization error: {}", e))?
             );
         }
         Ok(())
@@ -538,12 +542,12 @@ impl TaskQueueReceive for RedisQueueConsumer {
         let main_queue_name = self.main_queue_name.clone();
         tokio::spawn(async move {
             // TODO: Receive messages in batches so it's not always a Vec with one member
-            let mut pool = pool.get().await?;
+            let mut pool = ctx!(pool.get().await)?;
 
             // There is no way to make it await a message for unbounded times, so simply block for a short
             // amount of time (to avoid locking) and loop if no messages were retreived
-            let resp: StreamReadReply = pool
-                .query_async(Cmd::xread_options(
+            let resp: StreamReadReply = ctx!(
+                pool.query_async(Cmd::xread_options(
                     &[&main_queue_name],
                     &[LISTEN_STREAM_ID],
                     &StreamReadOptions::default()
@@ -551,7 +555,8 @@ impl TaskQueueReceive for RedisQueueConsumer {
                         .count(1)
                         .block(10_000),
                 ))
-                .await?;
+                .await
+            )?;
 
             if !resp.keys.is_empty() && !resp.keys[0].ids.is_empty() {
                 let element = &resp.keys[0].ids[0];
@@ -575,7 +580,7 @@ impl TaskQueueReceive for RedisQueueConsumer {
             }
         })
         .await
-        .map_err(|e| Error::Generic(format!("task join error {}", e)))?
+        .map_err(|e| err_generic!("task join error {}", e))?
     }
 }
 
@@ -593,9 +598,8 @@ async fn migrate_list_to_stream(
 ) -> Result<()> {
     let batch_size = 1000;
     loop {
-        let legacy_keys: Vec<String> = pool
-            .lpop(legacy_queue, NonZeroUsize::new(batch_size))
-            .await?;
+        let legacy_keys: Vec<String> =
+            ctx!(pool.lpop(legacy_queue, NonZeroUsize::new(batch_size)).await)?;
         if legacy_keys.is_empty() {
             break Ok(());
         }
@@ -615,7 +619,7 @@ async fn migrate_list_to_stream(
             );
         }
 
-        let _: () = pool.query_async_pipeline(pipe).await?;
+        let _: () = ctx!(pool.query_async_pipeline(pipe).await)?;
     }
 }
 
@@ -635,9 +639,8 @@ async fn migrate_list(
     let batch_size = 1000;
     loop {
         // Checking for old messages from queue
-        let legacy_keys: Vec<String> = pool
-            .lpop(legacy_queue, NonZeroUsize::new(batch_size))
-            .await?;
+        let legacy_keys: Vec<String> =
+            ctx!(pool.lpop(legacy_queue, NonZeroUsize::new(batch_size)).await)?;
         if legacy_keys.is_empty() {
             break Ok(());
         }
@@ -646,7 +649,7 @@ async fn migrate_list(
             legacy_keys.len(),
             legacy_queue
         );
-        let _: () = pool.rpush(queue, legacy_keys).await?;
+        let _: () = ctx!(pool.rpush(queue, legacy_keys).await)?;
     }
 }
 
@@ -658,7 +661,7 @@ async fn migrate_sset(
     let batch_size = 1000;
     loop {
         // Checking for old messages from LEGACY_DELAYED
-        let legacy_keys: Vec<(String, f64)> = pool.zpopmin(legacy_queue, batch_size).await?;
+        let legacy_keys: Vec<(String, f64)> = ctx!(pool.zpopmin(legacy_queue, batch_size).await)?;
 
         if legacy_keys.is_empty() {
             break Ok(());
@@ -671,7 +674,7 @@ async fn migrate_sset(
         let legacy_keys: Vec<(f64, String)> =
             legacy_keys.into_iter().map(|(x, y)| (y, x)).collect();
 
-        let _: () = pool.zadd_multiple(queue, &legacy_keys).await?;
+        let _: () = ctx!(pool.zadd_multiple(queue, &legacy_keys).await)?;
     }
 }
 

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -10,7 +10,9 @@ use crate::{
             MessageIdOrUid, MessageStatus, StatusCodeClass,
         },
     },
+    ctx,
     db::models::{endpoint, message, messagedestination},
+    err_database,
     error::{Error, HttpError, Result},
     queue::{MessageTask, TaskQueueProducer},
     v1::{
@@ -130,10 +132,12 @@ async fn list_attempted_messages(
     }: AuthenticatedApplication,
 ) -> Result<Json<ListResponse<AttemptedMessageOut>>> {
     let PaginationLimit(limit) = pagination.limit;
-    let endp = endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endp_id)
-        .one(db)
-        .await?
-        .ok_or_else(|| HttpError::not_found(None, None))?;
+    let endp = ctx!(
+        endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endp_id)
+            .one(db)
+            .await
+    )?
+    .ok_or_else(|| HttpError::not_found(None, None))?;
 
     let mut dests_and_msgs = messagedestination::Entity::secure_find_by_endpoint(endp.id)
         .find_also_related(message::Entity);
@@ -151,11 +155,13 @@ async fn list_attempted_messages(
         db: &DatabaseConnection,
         msg_id: MessageId,
     ) -> Result<MessageEndpointId> {
-        Ok(messagedestination::Entity::secure_find_by_msg(msg_id)
-            .one(db)
-            .await?
-            .ok_or_else(|| HttpError::bad_request(None, Some("Invalid iterator".to_owned())))?
-            .id)
+        Ok(ctx!(
+            messagedestination::Entity::secure_find_by_msg(msg_id)
+                .one(db)
+                .await
+        )?
+        .ok_or_else(|| HttpError::bad_request(None, Some("Invalid iterator".to_owned())))?
+        .id)
     }
 
     let msg_dest_iterator = match pagination.iterator {
@@ -178,24 +184,19 @@ async fn list_attempted_messages(
     );
 
     let into = |(dest, msg): (messagedestination::Model, Option<message::Model>)| {
-        let msg = msg.ok_or_else(|| {
-            Error::Database("No associated message with messagedestination".to_owned())
-        })?;
+        let msg =
+            msg.ok_or_else(|| err_database!("No associated message with messagedestination"))?;
         Ok(AttemptedMessageOut::from_dest_and_msg(dest, msg))
     };
 
     let out = if is_prev {
-        dests_and_msgs
-            .all(db)
-            .await?
+        ctx!(dests_and_msgs.all(db).await)?
             .into_iter()
             .rev()
             .map(into)
             .collect::<Result<_>>()?
     } else {
-        dests_and_msgs
-            .all(db)
-            .await?
+        ctx!(dests_and_msgs.all(db).await)?
             .into_iter()
             .map(into)
             .collect::<Result<_>>()?
@@ -304,10 +305,12 @@ async fn list_attempts_by_endpoint(
 ) -> Result<Json<ListResponse<MessageAttemptOut>>> {
     let PaginationLimit(limit) = pagination.limit;
     // Confirm endpoint ID belongs to the given application
-    let endp = endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endp_id)
-        .one(db)
-        .await?
-        .ok_or_else(|| HttpError::not_found(None, None))?;
+    let endp = ctx!(
+        endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endp_id)
+            .one(db)
+            .await
+    )?
+    .ok_or_else(|| HttpError::not_found(None, None))?;
 
     let query = list_attempts_by_endpoint_or_message_filters(
         messageattempt::Entity::secure_find_by_endpoint(endp.id),
@@ -322,15 +325,16 @@ async fn list_attempts_by_endpoint(
     let query = apply_pagination(query, messageattempt::Column::Id, limit, iterator);
 
     let out = if is_prev {
-        query
-            .all(db)
-            .await?
+        ctx!(query.all(db).await)?
             .into_iter()
             .rev()
             .map(Into::into)
             .collect()
     } else {
-        query.all(db).await?.into_iter().map(Into::into).collect()
+        ctx!(query.all(db).await)?
+            .into_iter()
+            .map(Into::into)
+            .collect()
     };
 
     Ok(Json(MessageAttemptOut::list_response(
@@ -376,12 +380,14 @@ async fn list_attempts_by_msg(
 ) -> Result<Json<ListResponse<MessageAttemptOut>>> {
     let PaginationLimit(limit) = pagination.limit;
     // Confirm message ID belongs to the given application
-    if message::Entity::secure_find_by_id(app.id.clone(), msg_id.clone())
-        .one(db)
-        .await?
-        .is_none()
+    if ctx!(
+        message::Entity::secure_find_by_id(app.id.clone(), msg_id.clone())
+            .one(db)
+            .await
+    )?
+    .is_none()
     {
-        return Err(Error::Http(HttpError::not_found(None, None)));
+        return Err(Error::http(HttpError::not_found(None, None)));
     }
 
     let mut query = list_attempts_by_endpoint_or_message_filters(
@@ -394,14 +400,15 @@ async fn list_attempts_by_msg(
 
     if let Some(endpoint_id) = endpoint_id {
         // Ensure the endpoint ID/UID belongs to the given application
-        if let Some(endp) = endpoint::Entity::secure_find_by_id_or_uid(app.id, endpoint_id)
-            .one(db)
-            .await?
-        {
+        if let Some(endp) = ctx!(
+            endpoint::Entity::secure_find_by_id_or_uid(app.id, endpoint_id)
+                .one(db)
+                .await
+        )? {
             // And filter by its ID incase a UID was used
             query = query.filter(messageattempt::Column::EndpId.eq(endp.id));
         } else {
-            return Err(Error::Http(HttpError::not_found(None, None)));
+            return Err(Error::http(HttpError::not_found(None, None)));
         }
     }
 
@@ -409,15 +416,16 @@ async fn list_attempts_by_msg(
     let is_prev = matches!(iterator, Some(ReversibleIterator::Prev(_)));
     let query = apply_pagination(query, messageattempt::Column::Id, limit, iterator);
     let out = if is_prev {
-        query
-            .all(db)
-            .await?
+        ctx!(query.all(db).await)?
             .into_iter()
             .rev()
             .map(Into::into)
             .collect()
     } else {
-        query.all(db).await?.into_iter().map(Into::into).collect()
+        ctx!(query.all(db).await)?
+            .into_iter()
+            .map(Into::into)
+            .collect()
     };
 
     Ok(Json(MessageAttemptOut::list_response(
@@ -468,14 +476,14 @@ async fn list_attempted_destinations(
 
     // Confirm message ID belongs to the given application while fetching the ID in case a UID was
     // given
-    let msg_id = if let Some(message) =
+    let msg_id = if let Some(message) = ctx!(
         message::Entity::secure_find_by_id_or_uid(app.id.clone(), msg_id.clone())
             .one(db)
-            .await?
-    {
+            .await
+    )? {
         message.id
     } else {
-        return Err(Error::Http(HttpError::not_found(None, None)));
+        return Err(Error::http(HttpError::not_found(None, None)));
     };
 
     // Fetch the [`messagedestination::Model`] and associated [`endpoint::Model`]
@@ -489,14 +497,12 @@ async fn list_attempted_destinations(
     }
 
     Ok(Json(MessageEndpointOut::list_response_no_prev(
-        query
-            .all(db)
-            .await?
+        ctx!(query.all(db).await)?
             .into_iter()
             .map(
                 |(dest, endp): (messagedestination::Model, Option<endpoint::Model>)| {
                     let endp = endp.ok_or_else(|| {
-                        Error::Database("No associated endpoint with messagedestination".to_owned())
+                        err_database!("No associated endpoint with messagedestination")
                     })?;
                     Ok(MessageEndpointOut::from_dest_and_endp(dest, endp))
                 },
@@ -574,18 +580,22 @@ async fn list_messageattempts(
     }: AuthenticatedApplication,
 ) -> Result<Json<ListResponse<MessageAttemptOut>>> {
     let PaginationLimit(limit) = pagination.limit;
-    let msg = message::Entity::secure_find_by_id_or_uid(app.id.clone(), msg_id)
-        .one(db)
-        .await?
-        .ok_or_else(|| HttpError::not_found(None, None))?;
+    let msg = ctx!(
+        message::Entity::secure_find_by_id_or_uid(app.id.clone(), msg_id)
+            .one(db)
+            .await
+    )?
+    .ok_or_else(|| HttpError::not_found(None, None))?;
 
     let mut query = messageattempt::Entity::secure_find_by_msg(msg.id);
 
     if let Some(endpoint_id) = endpoint_id {
-        let endp = endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endpoint_id)
-            .one(db)
-            .await?
-            .ok_or_else(|| HttpError::not_found(None, None))?;
+        let endp = ctx!(
+            endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endpoint_id)
+                .one(db)
+                .await
+        )?
+        .ok_or_else(|| HttpError::not_found(None, None))?;
         query = query.filter(messageattempt::Column::EndpId.eq(endp.id))
     }
 
@@ -605,15 +615,16 @@ async fn list_messageattempts(
     let is_prev = matches!(iterator, Some(ReversibleIterator::Prev(_)));
     let query = apply_pagination(query, messageattempt::Column::Id, limit, iterator);
     let out = if is_prev {
-        query
-            .all(db)
-            .await?
+        ctx!(query.all(db).await)?
             .into_iter()
             .rev()
             .map(Into::into)
             .collect()
     } else {
-        query.all(db).await?.into_iter().map(Into::into).collect()
+        ctx!(query.all(db).await)?
+            .into_iter()
+            .map(Into::into)
+            .collect()
     };
 
     Ok(Json(MessageAttemptOut::list_response(
@@ -635,16 +646,20 @@ async fn get_messageattempt(
         app,
     }: AuthenticatedApplication,
 ) -> Result<Json<MessageAttemptOut>> {
-    let msg = message::Entity::secure_find_by_id_or_uid(app.id, msg_id)
-        .one(db)
-        .await?
-        .ok_or_else(|| HttpError::not_found(None, None))?;
+    let msg = ctx!(
+        message::Entity::secure_find_by_id_or_uid(app.id, msg_id)
+            .one(db)
+            .await
+    )?
+    .ok_or_else(|| HttpError::not_found(None, None))?;
 
-    let attempt = messageattempt::Entity::secure_find_by_msg(msg.id)
-        .filter(messageattempt::Column::Id.eq(attempt_id))
-        .one(db)
-        .await?
-        .ok_or_else(|| HttpError::not_found(None, None))?;
+    let attempt = ctx!(
+        messageattempt::Entity::secure_find_by_msg(msg.id)
+            .filter(messageattempt::Column::Id.eq(attempt_id))
+            .one(db)
+            .await
+    )?
+    .ok_or_else(|| HttpError::not_found(None, None))?;
     Ok(Json(attempt.into()))
 }
 
@@ -657,10 +672,12 @@ async fn resend_webhook(
         app,
     }: AuthenticatedApplication,
 ) -> Result<(StatusCode, Json<EmptyResponse>)> {
-    let msg = message::Entity::secure_find_by_id_or_uid(app.id.clone(), msg_id)
-        .one(db)
-        .await?
-        .ok_or_else(|| HttpError::not_found(None, None))?;
+    let msg = ctx!(
+        message::Entity::secure_find_by_id_or_uid(app.id.clone(), msg_id)
+            .one(db)
+            .await
+    )?
+    .ok_or_else(|| HttpError::not_found(None, None))?;
 
     if msg.payload.is_none() {
         return Err(HttpError::bad_request(
@@ -670,17 +687,21 @@ async fn resend_webhook(
         .into());
     }
 
-    let endp = endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endp_id)
-        .one(db)
-        .await?
-        .ok_or_else(|| HttpError::not_found(None, None))?;
+    let endp = ctx!(
+        endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endp_id)
+            .one(db)
+            .await
+    )?
+    .ok_or_else(|| HttpError::not_found(None, None))?;
 
     // Fetch it to make sure it was even a combination
-    let _msg_dest = messagedestination::Entity::secure_find_by_msg(msg.id.clone())
-        .filter(messagedestination::Column::EndpId.eq(endp.id.clone()))
-        .one(db)
-        .await?
-        .ok_or_else(|| HttpError::not_found(None, None))?;
+    let _msg_dest = ctx!(
+        messagedestination::Entity::secure_find_by_msg(msg.id.clone())
+            .filter(messagedestination::Column::EndpId.eq(endp.id.clone()))
+            .one(db)
+            .await
+    )?
+    .ok_or_else(|| HttpError::not_found(None, None))?;
 
     queue_tx
         .send(

--- a/server/svix-server/src/v1/endpoints/endpoint/headers.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/headers.rs
@@ -11,6 +11,7 @@ use crate::{
         security::AuthenticatedApplication,
         types::{ApplicationIdOrUid, EndpointIdOrUid},
     },
+    ctx,
     db::models::endpoint,
     error::{HttpError, Result},
     v1::utils::{EmptyResponse, ModelIn, ValidatedJson},
@@ -24,10 +25,12 @@ pub(super) async fn get_endpoint_headers(
         app,
     }: AuthenticatedApplication,
 ) -> Result<Json<EndpointHeadersOut>> {
-    let endp = endpoint::Entity::secure_find_by_id_or_uid(app.id, endp_id)
-        .one(db)
-        .await?
-        .ok_or_else(|| HttpError::not_found(None, None))?;
+    let endp = ctx!(
+        endpoint::Entity::secure_find_by_id_or_uid(app.id, endp_id)
+            .one(db)
+            .await
+    )?
+    .ok_or_else(|| HttpError::not_found(None, None))?;
 
     match endp.headers {
         Some(h) => Ok(Json(h.into())),
@@ -44,14 +47,16 @@ pub(super) async fn update_endpoint_headers(
         app,
     }: AuthenticatedApplication,
 ) -> Result<(StatusCode, Json<EmptyResponse>)> {
-    let endp = endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endp_id)
-        .one(db)
-        .await?
-        .ok_or_else(|| HttpError::not_found(None, None))?;
+    let endp = ctx!(
+        endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endp_id)
+            .one(db)
+            .await
+    )?
+    .ok_or_else(|| HttpError::not_found(None, None))?;
 
     let mut endp: endpoint::ActiveModel = endp.into();
     data.update_model(&mut endp);
-    endp.update(db).await?;
+    ctx!(endp.update(db).await)?;
 
     Ok((StatusCode::NO_CONTENT, Json(EmptyResponse {})))
 }
@@ -65,14 +70,16 @@ pub(super) async fn patch_endpoint_headers(
         app,
     }: AuthenticatedApplication,
 ) -> Result<(StatusCode, Json<EmptyResponse>)> {
-    let endp = endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endp_id)
-        .one(db)
-        .await?
-        .ok_or_else(|| HttpError::not_found(None, None))?;
+    let endp = ctx!(
+        endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endp_id)
+            .one(db)
+            .await
+    )?
+    .ok_or_else(|| HttpError::not_found(None, None))?;
 
     let mut endp: endpoint::ActiveModel = endp.into();
     data.update_model(&mut endp);
-    endp.update(db).await?;
+    ctx!(endp.update(db).await)?;
 
     Ok((StatusCode::NO_CONTENT, Json(EmptyResponse {})))
 }


### PR DESCRIPTION
This closes https://github.com/svix/svix-webhooks/issues/574, by adding diagnostic information to the main error type along with some helpful macros.

## Motivation

For internal server errors, we want to visibility into both the underlying error, in addition to where the error originated from. e.g. for code like this
```rust
fn foo() -> crate::error::Result<()> {
   let app = Application.fetch(...)?;
   app.bar = 12;
   app.save()?;
   Ok(())
}
```
Just looking at the logs, it can be hard to diagnose whether the underlying db error came from `Application.fetch(...)?` or `app.save()?`.

We want to be able to quickly correlate an error to a specific line, while still keeping error handling relatively boilerplate free.

## Solution

First, we extend the `error::Error` type with some diagnostic information - literally just the line number and file name.

To avoid really boilerplate heavy code, most of the `error::Error` initialization logic is now handled by macros. `queue_err!`, `generic_err!`, etc. This makes it pretty easy to add the file/line information without making error initialization excessively verbose (in some cases, we're actually able to make error initialization easier than before).

One point of friction is that we can't easily attach `location` information when propagating errors using `?` - which we lean on pretty heavily when converting `DbErr`, `RedisError`, `bb8::RunError`, etc. Adding the location information to an error should be easy, but it should also be something that is difficult to forget to do.

To circumvent this problem, I dropped the `From<...> for Error` implementations for `DbErr`, `RedisError`, etc. These were replaced with a very similar trait to just transforms `std::result::Result<T, E>` into `crate::error::Result<T>` for `DbErr`, `RedisError`, etc. There's then a `ctx!` macro that handles the conversion, and adds the `location` information. Now error handling looks closer too

```rust
fn foo() -> crate::error::Result<()> {
   let app = ctx!(Application.fetch(...))?;
   app.bar = 12;
   ctx!(app.save())?;
   Ok(())
}
```

So, marginally more boilerplate. But forgetting to include `ctx!` now becomes a compiler error, forcing developers to add the diagnostic information using `ctx!`.

In addition, `ctx!` adds tracing information if the error is already a `crate::result::Result`. 

What does this end up looking like in practice? If you have code like this
```rust
fn fallible_a() -> std::result::Result<(), DbErr> {
    Err(DbErr::Custom("db borked!".into()))
}

fn fallible_b() -> Result<()> {
    ctx!(fallible_a()) // line 182 in application.s
}

// . . .

ctx!(fallible_b())?; // line 190 in application.rs
```
when the error is transformed into a response from the axum handlers, we get logs like
```
2022-09-14T14:13:04.156518Z ERROR HTTP request{...}: svix_server::error: type: Database("Custom Error: db borked!"), location: ["svix-server/src/v1/endpoints/application.rs:182", "svix-server/src/v1/endpoints/application.rs:190"]
```