### PR TITLE
Server: Fix Span HTTP Routes

### DIFF
--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -17,16 +17,12 @@ use std::{
 };
 use tower::ServiceBuilder;
 use tower_http::cors::{AllowHeaders, Any, CorsLayer};
-use tower_http::trace::TraceLayer;
 use tracing_subscriber::{prelude::*, util::SubscriberInitExt};
 
 use crate::{
     cfg::{CacheBackend, Configuration},
     core::{
-        cache,
-        idempotency::IdempotencyService,
-        operational_webhooks::OperationalWebhookSenderInner,
-        otel_spans::{AxumOtelOnFailure, AxumOtelOnResponse, AxumOtelSpanCreator},
+        cache, idempotency::IdempotencyService, operational_webhooks::OperationalWebhookSenderInner,
     },
     db::init_db,
     expired_message_cleaner::expired_message_cleaner_loop,
@@ -129,12 +125,6 @@ pub async fn run_with_prefix(
                 .allow_methods(Any)
                 .allow_headers(AllowHeaders::mirror_request())
                 .max_age(Duration::from_secs(600)),
-        )
-        .layer(
-            TraceLayer::new_for_http()
-                .make_span_with(AxumOtelSpanCreator)
-                .on_response(AxumOtelOnResponse)
-                .on_failure(AxumOtelOnFailure),
         )
         .layer(Extension(pool.clone()))
         .layer(Extension(queue_tx.clone()))


### PR DESCRIPTION
HTTP routes broke after Axum upgrade to 0.6.0 due to changes
in how nested routes work so that matched routes were displaying
as the literal route in the request rather than a generic route
with placeholders for resource IDs. Adding the otel layer
directly in the nested API route fixes the problem.
