### PR TITLE
Add gitleaks config file for CI

### DIFF
--- a/.github/linters/.gitleaks.toml
+++ b/.github/linters/.gitleaks.toml
@@ -1,0 +1,5 @@
+[allowlist]
+description = "global allow list"
+regexes = [
+  '''eyJhcHBJZCI6ICJhcHBfMXRSdFl''',
+]


### PR DESCRIPTION
Adds a gitleaks config file so we can whitelist an example key
in our openapi.json spec file.