### PR TITLE
Server: cleanup CreateMessageApp

### DIFF
--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -232,8 +232,8 @@ async fn create_message(
         cache,
         db,
         Some(app.clone()),
-        app.id.clone(),
         app.org_id.clone(),
+        app.id.clone(),
         std::time::Duration::from_secs(30),
     )
     .await?
@@ -249,7 +249,7 @@ async fn create_message(
 
     let trigger_type = MessageAttemptTriggerType::Scheduled;
     if !create_message_app
-        .filtered_endpoints(trigger_type, &msg)
+        .filtered_endpoints(trigger_type, &msg.event_type, msg.channels.as_ref())
         .is_empty()
     {
         queue_tx

--- a/server/svix-server/src/worker.rs
+++ b/server/svix-server/src/worker.rs
@@ -573,8 +573,8 @@ async fn process_task(worker_context: WorkerContext<'_>, queue_task: Arc<QueueTa
         cache.clone(),
         db,
         None,
-        msg.app_id.clone(),
         msg.org_id.clone(),
+        msg.app_id.clone(),
         Duration::from_secs(30),
     )
     .await?
@@ -583,7 +583,7 @@ async fn process_task(worker_context: WorkerContext<'_>, queue_task: Arc<QueueTa
     let app_uid = create_message_app.uid.clone();
 
     let endpoints: Vec<CreateMessageEndpoint> = create_message_app
-        .filtered_endpoints(*trigger_type, &msg)
+        .filtered_endpoints(*trigger_type, &msg.event_type, msg.channels.as_ref())
         .iter()
         .filter(|endpoint| match &*queue_task {
             QueueTask::HealthCheck => unreachable!(),


### PR DESCRIPTION
1. Change param order to have org_id first and app_id second - we always go from "large" to small in our parameter order.
2. Make the filtered endpoints function to only get what it needs.
3. Fix cache key to accept references (we only needs refs anyway).
