### PR TITLE
Update string_wrapper! to use Arc internally

### DIFF
--- a/server/svix-server/src/core/security.rs
+++ b/server/svix-server/src/core/security.rs
@@ -23,12 +23,12 @@ use super::types::{ApplicationId, OrganizationId};
 
 /// The default org_id we use (useful for generating JWTs when testing).
 pub fn default_org_id() -> OrganizationId {
-    OrganizationId("org_23rb8YdGqMT0qIzpgGwdXfHirMu".to_owned())
+    "org_23rb8YdGqMT0qIzpgGwdXfHirMu".into()
 }
 
 /// The default org_id we use (useful for generating JWTs when testing).
 pub fn management_org_id() -> OrganizationId {
-    OrganizationId("org_00000000000SvixManagement00".to_owned())
+    "org_00000000000SvixManagement00".into()
 }
 
 pub enum AccessLevel {
@@ -87,13 +87,13 @@ pub fn permissions_from_jwt(claims: JWTClaims<CustomClaim>) -> Result<Permission
 
     // If there is an `org` field then it is an Application authentication
     if let Some(org_id) = claims.custom.organization {
-        let org_id = OrganizationId(org_id);
+        let org_id: OrganizationId = org_id.into();
         org_id
             .validate()
             .map_err(|_| bad_token("org", "organization"))?;
 
         if let Some(app_id) = claims.subject {
-            let app_id = ApplicationId(app_id);
+            let app_id: ApplicationId = app_id.into();
             app_id
                 .validate()
                 .map_err(|_| bad_token("sub", "application"))?;
@@ -110,7 +110,7 @@ pub fn permissions_from_jwt(claims: JWTClaims<CustomClaim>) -> Result<Permission
     }
     // Otherwise it's an Organization authentication
     else if let Some(org_id) = claims.subject {
-        let org_id = OrganizationId(org_id);
+        let org_id: OrganizationId = org_id.into();
         org_id.validate().map_err(|_| {
             HttpError::bad_request(
                 Some("bad_token".to_string()),
@@ -155,7 +155,7 @@ pub fn generate_app_token(
 ) -> Result<String> {
     let claims = Claims::with_custom_claims(
         CustomClaim {
-            organization: Some(org_id.0),
+            organization: Some(org_id.into()),
         },
         Duration::from_hours(24 * 28),
     )

--- a/server/svix-server/src/core/types/strings.rs
+++ b/server/svix-server/src/core/types/strings.rs
@@ -1,0 +1,67 @@
+#[macro_export]
+macro_rules! string_wrapper {
+    ($name_id:ident) => {
+        #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+        pub struct $name_id(pub String);
+
+        impl Deref for $name_id {
+            type Target = String;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl From<$name_id> for sea_orm::Value {
+            fn from(v: $name_id) -> Self {
+                Self::String(Some(Box::new(v.0)))
+            }
+        }
+
+        impl sea_orm::TryGetable for $name_id {
+            fn try_get(
+                res: &sea_orm::QueryResult,
+                pre: &str,
+                col: &str,
+            ) -> Result<Self, sea_orm::TryGetError> {
+                match String::try_get(res, pre, col) {
+                    Ok(v) => Ok($name_id(v)),
+                    Err(e) => Err(e),
+                }
+            }
+        }
+
+        impl sea_orm::sea_query::Nullable for $name_id {
+            fn null() -> sea_orm::Value {
+                sea_orm::Value::String(None)
+            }
+        }
+
+        impl sea_orm::sea_query::ValueType for $name_id {
+            fn try_from(v: sea_orm::Value) -> Result<Self, sea_orm::sea_query::ValueTypeErr> {
+                match v {
+                    sea_orm::Value::String(Some(x)) => Ok($name_id(*x)),
+                    _ => Err(sea_orm::sea_query::ValueTypeErr),
+                }
+            }
+
+            fn type_name() -> String {
+                stringify!($name_id).to_owned()
+            }
+
+            fn column_type() -> sea_orm::sea_query::ColumnType {
+                String::column_type()
+            }
+
+            fn array_type() -> sea_orm::sea_query::ArrayType {
+                String::array_type()
+            }
+        }
+
+        impl std::fmt::Display for $name_id {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                self.0.fmt(f)
+            }
+        }
+    };
+}

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -88,7 +88,7 @@ enum AsymmetricKeyCommands {
 }
 
 fn org_id_parser(s: &str) -> Result<OrganizationId, String> {
-    let ret = OrganizationId(s.to_owned());
+    let ret: OrganizationId = s.into();
     ret.validate().map_err(|x| x.to_string())?;
     Ok(ret)
 }

--- a/server/svix-server/src/queue/mod.rs
+++ b/server/svix-server/src/queue/mod.rs
@@ -203,9 +203,9 @@ mod tests {
     /// Creates a [`MessageTask`] with filler information and the given MessageId inner String
     fn mock_message(message_id: String) -> QueueTask {
         MessageTask::new_task(
-            MessageId(message_id),
-            ApplicationId("TestEndpointID".to_owned()),
-            EndpointId("TestEndpointID".to_owned()),
+            message_id.into(),
+            "TestEndpointID".into(),
+            "TestEndpointID".into(),
             MessageAttemptTriggerType::Scheduled,
         )
     }

--- a/server/svix-server/src/queue/redis.rs
+++ b/server/svix-server/src/queue/redis.rs
@@ -697,7 +697,7 @@ pub mod tests {
 
     use crate::{
         cfg::{CacheType, Configuration},
-        core::types::{ApplicationId, EndpointId, MessageAttemptTriggerType, MessageId},
+        core::types::MessageAttemptTriggerType,
         queue::{MessageTask, QueueTask, TaskQueueConsumer, TaskQueueDelivery, TaskQueueProducer},
         redis::{PoolLike, PooledConnectionLike, RedisPool},
     };
@@ -815,9 +815,9 @@ pub mod tests {
         flush_stale_queue_items(p.clone(), &mut c).await;
 
         let mt = QueueTask::MessageV1(MessageTask {
-            msg_id: MessageId("test".to_owned()),
-            app_id: ApplicationId("test".to_owned()),
-            endpoint_id: EndpointId("test".to_owned()),
+            msg_id: "test".into(),
+            app_id: "test".into(),
+            endpoint_id: "test".into(),
             trigger_type: MessageAttemptTriggerType::Manual,
             attempt_count: 0,
         });
@@ -890,9 +890,9 @@ pub mod tests {
         .await;
 
         let mt = QueueTask::MessageV1(MessageTask {
-            msg_id: MessageId("test2".to_owned()),
-            app_id: ApplicationId("test2".to_owned()),
-            endpoint_id: EndpointId("test2".to_owned()),
+            msg_id: "test2".into(),
+            app_id: "test2".into(),
+            endpoint_id: "test2".into(),
             trigger_type: MessageAttemptTriggerType::Manual,
             attempt_count: 0,
         });
@@ -939,9 +939,9 @@ pub mod tests {
         flush_stale_queue_items(p.clone(), &mut c).await;
 
         let mt = QueueTask::MessageV1(MessageTask {
-            msg_id: MessageId("test".to_owned()),
-            app_id: ApplicationId("test".to_owned()),
-            endpoint_id: EndpointId("test".to_owned()),
+            msg_id: "test".into(),
+            app_id: "test".into(),
+            endpoint_id: "test".into(),
             trigger_type: MessageAttemptTriggerType::Manual,
             attempt_count: 0,
         });
@@ -982,16 +982,16 @@ pub mod tests {
         flush_stale_queue_items(p.clone(), &mut c).await;
 
         let mt1 = QueueTask::MessageV1(MessageTask {
-            msg_id: MessageId("test1".to_owned()),
-            app_id: ApplicationId("test1".to_owned()),
-            endpoint_id: EndpointId("test1".to_owned()),
+            msg_id: "test1".into(),
+            app_id: "test1".into(),
+            endpoint_id: "test1".into(),
             trigger_type: MessageAttemptTriggerType::Scheduled,
             attempt_count: 0,
         });
         let mt2 = QueueTask::MessageV1(MessageTask {
-            msg_id: MessageId("test2".to_owned()),
-            app_id: ApplicationId("test2".to_owned()),
-            endpoint_id: EndpointId("test2".to_owned()),
+            msg_id: "test2".into(),
+            app_id: "test2".into(),
+            endpoint_id: "test2".into(),
             trigger_type: MessageAttemptTriggerType::Manual,
             attempt_count: 0,
         });
@@ -1064,9 +1064,9 @@ pub mod tests {
                         to_redis_key(&TaskQueueDelivery {
                             id: num.to_string(),
                             task: Arc::new(QueueTask::MessageV1(MessageTask {
-                                msg_id: MessageId(format!("TestMessageID{num}")),
-                                app_id: ApplicationId("TestApplicationID".to_owned()),
-                                endpoint_id: EndpointId("TestEndpointID".to_owned()),
+                                msg_id: format!("TestMessageID{num}").into(),
+                                app_id: "TestApplicationID".into(),
+                                endpoint_id: "TestEndpointID".into(),
                                 trigger_type: MessageAttemptTriggerType::Manual,
                                 attempt_count: 0,
                             })),
@@ -1083,9 +1083,9 @@ pub mod tests {
                         to_redis_key(&TaskQueueDelivery {
                             id: num.to_string(),
                             task: Arc::new(QueueTask::MessageV1(MessageTask {
-                                msg_id: MessageId(format!("TestMessageID{num}")),
-                                app_id: ApplicationId("TestApplicationID".to_owned()),
-                                endpoint_id: EndpointId("TestEndpointID".to_owned()),
+                                msg_id: format!("TestMessageID{num}").into(),
+                                app_id: "TestApplicationID".into(),
+                                endpoint_id: "TestEndpointID".into(),
                                 trigger_type: MessageAttemptTriggerType::Manual,
                                 attempt_count: 0,
                             })),
@@ -1145,9 +1145,9 @@ pub mod tests {
             assert_eq!(
                 &*recv.task,
                 &QueueTask::MessageV1(MessageTask {
-                    msg_id: MessageId(format!("TestMessageID{num}")),
-                    app_id: ApplicationId("TestApplicationID".to_owned()),
-                    endpoint_id: EndpointId("TestEndpointID".to_owned()),
+                    msg_id: (format!("TestMessageID{num}")).into(),
+                    app_id: ("TestApplicationID").into(),
+                    endpoint_id: ("TestEndpointID").into(),
                     trigger_type: MessageAttemptTriggerType::Manual,
                     attempt_count: 0,
                 })
@@ -1159,9 +1159,9 @@ pub mod tests {
             assert_eq!(
                 &*recv.task,
                 &QueueTask::MessageV1(MessageTask {
-                    msg_id: MessageId(format!("TestMessageID{num}")),
-                    app_id: ApplicationId("TestApplicationID".to_owned()),
-                    endpoint_id: EndpointId("TestEndpointID".to_owned()),
+                    msg_id: (format!("TestMessageID{num}").into()),
+                    app_id: ("TestApplicationID".into()),
+                    endpoint_id: ("TestEndpointID".into()),
                     trigger_type: MessageAttemptTriggerType::Manual,
                     attempt_count: 0,
                 })
@@ -1173,9 +1173,9 @@ pub mod tests {
             assert_eq!(
                 &*recv.task,
                 &QueueTask::MessageV1(MessageTask {
-                    msg_id: MessageId(format!("TestMessageID{num}")),
-                    app_id: ApplicationId("TestApplicationID".to_owned()),
-                    endpoint_id: EndpointId("TestEndpointID".to_owned()),
+                    msg_id: (format!("TestMessageID{num}").into()),
+                    app_id: ("TestApplicationID".into()),
+                    endpoint_id: ("TestEndpointID".into()),
                     trigger_type: MessageAttemptTriggerType::Manual,
                     attempt_count: 0,
                 })

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
+use std::sync::Arc;
+
 use crate::{
     core::{
         permissions,
@@ -89,7 +91,7 @@ pub struct AttemptedMessageOut {
 }
 
 impl ModelOut for AttemptedMessageOut {
-    fn id_copy(&self) -> String {
+    fn id_copy(&self) -> Arc<String> {
         self.msg.id.0.clone()
     }
 }
@@ -442,7 +444,7 @@ pub struct MessageEndpointOut {
 }
 
 impl ModelOut for MessageEndpointOut {
-    fn id_copy(&self) -> String {
+    fn id_copy(&self) -> Arc<String> {
         self.id.0.clone()
     }
 }

--- a/server/svix-server/src/worker.rs
+++ b/server/svix-server/src/worker.rs
@@ -809,7 +809,7 @@ mod tests {
             &Encryption::new_noop(),
         )
         .unwrap();
-        let test_message_id = MessageId("msg_p5jXN8AQM9LWM0D4loKWxJek".to_owned());
+        let test_message_id: MessageId = "msg_p5jXN8AQM9LWM0D4loKWxJek".into();
 
         let expected_signature_str = "v1,g0hM9SsE+OTPJTGt/tmIKtSyZlE3uFJELVlNIOLJ1OE=";
 
@@ -847,7 +847,7 @@ mod tests {
             &Encryption::new_noop(),
         )
         .unwrap();
-        let msg_id = MessageId("msg_p5jXN8AQM9LWM0D4loKWxJek".to_owned());
+        let msg_id: MessageId = "msg_p5jXN8AQM9LWM0D4loKWxJek".into();
 
         let signatures = sign_msg(
             &Encryption::new_noop(),

--- a/server/svix-server/tests/e2e_application.rs
+++ b/server/svix-server/tests/e2e_application.rs
@@ -4,7 +4,7 @@
 use crate::utils::common_calls::metadata;
 use reqwest::StatusCode;
 use svix_server::{
-    cfg::CacheType, core::types::ApplicationUid, v1::endpoints::application::ApplicationIn,
+    cfg::CacheType, v1::endpoints::application::ApplicationIn,
     v1::endpoints::application::ApplicationOut,
 };
 
@@ -122,7 +122,7 @@ async fn test_patch() {
         .get::<ApplicationOut>(&format!("api/v1/app/{}/", app.id), StatusCode::OK)
         .await
         .unwrap();
-    assert_eq!(out.uid, Some(ApplicationUid("test_uid".to_owned())));
+    assert_eq!(out.uid, Some("test_uid".into()));
     // Assert that no other field was changed
     assert_eq!(out.name, "second_name".to_owned());
     assert_eq!(out.rate_limit, None);
@@ -362,7 +362,7 @@ async fn test_uid() {
             "api/v1/app/",
             ApplicationIn {
                 name: "App 1".to_owned(),
-                uid: Some(ApplicationUid("app1".to_owned())),
+                uid: Some("app1".into()),
                 ..Default::default()
             },
             StatusCode::CREATED,
@@ -378,7 +378,7 @@ async fn test_uid() {
             "api/v1/app/",
             ApplicationIn {
                 name: "App 1".to_owned(),
-                uid: Some(ApplicationUid("app1".to_owned())),
+                uid: Some("app1".into()),
                 ..Default::default()
             },
             StatusCode::CONFLICT,
@@ -404,7 +404,7 @@ async fn test_uid() {
             &format!("api/v1/app/{}/", app2.id),
             ApplicationIn {
                 name: "App 2".to_owned(),
-                uid: Some(ApplicationUid("app1".to_owned())),
+                uid: Some("app1".into()),
                 ..Default::default()
             },
             StatusCode::CONFLICT,
@@ -418,7 +418,7 @@ async fn test_uid() {
             "api/v1/app/",
             ApplicationIn {
                 name: "App 2".to_owned(),
-                uid: Some(ApplicationUid("app2".to_owned())),
+                uid: Some("app2".into()),
                 ..Default::default()
             },
             StatusCode::CREATED,
@@ -431,7 +431,7 @@ async fn test_uid() {
             &format!("api/v1/app/{}/", app2.id),
             ApplicationIn {
                 name: "App 2".to_owned(),
-                uid: Some(ApplicationUid("app1".to_owned())),
+                uid: Some("app1".into()),
                 ..Default::default()
             },
             StatusCode::CONFLICT,
@@ -451,7 +451,7 @@ async fn test_uid() {
             &format!("api/v1/app/{}/", app2.id),
             ApplicationIn {
                 name: "App 2".to_owned(),
-                uid: Some(ApplicationUid("app1".to_owned())),
+                uid: Some("app1".into()),
                 ..Default::default()
             },
             StatusCode::OK,
@@ -473,7 +473,7 @@ async fn test_uid() {
             "api/v1/app/",
             ApplicationIn {
                 name: "App 1".to_owned(),
-                uid: Some(ApplicationUid("app1".to_owned())),
+                uid: Some("app1".into()),
                 ..Default::default()
             },
             StatusCode::CREATED,
@@ -487,7 +487,7 @@ async fn test_uid() {
             &format!("api/v1/app/{}/", app.id),
             ApplicationIn {
                 name: "App 1".to_owned(),
-                uid: Some(ApplicationUid("app1".to_owned())),
+                uid: Some("app1".into()),
                 ..Default::default()
             },
             StatusCode::OK,
@@ -501,7 +501,7 @@ async fn test_uid() {
             &format!("api/v1/app/{}/", app.id),
             ApplicationIn {
                 name: "App 1".to_owned(),
-                uid: Some(ApplicationUid("app3".to_owned())),
+                uid: Some("app3".into()),
                 ..Default::default()
             },
             StatusCode::OK,
@@ -516,7 +516,7 @@ async fn test_uid() {
 
     assert_eq!(app.id, app2.id);
     assert_eq!(app.uid, app2.uid);
-    assert_eq!(app2.uid.unwrap().0, "app3");
+    assert_eq!(app2.uid.unwrap(), "app3".into());
 
     // Remove the uid
     let app: ApplicationOut = client
@@ -558,7 +558,7 @@ async fn test_uid_across_users() {
             "api/v1/app/",
             ApplicationIn {
                 name: "App 1".to_owned(),
-                uid: Some(ApplicationUid("app1".to_owned())),
+                uid: Some("app1".into()),
                 ..Default::default()
             },
             StatusCode::CREATED,
@@ -571,7 +571,7 @@ async fn test_uid_across_users() {
             "api/v1/app/",
             ApplicationIn {
                 name: "App 1".to_owned(),
-                uid: Some(ApplicationUid("app1".to_owned())),
+                uid: Some("app1".into()),
                 ..Default::default()
             },
             StatusCode::CREATED,
@@ -589,7 +589,7 @@ async fn test_get_or_create() {
             "api/v1/app/",
             ApplicationIn {
                 name: "App 1".to_owned(),
-                uid: Some(ApplicationUid("app1".to_owned())),
+                uid: Some("app1".into()),
                 metadata: metadata(
                     r#"{
                     "foo": "bar"
@@ -616,7 +616,7 @@ async fn test_get_or_create() {
             "api/v1/app/",
             ApplicationIn {
                 name: "App 1".to_owned(),
-                uid: Some(ApplicationUid("app1".to_owned())),
+                uid: Some("app1".into()),
                 ..Default::default()
             },
             StatusCode::CONFLICT,
@@ -629,7 +629,7 @@ async fn test_get_or_create() {
             "api/v1/app/?get_if_exists=true",
             ApplicationIn {
                 name: "App 1 - SLIGHTLY DIFFERENT, BUT WON'T BE PERSISTED".to_owned(),
-                uid: Some(ApplicationUid("app1".to_owned())),
+                uid: Some("app1".into()),
                 ..Default::default()
             },
             StatusCode::OK,

--- a/server/svix-server/tests/e2e_attempt.rs
+++ b/server/svix-server/tests/e2e_attempt.rs
@@ -4,7 +4,7 @@
 use reqwest::StatusCode;
 
 use svix_server::{
-    core::types::{EndpointUid, MessageStatus},
+    core::types::MessageStatus,
     v1::{
         endpoints::{
             attempt::{AttemptedMessageOut, MessageAttemptOut},
@@ -43,7 +43,7 @@ async fn test_list_attempted_messages() {
 
     // Let's have an endponit with a UID too
     let mut endp2 = endpoint_in(&receiver_2.endpoint);
-    endp2.uid = Some(EndpointUid("test".to_owned()));
+    endp2.uid = Some("test".into());
     let endp_id_2 = client
         .post::<EndpointIn, EndpointOut>(
             &format!("api/v1/app/{app_id}/endpoint/"),

--- a/server/svix-server/tests/e2e_endpoint.rs
+++ b/server/svix-server/tests/e2e_endpoint.rs
@@ -22,8 +22,8 @@ use svix_server::{
         cryptography::{AsymmetricKey, Encryption},
         types::{
             ApplicationId, EndpointHeaders, EndpointHeadersPatch, EndpointSecret,
-            EndpointSecretInternal, EndpointUid, EventChannel, EventChannelSet, EventTypeName,
-            EventTypeNameSet, ExpiringSigningKeys,
+            EndpointSecretInternal, EndpointUid, EventChannelSet, EventTypeNameSet,
+            ExpiringSigningKeys,
         },
     },
     v1::{
@@ -200,7 +200,7 @@ async fn test_patch() {
         .get::<EndpointOut>(&url, StatusCode::OK)
         .await
         .unwrap();
-    assert_eq!(out.ep.uid, Some(EndpointUid("some".to_owned())));
+    assert_eq!(out.ep.uid, Some("some".into()));
     // Assert that no other changes were made
     assert_eq!(out.ep.description, "test".to_owned());
     assert_eq!(out.ep.rate_limit, None);
@@ -351,9 +351,7 @@ async fn test_patch() {
         .unwrap();
     assert_eq!(
         out.ep.event_types_ids,
-        Some(EventTypeNameSet(HashSet::from([EventTypeName(
-            "test".to_owned()
-        )])))
+        Some(EventTypeNameSet(HashSet::from([("test".into())])))
     );
     // Assert that no other changes were made
     assert_eq!(out.ep.description, "test".to_owned());
@@ -410,9 +408,7 @@ async fn test_patch() {
         .unwrap();
     assert_eq!(
         out.ep.channels,
-        Some(EventChannelSet(HashSet::from([EventChannel(
-            "test".to_owned()
-        )])))
+        Some(EventChannelSet(HashSet::from([("test".into())])))
     );
     // Assert that no other changes were made
     assert_eq!(out.ep.description, "test".to_owned());
@@ -662,7 +658,7 @@ async fn test_uid() {
     // Double Create -- on creation, it should return an error if identical UIDs are used for
     // endpoints in the same app
     let app_id = create_test_app(&client, APP_NAME_1).await.unwrap().id;
-    let uid = EndpointUid(DUPLICATE_UID.to_owned());
+    let uid: EndpointUid = DUPLICATE_UID.into();
 
     let mut ep_1 = endpoint_in(EP_URI_APP_1_EP_1);
     ep_1.uid = Some(uid.clone());
@@ -1467,7 +1463,7 @@ async fn test_endpoint_filter_events() {
         "version": 1
     });
 
-    let expected_et = EventTypeNameSet(HashSet::from([EventTypeName("et1".to_owned())]));
+    let expected_et = EventTypeNameSet(HashSet::from([("et1".into())]));
 
     let _ep_with_empty_events: IgnoredResponse = client
         .post(
@@ -1566,7 +1562,7 @@ async fn test_endpoint_filter_channels() {
         "version": 1
     });
 
-    let expected_ec = EventChannelSet(HashSet::from([EventChannel("tag1".to_owned())]));
+    let expected_ec = EventChannelSet(HashSet::from([("tag1".into())]));
 
     let _ep_w_empty_channel: IgnoredResponse = client
         .post(
@@ -1685,12 +1681,10 @@ async fn test_msg_event_types_filter() {
     }
 
     for event_types in [
-        Some(EventTypeNameSet(HashSet::from([EventTypeName(
-            "et1".to_owned(),
-        )]))),
+        Some(EventTypeNameSet(HashSet::from([("et1".into())]))),
         Some(EventTypeNameSet(HashSet::from([
-            EventTypeName("et1".to_owned()),
-            EventTypeName("et2".to_owned()),
+            ("et1".into()),
+            ("et2".into()),
         ]))),
         None,
     ] {
@@ -1708,10 +1702,7 @@ async fn test_msg_event_types_filter() {
     }
 
     // Number of attempts should match based on event-types registered to endpoints
-    for (event_name, expected_count) in [
-        (EventTypeName("et1".to_owned()), 3),
-        (EventTypeName("et2".to_owned()), 2),
-    ] {
+    for (event_name, expected_count) in [(("et1".into()), 3), (("et2".into()), 2)] {
         let msg: MessageOut = client
             .post(
                 &format!("api/v1/app/{}/msg/", &app_id),
@@ -1744,7 +1735,7 @@ async fn test_msg_channels_filter() {
 
     let _receiver = TestReceiver::start(StatusCode::OK);
 
-    let ec = EventChannelSet(HashSet::from([EventChannel("tag1".to_owned())]));
+    let ec = EventChannelSet(HashSet::from([("tag1".into())]));
 
     for channels in [Some(ec.clone()), None] {
         let _endp = post_endpoint(
@@ -1765,7 +1756,7 @@ async fn test_msg_channels_filter() {
                 &format!("api/v1/app/{}/msg/", &app_id),
                 MessageIn {
                     channels: channels.clone(),
-                    event_type: EventTypeName("et1".to_owned()),
+                    event_type: ("et1".into()),
                     payload: serde_json::json!({}),
                     uid: None,
                     payload_retention_period: 5,

--- a/server/svix-server/tests/e2e_operational_webhooks.rs
+++ b/server/svix-server/tests/e2e_operational_webhooks.rs
@@ -143,7 +143,7 @@ async fn test_endpoint_create_update_and_delete() {
             ApplicationIn {
                 name: "TestOperationalWebhookApplication".to_owned(),
                 rate_limit: None,
-                uid: Some(ApplicationUid(org_id.to_string())),
+                uid: Some(ApplicationUid(org_id.0)),
                 metadata: Metadata::default(),
             },
             StatusCode::CREATED,
@@ -289,7 +289,7 @@ async fn test_message_attempt_operational_webhooks() {
             ApplicationIn {
                 name: "TestOperationalWebhookApplication".to_owned(),
                 rate_limit: None,
-                uid: Some(ApplicationUid(org_id.to_string())),
+                uid: Some(ApplicationUid(org_id.0)),
                 metadata: Metadata::default(),
             },
             StatusCode::CREATED,

--- a/server/svix-server/tests/queue.rs
+++ b/server/svix-server/tests/queue.rs
@@ -8,7 +8,7 @@ use std::{str::FromStr, time::Duration};
 
 use svix_server::{
     cfg::{CacheType, Configuration},
-    core::types::{ApplicationId, EndpointId, MessageAttemptTriggerType, MessageId},
+    core::types::MessageAttemptTriggerType,
     queue::{
         new_pair, MessageTask, QueueTask, TaskQueueConsumer, TaskQueueDelivery, TaskQueueProducer,
     },
@@ -59,9 +59,9 @@ async fn test_many_queue_consumers_inner(prefix: &str, delay: Option<Duration>) 
         for num in 1..=50 {
             p.send(
                 QueueTask::MessageV1(MessageTask {
-                    msg_id: MessageId(format!("{}", index * 50 + num)),
-                    app_id: ApplicationId("TestApplicationId".to_owned()),
-                    endpoint_id: EndpointId("TestEndpointId".to_owned()),
+                    msg_id: (format!("{}", index * 50 + num).into()),
+                    app_id: ("TestApplicationId".into()),
+                    endpoint_id: ("TestEndpointId".into()),
                     trigger_type: MessageAttemptTriggerType::Manual,
                     attempt_count: 0,
                 }),

--- a/server/svix-server/tests/utils/common_calls.rs
+++ b/server/svix-server/tests/utils/common_calls.rs
@@ -9,7 +9,7 @@ use reqwest::{StatusCode, Url};
 
 use serde::{de::DeserializeOwned, Serialize};
 use svix_server::{
-    core::types::{metadata::Metadata, ApplicationId, EventTypeName, MessageId},
+    core::types::{metadata::Metadata, ApplicationId, MessageId},
     v1::{
         endpoints::{
             application::{ApplicationIn, ApplicationOut},
@@ -110,7 +110,7 @@ pub async fn put_endpoint(
 
 pub fn message_in<T: Serialize>(event_type: &str, payload: T) -> Result<MessageIn> {
     Ok(MessageIn {
-        event_type: EventTypeName(event_type.to_owned()),
+        event_type: event_type.into(),
         payload: serde_json::to_value(payload)?,
         payload_retention_period: 5,
         channels: None,
@@ -137,7 +137,7 @@ pub fn event_type_in(
     schema: impl Into<Option<serde_json::Value>>,
 ) -> Result<EventTypeIn> {
     Ok(EventTypeIn {
-        name: EventTypeName(name.to_owned()),
+        name: name.into(),
         description: "test-event-description".to_owned(),
         deleted: false,
         schemas: schema.into().map(|s| serde_json::from_value(s).unwrap()),

--- a/server/svix-server_derive/src/lib.rs
+++ b/server/svix-server_derive/src/lib.rs
@@ -43,7 +43,7 @@ pub fn derive_model_out(input: proc_macro::TokenStream) -> proc_macro::TokenStre
         // We want to use name as the id in this case
         quote! {
             impl #impl_generics crate::v1::utils::ModelOut for #name #ty_generics #where_clause {
-                fn id_copy(&self) -> String {
+                fn id_copy(&self) -> std::sync::Arc<String> {
                     self.name.0.clone()
                 }
             }
@@ -51,7 +51,7 @@ pub fn derive_model_out(input: proc_macro::TokenStream) -> proc_macro::TokenStre
     } else {
         quote! {
             impl #impl_generics crate::v1::utils::ModelOut for #name #ty_generics #where_clause {
-                fn id_copy(&self) -> String {
+                fn id_copy(&self) -> std::sync::Arc<String> {
                     self.id.0.clone()
                 }
             }


### PR DESCRIPTION
This PR updates `string_wrapper!` to `Arc` values internally.

## Motivation

The `string_wrapper!` is used to define different ID types, and some other types that under the hood are just regular strings.

We also `.clone()` `string_wrapper!` types a lot - particularly IDs. This is often because of sea_orm, which requires owned `String` types internally when inserting/updating things in the DB. But in other places it happens from pure convenience.

IDs are pretty small, but the frequent `.clone()`ing is still less than ideal, since it forces new heap allocations all the time.

## Solution

Wrapping Strings in `Arc` makes cloning these types much cheaper. Since we don't ever really mutate these strings once created, it's an easy optimization to add.

Strings will still get cloned when being inserted into the DB - but the at least with Arc, there's an optimization that only clones the underlying String if there's more than one reference.

In addition, all the places that clone IDs for convenience (such as worker) should make much fewer heap allocations now.

Finally, the `string_wrapper!` macro got moved to it's own file. This is partly because `types::mod` is too big, in my opinion. But the distinct module for string_wrapper! also forces better macro practices, since we have to fully qualify the types used in the macro call.