### PR TITLE
Change test server spawning to be async

### DIFF
--- a/server/svix-server/tests/e2e_application.rs
+++ b/server/svix-server/tests/e2e_application.rs
@@ -19,7 +19,7 @@ use utils::{
 // operation could fail. This should probably be made into a macro if at all possible.
 #[tokio::test]
 async fn test_patch() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app: ApplicationOut = client
         .post(
@@ -149,7 +149,7 @@ async fn test_patch() {
 
 #[tokio::test]
 async fn test_crud() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     const APP_NAME_1_1: &str = "v1ApplicationCrudTest11";
     const APP_NAME_1_2: &str = "v1ApplicationCrudTest12";
@@ -255,7 +255,7 @@ async fn test_crud() {
 
 #[tokio::test]
 async fn test_list() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     common_test_list::<ApplicationOut, ApplicationIn>(
         &client,
@@ -269,7 +269,7 @@ async fn test_list() {
 
 #[tokio::test]
 async fn test_uid() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app: ApplicationOut = client
         .post(
@@ -462,8 +462,8 @@ async fn test_uid() {
 
 #[tokio::test]
 async fn test_uid_across_users() {
-    let (client, _jh) = start_svix_server();
-    let (client2, _jh2) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
+    let (client2, _jh2) = start_svix_server().await;
 
     // Make sure that uids aren't unique across different users
 
@@ -496,7 +496,7 @@ async fn test_uid_across_users() {
 
 #[tokio::test]
 async fn test_get_or_create() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app: ApplicationOut = client
         .post(
@@ -542,7 +542,7 @@ async fn test_get_or_create() {
 
 #[tokio::test]
 async fn test_idempotency() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let cfg = svix_server::cfg::load().unwrap();
 

--- a/server/svix-server/tests/e2e_attempt.rs
+++ b/server/svix-server/tests/e2e_attempt.rs
@@ -29,7 +29,7 @@ use std::time::Duration;
 
 #[tokio::test]
 async fn test_list_attempted_messages() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
@@ -106,7 +106,7 @@ async fn test_list_attempted_messages() {
 
 #[tokio::test]
 async fn test_list_attempts_by_endpoint() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app_id = create_test_app(&client, "v1AttemptListAttemptsByEndpointTestApp")
         .await
@@ -190,7 +190,7 @@ async fn test_message_attempts() {
         .map(|_| Duration::from_millis(1))
         .collect();
 
-    let (client, _jh) = start_svix_server_with_cfg(&cfg);
+    let (client, _jh) = start_svix_server_with_cfg(&cfg).await;
 
     for (status_code, msg_status, attempt_count) in [
         // Success
@@ -272,7 +272,7 @@ async fn test_message_attempts_empty_retry_schedule() {
     let mut cfg = get_default_test_config();
     cfg.retry_schedule = vec![];
 
-    let (client, _jh) = start_svix_server_with_cfg(&cfg);
+    let (client, _jh) = start_svix_server_with_cfg(&cfg).await;
 
     let (status_code, msg_status, attempt_count) =
         (StatusCode::INTERNAL_SERVER_ERROR, MessageStatus::Fail, None);
@@ -312,7 +312,7 @@ async fn test_message_attempts_empty_retry_schedule() {
 
 #[tokio::test]
 async fn test_pagination_by_endpoint() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     // Setup six endpoints and six messages so there's a sufficient number to test pagination
     let app = create_test_app(&client, "app1").await.unwrap();
@@ -491,7 +491,7 @@ async fn test_pagination_by_endpoint() {
 
 #[tokio::test]
 async fn test_pagination_by_msg() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     // Setup six endpoints and six messages so there's a sufficient number to test pagination
     let app = create_test_app(&client, "app1").await.unwrap();
@@ -711,7 +711,7 @@ async fn test_pagination_by_msg() {
 
 #[tokio::test]
 async fn test_pagination_forward_and_back() {
-    let (client, _) = start_svix_server();
+    let (client, _) = start_svix_server().await;
 
     let app = create_test_app(&client, "test_app").await.unwrap();
 

--- a/server/svix-server/tests/e2e_auth.rs
+++ b/server/svix-server/tests/e2e_auth.rs
@@ -34,7 +34,7 @@ async fn dashboard_access(org_client: &TestClient, application_id: &ApplicationI
 /// Users with application-level tokens should only be allowed to read the information related to
 /// their one application. All other endpoints should error.
 async fn test_restricted_application_access() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app_id: ApplicationId = client
         .post::<_, ApplicationOut>(

--- a/server/svix-server/tests/e2e_endpoint.rs
+++ b/server/svix-server/tests/e2e_endpoint.rs
@@ -89,7 +89,7 @@ async fn delete_endpoint(client: &TestClient, app_id: &ApplicationId, ep_id: &st
 
 #[tokio::test]
 async fn test_patch() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app = create_test_app(&client, "v1EndpointPatchTestApp")
         .await
@@ -453,7 +453,7 @@ async fn test_patch() {
 
 #[tokio::test]
 async fn test_crud() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     const APP_NAME_1: &str = "v1EndpointCrudTestApp1";
     const APP_NAME_2: &str = "v1EndpointCrudTestApp2";
@@ -603,7 +603,7 @@ async fn test_crud() {
 
 #[tokio::test]
 async fn test_list() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app_id = create_test_app(&client, "App1").await.unwrap().id;
     common_test_list::<EndpointOut, EndpointIn>(
@@ -620,7 +620,7 @@ async fn test_list() {
 /// any application
 #[tokio::test]
 async fn test_uid() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     const APP_NAME_1: &str = "v1EndpointUidTestApp1";
     const APP_NAME_2: &str = "v1EndpointUidTestApp2";
@@ -724,7 +724,7 @@ async fn test_uid() {
 // Simply tests that upon rotating an endpoint secret that it differs from the prior one
 #[tokio::test]
 async fn test_endpoint_secret_get_and_rotation() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     const APP_NAME: &str = "v1EndpointSecretRotationTestApp";
     const EP_URI: &str = "http://v1EndpointSecretRotationTestEp.test";
@@ -786,7 +786,7 @@ async fn test_endpoint_secret_get_and_rotation() {
 
 #[tokio::test]
 async fn test_recovery_should_fail_if_start_time_too_old() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
@@ -821,7 +821,7 @@ async fn test_recovery_expected_retry_counts() {
     // total attempts for a failed message should be 1 (first attempt) + length of retry_schedule:
     let base_attempt_cnt = 1 + &cfg.retry_schedule.len();
 
-    let (client, _jh) = start_svix_server_with_cfg(&cfg);
+    let (client, _jh) = start_svix_server_with_cfg(&cfg).await;
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
@@ -873,7 +873,7 @@ async fn test_recovery_expected_retry_counts() {
 
 #[tokio::test]
 async fn test_endpoint_rotate_max() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
@@ -905,7 +905,7 @@ async fn test_endpoint_rotate_max() {
 
 #[tokio::test]
 async fn test_endpoint_rotate_signing_e2e() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
@@ -988,7 +988,7 @@ async fn test_endpoint_rotate_signing_e2e() {
 
 #[tokio::test]
 async fn test_endpoint_rotate_signing_symmetric_and_asymmetric() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
@@ -1086,7 +1086,7 @@ async fn test_endpoint_rotate_signing_symmetric_and_asymmetric() {
 async fn test_endpoint_secret_config() {
     let mut cfg = get_default_test_config();
     cfg.default_signature_type = DefaultSignatureType::Ed25519;
-    let (client, _jh) = start_svix_server_with_cfg(&cfg);
+    let (client, _jh) = start_svix_server_with_cfg(&cfg).await;
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
@@ -1140,7 +1140,7 @@ async fn test_endpoint_secret_config() {
 
 #[tokio::test]
 async fn test_custom_endpoint_secret() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
@@ -1211,7 +1211,7 @@ async fn test_custom_endpoint_secret() {
 async fn test_endpoint_secret_encryption() {
     let org_id = OrganizationId::new(None, None);
     let cfg = get_default_test_config();
-    let (client, _jh) = start_svix_server_with_cfg_and_org_id(&cfg, org_id.clone());
+    let (client, _jh) = start_svix_server_with_cfg_and_org_id(&cfg, org_id.clone()).await;
 
     #[derive(Deserialize)]
     pub struct EndpointSecretOutTest {
@@ -1242,7 +1242,7 @@ async fn test_endpoint_secret_encryption() {
     // Now add encryption and check the secret is still fine
     let mut cfg = get_default_test_config();
     cfg.encryption = Encryption::new([1; 32]);
-    let (client, _jh) = start_svix_server_with_cfg_and_org_id(&cfg, org_id.clone());
+    let (client, _jh) = start_svix_server_with_cfg_and_org_id(&cfg, org_id.clone()).await;
 
     let secret2 = client
         .get::<EndpointSecretOutTest>(
@@ -1280,7 +1280,7 @@ async fn test_endpoint_secret_encryption() {
 
     // Make sure we can't read it with the secret unset
     let cfg = get_default_test_config();
-    let (client, _jh) = start_svix_server_with_cfg_and_org_id(&cfg, org_id.clone());
+    let (client, _jh) = start_svix_server_with_cfg_and_org_id(&cfg, org_id.clone()).await;
     client
         .get::<IgnoredResponse>(
             &format!("api/v1/app/{}/endpoint/{}/secret/", app_id, ep.id),
@@ -1292,7 +1292,7 @@ async fn test_endpoint_secret_encryption() {
 
 #[tokio::test]
 async fn test_invalid_endpoint_secret() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
@@ -1324,7 +1324,7 @@ async fn test_invalid_endpoint_secret() {
 #[tokio::test]
 async fn test_legacy_endpoint_secret() {
     let cfg = get_default_test_config();
-    let (client, _jh) = start_svix_server_with_cfg(&cfg);
+    let (client, _jh) = start_svix_server_with_cfg(&cfg).await;
 
     let db = Arc::new(cfg);
     let db = svix_server::db::init_db(&db).await;
@@ -1383,7 +1383,7 @@ async fn test_legacy_endpoint_secret() {
 async fn test_endpoint_secret_encryption_in_database() {
     let mut cfg = get_default_test_config();
     cfg.encryption = Encryption::new([1; 32]);
-    let (client, _jh) = start_svix_server_with_cfg(&cfg);
+    let (client, _jh) = start_svix_server_with_cfg(&cfg).await;
 
     let db = Arc::new(cfg);
     let db = svix_server::db::init_db(&db).await;
@@ -1411,7 +1411,7 @@ async fn test_endpoint_secret_encryption_in_database() {
     let secret_encrypted: Vec<u8> = secret_encrypted.unwrap().try_get("", "key").unwrap();
 
     let cfg = get_default_test_config();
-    let (client, _jh) = start_svix_server_with_cfg(&cfg);
+    let (client, _jh) = start_svix_server_with_cfg(&cfg).await;
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
@@ -1441,7 +1441,7 @@ async fn test_endpoint_secret_encryption_in_database() {
 
 #[tokio::test]
 async fn test_endpoint_filter_events() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
@@ -1539,7 +1539,7 @@ async fn test_endpoint_filter_events() {
 
 #[tokio::test]
 async fn test_endpoint_filter_channels() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
@@ -1627,7 +1627,7 @@ async fn test_endpoint_filter_channels() {
 
 #[tokio::test]
 async fn test_rate_limit() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
@@ -1665,7 +1665,7 @@ async fn test_rate_limit() {
 
 #[tokio::test]
 async fn test_msg_event_types_filter() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
@@ -1736,7 +1736,7 @@ async fn test_msg_event_types_filter() {
 
 #[tokio::test]
 async fn test_msg_channels_filter() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
@@ -1796,7 +1796,7 @@ async fn test_msg_channels_filter() {
 
 #[tokio::test]
 async fn test_endpoint_headers_manipulation() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
@@ -1959,7 +1959,7 @@ async fn test_endpoint_headers_manipulation() {
 
 #[tokio::test]
 async fn test_endpoint_headers_sending() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
@@ -1998,7 +1998,7 @@ async fn test_endpoint_headers_sending() {
 
 #[tokio::test]
 async fn test_endpoint_header_key_capitalization() {
-    let (client, _jk) = start_svix_server();
+    let (client, _jk) = start_svix_server().await;
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
@@ -2045,7 +2045,7 @@ async fn test_endpoint_https_only() {
 
     // No https enforcement (default)
     let cfg = get_default_test_config();
-    let (client, _jh) = start_svix_server_with_cfg(&cfg);
+    let (client, _jh) = start_svix_server_with_cfg(&cfg).await;
 
     let app_id = create_test_app(&client, "App 1").await.unwrap().id;
 
@@ -2072,7 +2072,7 @@ async fn test_endpoint_https_only() {
     // Enforce https
     let mut cfg = get_default_test_config();
     cfg.endpoint_https_only = true;
-    let (client, _jh) = start_svix_server_with_cfg(&cfg);
+    let (client, _jh) = start_svix_server_with_cfg(&cfg).await;
 
     let app_id = create_test_app(&client, "App 1").await.unwrap().id;
 

--- a/server/svix-server/tests/e2e_event_type.rs
+++ b/server/svix-server/tests/e2e_event_type.rs
@@ -20,7 +20,7 @@ use utils::{
 
 #[tokio::test]
 async fn test_patch() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let et: EventTypeOut = client
         .post(
@@ -154,7 +154,7 @@ async fn test_patch() {
 
 #[tokio::test]
 async fn test_event_type_create_read_list() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let et: EventTypeOut = client
         .post(
@@ -193,7 +193,7 @@ async fn test_event_type_create_read_list() {
 
 #[tokio::test]
 async fn test_list() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     common_test_list::<EventTypeOut, EventTypeIn>(
         &client,
@@ -207,7 +207,7 @@ async fn test_list() {
 
 #[tokio::test]
 async fn test_schema() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
     let _: serde_json::Value = client
         .post(
             "api/v1/event-type",

--- a/server/svix-server/tests/e2e_message.rs
+++ b/server/svix-server/tests/e2e_message.rs
@@ -22,7 +22,7 @@ use utils::{
 
 #[tokio::test]
 async fn test_message_create_read_list() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app_id = create_test_app(&client, "v1MessageCRTestApp")
         .await
@@ -84,7 +84,7 @@ async fn test_message_create_read_list() {
 
 #[tokio::test]
 async fn test_message_create_read_list_with_content() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app_id = create_test_app(&client, "v1MessageCRTestApp")
         .await
@@ -177,7 +177,7 @@ async fn test_message_create_read_list_with_content() {
 
 #[tokio::test]
 async fn test_failed_message_gets_recorded() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app_id = create_test_app(&client, "v1MessageCRTestApp")
         .await
@@ -225,7 +225,7 @@ async fn test_failed_message_gets_recorded() {
 
 #[tokio::test]
 async fn test_mulitple_endpoints() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app_id = create_test_app(&client, "v1MessageCRTestApp")
         .await
@@ -297,7 +297,7 @@ async fn test_mulitple_endpoints() {
 
 #[tokio::test]
 async fn test_failed_message_gets_requeued() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
 
     let app_id = create_test_app(&client, "v1MessageCRTestApp")
         .await
@@ -350,7 +350,7 @@ async fn test_failed_message_gets_requeued() {
 
 #[tokio::test]
 async fn test_payload_retention_period() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
     dotenv::dotenv().ok();
     let cfg = svix_server::cfg::load().expect("Error loading configuration");
     let pool = svix_server::db::init_db(&cfg).await;

--- a/server/svix-server/tests/utils/mod.rs
+++ b/server/svix-server/tests/utils/mod.rs
@@ -226,17 +226,17 @@ pub fn get_default_test_config() -> ConfigurationInner {
     cfg.as_ref().clone()
 }
 
-pub fn start_svix_server() -> (TestClient, tokio::task::JoinHandle<()>) {
-    start_svix_server_with_cfg(&get_default_test_config())
+pub async fn start_svix_server() -> (TestClient, tokio::task::JoinHandle<()>) {
+    start_svix_server_with_cfg(&get_default_test_config()).await
 }
 
-pub fn start_svix_server_with_cfg(
+pub async fn start_svix_server_with_cfg(
     cfg: &ConfigurationInner,
 ) -> (TestClient, tokio::task::JoinHandle<()>) {
-    start_svix_server_with_cfg_and_org_id(cfg, OrganizationId::new(None, None))
+    start_svix_server_with_cfg_and_org_id(cfg, OrganizationId::new(None, None)).await
 }
 
-pub fn start_svix_server_with_cfg_and_org_id(
+pub async fn start_svix_server_with_cfg_and_org_id(
     cfg: &ConfigurationInner,
     org_id: OrganizationId,
 ) -> (TestClient, tokio::task::JoinHandle<()>) {

--- a/server/svix-server/tests/worker.rs
+++ b/server/svix-server/tests/worker.rs
@@ -78,7 +78,7 @@ async fn visit_reporting_receiver_route(
 // The worker has
 #[tokio::test]
 async fn test_no_redirects_policy() {
-    let (client, _jh) = start_svix_server();
+    let (client, _jh) = start_svix_server().await;
     let receiver = RedirectionVisitReportingReceiver::start(StatusCode::OK);
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
@@ -131,7 +131,7 @@ async fn test_endpoint_disable_on_repeated_failure() {
         cfg.retry_schedule = vec![];
         cfg.endpoint_failure_disable_after = Duration::from_secs(1);
 
-        let (client, _jh) = start_svix_server_with_cfg(&cfg);
+        let (client, _jh) = start_svix_server_with_cfg(&cfg).await;
 
         let app_id = create_test_app(&client, "app").await.unwrap().id;
         let ep_id = create_test_endpoint(&client, &app_id, "http://bad.url/")
@@ -181,7 +181,7 @@ async fn test_endpoint_disable_expiration_duration() {
         cfg.retry_schedule = vec![];
         cfg.endpoint_failure_disable_after = Duration::from_millis(250);
 
-        let (client, _jh) = start_svix_server_with_cfg(&cfg);
+        let (client, _jh) = start_svix_server_with_cfg(&cfg).await;
 
         let app_id = create_test_app(&client, "app").await.unwrap().id;
         let ep_id = create_test_endpoint(&client, &app_id, "http://bad.url/")
@@ -279,7 +279,7 @@ async fn test_endpoint_disable_on_sporadic_failure() {
         cfg.retry_schedule = vec![];
         cfg.endpoint_failure_disable_after = Duration::from_secs(1);
 
-        let (client, _jh) = start_svix_server_with_cfg(&cfg);
+        let (client, _jh) = start_svix_server_with_cfg(&cfg).await;
 
         let app_id = create_test_app(&client, "app").await.unwrap().id;
         let ep_id = create_test_endpoint(&client, &app_id, &receiver.base_uri)


### PR DESCRIPTION
Changes the functions for starting a test server to be async
in our e2e test suite.