### PR TITLE
CSharp-lib: Add netstandard2.0 support

### DIFF
--- a/csharp/Svix/Svix.csproj
+++ b/csharp/Svix/Svix.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
     <PackageId>Svix</PackageId>
     <Version>0.67.0</Version>
     <Authors>Svix</Authors>
@@ -9,10 +9,19 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
+  
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Polly" Version="7.2.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp/Svix/Webhook.cs
+++ b/csharp/Svix/Webhook.cs
@@ -55,12 +55,12 @@ namespace Svix
             var timestamp = Webhook.VerifyTimestamp(msgTimestamp);
 
             var signature = this.Sign(msgId, timestamp, payload);
-            var expectedSignature = signature.Split(",")[1];
+            var expectedSignature = signature.Split(',')[1];
 
             var passedSignatures = msgSignature.Split(' ');
             foreach (string versionedSignature in passedSignatures)
             {
-                var parts = versionedSignature.Split(",");
+                var parts = versionedSignature.Split(',');
                 if (parts.Length < 2)
                 {
                     throw new WebhookVerificationException("Invalid Signature Headers");

--- a/csharp/Svix/Webhook.cs
+++ b/csharp/Svix/Webhook.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Text;
+﻿using Svix.Exceptions;
+using System;
 using System.Net;
 using System.Security.Cryptography;
-
-using Svix.Exceptions;
+using System.Text;
 
 namespace Svix
 {
@@ -56,12 +55,12 @@ namespace Svix
             var timestamp = Webhook.VerifyTimestamp(msgTimestamp);
 
             var signature = this.Sign(msgId, timestamp, payload);
-            var expectedSignature = signature.Split(",")[1];
+            var expectedSignature = signature.Split(',')[1];
 
             var passedSignatures = msgSignature.Split(' ');
             foreach (string versionedSignature in passedSignatures)
             {
-                var parts = versionedSignature.Split(",");
+                var parts = versionedSignature.Split(',');
                 if (parts.Length < 2)
                 {
                     throw new WebhookVerificationException("Invalid Signature Headers");

--- a/csharp/Svix/Webhook.cs
+++ b/csharp/Svix/Webhook.cs
@@ -55,12 +55,12 @@ namespace Svix
             var timestamp = Webhook.VerifyTimestamp(msgTimestamp);
 
             var signature = this.Sign(msgId, timestamp, payload);
-            var expectedSignature = signature.Split(',')[1];
+            var expectedSignature = signature.Split(",")[1];
 
             var passedSignatures = msgSignature.Split(' ');
             foreach (string versionedSignature in passedSignatures)
             {
-                var parts = versionedSignature.Split(',');
+                var parts = versionedSignature.Split(",");
                 if (parts.Length < 2)
                 {
                     throw new WebhookVerificationException("Invalid Signature Headers");


### PR DESCRIPTION
## Motivation
If possible it is always nice to support old Dotnet Framework type of applications (windows only) when publishing a Nuget.

## Solution
Add support for Netstandard2.0 to project. Now it can be consumed by old Framework 4.7.2 or 4.8 applications.