### PR TITLE
Fix typo in error message for unimplemented endpoints

### DIFF
--- a/server/svix-server/src/error.rs
+++ b/server/svix-server/src/error.rs
@@ -354,7 +354,7 @@ impl HttpError {
         Self::new_standard(
             StatusCode::NOT_IMPLEMENTED,
             code.unwrap_or_else(|| "not_implemented".to_owned()),
-            detail.unwrap_or_else(|| "This API endpoint is not yet implented.".to_owned()),
+            detail.unwrap_or_else(|| "This API endpoint is not yet implemented.".to_owned()),
         )
     }
 }


### PR DESCRIPTION
## Motivation

While testing, I noticed the following response for unimplemented endpoints
```json
{"code":"not_implemented","detail":"This API endpoint is not yet implented."}
```
That's a typo. Should be "implemented"

## Solution

Fix the typo.