### PR TITLE
Add tracing to run-tests.sh

### DIFF
--- a/server/run-tests.sh
+++ b/server/run-tests.sh
@@ -7,6 +7,7 @@ TEST_COMMAND="cargo test --all --all-features --all-targets"
 # Common variables:
 export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres"
 export SVIX_JWT_SECRET="test value"
+export SVIX_LOG_LEVEL="trace"
 
 echo "*********** RUN 1 ***********"
 SVIX_QUEUE_TYPE="redis" \

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -6,7 +6,10 @@
 
 use axum::{extract::Extension, Router};
 
+use cfg::ConfigurationInner;
 use lazy_static::lazy_static;
+use opentelemetry::runtime::Tokio;
+use opentelemetry_otlp::WithExportConfig;
 use std::{
     net::TcpListener,
     sync::atomic::{AtomicBool, Ordering},
@@ -15,6 +18,7 @@ use std::{
 use tower::ServiceBuilder;
 use tower_http::cors::{AllowHeaders, Any, CorsLayer};
 use tower_http::trace::TraceLayer;
+use tracing_subscriber::{prelude::*, util::SubscriberInitExt};
 
 use crate::{
     cfg::{CacheBackend, Configuration},
@@ -38,6 +42,8 @@ pub mod queue;
 pub mod redis;
 pub mod v1;
 pub mod worker;
+
+const CRATE_NAME: &str = env!("CARGO_CRATE_NAME");
 
 lazy_static! {
     pub static ref SHUTTING_DOWN: AtomicBool = AtomicBool::new(false);
@@ -186,6 +192,79 @@ pub async fn run_with_prefix(
     server.expect("Error initializing server");
     worker_loop.expect("Error initializing worker");
     expired_message_cleaner_loop.expect("Error initializing expired message cleaner")
+}
+
+pub fn setup_tracing(cfg: &ConfigurationInner) {
+    if std::env::var_os("RUST_LOG").is_none() {
+        let level = cfg.log_level.to_string();
+        let mut var = vec![
+            format!("{crate}={level}", crate = CRATE_NAME),
+            format!("tower_http={level}"),
+        ];
+
+        if cfg.db_tracing {
+            var.push(format!("sqlx={level}"));
+        }
+
+        std::env::set_var("RUST_LOG", var.join(","));
+    }
+
+    let otel_layer = cfg.opentelemetry_address.as_ref().map(|addr| {
+        // Configure the OpenTelemetry tracing layer
+        opentelemetry::global::set_text_map_propagator(
+            opentelemetry::sdk::propagation::TraceContextPropagator::new(),
+        );
+
+        let exporter = opentelemetry_otlp::new_exporter()
+            .tonic()
+            .with_endpoint(addr);
+
+        let tracer = opentelemetry_otlp::new_pipeline()
+            .tracing()
+            .with_exporter(exporter)
+            .with_trace_config(
+                opentelemetry::sdk::trace::config()
+                    .with_sampler(
+                        cfg.opentelemetry_sample_ratio
+                            .map(opentelemetry::sdk::trace::Sampler::TraceIdRatioBased)
+                            .unwrap_or(opentelemetry::sdk::trace::Sampler::AlwaysOn),
+                    )
+                    .with_resource(opentelemetry::sdk::Resource::new(vec![
+                        opentelemetry::KeyValue::new("service.name", "svix_server"),
+                    ])),
+            )
+            .install_batch(Tokio)
+            .unwrap();
+        tracing_opentelemetry::layer().with_tracer(tracer)
+    });
+
+    // Then initialize logging with an additional layer priting to stdout. This additional layer is
+    // either formatted normally or in JSON format
+    // Fails if the subscriber was already initialized, which we can safely and silently ignore
+    let _ = match cfg.log_format {
+        cfg::LogFormat::Default => {
+            let stdout_layer = tracing_subscriber::fmt::layer();
+            tracing_subscriber::Registry::default()
+                .with(otel_layer)
+                .with(stdout_layer)
+                .with(tracing_subscriber::EnvFilter::from_default_env())
+                .try_init()
+        }
+        cfg::LogFormat::Json => {
+            let fmt = tracing_subscriber::fmt::format().json().flatten_event(true);
+            let json_fields = tracing_subscriber::fmt::format::JsonFields::new();
+
+            let stdout_layer = tracing_subscriber::fmt::layer()
+                .event_format(fmt)
+                .fmt_fields(json_fields);
+
+            tracing_subscriber::Registry::default()
+                .with(otel_layer)
+                .with(stdout_layer)
+                .with(tracing_subscriber::EnvFilter::from_default_env())
+                .try_init()
+        }
+    };
 }
 
 mod docs {

--- a/server/svix-server/tests/utils/mod.rs
+++ b/server/svix-server/tests/utils/mod.rs
@@ -19,6 +19,7 @@ use svix_server::{
         security::generate_org_token,
         types::{BaseId, OrganizationId},
     },
+    setup_tracing,
 };
 
 use http::HeaderMap;
@@ -240,6 +241,8 @@ pub async fn start_svix_server_with_cfg_and_org_id(
     cfg: &ConfigurationInner,
     org_id: OrganizationId,
 ) -> (TestClient, tokio::task::JoinHandle<()>) {
+    setup_tracing(cfg);
+
     let cfg = Arc::new(cfg.clone());
 
     let token = generate_org_token(&cfg.jwt_secret, org_id).unwrap();


### PR DESCRIPTION
This moves the tracing setup outside of `main.rs` so that tests can use tracing. This emits server logs in failed test runs, which makes diagnosing failed tests much easier, depending on the reason for failing.

There is a small functional change - instead of using `SubscriberInitExt::init`, we now use `SubscriberInitExt::try_init`. init will panic if the subscriber was already setup, whereas try_init will return an `Err(...)`. This doesn't matter in prod, but in tests we end up calling setup_tracing more than once. AFAICT we can safely ignore this error, so we do.