### PR TITLE
Change Pg connection to be lazy

### DIFF
--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -88,7 +88,7 @@ pub async fn run_with_prefix(
     cfg: Configuration,
     listener: Option<TcpListener>,
 ) {
-    let pool = init_db(&cfg).await;
+    let pool = init_db(&cfg);
 
     tracing::debug!("Cache type: {:?}", cfg.cache_type);
     let cache = match cfg.cache_backend() {

--- a/server/svix-server/tests/db.rs
+++ b/server/svix-server/tests/db.rs
@@ -127,7 +127,7 @@ async fn test_wiping_organization() {
     wipe_org(&cfg, org_id_1.clone()).await;
 
     // Start asserting everything is gone for org_id_1, but not org_id_2
-    let db = svix_server::db::init_db(&cfg).await;
+    let db = svix_server::db::init_db(&cfg);
 
     for endp_id in endp_ids_1 {
         assert_eq!(count_message_attempts(&db, endp_id.clone()).await, 0);

--- a/server/svix-server/tests/e2e_endpoint.rs
+++ b/server/svix-server/tests/e2e_endpoint.rs
@@ -1327,7 +1327,7 @@ async fn test_legacy_endpoint_secret() {
     let (client, _jh) = start_svix_server_with_cfg(&cfg).await;
 
     let db = Arc::new(cfg);
-    let db = svix_server::db::init_db(&db).await;
+    let db = svix_server::db::init_db(&db);
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
@@ -1386,7 +1386,7 @@ async fn test_endpoint_secret_encryption_in_database() {
     let (client, _jh) = start_svix_server_with_cfg(&cfg).await;
 
     let db = Arc::new(cfg);
-    let db = svix_server::db::init_db(&db).await;
+    let db = svix_server::db::init_db(&db);
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 

--- a/server/svix-server/tests/e2e_message.rs
+++ b/server/svix-server/tests/e2e_message.rs
@@ -353,7 +353,7 @@ async fn test_payload_retention_period() {
     let (client, _jh) = start_svix_server().await;
     dotenv::dotenv().ok();
     let cfg = svix_server::cfg::load().expect("Error loading configuration");
-    let pool = svix_server::db::init_db(&cfg).await;
+    let pool = svix_server::db::init_db(&cfg);
 
     let app_id = create_test_app(&client, "v1MessageCRTestApp")
         .await


### PR DESCRIPTION
This changes the connection pool to postgres to open connections lazily.

## Motivation

This might improve application startup a bit - both in speed and in reducing the likelihood of crashes on start up.

## Solution

Use the [connect_lazy](https://docs.rs/sqlx/latest/sqlx/struct.Pool.html#method.connect_lazy) function instead of `connect`, and remove now-unnecessary async/await calls.
