### PR TITLE
Server: add missing msg id index causing slow querying.

### DIFF
--- a/server/svix-server/migrations/20221206214656_missing_msg_dest_endpoint.down.sql
+++ b/server/svix-server/migrations/20221206214656_missing_msg_dest_endpoint.down.sql
@@ -1,0 +1,2 @@
+-- Add down migration script here
+DROP INDEX ix_messagedestination_per_msg_no_status;

--- a/server/svix-server/migrations/20221206214656_missing_msg_dest_endpoint.up.sql
+++ b/server/svix-server/migrations/20221206214656_missing_msg_dest_endpoint.up.sql
@@ -1,0 +1,2 @@
+-- Add up migration script here
+CREATE INDEX ix_messagedestination_per_msg_no_status ON messagedestination USING btree (msg_id);


### PR DESCRIPTION
It causes slow querying when trying to get a specific attempt for a message id. This happens in resend message, list attempts by msg and a few other places.