### PR TITLE
Fix GET /event-types permission regression

### DIFF
--- a/server/svix-server/src/core/permissions.rs
+++ b/server/svix-server/src/core/permissions.rs
@@ -17,6 +17,24 @@ use super::{
     types::{ApplicationId, ApplicationIdOrUid, OrganizationId},
 };
 
+pub struct ReadAll {
+    pub org_id: OrganizationId,
+}
+
+#[async_trait]
+impl<S> FromRequestParts<S> for ReadAll
+where
+    S: Send + Sync,
+{
+    type Rejection = Error;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self> {
+        let permissions = ctx!(permissions_from_bearer(parts, state).await)?;
+        let org_id = permissions.org_id();
+        Ok(Self { org_id })
+    }
+}
+
 pub struct Organization {
     pub org_id: OrganizationId,
 }

--- a/server/svix-server/src/v1/endpoints/event_type.rs
+++ b/server/svix-server/src/v1/endpoints/event_type.rs
@@ -170,7 +170,7 @@ async fn list_event_types(
     Extension(ref db): Extension<DatabaseConnection>,
     pagination: ValidatedQuery<Pagination<EventTypeName>>,
     fetch_options: ValidatedQuery<ListFetchOptions>,
-    permissions::Organization { org_id }: permissions::Organization,
+    permissions::ReadAll { org_id }: permissions::ReadAll,
 ) -> Result<Json<ListResponse<EventTypeOut>>> {
     let PaginationLimit(limit) = pagination.limit;
     let iterator = pagination.iterator.clone();


### PR DESCRIPTION
This PR fixes a regression with the `GET /event-type` endpoint.

## Motivation

In [#674](https://github.com/svix/svix-webhooks/commit/cc01b8482202ce7442487a4b5e86850cd3783fc3#diff-2a76cfc85cbfeae62fdc056d281dfa9a9c61fdfcb434435b02993b5cd31ddf58), we refactored a lot of our permission logic so that the `Permission` struct was no longer extracted directly in axum handlers. Instead, a `permission::<Struct>` is extracted instead, which describes the resources the user has authorized access too.

The regression was introduced [here](https://github.com/svix/svix-webhooks/commit/cc01b8482202ce7442487a4b5e86850cd3783fc3#diff-2a76cfc85cbfeae62fdc056d281dfa9a9c61fdfcb434435b02993b5cd31ddf58L176). Originally, `GET /event-type` accepted the `Permission` struct directly - which effectively means any authenticated user has access, but it was changed to `permissions::Organization`, which [enforces org-only access](https://github.com/svix/svix-webhooks/commit/cc01b8482202ce7442487a4b5e86850cd3783fc3#diff-6482eed99ed190ec2d1e3da2390b61e530eb26e6f8bd4d24cfa5149a95401e77R33).

## Solution

Update the `GET /event-type` to accept any authenticated user. Conceptually this maps to `permissions::ReadAll`, which is equivalent to the original code where the `Permission` struct was extracted directly in the Axum handler.