### PR TITLE
Simplify security.rs and authorization logic

### DIFF
--- a/server/svix-server/src/core/mod.rs
+++ b/server/svix-server/src/core/mod.rs
@@ -7,6 +7,7 @@ pub mod idempotency;
 pub mod message_app;
 pub mod operational_webhooks;
 pub mod otel_spans;
+pub mod permissions;
 pub mod run_with_retries;
 pub mod security;
 pub mod types;

--- a/server/svix-server/src/core/permissions.rs
+++ b/server/svix-server/src/core/permissions.rs
@@ -1,0 +1,107 @@
+use axum::{
+    async_trait,
+    extract::{FromRequest, Path, RequestParts},
+    Extension,
+};
+use sea_orm::DatabaseConnection;
+
+use crate::{
+    ctx,
+    db::models::application,
+    error::{Error, HttpError, Result},
+};
+
+use super::{
+    security::{permissions_from_bearer, AccessLevel},
+    types::{ApplicationIdOrUid, OrganizationId},
+};
+
+pub struct Organization {
+    pub org_id: OrganizationId,
+}
+
+#[async_trait]
+impl<B> FromRequest<B> for Organization
+where
+    B: Send,
+{
+    type Rejection = Error;
+
+    async fn from_request(req: &mut RequestParts<B>) -> Result<Self> {
+        let permissions = permissions_from_bearer(req).await?;
+
+        let org_id = match permissions.access_level {
+            AccessLevel::Organization(org_id) => org_id,
+            _ => return Err(HttpError::permission_denied(None, None).into()),
+        };
+
+        Ok(Self { org_id })
+    }
+}
+
+pub struct Application {
+    pub app: application::Model,
+}
+
+#[async_trait]
+impl<B> FromRequest<B> for Application
+where
+    B: Send,
+{
+    type Rejection = Error;
+
+    async fn from_request(req: &mut RequestParts<B>) -> Result<Self> {
+        let permissions = permissions_from_bearer(req).await?;
+
+        let Path(ApplicationPathParams { app_id }) =
+            ctx!(Path::<ApplicationPathParams>::from_request(req).await)?;
+        let Extension(ref db) = ctx!(Extension::<DatabaseConnection>::from_request(req).await)?;
+        let app = ctx!(
+            application::Entity::secure_find_by_id_or_uid(permissions.org_id(), app_id.to_owned(),)
+                .one(db)
+                .await
+        )?
+        .ok_or_else(|| HttpError::not_found(None, None))?;
+
+        if let Some(permitted_app_id) = permissions.app_id() {
+            if permitted_app_id != app.id {
+                return Err(HttpError::not_found(None, None).into());
+            }
+        }
+
+        Ok(Self { app })
+    }
+}
+
+// Organization level privileges, with the requested application
+pub struct OrganizationWithApplication {
+    pub app: application::Model,
+}
+
+#[async_trait]
+impl<B> FromRequest<B> for OrganizationWithApplication
+where
+    B: Send,
+{
+    type Rejection = Error;
+
+    async fn from_request(req: &mut RequestParts<B>) -> Result<Self> {
+        let Organization { org_id } = ctx!(Organization::from_request(req).await)?;
+
+        let Path(ApplicationPathParams { app_id }) =
+            ctx!(Path::<ApplicationPathParams>::from_request(req).await)?;
+        let Extension(ref db) = ctx!(Extension::<DatabaseConnection>::from_request(req).await)?;
+        let app = ctx!(
+            application::Entity::secure_find_by_id_or_uid(org_id, app_id.to_owned(),)
+                .one(db)
+                .await
+        )?
+        .ok_or_else(|| HttpError::not_found(None, None))?;
+        Ok(OrganizationWithApplication { app })
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct ApplicationPathParams {
+    app_id: ApplicationIdOrUid,
+}

--- a/server/svix-server/src/core/security.rs
+++ b/server/svix-server/src/core/security.rs
@@ -4,23 +4,21 @@
 use std::fmt::Debug;
 
 use axum::{
-    async_trait,
-    extract::{Extension, FromRequest, Path, RequestParts, TypedHeader},
+    extract::{Extension, FromRequest, RequestParts, TypedHeader},
     headers::{authorization::Bearer, Authorization},
 };
 
 use jwt_simple::prelude::*;
-use sea_orm::DatabaseConnection;
+
 use validator::Validate;
 
 use crate::{
     cfg::Configuration,
     ctx,
-    db::models::application,
-    error::{Error, HttpError, Result},
+    error::{HttpError, Result},
 };
 
-use super::types::{ApplicationId, ApplicationIdOrUid, OrganizationId};
+use super::types::{ApplicationId, OrganizationId};
 
 /// The default org_id we use (useful for generating JWTs when testing).
 pub fn default_org_id() -> OrganizationId {
@@ -32,34 +30,35 @@ pub fn management_org_id() -> OrganizationId {
     OrganizationId("org_00000000000SvixManagement00".to_owned())
 }
 
-pub struct Permissions {
-    pub type_: KeyType,
-    pub org_id: OrganizationId,
-    pub app_id: Option<ApplicationId>,
+pub enum AccessLevel {
+    Organization(OrganizationId),
+    Application(OrganizationId, ApplicationId),
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum KeyType {
-    Organization,
-    Application,
+pub struct Permissions {
+    pub access_level: AccessLevel,
+}
+
+impl Permissions {
+    pub fn org_id(&self) -> OrganizationId {
+        match &self.access_level {
+            AccessLevel::Organization(org_id) => org_id.clone(),
+            AccessLevel::Application(org_id, _) => org_id.clone(),
+        }
+    }
+
+    pub fn app_id(&self) -> Option<ApplicationId> {
+        match &self.access_level {
+            AccessLevel::Organization(_) => None,
+            AccessLevel::Application(_, app_id) => Some(app_id.clone()),
+        }
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct CustomClaim {
     #[serde(rename = "org", default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<String>,
-}
-
-#[async_trait]
-impl<B> FromRequest<B> for Permissions
-where
-    B: Send,
-{
-    type Rejection = Error;
-
-    async fn from_request(req: &mut RequestParts<B>) -> Result<Self> {
-        permissions_from_bearer(req).await
-    }
 }
 
 pub async fn permissions_from_bearer<B: Send>(req: &mut RequestParts<B>) -> Result<Permissions> {
@@ -102,9 +101,7 @@ pub fn permissions_from_jwt(claims: JWTClaims<CustomClaim>) -> Result<Permission
                 .map_err(|_| bad_token("sub", "application"))?;
 
             Ok(Permissions {
-                org_id,
-                app_id: Some(app_id),
-                type_: KeyType::Application,
+                access_level: AccessLevel::Application(org_id, app_id),
             })
         } else {
             Err(
@@ -123,119 +120,13 @@ pub fn permissions_from_jwt(claims: JWTClaims<CustomClaim>) -> Result<Permission
             )
         })?;
         Ok(Permissions {
-            org_id,
-            app_id: None,
-            type_: KeyType::Organization,
+            access_level: AccessLevel::Organization(org_id),
         })
     } else {
         Err(
             HttpError::unauthorized(None, Some("Invalid token (missing `sub`).".to_string()))
                 .into(),
         )
-    }
-}
-
-pub struct AuthenticatedOrganization {
-    pub permissions: Permissions,
-}
-
-#[async_trait]
-impl<B> FromRequest<B> for AuthenticatedOrganization
-where
-    B: Send,
-{
-    type Rejection = Error;
-
-    async fn from_request(req: &mut RequestParts<B>) -> Result<Self> {
-        let permissions = Permissions::from_request(req).await?;
-        match permissions.type_ {
-            KeyType::Organization => {}
-            KeyType::Application => {
-                return Err(HttpError::permission_denied(None, None).into());
-            }
-        }
-
-        Ok(AuthenticatedOrganization { permissions })
-    }
-}
-
-#[derive(Deserialize)]
-struct ApplicationPathParams {
-    app_id: ApplicationIdOrUid,
-}
-
-pub struct AuthenticatedOrganizationWithApplication {
-    pub permissions: Permissions,
-    pub app: application::Model,
-}
-
-#[async_trait]
-impl<B> FromRequest<B> for AuthenticatedOrganizationWithApplication
-where
-    B: Send,
-{
-    type Rejection = Error;
-
-    async fn from_request(req: &mut RequestParts<B>) -> Result<Self> {
-        let permissions = Permissions::from_request(req).await?;
-
-        match permissions.type_ {
-            KeyType::Organization => {}
-            KeyType::Application => {
-                return Err(HttpError::permission_denied(None, None).into());
-            }
-        }
-
-        let Path(ApplicationPathParams { app_id }) =
-            ctx!(Path::<ApplicationPathParams>::from_request(req).await)?;
-        let Extension(ref db) = ctx!(Extension::<DatabaseConnection>::from_request(req).await)?;
-        let app = ctx!(
-            application::Entity::secure_find_by_id_or_uid(
-                permissions.org_id.clone(),
-                app_id.to_owned(),
-            )
-            .one(db)
-            .await
-        )?
-        .ok_or_else(|| HttpError::not_found(None, None))?;
-        Ok(AuthenticatedOrganizationWithApplication { permissions, app })
-    }
-}
-
-pub struct AuthenticatedApplication {
-    pub permissions: Permissions,
-    pub app: application::Model,
-}
-
-#[async_trait]
-impl<B> FromRequest<B> for AuthenticatedApplication
-where
-    B: Send,
-{
-    type Rejection = Error;
-
-    async fn from_request(req: &mut RequestParts<B>) -> Result<Self> {
-        let permissions = Permissions::from_request(req).await?;
-        let Path(ApplicationPathParams { app_id }) =
-            ctx!(Path::<ApplicationPathParams>::from_request(req).await)?;
-        let Extension(ref db) = ctx!(Extension::<DatabaseConnection>::from_request(req).await)?;
-        let app = ctx!(
-            application::Entity::secure_find_by_id_or_uid(
-                permissions.org_id.clone(),
-                app_id.to_owned(),
-            )
-            .one(db)
-            .await
-        )?
-        .ok_or_else(|| HttpError::not_found(None, None))?;
-
-        if let Some(permitted_app_id) = &permissions.app_id {
-            if permitted_app_id != &app.id {
-                return Err(HttpError::not_found(None, None).into());
-            }
-        }
-
-        Ok(AuthenticatedApplication { permissions, app })
     }
 }
 

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     core::{
-        security::AuthenticatedApplication,
+        permissions,
         types::{
             ApplicationIdOrUid, EndpointId, EndpointIdOrUid, EventChannel, EventTypeNameSet,
             MessageAttemptId, MessageAttemptTriggerType, MessageEndpointId, MessageId,
@@ -126,10 +126,7 @@ async fn list_attempted_messages(
         after,
     }): ValidatedQuery<ListAttemptedMessagesQueryParameters>,
     Path((_app_id, endp_id)): Path<(ApplicationIdOrUid, EndpointIdOrUid)>,
-    AuthenticatedApplication {
-        permissions: _,
-        app,
-    }: AuthenticatedApplication,
+    permissions::Application { app }: permissions::Application,
 ) -> Result<Json<ListResponse<AttemptedMessageOut>>> {
     let PaginationLimit(limit) = pagination.limit;
     let endp = ctx!(
@@ -298,10 +295,7 @@ async fn list_attempts_by_endpoint(
         after,
     }): ValidatedQuery<ListAttemptsByEndpointQueryParameters>,
     Path((_app_id, endp_id)): Path<(ApplicationIdOrUid, EndpointIdOrUid)>,
-    AuthenticatedApplication {
-        permissions: _,
-        app,
-    }: AuthenticatedApplication,
+    permissions::Application { app }: permissions::Application,
 ) -> Result<Json<ListResponse<MessageAttemptOut>>> {
     let PaginationLimit(limit) = pagination.limit;
     // Confirm endpoint ID belongs to the given application
@@ -373,10 +367,7 @@ async fn list_attempts_by_msg(
         after,
     }): ValidatedQuery<ListAttemptsByMsgQueryParameters>,
     Path((_app_id, msg_id)): Path<(ApplicationIdOrUid, MessageId)>,
-    AuthenticatedApplication {
-        permissions: _,
-        app,
-    }: AuthenticatedApplication,
+    permissions::Application { app }: permissions::Application,
 ) -> Result<Json<ListResponse<MessageAttemptOut>>> {
     let PaginationLimit(limit) = pagination.limit;
     // Confirm message ID belongs to the given application
@@ -466,10 +457,7 @@ async fn list_attempted_destinations(
     Extension(ref db): Extension<DatabaseConnection>,
     ValidatedQuery(mut pagination): ValidatedQuery<Pagination<EndpointId>>,
     Path((_app_id, msg_id)): Path<(ApplicationIdOrUid, MessageIdOrUid)>,
-    AuthenticatedApplication {
-        permissions: _,
-        app,
-    }: AuthenticatedApplication,
+    permissions::Application { app }: permissions::Application,
 ) -> Result<Json<ListResponse<MessageEndpointOut>>> {
     let PaginationLimit(limit) = pagination.limit;
     let iterator = pagination.iterator.take();
@@ -532,7 +520,7 @@ async fn list_attempts_for_endpoint(
     }): ValidatedQuery<ListAttemptsForEndpointQueryParameters>,
     list_filter: MessageListFetchOptions,
     Path((app_id, msg_id, endp_id)): Path<(ApplicationIdOrUid, MessageIdOrUid, EndpointIdOrUid)>,
-    auth_app: AuthenticatedApplication,
+    auth_app: permissions::Application,
 ) -> Result<Json<ListResponse<MessageAttemptOut>>> {
     list_messageattempts(
         extension,
@@ -574,10 +562,7 @@ async fn list_messageattempts(
     }): ValidatedQuery<AttemptListFetchOptions>,
     list_filter: MessageListFetchOptions,
     Path((_app_id, msg_id)): Path<(ApplicationIdOrUid, MessageIdOrUid)>,
-    AuthenticatedApplication {
-        permissions: _,
-        app,
-    }: AuthenticatedApplication,
+    permissions::Application { app }: permissions::Application,
 ) -> Result<Json<ListResponse<MessageAttemptOut>>> {
     let PaginationLimit(limit) = pagination.limit;
     let msg = ctx!(
@@ -641,10 +626,7 @@ async fn get_messageattempt(
         MessageIdOrUid,
         MessageAttemptId,
     )>,
-    AuthenticatedApplication {
-        permissions: _,
-        app,
-    }: AuthenticatedApplication,
+    permissions::Application { app }: permissions::Application,
 ) -> Result<Json<MessageAttemptOut>> {
     let msg = ctx!(
         message::Entity::secure_find_by_id_or_uid(app.id, msg_id)
@@ -667,10 +649,7 @@ async fn resend_webhook(
     Extension(ref db): Extension<DatabaseConnection>,
     Extension(queue_tx): Extension<TaskQueueProducer>,
     Path((_app_id, msg_id, endp_id)): Path<(ApplicationIdOrUid, MessageIdOrUid, EndpointIdOrUid)>,
-    AuthenticatedApplication {
-        permissions: _,
-        app,
-    }: AuthenticatedApplication,
+    permissions::Application { app }: permissions::Application,
 ) -> Result<(StatusCode, Json<EmptyResponse>)> {
     let msg = ctx!(
         message::Entity::secure_find_by_id_or_uid(app.id.clone(), msg_id)

--- a/server/svix-server/src/v1/endpoints/auth.rs
+++ b/server/svix-server/src/v1/endpoints/auth.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     cfg::Configuration,
-    core::security::{generate_app_token, AuthenticatedOrganizationWithApplication},
+    core::{permissions, security::generate_app_token},
     error::{HttpError, Result},
     v1::utils::api_not_implemented,
 };
@@ -16,9 +16,9 @@ pub struct DashboardAccessOut {
 
 async fn dashboard_access(
     Extension(cfg): Extension<Configuration>,
-    AuthenticatedOrganizationWithApplication { permissions, app }: AuthenticatedOrganizationWithApplication,
+    permissions::OrganizationWithApplication { app }: permissions::OrganizationWithApplication,
 ) -> Result<Json<DashboardAccessOut>> {
-    let token = generate_app_token(&cfg.jwt_secret, permissions.org_id, app.id.clone())?;
+    let token = generate_app_token(&cfg.jwt_secret, app.org_id, app.id.clone())?;
 
     let login_key = serde_json::to_vec(&serde_json::json!({
         "appId": app.id,

--- a/server/svix-server/src/v1/endpoints/endpoint/headers.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/headers.rs
@@ -8,7 +8,7 @@ use sea_orm::{ActiveModelTrait, DatabaseConnection};
 use super::{EndpointHeadersIn, EndpointHeadersOut, EndpointHeadersPatchIn};
 use crate::{
     core::{
-        security::AuthenticatedApplication,
+        permissions,
         types::{ApplicationIdOrUid, EndpointIdOrUid},
     },
     ctx,
@@ -20,10 +20,7 @@ use crate::{
 pub(super) async fn get_endpoint_headers(
     Extension(ref db): Extension<DatabaseConnection>,
     Path((_app_id, endp_id)): Path<(ApplicationIdOrUid, EndpointIdOrUid)>,
-    AuthenticatedApplication {
-        permissions: _,
-        app,
-    }: AuthenticatedApplication,
+    permissions::Application { app }: permissions::Application,
 ) -> Result<Json<EndpointHeadersOut>> {
     let endp = ctx!(
         endpoint::Entity::secure_find_by_id_or_uid(app.id, endp_id)
@@ -42,10 +39,7 @@ pub(super) async fn update_endpoint_headers(
     Extension(ref db): Extension<DatabaseConnection>,
     Path((_app_id, endp_id)): Path<(ApplicationIdOrUid, EndpointIdOrUid)>,
     ValidatedJson(data): ValidatedJson<EndpointHeadersIn>,
-    AuthenticatedApplication {
-        permissions: _,
-        app,
-    }: AuthenticatedApplication,
+    permissions::Application { app }: permissions::Application,
 ) -> Result<(StatusCode, Json<EmptyResponse>)> {
     let endp = ctx!(
         endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endp_id)
@@ -65,10 +59,7 @@ pub(super) async fn patch_endpoint_headers(
     Extension(ref db): Extension<DatabaseConnection>,
     Path((_app_id, endp_id)): Path<(ApplicationIdOrUid, EndpointIdOrUid)>,
     ValidatedJson(data): ValidatedJson<EndpointHeadersPatchIn>,
-    AuthenticatedApplication {
-        permissions: _,
-        app,
-    }: AuthenticatedApplication,
+    permissions::Application { app }: permissions::Application,
 ) -> Result<(StatusCode, Json<EmptyResponse>)> {
     let endp = ctx!(
         endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endp_id)

--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -7,7 +7,7 @@ mod secrets;
 
 use crate::{
     core::{
-        security::AuthenticatedApplication,
+        permissions,
         types::{
             ApplicationIdOrUid, BaseId, EndpointId, EndpointIdOrUid, EndpointUid, EventChannelSet,
             EventTypeNameSet, MessageEndpointId, MessageStatus,
@@ -455,10 +455,7 @@ pub struct EndpointStatsQueryOut {
 async fn endpoint_stats(
     Extension(ref db): Extension<DatabaseConnection>,
     Path((_app_id, endp_id)): Path<(ApplicationIdOrUid, EndpointIdOrUid)>,
-    AuthenticatedApplication {
-        permissions: _,
-        app,
-    }: AuthenticatedApplication,
+    permissions::Application { app }: permissions::Application,
 ) -> crate::error::Result<Json<EndpointStatsOut>> {
     let endpoint = ctx!(
         crate::db::models::endpoint::Entity::secure_find_by_id_or_uid(app.id, endp_id)

--- a/server/svix-server/src/v1/endpoints/endpoint/recovery.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/recovery.rs
@@ -10,7 +10,7 @@ use sea_orm::{DatabaseConnection, QuerySelect};
 use super::RecoverIn;
 use crate::{
     core::{
-        security::AuthenticatedApplication,
+        permissions,
         types::{
             ApplicationIdOrUid, BaseId, EndpointIdOrUid, MessageAttemptTriggerType,
             MessageEndpointId, MessageStatus,
@@ -78,10 +78,7 @@ pub(super) async fn recover_failed_webhooks(
     Extension(queue_tx): Extension<TaskQueueProducer>,
     Path((_app_id, endp_id)): Path<(ApplicationIdOrUid, EndpointIdOrUid)>,
     ValidatedJson(data): ValidatedJson<RecoverIn>,
-    AuthenticatedApplication {
-        permissions: _,
-        app,
-    }: AuthenticatedApplication,
+    permissions::Application { app }: permissions::Application,
 ) -> Result<(StatusCode, Json<EmptyResponse>)> {
     // Add five minutes so that people can easily just do `now() - two_weeks` without having to worry about clock sync
     let timeframe = chrono::Duration::days(14);

--- a/server/svix-server/src/v1/endpoints/endpoint/secrets.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/secrets.rs
@@ -13,7 +13,7 @@ use crate::{
     cfg::{Configuration, DefaultSignatureType},
     core::{
         cryptography::Encryption,
-        security::AuthenticatedApplication,
+        permissions,
         types::{
             ApplicationIdOrUid, EndpointIdOrUid, EndpointSecretInternal, ExpiringSigningKey,
             ExpiringSigningKeys,
@@ -39,10 +39,7 @@ pub(super) async fn get_endpoint_secret(
     Extension(ref db): Extension<DatabaseConnection>,
     Extension(cfg): Extension<Configuration>,
     Path((_app_id, endp_id)): Path<(ApplicationIdOrUid, EndpointIdOrUid)>,
-    AuthenticatedApplication {
-        permissions: _,
-        app,
-    }: AuthenticatedApplication,
+    permissions::Application { app }: permissions::Application,
 ) -> Result<Json<EndpointSecretOut>> {
     let endp = ctx!(
         endpoint::Entity::secure_find_by_id_or_uid(app.id, endp_id)
@@ -60,10 +57,7 @@ pub(super) async fn rotate_endpoint_secret(
     Extension(cfg): Extension<Configuration>,
     Path((_app_id, endp_id)): Path<(ApplicationIdOrUid, EndpointIdOrUid)>,
     ValidatedJson(data): ValidatedJson<EndpointSecretRotateIn>,
-    AuthenticatedApplication {
-        permissions: _,
-        app,
-    }: AuthenticatedApplication,
+    permissions::Application { app }: permissions::Application,
 ) -> Result<(StatusCode, Json<EmptyResponse>)> {
     let mut endp = ctx!(
         endpoint::Entity::secure_find_by_id_or_uid(app.id, endp_id)


### PR DESCRIPTION
This PR refactors `security.rs` and our auth* related axum extractors.

## Motivation

* Cut down on lines-of-code
* Make permission/authorization parsing a bit more intuitive for axum handlers
* Better leverage the type system to restrict axum handlers only to the permission-level information they need.

## Solution

Some specifics
* Many of our extractors had redundant information, or largely unused fields. This PR removes them
* The `Permissions` struct has been simplified a bit, namely by moving things into an enum (as opposed to using the `type_` enum just as a tag.
* Removed the axum extractor for `Permissions`. We often chain authorization logic on top of the `Permissions`. However, the axum extractor for `Permissions` only authenticates requests, it doesn't authorize them. 
* Fixes a discrepancy between `list_event_types` and `get_event_type`. `list_event_types` was not checking for Organization privileges like `get_event_types` was.
* `AuthenticatedOrganization`, `AuthenticatedApp`, etc, were also simplified a bit, and moved into a separate `permissions.rs` module.