### PR TITLE
Ensure Cargo.lock is up to date with Cargo.toml

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2957,7 +2957,7 @@ dependencies = [
 
 [[package]]
 name = "svix-server"
-version = "0.67.0"
+version = "0.68.0"
 dependencies = [
  "anyhow",
  "axum",


### PR DESCRIPTION
Recent Docker releases failed because of a frozen `Cargo.lock` on release. Upon a little investigation it was found that the `Cargo.lock` was slightly out of sync with the `Cargo.toml`. This change will probably fix the Docker releases by ensuring the `Cargo.lock` matches what happens when the current `main` branch is built normally.