### PR TITLE
Update event-type schemas to be stricter

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -29,6 +29,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e6e951cfbb2db8de1828d49073a113a29fd7117b1596caa781a258c7e38d72"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "serde",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +278,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +330,12 @@ name = "bumpalo"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+
+[[package]]
+name = "bytecount"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
 name = "byteorder"
@@ -385,13 +419,28 @@ checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.18",
+ "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive 4.0.18",
+ "clap_lex 0.3.0",
+ "once_cell",
+ "strsim",
+ "termcolor",
 ]
 
 [[package]]
@@ -408,10 +457,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -750,6 +821,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "fancy-regex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0678ab2d46fa5195aaf59ad034c083d351377d4af57f3e073c074d0da3e3c766"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,6 +900,16 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99df8100674344d1cee346c764684f7ad688a4dcaa1a3efb2fdb45daf9acf4f9"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -978,7 +1069,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -1281,6 +1372,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
+name = "iso8601"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f21abb3d09069861499d93d41a970243a90e215df0cf763ac9a31b9b27178d0"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,6 +1402,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ca9e2b45609132ae2214d50482c03aeee78826cd6fd53a8940915b81acedf16"
+dependencies = [
+ "ahash 0.8.0",
+ "anyhow",
+ "base64",
+ "bytecount",
+ "clap 4.0.18",
+ "fancy-regex",
+ "fraction",
+ "iso8601",
+ "itoa",
+ "lazy_static",
+ "memchr",
+ "num-cmp",
+ "parking_lot 0.12.1",
+ "percent-encoding",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "time 0.3.14",
+ "url",
+ "uuid 1.1.2",
 ]
 
 [[package]]
@@ -1506,10 +1635,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint 0.4.3",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
+dependencies = [
+ "autocfg 1.1.0",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg 1.1.0",
  "num-integer",
@@ -1535,6 +1689,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,6 +1720,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg 1.1.0",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg 1.1.0",
+ "num-bigint 0.4.3",
  "num-integer",
  "num-traits",
 ]
@@ -2763,7 +2944,7 @@ version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48c61941ccf5ddcada342cd59e3e5173b007c509e1e8e990dafc830294d9dc5"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
  "atoi",
  "base64",
  "bitflags",
@@ -2789,7 +2970,7 @@ dependencies = [
  "log",
  "md-5",
  "memchr",
- "num-bigint",
+ "num-bigint 0.3.3",
  "once_cell",
  "paste",
  "percent-encoding",
@@ -2968,7 +3149,7 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "chrono",
- "clap",
+ "clap 3.2.20",
  "dotenv",
  "ed25519-compact",
  "enum_dispatch",
@@ -2977,6 +3158,7 @@ dependencies = [
  "hmac-sha256",
  "http",
  "hyper",
+ "jsonschema",
  "jwt-simple",
  "lazy_static",
  "num_enum",
@@ -3127,7 +3309,7 @@ dependencies = [
  "libc",
  "standback",
  "stdweb",
- "time-macros",
+ "time-macros 0.1.1",
  "version_check",
  "winapi",
 ]
@@ -3140,6 +3322,7 @@ checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
 dependencies = [
  "libc",
  "num_threads",
+ "time-macros 0.2.4",
 ]
 
 [[package]]
@@ -3151,6 +3334,12 @@ dependencies = [
  "proc-macro-hack",
  "time-macros-impl",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "time-macros-impl"

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -62,6 +62,7 @@ futures = "0.3"
 redis_cluster_async = { git = "https://github.com/redis-rs/redis-cluster-async.git", rev = "e6fe168" }
 url = "2.2.2"
 rand = "0.8.5"
+jsonschema = "0.16.1"
 
 [dev-dependencies]
 anyhow = "1.0.56"

--- a/server/svix-server/src/db/models/eventtype.rs
+++ b/server/svix-server/src/db/models/eventtype.rs
@@ -8,13 +8,10 @@ use crate::{
     json_wrapper,
 };
 use chrono::Utc;
+use jsonschema::{Draft, JSONSchema};
 use sea_orm::entity::prelude::*;
 use sea_orm::ActiveValue::Set;
 use serde::{Deserialize, Serialize};
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct Schema(pub HashMap<String, Json>);
-json_wrapper!(Schema);
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "eventtype")]
@@ -64,5 +61,34 @@ impl Entity {
 
     pub fn secure_find_by_name(org_id: OrganizationId, name: EventTypeName) -> Select<Entity> {
         Self::secure_find(org_id).filter(Column::Name.eq(name))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Default)]
+pub struct Schema(HashMap<String, Json>);
+json_wrapper!(Schema);
+
+impl<'de> Deserialize<'de> for Schema {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let inner: HashMap<String, Json> = Deserialize::deserialize(deserializer)?;
+
+        // JSONSchema doesn't implement (De)Serialize, so we have to
+        // manually enforce the values are valid JSON schemas
+
+        let mut opts = JSONSchema::options();
+        opts.with_draft(Draft::Draft7);
+
+        if let Some(error) = inner
+            .values()
+            .filter_map(|schema| opts.compile(schema).err())
+            .next()
+        {
+            return Err(serde::de::Error::custom(error));
+        }
+
+        Ok(Self(inner))
     }
 }

--- a/server/svix-server/tests/e2e_endpoint.rs
+++ b/server/svix-server/tests/e2e_endpoint.rs
@@ -1485,7 +1485,7 @@ async fn test_endpoint_filter_events() {
     let _et: EventTypeOut = client
         .post(
             "api/v1/event-type",
-            event_type_in("et1", serde_json::json!({"test": "value"})).unwrap(),
+            event_type_in("et1", None).unwrap(),
             StatusCode::CREATED,
         )
         .await
@@ -1672,8 +1672,8 @@ async fn test_msg_event_types_filter() {
     let receiver = TestReceiver::start(StatusCode::OK);
 
     for et in [
-        event_type_in("et1", serde_json::json!({"test": "value"})).unwrap(),
-        event_type_in("et2", serde_json::json!({"test": "value"})).unwrap(),
+        event_type_in("et1", None).unwrap(),
+        event_type_in("et2", None).unwrap(),
     ] {
         let _: EventTypeOut = client
             .post("api/v1/event-type", et, StatusCode::CREATED)

--- a/server/svix-server/tests/e2e_event_type.rs
+++ b/server/svix-server/tests/e2e_event_type.rs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
-use std::collections::HashMap;
-
 use reqwest::StatusCode;
 
 use svix_server::{
@@ -27,7 +25,22 @@ async fn test_patch() {
     let et: EventTypeOut = client
         .post(
             "api/v1/event-type",
-            event_type_in("test-event-type", serde_json::json!({"test": "value"})).unwrap(),
+            event_type_in(
+                "test-event-type",
+                serde_json::json!({
+                    "1": {
+                        "type": "object",
+                        "title": "Longitude and Latitude Values",
+                        "description": "A geographical coordinate.",
+                        "required": ["latitude", "longitude"],
+                        "properties": {
+                        "latitude": {"type": "number", "minimum": -90, "maximum": 90},
+                        "longitude": {"type": "number", "minimum": -180, "maximum": 180},
+                        },
+                    }
+                }),
+            )
+            .unwrap(),
             StatusCode::CREATED,
         )
         .await
@@ -37,7 +50,7 @@ async fn test_patch() {
     let _: EventTypeOut = client
         .put(
             "api/v1/event-type/fake-id",
-            event_type_in("test-event-type", serde_json::json!({"test": "value"})).unwrap(),
+            event_type_in("test-event-type", None).unwrap(),
             StatusCode::CREATED,
         )
         .await
@@ -84,7 +97,7 @@ async fn test_patch() {
         .await
         .unwrap();
 
-    assert_eq!(out.schemas, Some(Schema(HashMap::new())));
+    assert_eq!(out.schemas, Some(Schema::default()));
 
     // Assert the other fields remain unchanged
     assert_eq!(out.deleted, et.deleted);
@@ -146,7 +159,7 @@ async fn test_event_type_create_read_list() {
     let et: EventTypeOut = client
         .post(
             "api/v1/event-type",
-            event_type_in("test-event-type", serde_json::json!({"test": "value"})).unwrap(),
+            event_type_in("test-event-type", None).unwrap(),
             StatusCode::CREATED,
         )
         .await
@@ -185,15 +198,28 @@ async fn test_list() {
     common_test_list::<EventTypeOut, EventTypeIn>(
         &client,
         "api/v1/event-type/",
-        |i| {
-            event_type_in(
-                &format!("test-event-type-{i}"),
-                serde_json::json!({"test": "value"}),
-            )
-            .unwrap()
-        },
+        |i| event_type_in(&format!("test-event-type-{i}"), None).unwrap(),
         true,
     )
     .await
     .unwrap();
+}
+
+#[tokio::test]
+async fn test_schema() {
+    let (client, _jh) = start_svix_server();
+    let _: serde_json::Value = client
+        .post(
+            "api/v1/event-type",
+            serde_json::json!({
+                            "name": "bad-schema",
+                            "description": "I have a bad schema",
+                            "schemas": {
+                                "1": {"readOnly": 15},
+                            },
+            }),
+            StatusCode::UNPROCESSABLE_ENTITY,
+        )
+        .await
+        .unwrap();
 }

--- a/server/svix-server/tests/utils/common_calls.rs
+++ b/server/svix-server/tests/utils/common_calls.rs
@@ -118,14 +118,15 @@ pub async fn create_test_message(
         .await
 }
 
-pub fn event_type_in(name: &str, payload: serde_json::Value) -> Result<EventTypeIn> {
-    let schema = serde_json::from_value(payload).unwrap();
-
+pub fn event_type_in(
+    name: &str,
+    schema: impl Into<Option<serde_json::Value>>,
+) -> Result<EventTypeIn> {
     Ok(EventTypeIn {
         name: EventTypeName(name.to_owned()),
         description: "test-event-description".to_owned(),
         deleted: false,
-        schemas: Some(schema),
+        schemas: schema.into().map(|s| serde_json::from_value(s).unwrap()),
     })
 }
 


### PR DESCRIPTION
This updates the /event-type endpoints "schemas" parsing to match our API more closely.

## Motivation

In our API, we specifically parse event-type schemas as a map of version numbers to Json Schemas. While we don't enforce the version numbers, we do enforce that the Json schemas are, well, valid JSON schemas!

The open-source repo was allowing arbitrary JSON objects, which is too lax.

## Solution

We use the `jsonschemas` library to parse Json Schemas. This library has a compatible license (MIT), no known vulnerabilities, is actively maintained, with modest popularity (283 stars in Github, a little over half a million downloads).

We still need to (de)serialize the `event_type::Schema`, and `jsonschema::JSONSchema` doesn't implement any of the (de)serialization traits. Consequently, the type definition is still a wrapper over a Hash of strings to Json, and we manually implement deserialize to enforce that that the json schema is always correct.
