### PR TITLE
Ensure NACKed QueueTasks do not have stale duplicates after reinsertion

### DIFF
--- a/server/svix-server/src/queue/mod.rs
+++ b/server/svix-server/src/queue/mod.rs
@@ -173,11 +173,13 @@ trait TaskQueueSend: Sync + Send {
 
     async fn ack(&self, delivery: &TaskQueueDelivery) -> Result<()>;
 
-    /// By default NACKing a [`TaskQueueDelivery`] simply reinserts it in the back of the queue without
-    /// any delay.
+    /// By default NACKing a [`TaskQueueDelivery`] simply reinserts it in the back of the queue
+    /// without any delay. Additionally it `ack`s the orignal, now duplicated task, such as to
+    /// avoid memory leaks in persistent implementations of the queue.
     async fn nack(&self, delivery: &TaskQueueDelivery) -> Result<()> {
         tracing::debug!("nack {}", delivery.id);
-        self.send(delivery.task.clone(), None).await
+        self.send(delivery.task.clone(), None).await?;
+        self.ack(delivery).await
     }
 }
 


### PR DESCRIPTION
A followup to #671 which corrects an additional place where stale `QueueTasks` can be left in the Redis queue. This change simply modifies the `nack` method to acknowledge and delete the original task after it's clone has been inserted back into the queue.