### PR TITLE
Adding metadata to application CRUD group

### DIFF
--- a/server/run-tests.sh
+++ b/server/run-tests.sh
@@ -7,7 +7,7 @@ TEST_COMMAND="cargo test --all --all-features --all-targets"
 # Common variables:
 export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres"
 export SVIX_JWT_SECRET="test value"
-export SVIX_LOG_LEVEL="trace"
+export SVIX_LOG_LEVEL="info"
 
 echo "*********** RUN 1 ***********"
 SVIX_QUEUE_TYPE="redis" \

--- a/server/svix-server/migrations/20221104170041_add_applicationmetadata.down.sql
+++ b/server/svix-server/migrations/20221104170041_add_applicationmetadata.down.sql
@@ -1,0 +1,2 @@
+-- Add down migration script here
+DROP TABLE IF EXISTS applicationmetadata;

--- a/server/svix-server/migrations/20221104170041_add_applicationmetadata.up.sql
+++ b/server/svix-server/migrations/20221104170041_add_applicationmetadata.up.sql
@@ -1,0 +1,10 @@
+-- Add up migration script here
+CREATE TABLE applicationmetadata (
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL,
+    id character varying NOT NULL COLLATE pg_catalog."C",
+    data jsonb NOT NULL
+);
+
+ALTER TABLE ONLY applicationmetadata
+    ADD CONSTRAINT applicationmetadata_pkey PRIMARY KEY (id);

--- a/server/svix-server/src/core/permissions.rs
+++ b/server/svix-server/src/core/permissions.rs
@@ -7,17 +7,28 @@ use sea_orm::DatabaseConnection;
 
 use crate::{
     ctx,
-    db::models::application,
+    db::models::{application, applicationmetadata},
     error::{Error, HttpError, Result},
 };
 
 use super::{
-    security::{permissions_from_bearer, AccessLevel},
-    types::{ApplicationIdOrUid, OrganizationId},
+    security::{permissions_from_bearer, AccessLevel, Permissions},
+    types::{ApplicationId, ApplicationIdOrUid, OrganizationId},
 };
 
 pub struct Organization {
     pub org_id: OrganizationId,
+}
+
+impl Permissions {
+    fn check_app_is_permitted(&self, app_id: &ApplicationId) -> Result<()> {
+        if let Some(ref permitted_app_id) = self.app_id() {
+            if permitted_app_id != app_id {
+                return Err(HttpError::not_found(None, None).into());
+            }
+        }
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -63,11 +74,7 @@ where
         )?
         .ok_or_else(|| HttpError::not_found(None, None))?;
 
-        if let Some(permitted_app_id) = permissions.app_id() {
-            if permitted_app_id != app.id {
-                return Err(HttpError::not_found(None, None).into());
-            }
-        }
+        permissions.check_app_is_permitted(&app.id)?;
 
         Ok(Self { app })
     }
@@ -98,6 +105,36 @@ where
         )?
         .ok_or_else(|| HttpError::not_found(None, None))?;
         Ok(OrganizationWithApplication { app })
+    }
+}
+
+pub struct ApplicationWithMetadata {
+    pub app: application::Model,
+    pub metadata: applicationmetadata::Model,
+}
+
+#[async_trait]
+impl<B> FromRequest<B> for ApplicationWithMetadata
+where
+    B: Send,
+{
+    type Rejection = Error;
+
+    async fn from_request(req: &mut RequestParts<B>) -> Result<Self> {
+        let permissions = permissions_from_bearer(req).await?;
+
+        let Path(ApplicationPathParams { app_id }) =
+            ctx!(Path::<ApplicationPathParams>::from_request(req).await)?;
+        let Extension(ref db) = ctx!(Extension::<DatabaseConnection>::from_request(req).await)?;
+        let (app, metadata) = ctx!(
+            application::Model::fetch_with_metadata(db, permissions.org_id(), app_id.to_owned())
+                .await
+        )?
+        .ok_or_else(|| HttpError::not_found(None, None))?;
+
+        permissions.check_app_is_permitted(&app.id)?;
+
+        Ok(Self { app, metadata })
     }
 }
 

--- a/server/svix-server/src/core/types/metadata.rs
+++ b/server/svix-server/src/core/types/metadata.rs
@@ -1,0 +1,39 @@
+use std::collections::HashMap;
+
+use crate::json_wrapper;
+use serde::{Deserialize, Serialize};
+
+pub const MAX_METADATA_SIZE: usize = 4096;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Default)]
+pub struct Metadata(HashMap<String, String>);
+
+json_wrapper!(Metadata);
+
+impl Metadata {
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl<'de> Deserialize<'de> for Metadata {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let inner: Option<HashMap<String, String>> = Deserialize::deserialize(deserializer)?;
+        let metadata = inner.unwrap_or_default(); // coerce `null` to `{}`
+
+        let size = serde_json::to_string(&metadata)
+            .map(|blob| blob.len())
+            .map_err(|_| serde::de::Error::custom("metadata is not valid json"))?;
+
+        if size > MAX_METADATA_SIZE {
+            return Err(serde::de::Error::custom(format!(
+                "metadata must be less than or equal to {MAX_METADATA_SIZE} bytes"
+            )));
+        }
+
+        Ok(Self(metadata))
+    }
+}

--- a/server/svix-server/src/core/types/mod.rs
+++ b/server/svix-server/src/core/types/mod.rs
@@ -17,6 +17,8 @@ use validator::{Validate, ValidationErrors};
 
 use crate::{err_generic, v1::utils::validation_error};
 
+pub mod metadata;
+
 use super::cryptography::{AsymmetricKey, Encryption};
 
 const ALL_ERROR: &str = "__all__";

--- a/server/svix-server/src/db/mod.rs
+++ b/server/svix-server/src/db/mod.rs
@@ -134,3 +134,16 @@ pub async fn wipe_org(cfg: &Configuration, org_id: OrganizationId) {
             )
         });
 }
+
+#[macro_export]
+/// Runs an async closure inside of a DB Transaction. The closure should return an [`error::Result<T>`]. If the closure returns an error for any reason, the transaction is rolled back.
+macro_rules! transaction {
+    ($db:expr, $do:expr) => {
+        $crate::ctx!(
+            sea_orm::TransactionTrait::transaction::<_, _, $crate::error::Error>($db, |txn| {
+                std::boxed::Box::pin({ $do(txn) })
+            })
+            .await
+        )
+    };
+}

--- a/server/svix-server/src/db/models/applicationmetadata.rs
+++ b/server/svix-server/src/db/models/applicationmetadata.rs
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: © 2022 Svix Authors
+// SPDX-License-Identifier: MIT
+use crate::core::types::ApplicationId;
+
+use crate::core::types::metadata::Metadata;
+use crate::{ctx, error};
+use chrono::Utc;
+use sea_orm::entity::prelude::*;
+use sea_orm::sea_query::OnConflict;
+use sea_orm::ActiveValue::Set;
+use sea_orm::{ConnectionTrait, TryIntoModel};
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "applicationmetadata")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: ApplicationId,
+    pub created_at: DateTimeWithTimeZone,
+    pub updated_at: DateTimeWithTimeZone,
+    pub data: Metadata,
+}
+
+impl Model {
+    pub fn metadata(self) -> Metadata {
+        self.data
+    }
+
+    pub fn new(app_id: ApplicationId) -> Self {
+        ActiveModel::new(app_id, None)
+            .try_into_model()
+            .expect("ActiveModel::create(...) should have set all fields")
+    }
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::application::Entity",
+        from = "Column::Id",
+        to = "super::application::Column::Id",
+        on_update = "NoAction",
+        on_delete = "Restrict"
+    )]
+    Application,
+}
+
+impl Related<super::application::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Application.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {
+    fn before_save(mut self, _insert: bool) -> Result<Self, DbErr> {
+        self.updated_at = Set(Utc::now().into());
+        Ok(self)
+    }
+}
+
+impl ActiveModel {
+    pub fn new(app_id: ApplicationId, metadata: impl Into<Option<Metadata>>) -> Self {
+        let id = Set(app_id);
+        let data = Set(metadata.into().unwrap_or_default());
+        let timestamp = Utc::now();
+        Self {
+            id,
+            data,
+            created_at: Set(timestamp.into()),
+            updated_at: Set(timestamp.into()),
+        }
+    }
+
+    /// Upserts the record if it's new or updated, AND data is nonempty. Otherwise the record is
+    /// ignored or destroyed as appropriate.
+    pub async fn upsert_or_delete(self, db: &impl ConnectionTrait) -> error::Result<Model> {
+        let data = self.data.clone().take().unwrap_or_default();
+
+        if data.is_empty() {
+            let model = ctx!(self.clone().try_into_model())?;
+            ctx!(self.delete(db).await)?;
+            return Ok(model);
+        }
+
+        ctx!(Entity::upsert(self).exec_with_returning(db).await)
+    }
+}
+
+impl Entity {
+    pub fn secure_find(app_id: ApplicationId) -> sea_orm::Select<Entity> {
+        Self::find().filter(Column::Id.eq(app_id))
+    }
+
+    pub fn upsert(am: ActiveModel) -> sea_orm::Insert<ActiveModel> {
+        Self::insert(am).on_conflict(
+            OnConflict::column(Column::Id)
+                .update_columns([Column::Data, Column::UpdatedAt])
+                .to_owned(),
+        )
+    }
+}

--- a/server/svix-server/src/db/models/mod.rs
+++ b/server/svix-server/src/db/models/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 pub mod application;
+pub mod applicationmetadata;
 pub mod endpoint;
 pub mod eventtype;
 pub mod message;

--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -4,11 +4,12 @@
 use crate::{
     core::{
         permissions,
-        types::{ApplicationId, ApplicationIdOrUid, ApplicationUid},
+        types::{metadata::Metadata, ApplicationId, ApplicationIdOrUid, ApplicationUid},
     },
     ctx,
-    db::models::application,
-    error::Result,
+    db::models::{application, applicationmetadata},
+    error::{HttpError, Result},
+    transaction,
     v1::utils::{
         patch::{
             patch_field_non_nullable, patch_field_nullable, UnrequiredField,
@@ -26,13 +27,13 @@ use axum::{
 };
 use chrono::{DateTime, Utc};
 use hyper::StatusCode;
-use sea_orm::{entity::prelude::*, ActiveValue::Set, QueryOrder};
-use sea_orm::{ActiveModelTrait, DatabaseConnection, QuerySelect};
+use sea_orm::ActiveValue::Set;
+use sea_orm::{ActiveModelTrait, DatabaseConnection};
 use serde::{Deserialize, Serialize};
-use svix_server_derive::{ModelIn, ModelOut};
+use svix_server_derive::ModelOut;
 use validator::{Validate, ValidationError};
 
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Validate, ModelIn)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Validate)]
 #[serde(rename_all = "camelCase")]
 pub struct ApplicationIn {
     #[validate(
@@ -48,26 +49,31 @@ pub struct ApplicationIn {
     #[validate]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uid: Option<ApplicationUid>,
+
+    #[serde(default)]
+    pub metadata: Metadata,
 }
 
 // FIXME: This can and should be a derive macro
 impl ModelIn for ApplicationIn {
-    type ActiveModel = application::ActiveModel;
+    type ActiveModel = (application::ActiveModel, applicationmetadata::ActiveModel);
 
-    fn update_model(self, model: &mut Self::ActiveModel) {
+    fn update_model(self, (app, app_metadata): &mut Self::ActiveModel) {
         let ApplicationIn {
             name,
             rate_limit,
             uid,
+            metadata,
         } = self;
 
-        model.name = Set(name);
-        model.rate_limit = Set(rate_limit.map(|x| x.into()));
-        model.uid = Set(uid);
+        app.name = Set(name);
+        app.rate_limit = Set(rate_limit.map(|x| x.into()));
+        app.uid = Set(uid);
+        app_metadata.data = Set(metadata);
     }
 }
 
-#[derive(Deserialize, ModelIn, Serialize, Validate)]
+#[derive(Deserialize, Serialize, Validate)]
 #[serde(rename_all = "camelCase")]
 pub struct ApplicationPatch {
     #[serde(default, skip_serializing_if = "UnrequiredField::is_absent")]
@@ -84,24 +90,30 @@ pub struct ApplicationPatch {
     #[serde(default, skip_serializing_if = "UnrequiredNullableField::is_absent")]
     #[validate]
     pub uid: UnrequiredNullableField<ApplicationUid>,
+
+    #[serde(default, skip_serializing_if = "UnrequiredField::is_absent")]
+    pub metadata: UnrequiredField<Metadata>,
 }
 
 impl ModelIn for ApplicationPatch {
-    type ActiveModel = application::ActiveModel;
+    type ActiveModel = (application::ActiveModel, applicationmetadata::ActiveModel);
 
-    fn update_model(self, model: &mut Self::ActiveModel) {
+    fn update_model(self, (app, app_metadata): &mut Self::ActiveModel) {
         let ApplicationPatch {
             name,
             rate_limit,
             uid,
+            metadata,
         } = self;
 
         // `model`'s version of `rate_limit` is an i32, while `self`'s is a u16.
         let rate_limit_map = |x: u16| -> i32 { x.into() };
+        let data = metadata;
 
-        patch_field_non_nullable!(model, name);
-        patch_field_nullable!(model, rate_limit, rate_limit_map);
-        patch_field_nullable!(model, uid);
+        patch_field_non_nullable!(app, name);
+        patch_field_nullable!(app, rate_limit, rate_limit_map);
+        patch_field_nullable!(app, uid);
+        patch_field_non_nullable!(app_metadata, data);
     }
 }
 
@@ -154,19 +166,19 @@ pub struct ApplicationOut {
     pub id: ApplicationId,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub metadata: Metadata,
 }
 
-// FIXME: This can and should be a derive macro
-impl From<application::Model> for ApplicationOut {
-    fn from(model: application::Model) -> Self {
+impl From<(application::Model, applicationmetadata::Model)> for ApplicationOut {
+    fn from((app, metadata): (application::Model, applicationmetadata::Model)) -> Self {
         Self {
-            uid: model.uid,
-            name: model.name,
-            rate_limit: model.rate_limit.map(|x| x as u16),
-
-            id: model.id,
-            created_at: model.created_at.into(),
-            updated_at: model.updated_at.into(),
+            uid: app.uid,
+            name: app.name,
+            rate_limit: app.rate_limit.map(|x| x as u16),
+            id: app.id,
+            created_at: app.created_at.into(),
+            updated_at: app.updated_at.into(),
+            metadata: metadata.metadata(),
         }
     }
 }
@@ -179,19 +191,13 @@ async fn list_applications(
     let PaginationLimit(limit) = pagination.limit;
     let iterator = pagination.iterator.clone();
 
-    let mut query = application::Entity::secure_find(org_id)
-        .order_by_asc(application::Column::Id)
-        .limit(limit + 1);
+    let apps =
+        ctx!(application::Model::fetch_many_with_metadata(db, org_id, limit + 1, iterator).await)?;
 
-    if let Some(iterator) = iterator {
-        query = query.filter(application::Column::Id.gt(iterator))
-    }
+    let results = apps.map(ApplicationOut::from).collect();
 
     Ok(Json(ApplicationOut::list_response_no_prev(
-        ctx!(query.all(db).await)?
-            .into_iter()
-            .map(|x| x.into())
-            .collect(),
+        results,
         limit as usize,
     )))
 }
@@ -212,32 +218,41 @@ async fn create_application(
     query: ValidatedQuery<CreateApplicationQuery>,
     permissions::Organization { org_id }: permissions::Organization,
 ) -> Result<(StatusCode, Json<ApplicationOut>)> {
-    if query.get_if_exists {
-        if let Some(ref uid) = data.uid {
-            let app = ctx!(
-                application::Entity::secure_find(org_id.clone())
-                    .filter(application::Column::Uid.eq(uid.to_owned()))
-                    .one(db)
-                    .await
-            )?;
-            if let Some(ret) = app {
-                return Ok((StatusCode::OK, Json(ret.into())));
+    if let Some(ref uid) = data.uid {
+        if let Some((app, metadata)) = ctx!(
+            application::Model::fetch_with_metadata(db, org_id.clone(), uid.clone().into()).await
+        )? {
+            if query.get_if_exists {
+                return Ok((StatusCode::OK, Json((app, metadata).into())));
             }
-        }
+            return Err(HttpError::conflict(
+                None,
+                Some("An application with that id or uid already exists".into()),
+            )
+            .into());
+        };
     }
 
-    let app = application::ActiveModel {
-        org_id: Set(org_id),
-        ..data.into()
-    };
-    let ret = ctx!(app.insert(db).await)?;
-    Ok((StatusCode::CREATED, Json(ret.into())))
+    let app = application::ActiveModel::new(org_id.clone());
+    let metadata = applicationmetadata::ActiveModel::new(app.id.clone().unwrap(), None);
+
+    let mut model = (app, metadata);
+    data.update_model(&mut model);
+    let (app, metadata) = model;
+
+    let (app, metadata) = transaction!(db, |txn| async move {
+        let app_result = ctx!(app.insert(txn).await)?;
+        let metadata = ctx!(metadata.upsert_or_delete(txn).await)?;
+        Ok((app_result, metadata))
+    })?;
+
+    Ok((StatusCode::CREATED, Json((app, metadata).into())))
 }
 
 async fn get_application(
-    permissions::Application { app }: permissions::Application,
+    permissions::ApplicationWithMetadata { app, metadata }: permissions::ApplicationWithMetadata,
 ) -> Result<Json<ApplicationOut>> {
-    Ok(Json(app.into()))
+    Ok(Json((app, metadata).into()))
 }
 
 async fn update_application(
@@ -246,33 +261,36 @@ async fn update_application(
     Path(app_id): Path<ApplicationIdOrUid>,
     permissions::Organization { org_id }: permissions::Organization,
 ) -> Result<(StatusCode, Json<ApplicationOut>)> {
-    let app = ctx!(
-        application::Entity::secure_find_by_id_or_uid(org_id.clone(), app_id)
-            .one(db)
-            .await
-    )?;
+    let (app, metadata, create_models) = if let Some((app, metadata)) =
+        ctx!(application::Model::fetch_with_metadata(db, org_id.clone(), app_id).await)?
+    {
+        (app.into(), metadata.into(), false)
+    } else {
+        let app = application::ActiveModel::new(org_id);
+        let metadata = applicationmetadata::ActiveModel::new(app.id.clone().unwrap(), None);
+        (app, metadata, true)
+    };
 
-    match app {
-        Some(app) => {
-            let mut app: application::ActiveModel = app.into();
-            data.update_model(&mut app);
-            let ret = ctx!(app.update(db).await)?;
+    let mut models = (app, metadata);
+    data.update_model(&mut models);
+    let (app, metadata) = models;
 
-            Ok((StatusCode::OK, Json(ret.into())))
-        }
-        None => {
-            let ret = ctx!(
-                application::ActiveModel {
-                    org_id: Set(org_id),
-                    ..data.into()
-                }
-                .insert(db)
-                .await
-            )?;
+    let (app, metadata) = transaction!(db, |txn| async move {
+        let app = if create_models {
+            ctx!(app.insert(txn).await)?
+        } else {
+            ctx!(app.update(txn).await)?
+        };
+        let metadata = ctx!(metadata.upsert_or_delete(txn).await)?;
+        Ok((app, metadata))
+    })?;
 
-            Ok((StatusCode::CREATED, Json(ret.into())))
-        }
-    }
+    let status = if create_models {
+        StatusCode::CREATED
+    } else {
+        StatusCode::OK
+    };
+    Ok((status, Json((app, metadata).into())))
 }
 
 async fn patch_application(
@@ -280,11 +298,20 @@ async fn patch_application(
     ValidatedJson(data): ValidatedJson<ApplicationPatch>,
     permissions::OrganizationWithApplication { app }: permissions::OrganizationWithApplication,
 ) -> Result<Json<ApplicationOut>> {
-    let mut app: application::ActiveModel = app.into();
-    data.update_model(&mut app);
+    let metadata = ctx!(app.fetch_or_create_metadata(db).await)?;
+    let app: application::ActiveModel = app.into();
 
-    let ret = ctx!(app.update(db).await)?;
-    Ok(Json(ret.into()))
+    let mut model = (app, metadata);
+    data.update_model(&mut model);
+    let (app, metadata) = model;
+
+    let (app, metadata) = transaction!(db, |txn| async move {
+        let app = ctx!(app.update(txn).await)?;
+        let metadata = ctx!(metadata.upsert_or_delete(txn).await)?;
+        Ok((app, metadata))
+    })?;
+
+    Ok(Json((app, metadata).into()))
 }
 
 async fn delete_application(

--- a/server/svix-server/tests/e2e_operational_webhooks.rs
+++ b/server/svix-server/tests/e2e_operational_webhooks.rs
@@ -13,8 +13,8 @@ use svix_server::{
     core::{
         security::{generate_org_token, management_org_id},
         types::{
-            ApplicationId, ApplicationUid, BaseId, EndpointId, EndpointUid, MessageAttemptId,
-            MessageId, MessageUid, OrganizationId,
+            metadata::Metadata, ApplicationId, ApplicationUid, BaseId, EndpointId, EndpointUid,
+            MessageAttemptId, MessageId, MessageUid, OrganizationId,
         },
     },
     v1::endpoints::{
@@ -141,6 +141,7 @@ async fn test_endpoint_create_update_and_delete() {
                 name: "TestOperationalWebhookApplication".to_owned(),
                 rate_limit: None,
                 uid: Some(ApplicationUid(org_id.to_string())),
+                metadata: Metadata::default(),
             },
             StatusCode::CREATED,
         )
@@ -287,6 +288,7 @@ async fn test_message_attempt_operational_webhooks() {
                 name: "TestOperationalWebhookApplication".to_owned(),
                 rate_limit: None,
                 uid: Some(ApplicationUid(org_id.to_string())),
+                metadata: Metadata::default(),
             },
             StatusCode::CREATED,
         )

--- a/server/svix-server/tests/utils/common_calls.rs
+++ b/server/svix-server/tests/utils/common_calls.rs
@@ -9,7 +9,7 @@ use reqwest::StatusCode;
 
 use serde::{de::DeserializeOwned, Serialize};
 use svix_server::{
-    core::types::{ApplicationId, EventTypeName, MessageId},
+    core::types::{metadata::Metadata, ApplicationId, EventTypeName, MessageId},
     v1::{
         endpoints::{
             application::{ApplicationIn, ApplicationOut},
@@ -289,4 +289,8 @@ pub async fn get_msg_attempt_list_and_assert_count(
         Ok(list)
     })
     .await
+}
+
+pub fn metadata(s: &str) -> Metadata {
+    serde_json::from_str::<Metadata>(s).unwrap()
 }


### PR DESCRIPTION
This adds the `metadata` field to the application CRUD group.

## Motivation

The `metadata` field is just a JSON dictionary with string only values. This field was added to our public API, but never to our open source solution. This PR corrects that.

## Solution

We add the field to our `/apps` CRUD group. `Metadata` itself is a separate joined table, instead of a column on the apps field, because metadata can be quite large (up to 4096 bytes).

Because it's a separate model, the sea_orm queries end up being pretty tedious. I tried to keep things efficient and query for both records in a single round trip where possible, but in some places we needed two roundtrips.

A side effect is that the endpoints were starting to get fairly complicated, so I tried to offload a lot of the logic to the relevant `db::models` where appropriate to offset this.

Finally, the `metadata` field is entirely optional, but we default to rendering `{}` if it's unspecified. Additionally, we don't create empty `metadata` records. It ended up being _much_ simpler to just pass around an `applicationmetadata::[Model|ActiveModel]` around, and intelligently upsert only IFF the underlying data wasn't empty.