### PR TITLE
Fix typo - it's 'database' not 'databse'

### DIFF
--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -35,7 +35,7 @@ log_format = "default"
 # always sending. If the OpenTelemetry address is not set, this will do nothing.
 # opentelemetry_sample_ratio = 1.0
 
-# Whether to enable the logging of the databses at the configured log level. This may be useful for
+# Whether to enable the logging of the databases at the configured log level. This may be useful for
 # analyzing their response times.
 db_tracing = false
 

--- a/server/svix-server/src/core/cache/mod.rs
+++ b/server/svix-server/src/core/cache/mod.rs
@@ -29,7 +29,7 @@ pub enum Error {
     #[error("Redis pool error")]
     Pool(#[from] bb8::RunError<RedisError>),
 
-    #[error("Redis databse error")]
+    #[error("Redis database error")]
     Database(#[from] RedisError),
 
     #[error("input error: {0}")]


### PR DESCRIPTION
This fixes a typo. 

## Motivation

Typos are bad.

## Solution

Fix the typo.
