### PR TITLE
Endpoint.URL - change to parse, not validate

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -3789,6 +3789,7 @@ dependencies = [
  "form_urlencoded",
  "idna 0.3.0",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -60,7 +60,7 @@ http = "0.2"
 time = { version = "0.3.9", features = [ "std" ]}
 futures = "0.3"
 redis_cluster_async = { git = "https://github.com/redis-rs/redis-cluster-async.git", rev = "e6fe168" }
-url = "2.2.2"
+url = { version = "2.2.2", features = ["serde"] }
 rand = "0.8.5"
 jsonschema = "0.16.1"
 

--- a/server/svix-server/src/v1/endpoints/endpoint/crud.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/crud.rs
@@ -299,32 +299,20 @@ async fn validate_event_types(
     }
 }
 
-fn validate_endpoint_url(url: &str, https_only: bool) -> Result<()> {
+fn validate_endpoint_url(url: &Url, https_only: bool) -> Result<()> {
     if !https_only {
         return Ok(());
     }
 
-    match Url::parse(url) {
-        Ok(url) => {
-            let scheme = url.scheme();
-            if scheme == "https" {
-                Ok(())
-            } else {
-                Err(HttpError::unprocessable_entity(vec![ValidationErrorItem {
-                    loc: vec!["body".to_owned(), "url".to_owned()],
-                    msg: "Endpoint URL schemes must be https when endpoint_https_only is set."
-                        .to_owned(),
-                    ty: "value_error".to_owned(),
-                }])
-                .into())
-            }
-        }
-
-        Err(_) => Err(HttpError::unprocessable_entity(vec![ValidationErrorItem {
+    let scheme = url.scheme();
+    if scheme == "https" {
+        Ok(())
+    } else {
+        Err(HttpError::unprocessable_entity(vec![ValidationErrorItem {
             loc: vec!["body".to_owned(), "url".to_owned()],
-            msg: "Endpoint URLs must be valid".to_owned(),
+            msg: "Endpoint URL schemes must be https when endpoint_https_only is set.".to_owned(),
             ty: "value_error".to_owned(),
         }])
-        .into()),
+        .into())
     }
 }

--- a/server/svix-server/tests/e2e_endpoint.rs
+++ b/server/svix-server/tests/e2e_endpoint.rs
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
-use crate::utils::common_calls::metadata;
+use crate::utils::common_calls::{default_test_endpoint, metadata};
 use anyhow::Result;
 use chrono::Utc;
 use ed25519_compact::Signature;
-use reqwest::StatusCode;
+use reqwest::{StatusCode, Url};
 use sea_orm::{ConnectionTrait, DatabaseBackend, QueryResult, Statement};
 use std::sync::Arc;
 use std::{
@@ -123,7 +123,7 @@ async fn test_patch() {
     // Assert that no other changes were made
     assert_eq!(out.ep.rate_limit, None);
     assert_eq!(out.ep.uid, None);
-    assert_eq!(out.ep.url, "http://bad.url".to_owned());
+    assert_eq!(out.ep.url, "http://bad.url/".to_owned());
     assert_eq!(out.ep.version, 1);
     assert!(!out.ep.disabled);
     assert_eq!(out.ep.event_types_ids, None);
@@ -150,7 +150,7 @@ async fn test_patch() {
     // Assert that no other changes were made
     assert_eq!(out.ep.description, "test".to_owned());
     assert_eq!(out.ep.uid, None);
-    assert_eq!(out.ep.url, "http://bad.url".to_owned());
+    assert_eq!(out.ep.url, "http://bad.url/".to_owned());
     assert_eq!(out.ep.version, 1);
     assert!(!out.ep.disabled);
     assert_eq!(out.ep.event_types_ids, None);
@@ -177,7 +177,7 @@ async fn test_patch() {
     // Assert that no other changes were made
     assert_eq!(out.ep.description, "test".to_owned());
     assert_eq!(out.ep.uid, None);
-    assert_eq!(out.ep.url, "http://bad.url".to_owned());
+    assert_eq!(out.ep.url, "http://bad.url/".to_owned());
     assert_eq!(out.ep.version, 1);
     assert!(!out.ep.disabled);
     assert_eq!(out.ep.event_types_ids, None);
@@ -204,7 +204,7 @@ async fn test_patch() {
     // Assert that no other changes were made
     assert_eq!(out.ep.description, "test".to_owned());
     assert_eq!(out.ep.rate_limit, None);
-    assert_eq!(out.ep.url, "http://bad.url".to_owned());
+    assert_eq!(out.ep.url, "http://bad.url/".to_owned());
     assert_eq!(out.ep.version, 1);
     assert!(!out.ep.disabled);
     assert_eq!(out.ep.event_types_ids, None);
@@ -231,7 +231,7 @@ async fn test_patch() {
     // Assert that no other changes were made
     assert_eq!(out.ep.description, "test".to_owned());
     assert_eq!(out.ep.rate_limit, None);
-    assert_eq!(out.ep.url, "http://bad.url".to_owned());
+    assert_eq!(out.ep.url, "http://bad.url/".to_owned());
     assert_eq!(out.ep.version, 1);
     assert!(!out.ep.disabled);
     assert_eq!(out.ep.event_types_ids, None);
@@ -254,7 +254,7 @@ async fn test_patch() {
         .get::<EndpointOut>(&url, StatusCode::OK)
         .await
         .unwrap();
-    assert_eq!(out.ep.url, "http://bad.url2".to_owned());
+    assert_eq!(out.ep.url, "http://bad.url2/".to_owned());
     // Assert that no other changes were made
     assert_eq!(out.ep.description, "test".to_owned());
     assert_eq!(out.ep.rate_limit, None);
@@ -286,7 +286,7 @@ async fn test_patch() {
     assert_eq!(out.ep.description, "test".to_owned());
     assert_eq!(out.ep.rate_limit, None);
     assert_eq!(out.ep.uid, None);
-    assert_eq!(out.ep.url, "http://bad.url2".to_owned());
+    assert_eq!(out.ep.url, "http://bad.url2/".to_owned());
     assert!(!out.ep.disabled);
     assert_eq!(out.ep.event_types_ids, None);
     assert_eq!(out.ep.channels, None);
@@ -313,7 +313,7 @@ async fn test_patch() {
     assert_eq!(out.ep.description, "test".to_owned());
     assert_eq!(out.ep.rate_limit, None);
     assert_eq!(out.ep.uid, None);
-    assert_eq!(out.ep.url, "http://bad.url2".to_owned());
+    assert_eq!(out.ep.url, "http://bad.url2/".to_owned());
     assert_eq!(out.ep.version, 2);
     assert_eq!(out.ep.event_types_ids, None);
     assert_eq!(out.ep.channels, None);
@@ -359,7 +359,7 @@ async fn test_patch() {
     assert_eq!(out.ep.description, "test".to_owned());
     assert_eq!(out.ep.rate_limit, None);
     assert_eq!(out.ep.uid, None);
-    assert_eq!(out.ep.url, "http://bad.url2".to_owned());
+    assert_eq!(out.ep.url, "http://bad.url2/".to_owned());
     assert_eq!(out.ep.version, 2);
     assert!(out.ep.disabled);
     assert_eq!(out.ep.channels, None);
@@ -386,7 +386,7 @@ async fn test_patch() {
     assert_eq!(out.ep.description, "test".to_owned());
     assert_eq!(out.ep.rate_limit, None);
     assert_eq!(out.ep.uid, None);
-    assert_eq!(out.ep.url, "http://bad.url2".to_owned());
+    assert_eq!(out.ep.url, "http://bad.url2/".to_owned());
     assert_eq!(out.ep.version, 2);
     assert!(out.ep.disabled);
     assert_eq!(out.ep.channels, None);
@@ -418,7 +418,7 @@ async fn test_patch() {
     assert_eq!(out.ep.description, "test".to_owned());
     assert_eq!(out.ep.rate_limit, None);
     assert_eq!(out.ep.uid, None);
-    assert_eq!(out.ep.url, "http://bad.url2".to_owned());
+    assert_eq!(out.ep.url, "http://bad.url2/".to_owned());
     assert_eq!(out.ep.version, 2);
     assert!(out.ep.disabled);
     assert_eq!(out.ep.event_types_ids, None);
@@ -445,7 +445,7 @@ async fn test_patch() {
     assert_eq!(out.ep.description, "test".to_owned());
     assert_eq!(out.ep.rate_limit, None);
     assert_eq!(out.ep.uid, None);
-    assert_eq!(out.ep.url, "http://bad.url2".to_owned());
+    assert_eq!(out.ep.url, "http://bad.url2/".to_owned());
     assert_eq!(out.ep.version, 2);
     assert!(out.ep.disabled);
     assert_eq!(out.ep.event_types_ids, None);
@@ -458,11 +458,11 @@ async fn test_crud() {
     const APP_NAME_1: &str = "v1EndpointCrudTestApp1";
     const APP_NAME_2: &str = "v1EndpointCrudTestApp2";
 
-    const EP_URI_APP_1_EP_1_VER_1: &str = "http://v1EndpointCrudTestApp1Ep1Ver1.test";
-    const EP_URI_APP_1_EP_1_VER_2: &str = "http://v1EndpointCrudTestApp1Ep1Ver2.test";
-    const EP_URI_APP_1_EP_2: &str = "http://v1EndpointCrudTestApp1Ep2.test";
-    const EP_URI_APP_2_EP_1: &str = "http://v1EndpointCrudTestApp2Ep1.test";
-    const EP_URI_APP_2_EP_2: &str = "http://v1EndpointCrudTestApp2Ep2.test";
+    const EP_URI_APP_1_EP_1_VER_1: &str = "http://v1EndpointCrudTestApp1Ep1Ver1.test/foo";
+    const EP_URI_APP_1_EP_1_VER_2: &str = "http://v1EndpointCrudTestApp1Ep1Ver2.test/";
+    const EP_URI_APP_1_EP_2: &str = "http://v1EndpointCrudTestApp1Ep2.test/";
+    const EP_URI_APP_2_EP_1: &str = "http://v1EndpointCrudTestApp2Ep1.test/";
+    const EP_URI_APP_2_EP_2: &str = "http://v1EndpointCrudTestApp2Ep2.test/";
 
     let app_1 = create_test_app(&client, APP_NAME_1).await.unwrap().id;
     let app_2 = create_test_app(&client, APP_NAME_2).await.unwrap().id;
@@ -471,25 +471,25 @@ async fn test_crud() {
     let app_1_ep_1 = create_test_endpoint(&client, &app_1, EP_URI_APP_1_EP_1_VER_1)
         .await
         .unwrap();
-    assert_eq!(app_1_ep_1.ep.url, EP_URI_APP_1_EP_1_VER_1);
+    assert_eq!(app_1_ep_1.ep.url, EP_URI_APP_1_EP_1_VER_1.to_lowercase());
     assert_eq!(app_1_ep_1.ep.version, 1);
 
     let app_1_ep_2 = create_test_endpoint(&client, &app_1, EP_URI_APP_1_EP_2)
         .await
         .unwrap();
-    assert_eq!(app_1_ep_2.ep.url, EP_URI_APP_1_EP_2);
+    assert_eq!(app_1_ep_2.ep.url, EP_URI_APP_1_EP_2.to_lowercase());
     assert_eq!(app_1_ep_2.ep.version, 1);
 
     let app_2_ep_1 = create_test_endpoint(&client, &app_2, EP_URI_APP_2_EP_1)
         .await
         .unwrap();
-    assert_eq!(app_2_ep_1.ep.url, EP_URI_APP_2_EP_1);
+    assert_eq!(app_2_ep_1.ep.url, EP_URI_APP_2_EP_1.to_lowercase());
     assert_eq!(app_2_ep_1.ep.version, 1);
 
     let app_2_ep_2 = create_test_endpoint(&client, &app_2, EP_URI_APP_2_EP_2)
         .await
         .unwrap();
-    assert_eq!(app_2_ep_2.ep.url, EP_URI_APP_2_EP_2);
+    assert_eq!(app_2_ep_2.ep.url, EP_URI_APP_2_EP_2.to_lowercase());
     assert_eq!(app_2_ep_2.ep.version, 1);
 
     // READ
@@ -536,7 +536,7 @@ async fn test_crud() {
         )
         .await
         .unwrap();
-    assert_eq!(app_1_ep_1.ep.url, EP_URI_APP_1_EP_1_VER_2);
+    assert_eq!(app_1_ep_1.ep.url, EP_URI_APP_1_EP_1_VER_2.to_lowercase());
 
     // CONFIRM UPDATE
     assert_eq!(
@@ -1030,10 +1030,9 @@ async fn test_endpoint_rotate_signing_symmetric_and_asymmetric() {
     let secret_3 = EndpointSecret::Symmetric(base64::decode("TUdfVE5UMnZlci1TeWxOYXQtX1ZlTW1kLTRtMFdhYmEwanIxdHJvenRCbmlTQ2hFdzBnbHhFbWdFaTJLdzQwSA==").unwrap());
 
     let ep_in = EndpointIn {
-        url: receiver.endpoint.clone(),
-        version: 1,
+        url: Url::parse(&receiver.endpoint).unwrap(),
         key: Some(secret_1.clone()),
-        ..Default::default()
+        ..default_test_endpoint()
     };
 
     let endp = post_endpoint(&client, &app_id, ep_in.clone())
@@ -1116,11 +1115,7 @@ async fn test_endpoint_secret_config() {
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
-    let ep_in = EndpointIn {
-        url: "http://www.example.com".to_owned(),
-        version: 1,
-        ..Default::default()
-    };
+    let ep_in = default_test_endpoint();
 
     let ep = post_endpoint(&client, &app_id, ep_in.clone())
         .await
@@ -1184,10 +1179,8 @@ async fn test_custom_endpoint_secret() {
     );
 
     let mut ep_in = EndpointIn {
-        url: "http://www.example.com".to_owned(),
-        version: 1,
         key: Some(secret_1.clone()),
-        ..Default::default()
+        ..default_test_endpoint()
     };
 
     let endp_1 = post_endpoint(&client, &app_id, ep_in.clone())
@@ -1246,11 +1239,7 @@ async fn test_endpoint_secret_encryption() {
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
-    let ep_in = EndpointIn {
-        url: "http://www.example.com".to_owned(),
-        version: 1,
-        ..Default::default()
-    };
+    let ep_in = default_test_endpoint();
 
     let ep = post_endpoint(&client, &app_id, ep_in.clone())
         .await
@@ -1365,10 +1354,8 @@ async fn test_legacy_endpoint_secret() {
     let secret_1 = EndpointSecret::Symmetric(raw_key.clone());
 
     let ep_in = EndpointIn {
-        url: "http://www.example.com".to_owned(),
-        version: 1,
         key: Some(secret_throwaway.clone()),
-        ..Default::default()
+        ..default_test_endpoint()
     };
 
     let endp_1 = post_endpoint(&client, &app_id, ep_in.clone())
@@ -1416,11 +1403,7 @@ async fn test_endpoint_secret_encryption_in_database() {
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
-    let ep_in = EndpointIn {
-        url: "http://www.example.com".to_owned(),
-        version: 1,
-        ..Default::default()
-    };
+    let ep_in = default_test_endpoint();
 
     let ep = post_endpoint(&client, &app_id, ep_in.clone())
         .await
@@ -1441,11 +1424,7 @@ async fn test_endpoint_secret_encryption_in_database() {
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
-    let ep_in = EndpointIn {
-        url: "http://www.example.com".to_owned(),
-        version: 1,
-        ..Default::default()
-    };
+    let ep_in = default_test_endpoint();
 
     let ep = post_endpoint(&client, &app_id, ep_in.clone())
         .await
@@ -1658,10 +1637,8 @@ async fn test_rate_limit() {
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
     let ep_in = EndpointIn {
-        url: "http://www.example.com".to_owned(),
-        version: 1,
         rate_limit: Some(100),
-        ..Default::default()
+        ..default_test_endpoint()
     };
 
     let endp = post_endpoint(&client, &app_id, ep_in.clone())
@@ -1721,10 +1698,9 @@ async fn test_msg_event_types_filter() {
             &client,
             &app_id,
             EndpointIn {
-                url: receiver.endpoint.to_owned(),
-                version: 1,
+                url: Url::parse(&receiver.endpoint).unwrap(),
                 event_types_ids: event_types,
-                ..Default::default()
+                ..default_test_endpoint()
             },
         )
         .await
@@ -1766,7 +1742,7 @@ async fn test_msg_channels_filter() {
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
-    let receiver = TestReceiver::start(StatusCode::OK);
+    let _receiver = TestReceiver::start(StatusCode::OK);
 
     let ec = EventChannelSet(HashSet::from([EventChannel("tag1".to_owned())]));
 
@@ -1775,10 +1751,8 @@ async fn test_msg_channels_filter() {
             &client,
             &app_id,
             EndpointIn {
-                url: receiver.endpoint.to_owned(),
-                version: 1,
                 channels,
-                ..Default::default()
+                ..default_test_endpoint()
             },
         )
         .await

--- a/server/svix-server/tests/e2e_operational_webhooks.rs
+++ b/server/svix-server/tests/e2e_operational_webhooks.rs
@@ -6,6 +6,7 @@ use std::{net::TcpListener, sync::Arc, time::Duration};
 use chrono::{DateTime, Utc};
 use http::StatusCode;
 
+use reqwest::Url;
 use serde::Deserialize;
 use svix_ksuid::KsuidLike;
 use svix_server::{
@@ -28,6 +29,8 @@ use utils::{
     common_calls::{create_test_app, create_test_endpoint, create_test_message},
     get_default_test_config, IgnoredResponse, TestClient, TestReceiver,
 };
+
+use crate::utils::common_calls::default_test_endpoint;
 
 /// Sent when an endpoint has been automatically disabled after continuous failures.
 #[derive(Debug, Deserialize)]
@@ -155,9 +158,8 @@ async fn test_endpoint_create_update_and_delete() {
             &format!("api/v1/app/{}/endpoint/", op_webhook_app.id),
             EndpointIn {
                 description: "TestOperationalWebhookEndpoint".to_owned(),
-                url: receiver.endpoint.clone(),
-                version: 1,
-                ..Default::default()
+                url: Url::parse(&receiver.endpoint).unwrap(),
+                ..default_test_endpoint()
             },
             StatusCode::CREATED,
         )
@@ -203,9 +205,9 @@ async fn test_endpoint_create_update_and_delete() {
             ),
             EndpointIn {
                 description: "Updated description".to_owned(),
-                url: receiver.endpoint,
+                url: Url::parse(&receiver.endpoint).unwrap(),
                 version: 2,
-                ..Default::default()
+                ..default_test_endpoint()
             },
             StatusCode::OK,
         )
@@ -302,9 +304,8 @@ async fn test_message_attempt_operational_webhooks() {
             &format!("api/v1/app/{}/endpoint/", op_webhook_app.id),
             EndpointIn {
                 description: "TestOperationalWebhookEndpoint".to_owned(),
-                url: receiver.endpoint.clone(),
-                version: 1,
-                ..Default::default()
+                url: Url::parse(&receiver.endpoint).unwrap(),
+                ..default_test_endpoint()
             },
             StatusCode::CREATED,
         )

--- a/server/svix-server/tests/utils/common_calls.rs
+++ b/server/svix-server/tests/utils/common_calls.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use reqwest::StatusCode;
+use reqwest::{StatusCode, Url};
 
 use serde::{de::DeserializeOwned, Serialize};
 use svix_server::{
@@ -47,11 +47,25 @@ pub async fn delete_test_app(client: &TestClient, id: ApplicationId) -> Result<I
 
 // Endpoint
 
+pub fn default_test_endpoint() -> EndpointIn {
+    EndpointIn {
+        description: Default::default(),
+        rate_limit: Default::default(),
+        uid: Default::default(),
+        url: Url::parse("http://example.com").unwrap(),
+        version: 1,
+        disabled: Default::default(),
+        event_types_ids: Default::default(),
+        channels: Default::default(),
+        key: Default::default(),
+        metadata: Default::default(),
+    }
+}
+
 pub fn endpoint_in(url: &str) -> EndpointIn {
     EndpointIn {
-        url: url.to_owned(),
-        version: 1,
-        ..Default::default()
+        url: Url::parse(url).unwrap(),
+        ..default_test_endpoint()
     }
 }
 


### PR DESCRIPTION
## Motivation

Right now, we call `Url::parse(...)` multiple times on `EndpointIn`'s URL field. This isn't a huge inconvenience, but it's definitely more complicated and inefficient than things need to be.

## Solution

This PR changes the EndpointIn field to be a URL type instead of a String - leveraging the URL crate's serde (de)serialization to only `Url::parse` once.

The only annoying downside is that `Url` doesn't have a default implementation - so we had to role our own. However, this ended up cleaning up a lot of test logic (since that's all that uses `EndpointIn::default()`), so more likely a win.

In addition, `Url::to_string()` normalizes the URL domain, down-casing the string and adding a trailing `/`. This meant updating a few tests, although this shouldn't be a functionally breaking change for anyone.
