### PR TITLE
Add endpoint metadata model

### DIFF
--- a/server/svix-server/migrations/20221215195541_add_endpoint_metadata.down.sql
+++ b/server/svix-server/migrations/20221215195541_add_endpoint_metadata.down.sql
@@ -1,0 +1,2 @@
+-- Add down migration script here
+DROP TABLE IF EXISTS endpointmetadata;

--- a/server/svix-server/migrations/20221215195541_add_endpoint_metadata.up.sql
+++ b/server/svix-server/migrations/20221215195541_add_endpoint_metadata.up.sql
@@ -1,0 +1,10 @@
+-- Add up migration script here
+CREATE TABLE endpointmetadata (
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL,
+    id character varying NOT NULL COLLATE pg_catalog."C",
+    data jsonb NOT NULL
+);
+
+ALTER TABLE ONLY endpointmetadata 
+    ADD CONSTRAINT endpointmetadata_pkey PRIMARY KEY (id);

--- a/server/svix-server/src/db/models/endpoint.rs
+++ b/server/svix-server/src/db/models/endpoint.rs
@@ -44,6 +44,8 @@ pub enum Relation {
     Application,
     #[sea_orm(has_many = "super::messagedestination::Entity")]
     Messagedestination,
+    #[sea_orm(has_one = "super::endpointmetadata::Entity")]
+    Metadata,
 }
 
 impl Related<super::application::Entity> for Entity {
@@ -55,6 +57,12 @@ impl Related<super::application::Entity> for Entity {
 impl Related<super::messagedestination::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::Messagedestination.def()
+    }
+}
+
+impl Related<super::endpointmetadata::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Metadata.def()
     }
 }
 

--- a/server/svix-server/src/db/models/endpointmetadata.rs
+++ b/server/svix-server/src/db/models/endpointmetadata.rs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2022 Svix Authors
+// SPDX-License-Identifier: MIT
+use crate::core::types::EndpointId;
+
+use crate::core::types::metadata::Metadata;
+
+use chrono::Utc;
+use sea_orm::entity::prelude::*;
+use sea_orm::ActiveValue::Set;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "applicationmetadata")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: EndpointId,
+    pub created_at: DateTimeWithTimeZone,
+    pub updated_at: DateTimeWithTimeZone,
+    pub data: Metadata,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::endpoint::Entity",
+        from = "Column::Id",
+        to = "super::endpoint::Column::Id",
+        on_update = "NoAction",
+        on_delete = "Restrict"
+    )]
+    Endpoint,
+}
+
+impl Related<super::endpoint::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Endpoint.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {
+    fn before_save(mut self, _insert: bool) -> Result<Self, DbErr> {
+        self.updated_at = Set(Utc::now().into());
+        Ok(self)
+    }
+}

--- a/server/svix-server/src/db/models/mod.rs
+++ b/server/svix-server/src/db/models/mod.rs
@@ -4,6 +4,7 @@
 pub mod application;
 pub mod applicationmetadata;
 pub mod endpoint;
+pub mod endpointmetadata;
 pub mod eventtype;
 pub mod message;
 pub mod messageattempt;


### PR DESCRIPTION
This is the initial PR to add metadata support to our OSS. We already have this field for endpoints in our propriety solution, as well as metadata support for applications in the OSS.

This PR just adds the necessary migrations and model boilerplate. That's pretty much it. In future PRs we'll update the CRUD group to make this field visible/configurable to users.