### PR TITLE
Abstract JWT validation logic into separate function

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -183,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f44a0e6200e9d11a1cdc989e4b358f6e3d354fbf48478f345a17f4e43f8635"
+checksum = "d9f0c0a60006f2a293d82d571f635042a72edf927539b7685bd62d361963839b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -193,6 +193,8 @@ dependencies = [
  "http",
  "http-body",
  "mime",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/server/svix-server/src/core/security.rs
+++ b/server/svix-server/src/core/security.rs
@@ -250,7 +250,6 @@ pub fn generate_org_token(keys: &Keys, org_id: OrganizationId) -> Result<String>
         Duration::from_hours(24 * 365 * 10),
     )
     .with_issuer(JWT_ISSUER)
-    .with_jwt_id(JWT_ISSUER)
     .with_subject(org_id.0);
     Ok(keys.key.authenticate(claims).unwrap())
 }
@@ -259,7 +258,6 @@ pub fn generate_management_token(keys: &Keys) -> Result<String> {
     let claims =
         Claims::with_custom_claims(CustomClaim { organization: None }, Duration::from_mins(10))
             .with_issuer(JWT_ISSUER)
-            .with_jwt_id(JWT_ISSUER)
             .with_subject(management_org_id());
     Ok(keys.key.authenticate(claims).unwrap())
 }
@@ -276,7 +274,6 @@ pub fn generate_app_token(
         Duration::from_hours(24 * 28),
     )
     .with_issuer(JWT_ISSUER)
-    .with_jwt_id(JWT_ISSUER)
     .with_subject(app_id.0);
     Ok(keys.key.authenticate(claims).unwrap())
 }

--- a/server/svix-server/src/core/security.rs
+++ b/server/svix-server/src/core/security.rs
@@ -71,58 +71,39 @@ where
                 .await
                 .map_err(|_| HttpError::unauthorized(None, Some("Invalid token".to_string())))?;
 
-        let claims = cfg
-            .jwt_secret
-            .key
-            .verify_token::<CustomClaim>(bearer.token(), None)
-            .map_err(|_| HttpError::unauthorized(None, Some("Invalid token".to_string())))?;
+        permissions_from_bearer(&cfg.jwt_secret.key, bearer)
+    }
+}
 
-        let bad_token = |field: &str, id_type: &str| {
-            HttpError::bad_request(
-                Some("bad token".to_string()),
-                Some(format!("`{}` is not a valid {} id", field, id_type)),
-            )
-        };
+pub fn permissions_from_bearer(key: &HS256Key, bearer: Bearer) -> Result<Permissions> {
+    let claims = key
+        .verify_token::<CustomClaim>(bearer.token(), None)
+        .map_err(|_| HttpError::unauthorized(None, Some("Invalid token".to_string())))?;
 
-        // If there is an `org` field then it is an Application authentication
-        if let Some(org_id) = claims.custom.organization {
-            let org_id = OrganizationId(org_id);
-            org_id
+    let bad_token = |field: &str, id_type: &str| {
+        HttpError::bad_request(
+            Some("bad token".to_string()),
+            Some(format!("`{}` is not a valid {} id", field, id_type)),
+        )
+    };
+
+    // If there is an `org` field then it is an Application authentication
+    if let Some(org_id) = claims.custom.organization {
+        let org_id = OrganizationId(org_id);
+        org_id
+            .validate()
+            .map_err(|_| bad_token("org", "organization"))?;
+
+        if let Some(app_id) = claims.subject {
+            let app_id = ApplicationId(app_id);
+            app_id
                 .validate()
-                .map_err(|_| bad_token("org", "organization"))?;
+                .map_err(|_| bad_token("sub", "application"))?;
 
-            if let Some(app_id) = claims.subject {
-                let app_id = ApplicationId(app_id);
-                app_id
-                    .validate()
-                    .map_err(|_| bad_token("sub", "application"))?;
-
-                Ok(Permissions {
-                    org_id,
-                    app_id: Some(app_id),
-                    type_: KeyType::Application,
-                })
-            } else {
-                Err(HttpError::unauthorized(
-                    None,
-                    Some("Invalid token (missing `sub`).".to_string()),
-                )
-                .into())
-            }
-        }
-        // Otherwsie it's an Organization authentication
-        else if let Some(org_id) = claims.subject {
-            let org_id = OrganizationId(org_id);
-            org_id.validate().map_err(|_| {
-                HttpError::bad_request(
-                    Some("bad_token".to_string()),
-                    Some("`sub' is not a valid organization id.".to_string()),
-                )
-            })?;
             Ok(Permissions {
                 org_id,
-                app_id: None,
-                type_: KeyType::Organization,
+                app_id: Some(app_id),
+                type_: KeyType::Application,
             })
         } else {
             Err(
@@ -130,6 +111,26 @@ where
                     .into(),
             )
         }
+    }
+    // Otherwsie it's an Organization authentication
+    else if let Some(org_id) = claims.subject {
+        let org_id = OrganizationId(org_id);
+        org_id.validate().map_err(|_| {
+            HttpError::bad_request(
+                Some("bad_token".to_string()),
+                Some("`sub' is not a valid organization id.".to_string()),
+            )
+        })?;
+        Ok(Permissions {
+            org_id,
+            app_id: None,
+            type_: KeyType::Organization,
+        })
+    } else {
+        Err(
+            HttpError::unauthorized(None, Some("Invalid token (missing `sub`).".to_string()))
+                .into(),
+        )
     }
 }
 
@@ -249,6 +250,7 @@ pub fn generate_org_token(keys: &Keys, org_id: OrganizationId) -> Result<String>
         Duration::from_hours(24 * 365 * 10),
     )
     .with_issuer(JWT_ISSUER)
+    .with_jwt_id(JWT_ISSUER)
     .with_subject(org_id.0);
     Ok(keys.key.authenticate(claims).unwrap())
 }
@@ -257,6 +259,7 @@ pub fn generate_management_token(keys: &Keys) -> Result<String> {
     let claims =
         Claims::with_custom_claims(CustomClaim { organization: None }, Duration::from_mins(10))
             .with_issuer(JWT_ISSUER)
+            .with_jwt_id(JWT_ISSUER)
             .with_subject(management_org_id());
     Ok(keys.key.authenticate(claims).unwrap())
 }
@@ -273,6 +276,7 @@ pub fn generate_app_token(
         Duration::from_hours(24 * 28),
     )
     .with_issuer(JWT_ISSUER)
+    .with_jwt_id(JWT_ISSUER)
     .with_subject(app_id.0);
     Ok(keys.key.authenticate(claims).unwrap())
 }


### PR DESCRIPTION
Abstracts the JWT validation and Permissions struct generation logic
in `security.rs` into its own function that can be programmatically
called.

Mostly just whitespace changes / moving code around.