### PR TITLE
Fix Java library server resolution

### DIFF
--- a/java/lib/src/main/java/com/svix/Svix.java
+++ b/java/lib/src/main/java/com/svix/Svix.java
@@ -29,9 +29,10 @@ public final class Svix {
 			apiClient.setBasePath("https://api.eu.svix.com");
 		} else if (region.equals("in")) {
 			apiClient.setBasePath("https://api.in.svix.com");
+		} else {
+			apiClient.setBasePath(options.getServerUrl());
 		}
 
-		apiClient.setBasePath(options.getServerUrl());
 		apiClient.setUserAgent(String.format("svix-libs/%s/java", Svix.VERSION));
 
 		HttpBearerAuth httpBearer = (HttpBearerAuth) apiClient.getAuthentication("HTTPBearer");


### PR DESCRIPTION
Fixes a bug in our Java library that was overwriting any token-based
server resolution to the default Svix server.

Closes #694. 