### PR TITLE
Server: omit prevIterator when null.

### DIFF
--- a/server/svix-server/src/v1/utils/mod.rs
+++ b/server/svix-server/src/v1/utils/mod.rs
@@ -161,6 +161,7 @@ pub struct EmptyResponse {}
 pub struct ListResponse<T: Clone> {
     pub data: Vec<T>,
     pub iterator: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub prev_iterator: Option<String>,
     pub done: bool,
 }


### PR DESCRIPTION
We use the ListResponse type everywhere where we have lists, and we haven't added prev iterator support for all of them. This means that for those we haven't supported, we were just seeing prevIterator=null which is confusing and wrong.

This change omits the serialization of prev iterator when it's none. At least until we actually get around to implementing it for all of the routes.
