### PR TITLE
Fix GET /event-type/:name permissions

### DIFF
--- a/server/svix-server/src/v1/endpoints/event_type.rs
+++ b/server/svix-server/src/v1/endpoints/event_type.rs
@@ -241,7 +241,7 @@ async fn create_event_type(
 async fn get_event_type(
     Extension(ref db): Extension<DatabaseConnection>,
     Path(evtype_name): Path<EventTypeName>,
-    permissions::Organization { org_id }: permissions::Organization,
+    permissions::ReadAll { org_id }: permissions::ReadAll,
 ) -> Result<Json<EventTypeOut>> {
     let evtype = ctx!(
         eventtype::Entity::secure_find_by_name(org_id, evtype_name)


### PR DESCRIPTION
## Motivation

This fixes the permissions for the singular `GET /event-type/:name` endpoint. This wasn't a regression, we just noticed it's been wrong all this time.

## Solution

Change the permissions to `ReadAll`, which matches `GET /event-type/`.
