### PR TITLE
Integrate aide for automatic OpenAPI generation

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -51,6 +51,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "aide"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befdff0b4683a0824fc8719ce639a252d9d62cd89c8d0004c39e2417128c1eb8"
+dependencies = [
+ "aide-macros",
+ "axum",
+ "bytes",
+ "cfg-if",
+ "http",
+ "indexmap",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "aide-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae9102630967c9c07c40a3383cd1e6b043bdd203793731ad39eac7f7dce0d4c"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +719,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +830,12 @@ name = "dotenvy"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03d8c417d7a8cb362e0c37e5d815f5eb7c37f79ff93707329d5a194e42e54ca0"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
 
 [[package]]
 name = "ecdsa"
@@ -1374,6 +1448,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,6 +1488,7 @@ checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg 1.1.0",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -2642,6 +2723,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a5fb6c61f29e723026dc8e923d94c694313212abbecbbe5f55a7748eec5b307"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "indexmap",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f188d036977451159430f3b8dc82ec76364a42b7e289c2b18a9a18f4470058e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2810,6 +2918,17 @@ name = "serde_derive"
 version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3138,6 +3257,7 @@ dependencies = [
 name = "svix-server"
 version = "0.74.1"
 dependencies = [
+ "aide",
  "anyhow",
  "axum",
  "base64",
@@ -3156,6 +3276,7 @@ dependencies = [
  "hmac-sha256",
  "http",
  "hyper",
+ "indexmap",
  "jsonschema",
  "jwt-simple",
  "lazy_static",
@@ -3168,6 +3289,7 @@ dependencies = [
  "redis_cluster_async",
  "regex",
  "reqwest",
+ "schemars",
  "sea-orm",
  "serde",
  "serde_json",

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -63,6 +63,9 @@ redis_cluster_async = { git = "https://github.com/redis-rs/redis-cluster-async.g
 url = { version = "2.2.2", features = ["serde"] }
 rand = "0.8.5"
 jsonschema = "0.16.1"
+aide = { version = "0.9.0", features = ["axum", "redoc", "macros"] }
+schemars = { version = "0.8.11", features = ["chrono", "url"] }
+indexmap = "1.9.2"
 
 [dev-dependencies]
 anyhow = "1.0.56"

--- a/server/svix-server/src/core/permissions.rs
+++ b/server/svix-server/src/core/permissions.rs
@@ -1,3 +1,4 @@
+use aide::OperationInput;
 use axum::{
     async_trait,
     extract::{FromRequestParts, Path},
@@ -31,9 +32,13 @@ impl FromRequestParts<AppState> for ReadAll {
     }
 }
 
+impl OperationInput for ReadAll {}
+
 pub struct Organization {
     pub org_id: OrganizationId,
 }
+
+impl OperationInput for Organization {}
 
 impl Permissions {
     fn check_app_is_permitted(&self, app_id: &ApplicationId) -> Result<()> {
@@ -88,10 +93,14 @@ impl FromRequestParts<AppState> for Application {
     }
 }
 
+impl OperationInput for Application {}
+
 // Organization level privileges, with the requested application
 pub struct OrganizationWithApplication {
     pub app: application::Model,
 }
+
+impl OperationInput for OrganizationWithApplication {}
 
 #[async_trait]
 impl FromRequestParts<AppState> for OrganizationWithApplication {
@@ -116,6 +125,8 @@ pub struct ApplicationWithMetadata {
     pub app: application::Model,
     pub metadata: applicationmetadata::Model,
 }
+
+impl OperationInput for ApplicationWithMetadata {}
 
 #[async_trait]
 impl FromRequestParts<AppState> for ApplicationWithMetadata {

--- a/server/svix-server/src/core/types/metadata.rs
+++ b/server/svix-server/src/core/types/metadata.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 
 use crate::json_wrapper;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 pub const MAX_METADATA_SIZE: usize = 4096;
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Default, JsonSchema)]
 pub struct Metadata(HashMap<String, String>);
 
 json_wrapper!(Metadata);

--- a/server/svix-server/src/db/models/eventtype.rs
+++ b/server/svix-server/src/db/models/eventtype.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use chrono::Utc;
 use jsonschema::{Draft, JSONSchema};
+use schemars::JsonSchema;
 use sea_orm::entity::prelude::*;
 use sea_orm::ActiveValue::Set;
 use serde::{Deserialize, Serialize};
@@ -64,7 +65,7 @@ impl Entity {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Default, JsonSchema)]
 pub struct Schema(HashMap<String, Json>);
 json_wrapper!(Schema);
 

--- a/server/svix-server/src/error.rs
+++ b/server/svix-server/src/error.rs
@@ -4,6 +4,7 @@
 use std::error;
 use std::fmt;
 
+use aide::OperationOutput;
 use axum::extract::rejection::ExtensionRejection;
 use axum::extract::rejection::PathRejection;
 use axum::extract::rejection::TypedHeaderRejection;
@@ -14,6 +15,7 @@ use axum::response::Response;
 use axum::Json;
 use axum::TypedHeader;
 use hyper::StatusCode;
+use schemars::JsonSchema;
 use sea_orm::DbErr;
 use sea_orm::RuntimeErr;
 use sea_orm::TransactionError;
@@ -107,6 +109,10 @@ impl IntoResponse for Error {
             }
         }
     }
+}
+
+impl OperationOutput for Error {
+    type Inner = Self;
 }
 
 /// Returns a [&'static str] of the file.rs:<line_number>.
@@ -293,7 +299,7 @@ pub enum HttpErrorBody {
     Validation { detail: Vec<ValidationErrorItem> },
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, JsonSchema)]
 /// Validation errors have their own schema to provide context for invalid requests eg. mismatched
 /// types and out of bounds values. There may be any number of these per 422 UNPROCESSABLE ENTITY
 /// error.

--- a/server/svix-server/src/v1/endpoints/auth.rs
+++ b/server/svix-server/src/v1/endpoints/auth.rs
@@ -1,14 +1,16 @@
-use axum::{extract::State, routing::post, Json, Router};
+use aide::axum::{routing::post, ApiRouter};
+use axum::{extract::State, Json};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     core::{permissions, security::generate_app_token},
     error::{HttpError, Result},
-    v1::utils::api_not_implemented,
+    v1::utils::{api_not_implemented, openapi_tag},
     AppState,
 };
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, JsonSchema)]
 pub struct DashboardAccessOut {
     pub url: String,
     pub token: String,
@@ -35,8 +37,16 @@ async fn dashboard_access(
     Ok(Json(DashboardAccessOut { url, token }))
 }
 
-pub fn router() -> Router<AppState> {
-    Router::new()
-        .route("/auth/dashboard-access/:app_id/", post(dashboard_access))
-        .route("/auth/logout/", post(api_not_implemented))
+pub fn router() -> ApiRouter<AppState> {
+    ApiRouter::new()
+        .api_route_with(
+            "/auth/dashboard-access/:app_id/",
+            post(dashboard_access),
+            openapi_tag("Authentication"),
+        )
+        .api_route_with(
+            "/auth/logout/",
+            post(api_not_implemented),
+            openapi_tag("Authentication"),
+        )
 }

--- a/server/svix-server/src/v1/endpoints/health.rs
+++ b/server/svix-server/src/v1/endpoints/health.rs
@@ -3,7 +3,8 @@
 
 use std::time::Duration;
 
-use axum::{extract::State, http::StatusCode, routing::get, Json, Router};
+use aide::axum::ApiRouter;
+use axum::{extract::State, http::StatusCode, routing::get, Json};
 use sea_orm::{query::Statement, ConnectionTrait, DatabaseBackend};
 use serde::{Deserialize, Serialize};
 
@@ -121,8 +122,8 @@ async fn health(
     )
 }
 
-pub fn router() -> Router<AppState> {
-    Router::new()
+pub fn router() -> ApiRouter<AppState> {
+    ApiRouter::new()
         .route("/health/ping/", get(ping).head(ping))
         .route("/health/", get(health).head(health))
 }

--- a/server/svix-server/src/v1/mod.rs
+++ b/server/svix-server/src/v1/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
-use axum::Router;
+use aide::axum::ApiRouter;
 use tower_http::trace::TraceLayer;
 
 use crate::{
@@ -12,8 +12,8 @@ use crate::{
 pub mod endpoints;
 pub mod utils;
 
-pub fn router() -> Router<AppState> {
-    let ret: Router<AppState> = Router::new()
+pub fn router() -> ApiRouter<AppState> {
+    let ret: ApiRouter<AppState> = ApiRouter::new()
         .merge(endpoints::health::router())
         .merge(endpoints::auth::router())
         .merge(endpoints::application::router())
@@ -30,7 +30,8 @@ pub fn router() -> Router<AppState> {
 
     #[cfg(debug_assertions)]
     if cfg!(debug_assertions) {
-        return ret.merge(development::router());
+        let dev_router: ApiRouter<AppState> = development::router().into();
+        return ret.merge(dev_router);
     }
     ret
 }

--- a/server/svix-server/src/v1/utils/patch.rs
+++ b/server/svix-server/src/v1/utils/patch.rs
@@ -3,6 +3,7 @@
 
 //! Module defining utilites for PATCH requests focused mostly around non-required field types.
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
@@ -177,6 +178,34 @@ where
             )),
             UnrequiredField::Some(v) => v.serialize(serializer),
         }
+    }
+}
+
+impl<T: JsonSchema> JsonSchema for UnrequiredField<T> {
+    fn is_referenceable() -> bool {
+        false
+    }
+
+    fn schema_name() -> String {
+        format!("Unrequired_{}", T::schema_name())
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        Option::<T>::json_schema(gen)
+    }
+}
+
+impl<T: JsonSchema> JsonSchema for UnrequiredNullableField<T> {
+    fn is_referenceable() -> bool {
+        false
+    }
+
+    fn schema_name() -> String {
+        format!("UnrequiredNullable_{}", T::schema_name())
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        Option::<T>::json_schema(gen)
     }
 }
 


### PR DESCRIPTION
Aide is a library that automatically generates an OpenAPI schema by integrating with axum, extracting API information based on axum routing and extractors.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Replace the currently static OpenAPI definition with an automatically generated one, based on code. Among other benefits, it's useful to ensure we don't make breaking changes to the API by accident.

## Solution
`aide` was chosen as it is lightweight and has the most features out of the box for us. Alternatives considered:
* [`utoipa`](https://github.com/juhaku/utoipa) - integrates with axum like aide but relies heavily on code generation with a lot of annotations that aide is able to derive automatically out of the box
* [`okapi`](https://github.com/GREsau/okapi) - does not integrate with axum out of the box

While aide is newer and perhaps less mature it has fewer dependencies. Nearly all of its direct dependencies are crates we already include other than `schemars`, and `dyn-clone` for aide-macros, the latter being optional. `cargo audit` reports no known vulnerabilities in its dependency tree that we don't already depend on (`time=0.1.45`) otherwise.