### PR TITLE
Fix metadata field in Go and Python SDKs 

### DIFF
--- a/go/internal/openapi/model_application_in.go
+++ b/go/internal/openapi/model_application_in.go
@@ -16,6 +16,7 @@ import (
 
 // ApplicationIn struct for ApplicationIn
 type ApplicationIn struct {
+	Metadata map[string]string `json:"metadata,omitempty"`
 	Name string `json:"name"`
 	RateLimit NullableInt32 `json:"rateLimit,omitempty"`
 	// Optional unique identifier for the application
@@ -38,6 +39,39 @@ func NewApplicationIn(name string) *ApplicationIn {
 func NewApplicationInWithDefaults() *ApplicationIn {
 	this := ApplicationIn{}
 	return &this
+}
+
+// GetMetadata returns the Metadata field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *ApplicationIn) GetMetadata() map[string]string {
+	if o == nil  {
+		var ret map[string]string
+		return ret
+	}
+	return o.Metadata
+}
+
+// GetMetadataOk returns a tuple with the Metadata field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *ApplicationIn) GetMetadataOk() (*map[string]string, bool) {
+	if o == nil || o.Metadata == nil {
+		return nil, false
+	}
+	return &o.Metadata, true
+}
+
+// HasMetadata returns a boolean if a field has been set.
+func (o *ApplicationIn) HasMetadata() bool {
+	if o != nil && o.Metadata != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetMetadata gets a reference to the given map[string]string and assigns it to the Metadata field.
+func (o *ApplicationIn) SetMetadata(v map[string]string) {
+	o.Metadata = v
 }
 
 // GetName returns the Name field value
@@ -150,6 +184,9 @@ func (o *ApplicationIn) UnsetUid() {
 
 func (o ApplicationIn) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
+	if o.Metadata != nil {
+		toSerialize["metadata"] = o.Metadata
+	}
 	if true {
 		toSerialize["name"] = o.Name
 	}

--- a/go/internal/openapi/model_application_out.go
+++ b/go/internal/openapi/model_application_out.go
@@ -19,6 +19,7 @@ import (
 type ApplicationOut struct {
 	CreatedAt time.Time `json:"createdAt"`
 	Id string `json:"id"`
+	Metadata map[string]string `json:"metadata,omitempty"`
 	Name string `json:"name"`
 	RateLimit NullableInt32 `json:"rateLimit,omitempty"`
 	// Optional unique identifier for the application
@@ -93,6 +94,39 @@ func (o *ApplicationOut) GetIdOk() (*string, bool) {
 // SetId sets field value
 func (o *ApplicationOut) SetId(v string) {
 	o.Id = v
+}
+
+// GetMetadata returns the Metadata field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *ApplicationOut) GetMetadata() map[string]string {
+	if o == nil  {
+		var ret map[string]string
+		return ret
+	}
+	return o.Metadata
+}
+
+// GetMetadataOk returns a tuple with the Metadata field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *ApplicationOut) GetMetadataOk() (*map[string]string, bool) {
+	if o == nil || o.Metadata == nil {
+		return nil, false
+	}
+	return &o.Metadata, true
+}
+
+// HasMetadata returns a boolean if a field has been set.
+func (o *ApplicationOut) HasMetadata() bool {
+	if o != nil && o.Metadata != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetMetadata gets a reference to the given map[string]string and assigns it to the Metadata field.
+func (o *ApplicationOut) SetMetadata(v map[string]string) {
+	o.Metadata = v
 }
 
 // GetName returns the Name field value
@@ -234,6 +268,9 @@ func (o ApplicationOut) MarshalJSON() ([]byte, error) {
 	}
 	if true {
 		toSerialize["id"] = o.Id
+	}
+	if o.Metadata != nil {
+		toSerialize["metadata"] = o.Metadata
 	}
 	if true {
 		toSerialize["name"] = o.Name

--- a/go/internal/openapi/model_endpoint_in.go
+++ b/go/internal/openapi/model_endpoint_in.go
@@ -21,6 +21,7 @@ type EndpointIn struct {
 	Description *string `json:"description,omitempty"`
 	Disabled *bool `json:"disabled,omitempty"`
 	FilterTypes []string `json:"filterTypes,omitempty"`
+	Metadata map[string]string `json:"metadata,omitempty"`
 	RateLimit NullableInt32 `json:"rateLimit,omitempty"`
 	// The endpoint's verification secret. If `null` is passed, a secret is automatically generated. Format: `base64` encoded random bytes optionally prefixed with `whsec_`. Recommended size: 24.
 	Secret NullableString `json:"secret,omitempty"`
@@ -185,6 +186,39 @@ func (o *EndpointIn) HasFilterTypes() bool {
 // SetFilterTypes gets a reference to the given []string and assigns it to the FilterTypes field.
 func (o *EndpointIn) SetFilterTypes(v []string) {
 	o.FilterTypes = v
+}
+
+// GetMetadata returns the Metadata field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *EndpointIn) GetMetadata() map[string]string {
+	if o == nil  {
+		var ret map[string]string
+		return ret
+	}
+	return o.Metadata
+}
+
+// GetMetadataOk returns a tuple with the Metadata field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *EndpointIn) GetMetadataOk() (*map[string]string, bool) {
+	if o == nil || o.Metadata == nil {
+		return nil, false
+	}
+	return &o.Metadata, true
+}
+
+// HasMetadata returns a boolean if a field has been set.
+func (o *EndpointIn) HasMetadata() bool {
+	if o != nil && o.Metadata != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetMetadata gets a reference to the given map[string]string and assigns it to the Metadata field.
+func (o *EndpointIn) SetMetadata(v map[string]string) {
+	o.Metadata = v
 }
 
 // GetRateLimit returns the RateLimit field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -374,6 +408,9 @@ func (o EndpointIn) MarshalJSON() ([]byte, error) {
 	}
 	if o.FilterTypes != nil {
 		toSerialize["filterTypes"] = o.FilterTypes
+	}
+	if o.Metadata != nil {
+		toSerialize["metadata"] = o.Metadata
 	}
 	if o.RateLimit.IsSet() {
 		toSerialize["rateLimit"] = o.RateLimit.Get()

--- a/go/internal/openapi/model_endpoint_out.go
+++ b/go/internal/openapi/model_endpoint_out.go
@@ -24,6 +24,7 @@ type EndpointOut struct {
 	Disabled *bool `json:"disabled,omitempty"`
 	FilterTypes []string `json:"filterTypes,omitempty"`
 	Id string `json:"id"`
+	Metadata map[string]string `json:"metadata,omitempty"`
 	RateLimit NullableInt32 `json:"rateLimit,omitempty"`
 	// Optional unique identifier for the endpoint
 	Uid NullableString `json:"uid,omitempty"`
@@ -240,6 +241,39 @@ func (o *EndpointOut) SetId(v string) {
 	o.Id = v
 }
 
+// GetMetadata returns the Metadata field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *EndpointOut) GetMetadata() map[string]string {
+	if o == nil  {
+		var ret map[string]string
+		return ret
+	}
+	return o.Metadata
+}
+
+// GetMetadataOk returns a tuple with the Metadata field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *EndpointOut) GetMetadataOk() (*map[string]string, bool) {
+	if o == nil || o.Metadata == nil {
+		return nil, false
+	}
+	return &o.Metadata, true
+}
+
+// HasMetadata returns a boolean if a field has been set.
+func (o *EndpointOut) HasMetadata() bool {
+	if o != nil && o.Metadata != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetMetadata gets a reference to the given map[string]string and assigns it to the Metadata field.
+func (o *EndpointOut) SetMetadata(v map[string]string) {
+	o.Metadata = v
+}
+
 // GetRateLimit returns the RateLimit field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EndpointOut) GetRateLimit() int32 {
 	if o == nil || o.RateLimit.Get() == nil {
@@ -415,6 +449,9 @@ func (o EndpointOut) MarshalJSON() ([]byte, error) {
 	}
 	if true {
 		toSerialize["id"] = o.Id
+	}
+	if o.Metadata != nil {
+		toSerialize["metadata"] = o.Metadata
 	}
 	if o.RateLimit.IsSet() {
 		toSerialize["rateLimit"] = o.RateLimit.Get()

--- a/go/internal/openapi/model_endpoint_update.go
+++ b/go/internal/openapi/model_endpoint_update.go
@@ -21,6 +21,7 @@ type EndpointUpdate struct {
 	Description *string `json:"description,omitempty"`
 	Disabled *bool `json:"disabled,omitempty"`
 	FilterTypes []string `json:"filterTypes,omitempty"`
+	Metadata map[string]string `json:"metadata,omitempty"`
 	RateLimit NullableInt32 `json:"rateLimit,omitempty"`
 	// Optional unique identifier for the endpoint
 	Uid NullableString `json:"uid,omitempty"`
@@ -185,6 +186,39 @@ func (o *EndpointUpdate) SetFilterTypes(v []string) {
 	o.FilterTypes = v
 }
 
+// GetMetadata returns the Metadata field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *EndpointUpdate) GetMetadata() map[string]string {
+	if o == nil  {
+		var ret map[string]string
+		return ret
+	}
+	return o.Metadata
+}
+
+// GetMetadataOk returns a tuple with the Metadata field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *EndpointUpdate) GetMetadataOk() (*map[string]string, bool) {
+	if o == nil || o.Metadata == nil {
+		return nil, false
+	}
+	return &o.Metadata, true
+}
+
+// HasMetadata returns a boolean if a field has been set.
+func (o *EndpointUpdate) HasMetadata() bool {
+	if o != nil && o.Metadata != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetMetadata gets a reference to the given map[string]string and assigns it to the Metadata field.
+func (o *EndpointUpdate) SetMetadata(v map[string]string) {
+	o.Metadata = v
+}
+
 // GetRateLimit returns the RateLimit field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EndpointUpdate) GetRateLimit() int32 {
 	if o == nil || o.RateLimit.Get() == nil {
@@ -330,6 +364,9 @@ func (o EndpointUpdate) MarshalJSON() ([]byte, error) {
 	}
 	if o.FilterTypes != nil {
 		toSerialize["filterTypes"] = o.FilterTypes
+	}
+	if o.Metadata != nil {
+		toSerialize["metadata"] = o.Metadata
 	}
 	if o.RateLimit.IsSet() {
 		toSerialize["rateLimit"] = o.RateLimit.Get()

--- a/go/internal/openapi/model_message_endpoint_out.go
+++ b/go/internal/openapi/model_message_endpoint_out.go
@@ -24,6 +24,7 @@ type MessageEndpointOut struct {
 	Disabled *bool `json:"disabled,omitempty"`
 	FilterTypes []string `json:"filterTypes,omitempty"`
 	Id string `json:"id"`
+	Metadata map[string]string `json:"metadata,omitempty"`
 	NextAttempt NullableTime `json:"nextAttempt,omitempty"`
 	RateLimit NullableInt32 `json:"rateLimit,omitempty"`
 	Status MessageStatus `json:"status"`
@@ -239,6 +240,39 @@ func (o *MessageEndpointOut) GetIdOk() (*string, bool) {
 // SetId sets field value
 func (o *MessageEndpointOut) SetId(v string) {
 	o.Id = v
+}
+
+// GetMetadata returns the Metadata field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *MessageEndpointOut) GetMetadata() map[string]string {
+	if o == nil  {
+		var ret map[string]string
+		return ret
+	}
+	return o.Metadata
+}
+
+// GetMetadataOk returns a tuple with the Metadata field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *MessageEndpointOut) GetMetadataOk() (*map[string]string, bool) {
+	if o == nil || o.Metadata == nil {
+		return nil, false
+	}
+	return &o.Metadata, true
+}
+
+// HasMetadata returns a boolean if a field has been set.
+func (o *MessageEndpointOut) HasMetadata() bool {
+	if o != nil && o.Metadata != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetMetadata gets a reference to the given map[string]string and assigns it to the Metadata field.
+func (o *MessageEndpointOut) SetMetadata(v map[string]string) {
+	o.Metadata = v
 }
 
 // GetNextAttempt returns the NextAttempt field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -458,6 +492,9 @@ func (o MessageEndpointOut) MarshalJSON() ([]byte, error) {
 	}
 	if true {
 		toSerialize["id"] = o.Id
+	}
+	if o.Metadata != nil {
+		toSerialize["metadata"] = o.Metadata
 	}
 	if o.NextAttempt.IsSet() {
 		toSerialize["nextAttempt"] = o.NextAttempt.Get()

--- a/go/internal/openapi/model_settings_in.go
+++ b/go/internal/openapi/model_settings_in.go
@@ -30,6 +30,7 @@ type SettingsIn struct {
 	EnableTransformations *bool `json:"enableTransformations,omitempty"`
 	EnforceHttps *bool `json:"enforceHttps,omitempty"`
 	EventCatalogPublished NullableBool `json:"eventCatalogPublished,omitempty"`
+	ReadOnly *bool `json:"readOnly,omitempty"`
 }
 
 // NewSettingsIn instantiates a new SettingsIn object
@@ -50,6 +51,8 @@ func NewSettingsIn() *SettingsIn {
 	this.EnforceHttps = &enforceHttps
 	var eventCatalogPublished bool = false
 	this.EventCatalogPublished = *NewNullableBool(&eventCatalogPublished)
+	var readOnly bool = false
+	this.ReadOnly = &readOnly
 	return &this
 }
 
@@ -70,6 +73,8 @@ func NewSettingsInWithDefaults() *SettingsIn {
 	this.EnforceHttps = &enforceHttps
 	var eventCatalogPublished bool = false
 	this.EventCatalogPublished = *NewNullableBool(&eventCatalogPublished)
+	var readOnly bool = false
+	this.ReadOnly = &readOnly
 	return &this
 }
 
@@ -581,6 +586,38 @@ func (o *SettingsIn) UnsetEventCatalogPublished() {
 	o.EventCatalogPublished.Unset()
 }
 
+// GetReadOnly returns the ReadOnly field value if set, zero value otherwise.
+func (o *SettingsIn) GetReadOnly() bool {
+	if o == nil || o.ReadOnly == nil {
+		var ret bool
+		return ret
+	}
+	return *o.ReadOnly
+}
+
+// GetReadOnlyOk returns a tuple with the ReadOnly field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *SettingsIn) GetReadOnlyOk() (*bool, bool) {
+	if o == nil || o.ReadOnly == nil {
+		return nil, false
+	}
+	return o.ReadOnly, true
+}
+
+// HasReadOnly returns a boolean if a field has been set.
+func (o *SettingsIn) HasReadOnly() bool {
+	if o != nil && o.ReadOnly != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetReadOnly gets a reference to the given bool and assigns it to the ReadOnly field.
+func (o *SettingsIn) SetReadOnly(v bool) {
+	o.ReadOnly = &v
+}
+
 func (o SettingsIn) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.ColorPaletteDark != nil {
@@ -624,6 +661,9 @@ func (o SettingsIn) MarshalJSON() ([]byte, error) {
 	}
 	if o.EventCatalogPublished.IsSet() {
 		toSerialize["eventCatalogPublished"] = o.EventCatalogPublished.Get()
+	}
+	if o.ReadOnly != nil {
+		toSerialize["readOnly"] = o.ReadOnly
 	}
 	return json.Marshal(toSerialize)
 }

--- a/go/internal/openapi/model_settings_out.go
+++ b/go/internal/openapi/model_settings_out.go
@@ -30,6 +30,7 @@ type SettingsOut struct {
 	EnableTransformations *bool `json:"enableTransformations,omitempty"`
 	EnforceHttps *bool `json:"enforceHttps,omitempty"`
 	EventCatalogPublished NullableBool `json:"eventCatalogPublished,omitempty"`
+	ReadOnly *bool `json:"readOnly,omitempty"`
 }
 
 // NewSettingsOut instantiates a new SettingsOut object
@@ -50,6 +51,8 @@ func NewSettingsOut() *SettingsOut {
 	this.EnforceHttps = &enforceHttps
 	var eventCatalogPublished bool = false
 	this.EventCatalogPublished = *NewNullableBool(&eventCatalogPublished)
+	var readOnly bool = false
+	this.ReadOnly = &readOnly
 	return &this
 }
 
@@ -70,6 +73,8 @@ func NewSettingsOutWithDefaults() *SettingsOut {
 	this.EnforceHttps = &enforceHttps
 	var eventCatalogPublished bool = false
 	this.EventCatalogPublished = *NewNullableBool(&eventCatalogPublished)
+	var readOnly bool = false
+	this.ReadOnly = &readOnly
 	return &this
 }
 
@@ -581,6 +586,38 @@ func (o *SettingsOut) UnsetEventCatalogPublished() {
 	o.EventCatalogPublished.Unset()
 }
 
+// GetReadOnly returns the ReadOnly field value if set, zero value otherwise.
+func (o *SettingsOut) GetReadOnly() bool {
+	if o == nil || o.ReadOnly == nil {
+		var ret bool
+		return ret
+	}
+	return *o.ReadOnly
+}
+
+// GetReadOnlyOk returns a tuple with the ReadOnly field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *SettingsOut) GetReadOnlyOk() (*bool, bool) {
+	if o == nil || o.ReadOnly == nil {
+		return nil, false
+	}
+	return o.ReadOnly, true
+}
+
+// HasReadOnly returns a boolean if a field has been set.
+func (o *SettingsOut) HasReadOnly() bool {
+	if o != nil && o.ReadOnly != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetReadOnly gets a reference to the given bool and assigns it to the ReadOnly field.
+func (o *SettingsOut) SetReadOnly(v bool) {
+	o.ReadOnly = &v
+}
+
 func (o SettingsOut) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.ColorPaletteDark != nil {
@@ -624,6 +661,9 @@ func (o SettingsOut) MarshalJSON() ([]byte, error) {
 	}
 	if o.EventCatalogPublished.IsSet() {
 		toSerialize["eventCatalogPublished"] = o.EventCatalogPublished.Get()
+	}
+	if o.ReadOnly != nil {
+		toSerialize["readOnly"] = o.ReadOnly
 	}
 	return json.Marshal(toSerialize)
 }

--- a/python/templates/model.py.jinja
+++ b/python/templates/model.py.jinja
@@ -146,7 +146,11 @@ return field_dict
     {% import "property_templates/" + property.template as prop_template %}
     {% if prop_template.construct %}
         {% if property.class_info and property.required_properties == [] and property.optional_properties == [] %}
+            {% if property.required %}
         {{ property.python_name }} = dict_copy.pop("{{ property.name }}")
+            {% else %}
+        {{ property.python_name }} = dict_copy.pop("{{ property.name }}", UNSET)
+            {% endif %}
         {% else %}
         {{ prop_template.construct(property, property_source) | indent(8) }}
         {% endif %}


### PR DESCRIPTION
This fixes the go sdk by running regen_openapi.sh.

The python templates were generating incorrect code. It wasn't accounting for optional fields when constructing responses.

Tested by
* Regenerating the python sdk locally
* Running the server locally with docker-compose and cargo run
* pointing my SDK to the local server
* Creating applications and making sure I didn't get any KeyErrors.


Here's the diff for /python/internal
```
54c54
<         metadata = dict_copy.pop("metadata")
---
>         metadata = dict_copy.pop("metadata", UNSET)
diff -rw svix/internal/openapi_client/models/application_out.py /Users/gabriel/Repos/svix-webhooks/python/svix/internal/openapi_client/models/application_out.py
76c76
<         metadata = dict_copy.pop("metadata")
---
>         metadata = dict_copy.pop("metadata", UNSET)
diff -rw svix/internal/openapi_client/models/endpoint_in.py /Users/gabriel/Repos/svix-webhooks/python/svix/internal/openapi_client/models/endpoint_in.py
108c108
<         metadata = dict_copy.pop("metadata")
---
>         metadata = dict_copy.pop("metadata", UNSET)
diff -rw svix/internal/openapi_client/models/endpoint_out.py /Users/gabriel/Repos/svix-webhooks/python/svix/internal/openapi_client/models/endpoint_out.py
123c123
<         metadata = dict_copy.pop("metadata")
---
>         metadata = dict_copy.pop("metadata", UNSET)
diff -rw svix/internal/openapi_client/models/endpoint_update.py /Users/gabriel/Repos/svix-webhooks/python/svix/internal/openapi_client/models/endpoint_update.py
101c101
<         metadata = dict_copy.pop("metadata")
---
>         metadata = dict_copy.pop("metadata", UNSET)
diff -rw svix/internal/openapi_client/models/event_type_in.py /Users/gabriel/Repos/svix-webhooks/python/svix/internal/openapi_client/models/event_type_in.py
60c60
<         schemas = dict_copy.pop("schemas")
---
>         schemas = dict_copy.pop("schemas", UNSET)
diff -rw svix/internal/openapi_client/models/event_type_out.py /Users/gabriel/Repos/svix-webhooks/python/svix/internal/openapi_client/models/event_type_out.py
76c76
<         schemas = dict_copy.pop("schemas")
---
>         schemas = dict_copy.pop("schemas", UNSET)
diff -rw svix/internal/openapi_client/models/event_type_update.py /Users/gabriel/Repos/svix-webhooks/python/svix/internal/openapi_client/models/event_type_update.py
54c54
<         schemas = dict_copy.pop("schemas")
---
>         schemas = dict_copy.pop("schemas", UNSET)
diff -rw svix/internal/openapi_client/models/message_endpoint_out.py /Users/gabriel/Repos/svix-webhooks/python/svix/internal/openapi_client/models/message_endpoint_out.py
136c136
<         metadata = dict_copy.pop("metadata")
---
>         metadata = dict_copy.pop("metadata", UNSET)
```