### PR TITLE
Run cargo update for svix-server_derive

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -3367,9 +3367,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec8ecbbb74d42a8dd0ce8ea9bfc38ad13e2ed5203c4f272dbe144f4e17d70ac"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
A followup to #710 which runs `cargo update` on `svix-server_derive` too to avoid a yanked crate.