### PR TITLE
Java: Do not use default API Client

### DIFF
--- a/java/lib/src/main/java/com/svix/Svix.java
+++ b/java/lib/src/main/java/com/svix/Svix.java
@@ -19,7 +19,7 @@ public final class Svix {
 	}
 
 	public Svix(final String token, final SvixOptions options) {
-		ApiClient apiClient = Configuration.getDefaultApiClient();
+		ApiClient apiClient = new ApiClient();
 
 		String[] tokenParts = token.split("\\.");
 		String region = tokenParts[tokenParts.length - 1];


### PR DESCRIPTION
The default API client is not safe to reuse;
simply removing the use of it now until we
decide to undertake a more ambitious rewrite
of the default generated API.