### PR TITLE
Server: Configurable Healthchecks

### DIFF
--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -94,3 +94,15 @@ api_enabled = true
 
 # Should this instance run the message worker
 worker_enabled = true
+
+# Whether to enable the queue health check, which will test that a message can
+# be published into the queue. Defaults to true.
+queue_health_check_enabled = true
+
+# Whether to enable the cache health check, which will add a test key-value pair to 
+# the cache. Defaults to true.
+cache_health_check_enabled = true
+
+# Whether to enable the db health check, which runs a simple query 
+# against the database. Defaults to true.
+db_health_check_enabled = true

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -173,6 +173,16 @@ pub struct ConfigurationInner {
     /// Should this instance run the message worker
     pub worker_enabled: bool,
 
+    /// Whether to enable the queue health check, which will test that a message can
+    /// be published into the queue. Defaults to true.
+    pub queue_health_check_enabled: bool,
+    /// Whether to enable the cache health check, which will add a test key-value pair to
+    /// the cache. Defaults to true.
+    pub cache_health_check_enabled: bool,
+    /// Whether to enable the db health check, which runs a simple query
+    /// against the database. Defaults to true.
+    pub db_health_check_enabled: bool,
+
     #[serde(flatten)]
     pub internal: InternalConfig,
 }

--- a/server/svix-server/src/v1/endpoints/health.rs
+++ b/server/svix-server/src/v1/endpoints/health.rs
@@ -8,6 +8,7 @@ use sea_orm::{query::Statement, ConnectionTrait, DatabaseBackend, DatabaseConnec
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    cfg::Configuration,
     core::cache::{kv_def, Cache, CacheBehavior, CacheKey, CacheValue},
     queue::{QueueTask, TaskQueueProducer},
 };
@@ -16,14 +17,15 @@ async fn ping() -> StatusCode {
     StatusCode::NO_CONTENT
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum HealthStatusVariant {
     Ok,
     Error,
+    NotApplicable,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
 pub struct HealthStatus {
     status: HealthStatusVariant,
     // TODO: information field
@@ -42,16 +44,20 @@ impl HealthStatus {
         }
     }
 
+    pub fn new_na() -> HealthStatus {
+        HealthStatus {
+            status: HealthStatusVariant::NotApplicable,
+        }
+    }
+
     pub fn is_ok(&self) -> bool {
-        matches!(
-            self,
-            HealthStatus {
-                status: HealthStatusVariant::Ok,
-                ..
-            }
-        )
+        match self.status {
+            HealthStatusVariant::Ok | HealthStatusVariant::NotApplicable => true,
+            HealthStatusVariant::Error => false,
+        }
     }
 }
+
 impl<O, E> From<Result<O, E>> for HealthStatus {
     fn from(res: Result<O, E>) -> Self {
         match res {
@@ -63,10 +69,10 @@ impl<O, E> From<Result<O, E>> for HealthStatus {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct HealthReport {
-    database: HealthStatus,
+    pub database: HealthStatus,
 
-    queue: HealthStatus,
-    cache: HealthStatus,
+    pub queue: HealthStatus,
+    pub cache: HealthStatus,
 }
 
 #[derive(Deserialize, Serialize, Debug, PartialEq)]
@@ -77,29 +83,41 @@ async fn health(
     Extension(ref db): Extension<DatabaseConnection>,
     Extension(queue_tx): Extension<TaskQueueProducer>,
     Extension(cache): Extension<Cache>,
+    Extension(cfg): Extension<Configuration>,
 ) -> (StatusCode, Json<HealthReport>) {
     // SELECT 1 FROM any table
-    let database: HealthStatus = db
-        .execute(Statement::from_string(
+    let database: HealthStatus = if cfg.db_health_check_enabled {
+        db.execute(Statement::from_string(
             DatabaseBackend::Postgres,
             "SELECT 1".to_owned(),
         ))
         .await
-        .into();
+        .into()
+    } else {
+        HealthStatus::new_na()
+    };
 
     // Send a [`HealthCheck`] through the queue
-    let queue: HealthStatus = queue_tx.send(QueueTask::HealthCheck, None).await.into();
+    let queue: HealthStatus = if cfg.queue_health_check_enabled {
+        queue_tx.send(QueueTask::HealthCheck, None).await.into()
+    } else {
+        HealthStatus::new_na()
+    };
 
     // Set a cache value with an expiration to ensure it works
-    let cache: HealthStatus = cache
-        .set(
-            &HealthCheckCacheKey("health_check_value".to_owned()),
-            &HealthCheckCacheValue(()),
-            // Expires after this time, so it won't pollute the DB
-            Duration::from_millis(100),
-        )
-        .await
-        .into();
+    let cache: HealthStatus = if cfg.cache_health_check_enabled {
+        cache
+            .set(
+                &HealthCheckCacheKey("health_check_value".to_owned()),
+                &HealthCheckCacheValue(()),
+                // Expires after this time, so it won't pollute the DB
+                Duration::from_millis(100),
+            )
+            .await
+            .into()
+    } else {
+        HealthStatus::new_na()
+    };
 
     let status = if database.is_ok() && queue.is_ok() && cache.is_ok() {
         StatusCode::OK

--- a/server/svix-server/tests/e2e_health.rs
+++ b/server/svix-server/tests/e2e_health.rs
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2022 Svix Authors
+// SPDX-License-Identifier: MIT
+
+use reqwest::StatusCode;
+
+mod utils;
+
+use svix_server::v1::endpoints::health::{HealthReport, HealthStatus};
+use utils::{get_default_test_config, start_svix_server, start_svix_server_with_cfg};
+
+#[tokio::test]
+async fn test_health() {
+    let (client, _jh) = start_svix_server().await;
+
+    let health_info: HealthReport = client.get("api/v1/health/", StatusCode::OK).await.unwrap();
+
+    assert_eq!(health_info.queue, HealthStatus::new_ok());
+    assert_eq!(health_info.database, HealthStatus::new_ok());
+    assert_eq!(health_info.cache, HealthStatus::new_ok());
+}
+
+#[tokio::test]
+async fn test_health_na() {
+    let mut cfg = get_default_test_config();
+    cfg.queue_health_check_enabled = false;
+    cfg.cache_health_check_enabled = false;
+    cfg.db_health_check_enabled = false;
+
+    let (client, _jh) = start_svix_server_with_cfg(&cfg).await;
+
+    let health_info: HealthReport = client.get("api/v1/health/", StatusCode::OK).await.unwrap();
+
+    assert_eq!(health_info.queue, HealthStatus::new_na());
+    assert_eq!(health_info.database, HealthStatus::new_na());
+    assert_eq!(health_info.cache, HealthStatus::new_na());
+}


### PR DESCRIPTION
Allow configuration of whether to enable
health-checks of downstream services. This
change enables them by default but makes
them configurable. If not configured, a
status of "notapplicable" will be returned,
which does not affect the health-check return
code.
