### PR TITLE
Update axum to 0.6

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -149,9 +149,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.17"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
+checksum = "08b108ad2665fa3f6e6a517c3d80ec3e77d224c47d605167aefaa5d7ef97fa48"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -168,8 +168,10 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
+ "rustversion",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
@@ -181,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
+checksum = "79b8558f5a0581152dc94dcd289132a1d377494bdeafcd41869b3258e3e2ad92"
 dependencies = [
  "async-trait",
  "bytes",
@@ -191,6 +193,7 @@ dependencies = [
  "http",
  "http-body",
  "mime",
+ "rustversion",
  "tower-layer",
  "tower-service",
 ]
@@ -1653,9 +1656,9 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "matchit"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
 name = "md-5"

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -20,7 +20,7 @@ dotenv = "0.15.0"
 sha2 = "0.10.2"
 hmac-sha256 = "1"
 clap = { version = "3.2.1", features = ["derive"] }
-axum = { version = "0.5.1", features = ["headers"] }
+axum = { version = "0.6.1", features = ["headers"] }
 base64 = "0.13.0"
 hyper = { version = "0.14.16", features = ["full"] }
 tokio = { version = "1.15.0", features = ["full"] }

--- a/server/svix-server/src/core/idempotency.rs
+++ b/server/svix-server/src/core/idempotency.rs
@@ -390,12 +390,12 @@ mod tests {
                     .serve(
                         Router::new()
                             .route("/", post(service_endpoint).get(service_endpoint))
-                            .layer(
-                                ServiceBuilder::new().layer_fn(|service| IdempotencyService {
+                            .layer(ServiceBuilder::new().layer_fn(move |service| {
+                                IdempotencyService {
                                     cache: cache.clone(),
                                     service,
-                                }),
-                            )
+                                }
+                            }))
                             .layer(Extension(count))
                             .layer(Extension(wait))
                             .into_make_service(),
@@ -591,12 +591,12 @@ mod tests {
                     .serve(
                         Router::new()
                             .route("/", post(empty_service_endpoint))
-                            .layer(
-                                ServiceBuilder::new().layer_fn(|service| IdempotencyService {
+                            .layer(ServiceBuilder::new().layer_fn(move |service| {
+                                IdempotencyService {
                                     cache: cache.clone(),
                                     service,
-                                }),
-                            )
+                                }
+                            }))
                             .layer(Extension(count))
                             .into_make_service(),
                     )

--- a/server/svix-server/src/core/security.rs
+++ b/server/svix-server/src/core/security.rs
@@ -4,10 +4,11 @@
 use std::fmt::Debug;
 
 use axum::{
-    extract::{Extension, FromRequest, RequestParts, TypedHeader},
+    extract::{Extension, FromRequestParts, TypedHeader},
     headers::{authorization::Bearer, Authorization},
 };
 
+use http::request::Parts;
 use jwt_simple::prelude::*;
 
 use validator::Validate;
@@ -61,11 +62,15 @@ pub struct CustomClaim {
     pub organization: Option<String>,
 }
 
-pub async fn permissions_from_bearer<B: Send>(req: &mut RequestParts<B>) -> Result<Permissions> {
-    let Extension(ref cfg) = ctx!(Extension::<Configuration>::from_request(req).await)?;
+pub async fn permissions_from_bearer<S: Send + Sync>(
+    parts: &mut Parts,
+    state: &S,
+) -> Result<Permissions> {
+    let Extension(ref cfg) =
+        ctx!(Extension::<Configuration>::from_request_parts(parts, state).await)?;
 
     let TypedHeader(Authorization(bearer)) =
-        ctx!(TypedHeader::<Authorization<Bearer>>::from_request(req).await)?;
+        ctx!(TypedHeader::<Authorization<Bearer>>::from_request_parts(parts, state).await)?;
 
     let claims = parse_bearer(&cfg.jwt_secret, &bearer)
         .ok_or_else(|| HttpError::unauthorized(None, Some("Invalid token".to_string())))?;

--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -214,9 +214,9 @@ pub struct CreateApplicationQuery {
 
 async fn create_application(
     Extension(ref db): Extension<DatabaseConnection>,
-    ValidatedJson(data): ValidatedJson<ApplicationIn>,
     query: ValidatedQuery<CreateApplicationQuery>,
     permissions::Organization { org_id }: permissions::Organization,
+    ValidatedJson(data): ValidatedJson<ApplicationIn>,
 ) -> Result<(StatusCode, Json<ApplicationOut>)> {
     if let Some(ref uid) = data.uid {
         if let Some((app, metadata)) = ctx!(
@@ -257,9 +257,9 @@ async fn get_application(
 
 async fn update_application(
     Extension(ref db): Extension<DatabaseConnection>,
-    ValidatedJson(data): ValidatedJson<ApplicationIn>,
     Path(app_id): Path<ApplicationIdOrUid>,
     permissions::Organization { org_id }: permissions::Organization,
+    ValidatedJson(data): ValidatedJson<ApplicationIn>,
 ) -> Result<(StatusCode, Json<ApplicationOut>)> {
     let (app, metadata, create_models) = if let Some((app, metadata)) =
         ctx!(application::Model::fetch_with_metadata(db, org_id.clone(), app_id).await)?
@@ -295,8 +295,8 @@ async fn update_application(
 
 async fn patch_application(
     Extension(ref db): Extension<DatabaseConnection>,
-    ValidatedJson(data): ValidatedJson<ApplicationPatch>,
     permissions::OrganizationWithApplication { app }: permissions::OrganizationWithApplication,
+    ValidatedJson(data): ValidatedJson<ApplicationPatch>,
 ) -> Result<Json<ApplicationOut>> {
     let metadata = ctx!(app.fetch_or_create_metadata(db).await)?;
     let app: application::ActiveModel = app.into();

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -697,30 +697,41 @@ async fn resend_webhook(
 }
 
 pub fn router() -> Router {
-    Router::new().nest(
-        "/app/:app_id/",
-        Router::new()
-            .nest(
-                "/msg/:msg_id",
-                Router::new()
-                    // NOTE: [`list_messageattempts`] is deprecated
-                    .route("/attempt/", get(list_messageattempts))
-                    .route("/attempt/:attempt_id/", get(get_messageattempt))
-                    .route("/endpoint/", get(list_attempted_destinations))
-                    .route("/endpoint/:endp_id/resend/", post(resend_webhook))
-                    // NOTE: [`list_attempts_for_endpoint`] is deprecated
-                    .route(
-                        "/endpoint/:endp_id/attempt/",
-                        get(list_attempts_for_endpoint),
-                    ),
-            )
-            .route("/endpoint/:endp_id/msg/", get(list_attempted_messages))
-            .route(
-                "/attempt/endpoint/:endp_id/",
-                get(list_attempts_by_endpoint),
-            )
-            .route("/attempt/msg/:msg_id/", get(list_attempts_by_msg)),
-    )
+    Router::new()
+        // NOTE: [`list_messageattempts`] is deprecated
+        .route(
+            "/app/:app_id/msg/:msg_id/attempt/",
+            get(list_messageattempts),
+        )
+        .route(
+            "/app/:app_id/msg/:msg_id/attempt/:attempt_id/",
+            get(get_messageattempt),
+        )
+        .route(
+            "/app/:app_id/msg/:msg_id/endpoint/",
+            get(list_attempted_destinations),
+        )
+        .route(
+            "/app/:app_id/msg/:msg_id/endpoint/:endp_id/resend/",
+            post(resend_webhook),
+        )
+        // NOTE: [`list_attempts_for_endpoint`] is deprecated
+        .route(
+            "/app/:app_id/msg/:msg_id/endpoint/:endp_id/attempt/",
+            get(list_attempts_for_endpoint),
+        )
+        .route(
+            "/app/:app_id/endpoint/:endp_id/msg/",
+            get(list_attempted_messages),
+        )
+        .route(
+            "/app/:app_id/attempt/endpoint/:endp_id/",
+            get(list_attempts_by_endpoint),
+        )
+        .route(
+            "/app/:app_id/attempt/msg/:msg_id/",
+            get(list_attempts_by_msg),
+        )
 }
 
 #[cfg(test)]

--- a/server/svix-server/src/v1/endpoints/endpoint/crud.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/crud.rs
@@ -60,8 +60,8 @@ pub(super) async fn create_endpoint(
     Extension(ref db): Extension<DatabaseConnection>,
     Extension(cfg): Extension<Configuration>,
     Extension(op_webhooks): Extension<OperationalWebhookSender>,
-    ValidatedJson(data): ValidatedJson<EndpointIn>,
     permissions::Application { app }: permissions::Application,
+    ValidatedJson(data): ValidatedJson<EndpointIn>,
 ) -> Result<(StatusCode, Json<EndpointOut>)> {
     if let Some(ref event_types_ids) = data.event_types_ids {
         validate_event_types(db, event_types_ids, &app.org_id).await?;
@@ -123,8 +123,8 @@ pub(super) async fn update_endpoint(
     Extension(cfg): Extension<Configuration>,
     Extension(op_webhooks): Extension<OperationalWebhookSender>,
     Path((_app_id, endp_id)): Path<(ApplicationIdOrUid, EndpointIdOrUid)>,
-    ValidatedJson(data): ValidatedJson<EndpointIn>,
     permissions::Application { app }: permissions::Application,
+    ValidatedJson(data): ValidatedJson<EndpointIn>,
 ) -> Result<(StatusCode, Json<EndpointOut>)> {
     let endp = ctx!(
         endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endp_id)
@@ -203,8 +203,8 @@ pub(super) async fn patch_endpoint(
     Extension(cfg): Extension<Configuration>,
     Extension(op_webhooks): Extension<OperationalWebhookSender>,
     Path((_app_id, endp_id)): Path<(ApplicationIdOrUid, EndpointIdOrUid)>,
-    ValidatedJson(data): ValidatedJson<EndpointPatch>,
     permissions::Application { app }: permissions::Application,
+    ValidatedJson(data): ValidatedJson<EndpointPatch>,
 ) -> Result<Json<EndpointOut>> {
     let endp = ctx!(
         endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endp_id)

--- a/server/svix-server/src/v1/endpoints/endpoint/headers.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/headers.rs
@@ -38,8 +38,8 @@ pub(super) async fn get_endpoint_headers(
 pub(super) async fn update_endpoint_headers(
     Extension(ref db): Extension<DatabaseConnection>,
     Path((_app_id, endp_id)): Path<(ApplicationIdOrUid, EndpointIdOrUid)>,
-    ValidatedJson(data): ValidatedJson<EndpointHeadersIn>,
     permissions::Application { app }: permissions::Application,
+    ValidatedJson(data): ValidatedJson<EndpointHeadersIn>,
 ) -> Result<(StatusCode, Json<EmptyResponse>)> {
     let endp = ctx!(
         endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endp_id)
@@ -58,8 +58,8 @@ pub(super) async fn update_endpoint_headers(
 pub(super) async fn patch_endpoint_headers(
     Extension(ref db): Extension<DatabaseConnection>,
     Path((_app_id, endp_id)): Path<(ApplicationIdOrUid, EndpointIdOrUid)>,
-    ValidatedJson(data): ValidatedJson<EndpointHeadersPatchIn>,
     permissions::Application { app }: permissions::Application,
+    ValidatedJson(data): ValidatedJson<EndpointHeadersPatchIn>,
 ) -> Result<(StatusCode, Json<EmptyResponse>)> {
     let endp = ctx!(
         endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endp_id)

--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -494,44 +494,41 @@ async fn endpoint_stats(
 }
 
 pub fn router() -> Router {
-    Router::new().nest(
-        "/app/:app_id",
-        Router::new()
-            .route(
-                "/endpoint/",
-                post(crud::create_endpoint).get(crud::list_endpoints),
-            )
-            .route(
-                "/endpoint/:endp_id/",
-                get(crud::get_endpoint)
-                    .put(crud::update_endpoint)
-                    .patch(crud::patch_endpoint)
-                    .delete(crud::delete_endpoint),
-            )
-            .route(
-                "/endpoint/:endp_id/secret/",
-                get(secrets::get_endpoint_secret),
-            )
-            .route(
-                "/endpoint/:endp_id/secret/rotate/",
-                post(secrets::rotate_endpoint_secret),
-            )
-            .route("/endpoint/:endp_id/stats/", get(endpoint_stats))
-            .route(
-                "/endpoint/:endp_id/send-example/",
-                post(api_not_implemented),
-            )
-            .route(
-                "/endpoint/:endp_id/recover/",
-                post(recovery::recover_failed_webhooks),
-            )
-            .route(
-                "/endpoint/:endp_id/headers/",
-                get(headers::get_endpoint_headers)
-                    .patch(headers::patch_endpoint_headers)
-                    .put(headers::update_endpoint_headers),
-            ),
-    )
+    Router::new()
+        .route(
+            "/app/:app_id/endpoint/",
+            post(crud::create_endpoint).get(crud::list_endpoints),
+        )
+        .route(
+            "/app/:app_id/endpoint/:endp_id/",
+            get(crud::get_endpoint)
+                .put(crud::update_endpoint)
+                .patch(crud::patch_endpoint)
+                .delete(crud::delete_endpoint),
+        )
+        .route(
+            "/app/:app_id/endpoint/:endp_id/secret/",
+            get(secrets::get_endpoint_secret),
+        )
+        .route(
+            "/app/:app_id/endpoint/:endp_id/secret/rotate/",
+            post(secrets::rotate_endpoint_secret),
+        )
+        .route("/app/:app_id/endpoint/:endp_id/stats/", get(endpoint_stats))
+        .route(
+            "/app/:app_id/endpoint/:endp_id/send-example/",
+            post(api_not_implemented),
+        )
+        .route(
+            "/app/:app_id/endpoint/:endp_id/recover/",
+            post(recovery::recover_failed_webhooks),
+        )
+        .route(
+            "/app/:app_id/endpoint/:endp_id/headers/",
+            get(headers::get_endpoint_headers)
+                .patch(headers::patch_endpoint_headers)
+                .put(headers::update_endpoint_headers),
+        )
 }
 
 #[cfg(test)]

--- a/server/svix-server/src/v1/endpoints/endpoint/recovery.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/recovery.rs
@@ -77,8 +77,8 @@ pub(super) async fn recover_failed_webhooks(
     Extension(ref db): Extension<DatabaseConnection>,
     Extension(queue_tx): Extension<TaskQueueProducer>,
     Path((_app_id, endp_id)): Path<(ApplicationIdOrUid, EndpointIdOrUid)>,
-    ValidatedJson(data): ValidatedJson<RecoverIn>,
     permissions::Application { app }: permissions::Application,
+    ValidatedJson(data): ValidatedJson<RecoverIn>,
 ) -> Result<(StatusCode, Json<EmptyResponse>)> {
     // Add five minutes so that people can easily just do `now() - two_weeks` without having to worry about clock sync
     let timeframe = chrono::Duration::days(14);

--- a/server/svix-server/src/v1/endpoints/endpoint/secrets.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/secrets.rs
@@ -56,8 +56,8 @@ pub(super) async fn rotate_endpoint_secret(
     Extension(ref db): Extension<DatabaseConnection>,
     Extension(cfg): Extension<Configuration>,
     Path((_app_id, endp_id)): Path<(ApplicationIdOrUid, EndpointIdOrUid)>,
-    ValidatedJson(data): ValidatedJson<EndpointSecretRotateIn>,
     permissions::Application { app }: permissions::Application,
+    ValidatedJson(data): ValidatedJson<EndpointSecretRotateIn>,
 ) -> Result<(StatusCode, Json<EmptyResponse>)> {
     let mut endp = ctx!(
         endpoint::Entity::secure_find_by_id_or_uid(app.id, endp_id)

--- a/server/svix-server/src/v1/endpoints/event_type.rs
+++ b/server/svix-server/src/v1/endpoints/event_type.rs
@@ -204,8 +204,8 @@ async fn list_event_types(
 
 async fn create_event_type(
     Extension(ref db): Extension<DatabaseConnection>,
-    ValidatedJson(data): ValidatedJson<EventTypeIn>,
     permissions::Organization { org_id }: permissions::Organization,
+    ValidatedJson(data): ValidatedJson<EventTypeIn>,
 ) -> Result<(StatusCode, Json<EventTypeOut>)> {
     let evtype = ctx!(
         eventtype::Entity::secure_find_by_name(org_id.clone(), data.name.to_owned())
@@ -255,8 +255,8 @@ async fn get_event_type(
 async fn update_event_type(
     Extension(ref db): Extension<DatabaseConnection>,
     Path(evtype_name): Path<EventTypeName>,
-    ValidatedJson(data): ValidatedJson<EventTypeUpdate>,
     permissions::Organization { org_id }: permissions::Organization,
+    ValidatedJson(data): ValidatedJson<EventTypeUpdate>,
 ) -> Result<(StatusCode, Json<EventTypeOut>)> {
     let evtype = ctx!(
         eventtype::Entity::secure_find_by_name(org_id.clone(), evtype_name.clone())
@@ -291,8 +291,8 @@ async fn update_event_type(
 async fn patch_event_type(
     Extension(ref db): Extension<DatabaseConnection>,
     Path(evtype_name): Path<EventTypeName>,
-    ValidatedJson(data): ValidatedJson<EventTypePatch>,
     permissions::Organization { org_id }: permissions::Organization,
+    ValidatedJson(data): ValidatedJson<EventTypePatch>,
 ) -> Result<Json<EventTypeOut>> {
     let evtype = ctx!(
         eventtype::Entity::secure_find_by_name(org_id, evtype_name)

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -225,8 +225,8 @@ async fn create_message(
     ValidatedQuery(CreateMessageQueryParams { with_content }): ValidatedQuery<
         CreateMessageQueryParams,
     >,
-    ValidatedJson(data): ValidatedJson<MessageIn>,
     permissions::OrganizationWithApplication { app }: permissions::OrganizationWithApplication,
+    ValidatedJson(data): ValidatedJson<MessageIn>,
 ) -> Result<(StatusCode, Json<MessageOut>)> {
     let create_message_app = CreateMessageApp::layered_fetch(
         cache,
@@ -299,12 +299,9 @@ async fn get_message(
 }
 
 pub fn router() -> Router {
-    Router::new().nest(
-        "/app/:app_id",
-        Router::new()
-            .route("/msg/", post(create_message).get(list_messages))
-            .route("/msg/:msg_id/", get(get_message)),
-    )
+    Router::new()
+        .route("/app/:app_id/msg/", post(create_message).get(list_messages))
+        .route("/app/:app_id/msg/:msg_id/", get(get_message))
 }
 
 #[cfg(test)]

--- a/server/svix-server/src/v1/mod.rs
+++ b/server/svix-server/src/v1/mod.rs
@@ -25,12 +25,8 @@ pub fn router() -> Router {
 
 #[cfg(debug_assertions)]
 mod development {
-    use axum::{
-        async_trait,
-        extract::{FromRequest, RequestParts},
-        routing::get,
-        Json, Router,
-    };
+    use axum::{async_trait, extract::FromRequestParts, routing::get, Json, Router};
+    use http::request::Parts;
 
     use crate::error::{Error, Result};
     use crate::v1::utils::EmptyResponse;
@@ -40,14 +36,14 @@ mod development {
     }
 
     #[async_trait]
-    impl<B> FromRequest<B> for EchoData
+    impl<S> FromRequestParts<S> for EchoData
     where
-        B: Send,
+        S: Send + Sync,
     {
         type Rejection = Error;
 
-        async fn from_request(req: &mut RequestParts<B>) -> Result<Self> {
-            let headers = format!("{:?}", req.headers());
+        async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self> {
+            let headers = format!("{:?}", parts.headers);
             Ok(EchoData { headers })
         }
     }

--- a/server/svix-server/src/v1/utils/mod.rs
+++ b/server/svix-server/src/v1/utils/mod.rs
@@ -6,10 +6,11 @@ use std::{borrow::Cow, collections::HashSet, error::Error as StdError, ops::Dere
 use axum::{
     async_trait,
     body::HttpBody,
-    extract::{FromRequest, Query, RequestParts},
+    extract::{FromRequest, FromRequestParts, Query},
     BoxError,
 };
 use chrono::{DateTime, Utc};
+use http::{request::Parts, Request};
 use regex::Regex;
 use sea_orm::{ColumnTrait, QueryFilter, QueryOrder, QuerySelect};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -277,17 +278,18 @@ fn validation_errors(
 pub struct ValidatedJson<T>(pub T);
 
 #[async_trait]
-impl<T, B> FromRequest<B> for ValidatedJson<T>
+impl<T, S, B> FromRequest<S, B> for ValidatedJson<T>
 where
     T: DeserializeOwned + Validate,
-    B: HttpBody + Send,
+    S: Send + Sync,
+    B: HttpBody + Send + 'static,
     B::Data: Send,
     B::Error: Into<BoxError>,
 {
     type Rejection = Error;
 
-    async fn from_request(req: &mut RequestParts<B>) -> Result<Self> {
-        let b = bytes::Bytes::from_request(req).await.map_err(|e| {
+    async fn from_request(req: Request<B>, state: &S) -> Result<Self> {
+        let b = bytes::Bytes::from_request(req, state).await.map_err(|e| {
             tracing::error!("Error reading body as bytes: {}", e);
             HttpError::internal_server_error(None, Some("Failed to read request body".to_owned()))
         })?;
@@ -325,17 +327,15 @@ where
 pub struct ValidatedQuery<T>(pub T);
 
 #[async_trait]
-impl<T, B> FromRequest<B> for ValidatedQuery<T>
+impl<T, S> FromRequestParts<S> for ValidatedQuery<T>
 where
     T: DeserializeOwned + Validate,
-    B: HttpBody + Send,
-    B::Data: Send,
-    B::Error: Into<BoxError>,
+    S: Send + Sync,
 {
     type Rejection = Error;
 
-    async fn from_request(req: &mut RequestParts<B>) -> Result<Self> {
-        let Query(value) = Query::<T>::from_request(req)
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self> {
+        let Query(value) = Query::<T>::from_request_parts(parts, state)
             .await
             .map_err(|err| HttpError::bad_request(None, Some(err.to_string())))?;
         value.validate().map_err(|e| {
@@ -361,15 +361,15 @@ pub struct MessageListFetchOptions {
 }
 
 #[async_trait]
-impl<B> FromRequest<B> for MessageListFetchOptions
+impl<S> FromRequestParts<S> for MessageListFetchOptions
 where
-    B: Send,
+    S: Send + Sync,
 {
     type Rejection = Error;
 
-    async fn from_request(req: &mut RequestParts<B>) -> Result<Self> {
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self> {
         let pairs: Vec<(String, String)> =
-            serde_urlencoded::from_str(req.uri().query().unwrap_or_default())
+            serde_urlencoded::from_str(parts.uri.query().unwrap_or_default())
                 .map_err(|err| HttpError::bad_request(None, Some(err.to_string())))?;
 
         let mut before = None;

--- a/server/svix-server/tests/e2e_application.rs
+++ b/server/svix-server/tests/e2e_application.rs
@@ -293,7 +293,7 @@ async fn test_crud() {
 
     let updated: ApplicationOut = client
         .patch(
-            &format!("api/v1/app/{}", app.id),
+            &format!("api/v1/app/{}/", app.id),
             serde_json::json!({
                 "metadata": {
                     "bizz": "bar"
@@ -307,7 +307,7 @@ async fn test_crud() {
 
     let new_app: ApplicationOut = client
         .put(
-            "api/v1/app/one_upserted_boi",
+            "api/v1/app/one_upserted_boi/",
             serde_json::json!({
                 "name": "Apps for two",
                 "metadata": {
@@ -323,7 +323,7 @@ async fn test_crud() {
 
     let updated_metadata_app: ApplicationOut = client
         .put(
-            &format!("api/v1/app/{}", new_app.id),
+            &format!("api/v1/app/{}/", new_app.id),
             serde_json::json!({
                 "name": "New Name",
                 "metadata": {

--- a/server/svix-server/tests/e2e_auth.rs
+++ b/server/svix-server/tests/e2e_auth.rs
@@ -68,14 +68,14 @@ async fn test_restricted_application_access() {
         .unwrap();
     let _: IgnoredResponse = client
         .put(
-            &format!("api/v1/app/{}", app_id),
+            &format!("api/v1/app/{}/", app_id),
             application_in("TEST_APP_NAME"),
             StatusCode::FORBIDDEN,
         )
         .await
         .unwrap();
     let _: IgnoredResponse = client
-        .delete(&format!("api/v1/app/{}", app_id), StatusCode::FORBIDDEN)
+        .delete(&format!("api/v1/app/{}/", app_id), StatusCode::FORBIDDEN)
         .await
         .unwrap();
     let _: IgnoredResponse = client
@@ -85,11 +85,11 @@ async fn test_restricted_application_access() {
 
     // READ should succeed when accessing the app_id the token is auhtorized for but no others
     let _: IgnoredResponse = client
-        .get(&format!("api/v1/app/{}", app_id_2), StatusCode::NOT_FOUND)
+        .get(&format!("api/v1/app/{}/", app_id_2), StatusCode::NOT_FOUND)
         .await
         .unwrap();
     let _: ApplicationOut = client
-        .get(&format!("api/v1/app/{}", app_id), StatusCode::OK)
+        .get(&format!("api/v1/app/{}/", app_id), StatusCode::OK)
         .await
         .unwrap();
 }

--- a/server/svix-server/tests/e2e_endpoint.rs
+++ b/server/svix-server/tests/e2e_endpoint.rs
@@ -323,7 +323,7 @@ async fn test_patch() {
     // But first make an event type to set it to
     let _: EventTypeOut = client
         .post(
-            "api/v1/event-type",
+            "api/v1/event-type/",
             serde_json::json!({
                 "description": "a test event type",
                 "name": "test",
@@ -1484,7 +1484,7 @@ async fn test_endpoint_filter_events() {
 
     let _et: EventTypeOut = client
         .post(
-            "api/v1/event-type",
+            "api/v1/event-type/",
             event_type_in("et1", None).unwrap(),
             StatusCode::CREATED,
         )
@@ -1676,7 +1676,7 @@ async fn test_msg_event_types_filter() {
         event_type_in("et2", None).unwrap(),
     ] {
         let _: EventTypeOut = client
-            .post("api/v1/event-type", et, StatusCode::CREATED)
+            .post("api/v1/event-type/", et, StatusCode::CREATED)
             .await
             .unwrap();
     }
@@ -1784,7 +1784,7 @@ async fn test_msg_channels_filter() {
 
         let msg: MessageOut = client
             .get(
-                &format!("api/v1/app/{}/msg/{}", &app_id, &msg.id),
+                &format!("api/v1/app/{}/msg/{}/", &app_id, &msg.id),
                 StatusCode::OK,
             )
             .await
@@ -1813,7 +1813,7 @@ async fn test_endpoint_headers_manipulation() {
 
     let _: IgnoredResponse = client
         .patch(
-            &format!("api/v1/app/{}/endpoint/{}/headers", app_id, endp.id),
+            &format!("api/v1/app/{}/endpoint/{}/headers/", app_id, endp.id),
             patched_headers_in,
             StatusCode::NO_CONTENT,
         )
@@ -1822,7 +1822,7 @@ async fn test_endpoint_headers_manipulation() {
 
     let recvd_headers: EndpointHeadersOut = client
         .get(
-            &format!("api/v1/app/{}/endpoint/{}/headers", app_id, endp.id),
+            &format!("api/v1/app/{}/endpoint/{}/headers/", app_id, endp.id),
             StatusCode::OK,
         )
         .await
@@ -1847,7 +1847,7 @@ async fn test_endpoint_headers_manipulation() {
     ] {
         let _: IgnoredResponse = client
             .put(
-                &format!("api/v1/app/{}/endpoint/{}/headers", app_id, endp.id),
+                &format!("api/v1/app/{}/endpoint/{}/headers/", app_id, endp.id),
                 serde_json::json!({ "headers": { bad_hdr: "123"}}),
                 StatusCode::UNPROCESSABLE_ENTITY,
             )
@@ -1872,7 +1872,7 @@ async fn test_endpoint_headers_manipulation() {
     for hdrs in [&org_headers, &updated_headers] {
         let _: IgnoredResponse = client
             .put(
-                &format!("api/v1/app/{}/endpoint/{}/headers", app_id, endp.id),
+                &format!("api/v1/app/{}/endpoint/{}/headers/", app_id, endp.id),
                 hdrs,
                 StatusCode::NO_CONTENT,
             )
@@ -1881,7 +1881,7 @@ async fn test_endpoint_headers_manipulation() {
 
         let recvd_headers: EndpointHeadersOut = client
             .get(
-                &format!("api/v1/app/{}/endpoint/{}/headers", app_id, endp.id),
+                &format!("api/v1/app/{}/endpoint/{}/headers/", app_id, endp.id),
                 StatusCode::OK,
             )
             .await
@@ -1899,7 +1899,7 @@ async fn test_endpoint_headers_manipulation() {
 
     let _: IgnoredResponse = client
         .patch(
-            &format!("api/v1/app/{}/endpoint/{}/headers", app_id, endp.id),
+            &format!("api/v1/app/{}/endpoint/{}/headers/", app_id, endp.id),
             &patched_headers_in,
             StatusCode::NO_CONTENT,
         )
@@ -1908,7 +1908,7 @@ async fn test_endpoint_headers_manipulation() {
 
     let recvd_headers: EndpointHeadersOut = client
         .get(
-            &format!("api/v1/app/{}/endpoint/{}/headers", app_id, endp.id),
+            &format!("api/v1/app/{}/endpoint/{}/headers/", app_id, endp.id),
             StatusCode::OK,
         )
         .await
@@ -1931,7 +1931,7 @@ async fn test_endpoint_headers_manipulation() {
 
     let _: IgnoredResponse = client
         .put(
-            &format!("api/v1/app/{}/endpoint/{}/headers", app_id, endp.id),
+            &format!("api/v1/app/{}/endpoint/{}/headers/", app_id, endp.id),
             redacted_headers,
             StatusCode::NO_CONTENT,
         )
@@ -1940,7 +1940,7 @@ async fn test_endpoint_headers_manipulation() {
 
     let recvd_headers: EndpointHeadersOut = client
         .get(
-            &format!("api/v1/app/{}/endpoint/{}/headers", app_id, endp.id),
+            &format!("api/v1/app/{}/endpoint/{}/headers/", app_id, endp.id),
             StatusCode::OK,
         )
         .await
@@ -1978,7 +1978,7 @@ async fn test_endpoint_headers_sending() {
 
     let _: IgnoredResponse = client
         .put(
-            &format!("api/v1/app/{}/endpoint/{}/headers", app_id, endp.id),
+            &format!("api/v1/app/{}/endpoint/{}/headers/", app_id, endp.id),
             &headers,
             StatusCode::NO_CONTENT,
         )
@@ -2017,7 +2017,7 @@ async fn test_endpoint_header_key_capitalization() {
 
     let _: IgnoredResponse = client
         .put(
-            &format!("api/v1/app/{}/endpoint/{}/headers", app_id, endp.id),
+            &format!("api/v1/app/{}/endpoint/{}/headers/", app_id, endp.id),
             &headers,
             StatusCode::NO_CONTENT,
         )
@@ -2026,7 +2026,7 @@ async fn test_endpoint_header_key_capitalization() {
 
     let retrieved_headers: EndpointHeadersOut = client
         .get(
-            &format!("api/v1/app/{}/endpoint/{}/headers", app_id, endp.id),
+            &format!("api/v1/app/{}/endpoint/{}/headers/", app_id, endp.id),
             StatusCode::OK,
         )
         .await

--- a/server/svix-server/tests/e2e_event_type.rs
+++ b/server/svix-server/tests/e2e_event_type.rs
@@ -24,7 +24,7 @@ async fn test_patch() {
 
     let et: EventTypeOut = client
         .post(
-            "api/v1/event-type",
+            "api/v1/event-type/",
             event_type_in(
                 "test-event-type",
                 serde_json::json!({
@@ -49,7 +49,7 @@ async fn test_patch() {
     // Test that PUT with invalid ID creates an event type
     let _: EventTypeOut = client
         .put(
-            "api/v1/event-type/fake-id",
+            "api/v1/event-type/fake-id/",
             event_type_in("test-event-type", None).unwrap(),
             StatusCode::CREATED,
         )
@@ -158,7 +158,7 @@ async fn test_event_type_create_read_list() {
 
     let et: EventTypeOut = client
         .post(
-            "api/v1/event-type",
+            "api/v1/event-type/",
             event_type_in("test-event-type", None).unwrap(),
             StatusCode::CREATED,
         )
@@ -181,7 +181,7 @@ async fn test_event_type_create_read_list() {
     assert!(list.data.contains(&et));
 
     let list: ListResponse<EventTypeOut> = client
-        .get("api/v1/event-type", StatusCode::OK)
+        .get("api/v1/event-type/", StatusCode::OK)
         .await
         .unwrap();
     assert_eq!(list.data.len(), 1);
@@ -210,7 +210,7 @@ async fn test_schema() {
     let (client, _jh) = start_svix_server().await;
     let _: serde_json::Value = client
         .post(
-            "api/v1/event-type",
+            "api/v1/event-type/",
             serde_json::json!({
                             "name": "bad-schema",
                             "description": "I have a bad schema",

--- a/server/svix-server/tests/e2e_message.rs
+++ b/server/svix-server/tests/e2e_message.rs
@@ -100,7 +100,7 @@ async fn test_message_create_read_list_with_content() {
 
     let msg_1_w_payload: MessageOut = client
         .post(
-            &format!("api/v1/app/{}/msg", &app_id),
+            &format!("api/v1/app/{}/msg/", &app_id),
             message_in(&app_id, msg_payload.clone()).unwrap(),
             StatusCode::ACCEPTED,
         )
@@ -156,7 +156,7 @@ async fn test_message_create_read_list_with_content() {
     }
 
     let list: ListResponse<MessageOut> = client
-        .get(&format!("api/v1/app/{}/msg", &app_id), StatusCode::OK)
+        .get(&format!("api/v1/app/{}/msg/", &app_id), StatusCode::OK)
         .await
         .unwrap();
     assert_eq!(list.data.len(), 2);
@@ -195,7 +195,7 @@ async fn test_failed_message_gets_recorded() {
 
     let msg_res: MessageOut = client
         .post(
-            &format!("api/v1/app/{}/msg", &app_id),
+            &format!("api/v1/app/{}/msg/", &app_id),
             message_in(&app_id, msg_payload.clone()).unwrap(),
             StatusCode::ACCEPTED,
         )
@@ -253,7 +253,7 @@ async fn test_mulitple_endpoints() {
 
     let msg_res: MessageOut = client
         .post(
-            &format!("api/v1/app/{}/msg", &app_id),
+            &format!("api/v1/app/{}/msg/", &app_id),
             message_in(&app_id, msg_payload.clone()).unwrap(),
             StatusCode::ACCEPTED,
         )
@@ -314,7 +314,7 @@ async fn test_failed_message_gets_requeued() {
 
     let msg_res: MessageOut = client
         .post(
-            &format!("api/v1/app/{}/msg", &app_id),
+            &format!("api/v1/app/{}/msg/", &app_id),
             message_in(&app_id, msg_payload.clone()).unwrap(),
             StatusCode::ACCEPTED,
         )

--- a/server/svix-server/tests/utils/mod.rs
+++ b/server/svix-server/tests/utils/mod.rs
@@ -316,13 +316,13 @@ impl TestReceiver {
 }
 
 async fn test_receiver_route(
-    axum::Json(json): axum::Json<serde_json::Value>,
     axum::extract::Extension(ref tx): axum::extract::Extension<mpsc::Sender<serde_json::Value>>,
     axum::extract::Extension(ref header_tx): axum::extract::Extension<mpsc::Sender<HeaderMap>>,
     axum::extract::Extension(response_status_code): axum::extract::Extension<
         Arc<Mutex<ResponseStatusCode>>,
     >,
     headers: HeaderMap,
+    axum::Json(json): axum::Json<serde_json::Value>,
 ) -> axum::http::StatusCode {
     tx.send(json).await.unwrap();
     header_tx.send(headers).await.unwrap();


### PR DESCRIPTION
## Motivation
Keep up with changes in axum.

The way routes were composed before with `nest` is no longer possible, `merge` panics when there's an existing route ending in a slash for which it has already installed a fallback handler. Therefore, each router has to fully qualify its paths.

