### PR TITLE
Add feature flag gating to event types

### DIFF
--- a/server/svix-server/migrations/20230116095641_add_event_type_feature_flags.down.sql
+++ b/server/svix-server/migrations/20230116095641_add_event_type_feature_flags.down.sql
@@ -1,0 +1,2 @@
+-- Add down migration script here
+ALTER TABLE ONLY eventtype DROP COLUMN feature_flag;

--- a/server/svix-server/migrations/20230116095641_add_event_type_feature_flags.up.sql
+++ b/server/svix-server/migrations/20230116095641_add_event_type_feature_flags.up.sql
@@ -1,0 +1,2 @@
+-- Add up migration script here
+ALTER TABLE ONLY eventtype ADD COLUMN feature_flag text;

--- a/server/svix-server/src/core/types/mod.rs
+++ b/server/svix-server/src/core/types/mod.rs
@@ -248,6 +248,12 @@ macro_rules! string_wrapper {
         #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
         pub struct $name_id(pub String);
 
+        string_wrapper_impl!($name_id);
+    };
+}
+
+macro_rules! string_wrapper_impl {
+    ($name_id:ident) => {
         impl Deref for $name_id {
             type Target = String;
 
@@ -1039,6 +1045,25 @@ pub enum StatusCodeClass {
 enum_wrapper!(MessageAttemptTriggerType);
 enum_wrapper!(MessageStatus);
 enum_wrapper!(StatusCodeClass);
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, JsonSchema)]
+pub struct FeatureFlag(pub String);
+
+string_wrapper_impl!(FeatureFlag);
+
+impl<'de> Deserialize<'de> for FeatureFlag {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        String::deserialize(deserializer).and_then(|s| {
+            validate_limited_str(&s).map_err(serde::de::Error::custom)?;
+            Ok(FeatureFlag(s))
+        })
+    }
+}
+
+pub type FeatureFlagSet = HashSet<FeatureFlag>;
 
 #[cfg(test)]
 mod tests {

--- a/server/svix-server/src/db/models/eventtype.rs
+++ b/server/svix-server/src/db/models/eventtype.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 
 use crate::{
-    core::types::{BaseId, EventTypeId, EventTypeName, OrganizationId},
+    core::types::{BaseId, EventTypeId, EventTypeName, FeatureFlag, OrganizationId},
     json_wrapper,
 };
 use chrono::Utc;
@@ -26,6 +26,7 @@ pub struct Model {
     pub deleted: bool,
     pub schemas: Option<Schema>,
     pub name: EventTypeName,
+    pub feature_flag: Option<FeatureFlag>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter)]

--- a/server/svix-server/tests/e2e_auth.rs
+++ b/server/svix-server/tests/e2e_auth.rs
@@ -4,31 +4,13 @@
 
 use reqwest::StatusCode;
 
-use svix_server::{
-    core::types::ApplicationId,
-    v1::endpoints::{application::ApplicationOut, auth::DashboardAccessOut},
-};
+use svix_server::{core::types::ApplicationId, v1::endpoints::application::ApplicationOut};
 
 mod utils;
-use utils::{common_calls::application_in, start_svix_server, IgnoredResponse, TestClient};
-
-/// Accesses the dashboard-access endpoint and returns a new [`TestClient`] with an auth header set
-/// to the returned token.
-async fn dashboard_access(org_client: &TestClient, application_id: &ApplicationId) -> TestClient {
-    let resp: DashboardAccessOut = org_client
-        .post(
-            &format!("api/v1/auth/dashboard-access/{application_id}/"),
-            (),
-            StatusCode::OK,
-        )
-        .await
-        .unwrap();
-
-    let mut app_client = org_client.clone();
-    app_client.set_auth_header(resp.token);
-
-    app_client
-}
+use utils::{
+    common_calls::{application_in, dashboard_access},
+    start_svix_server, IgnoredResponse,
+};
 
 #[tokio::test]
 /// Users with application-level tokens should only be allowed to read the information related to
@@ -55,7 +37,7 @@ async fn test_restricted_application_access() {
         .unwrap()
         .id;
 
-    let client = dashboard_access(&client, &app_id).await;
+    let client = dashboard_access(&client, &app_id, Default::default()).await;
 
     // CREATE, UPDATE, DELETE, and LIST ops
     let _: IgnoredResponse = client

--- a/server/svix-server/tests/e2e_event_type.rs
+++ b/server/svix-server/tests/e2e_event_type.rs
@@ -1,12 +1,18 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
+use std::collections::HashSet;
+
 use reqwest::StatusCode;
 
 use svix_server::{
+    core::types::{ApplicationId, EventTypeName, FeatureFlag, FeatureFlagSet},
     db::models::eventtype::Schema,
     v1::{
-        endpoints::event_type::{EventTypeIn, EventTypeOut},
+        endpoints::{
+            application::ApplicationOut,
+            event_type::{EventTypeIn, EventTypeOut},
+        },
         utils::ListResponse,
     },
 };
@@ -14,8 +20,8 @@ use svix_server::{
 mod utils;
 
 use utils::{
-    common_calls::{common_test_list, event_type_in},
-    start_svix_server,
+    common_calls::{application_in, common_test_list, dashboard_access, event_type_in},
+    start_svix_server, IgnoredResponse,
 };
 
 #[tokio::test]
@@ -189,6 +195,93 @@ async fn test_event_type_create_read_list() {
         schemas: None,
         ..et
     }));
+}
+
+#[tokio::test]
+async fn test_event_type_feature_flags() {
+    let (client, _jh) = start_svix_server().await;
+
+    let feature = FeatureFlag("foo-feature".into());
+    let another_feature = FeatureFlag("bar-feature".into());
+    let (features, other_features, union) = {
+        let mut s1 = HashSet::new();
+        s1.insert(feature.clone());
+        let mut s2 = HashSet::new();
+        s2.insert(another_feature);
+        let union: FeatureFlagSet = s1.union(&s2).cloned().collect();
+
+        (s1, s2, union)
+    };
+
+    let et: EventTypeOut = client
+        .post(
+            "api/v1/event-type/",
+            EventTypeIn {
+                name: EventTypeName("foo-event".to_owned()),
+                description: "test-event-description".to_owned(),
+                deleted: false,
+                schemas: None,
+                feature_flag: Some(feature),
+            },
+            StatusCode::CREATED,
+        )
+        .await
+        .unwrap();
+
+    let app: ApplicationId = client
+        .post::<_, ApplicationOut>(
+            "api/v1/app/",
+            application_in("TEST_APP_NAME"),
+            StatusCode::CREATED,
+        )
+        .await
+        .unwrap()
+        .id;
+
+    // Client with no feature flags set
+    let client1 = dashboard_access(&client, &app, FeatureFlagSet::default()).await;
+    // Client with a different set of feature flags than needed
+    let client2 = dashboard_access(&client, &app, other_features).await;
+    // Client with the right flag, plus extras
+    let client3 = dashboard_access(&client, &app, union.clone()).await;
+    // Client with only the right flag
+    let client4 = dashboard_access(&client, &app, features.clone()).await;
+
+    // Clients which don't have the right flag shouldn't see it
+    let list: ListResponse<EventTypeOut> = client1
+        .get("api/v1/event-type/", StatusCode::OK)
+        .await
+        .unwrap();
+    assert_eq!(list.data.len(), 0);
+    let path = format!("api/v1/event-type/{}/", et.name);
+    let _: IgnoredResponse = client1.get(&path, StatusCode::NOT_FOUND).await.unwrap();
+
+    let list: ListResponse<EventTypeOut> = client2
+        .get("api/v1/event-type/", StatusCode::OK)
+        .await
+        .unwrap();
+    assert_eq!(list.data.len(), 0);
+    let path = format!("api/v1/event-type/{}/", et.name);
+    let _: IgnoredResponse = client2.get(&path, StatusCode::NOT_FOUND).await.unwrap();
+
+    // Clients with the right flags set should see the event type
+    let list: ListResponse<EventTypeOut> = client3
+        .get("api/v1/event-type/", StatusCode::OK)
+        .await
+        .unwrap();
+    assert_eq!(list.data.len(), 1);
+    assert!(list.data.contains(&et));
+    let got_et: EventTypeOut = client3.get(&path, StatusCode::OK).await.unwrap();
+    assert_eq!(et, got_et);
+
+    let list: ListResponse<EventTypeOut> = client4
+        .get("api/v1/event-type/", StatusCode::OK)
+        .await
+        .unwrap();
+    assert_eq!(list.data.len(), 1);
+    assert!(list.data.contains(&et));
+    let got_et: EventTypeOut = client3.get(&path, StatusCode::OK).await.unwrap();
+    assert_eq!(et, got_et);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Motivation

Organizations might want to introduce new event types without first exposing them to their users. These changes allow adding an optional `feature_flag` to event types. If an event type has a feature flag set then only application tokens which have the corresponding feature flag set can see the event type. This does *not* filter receiving these events on endpoints though.

## Solution

Event types can now be gated behind a feature flag field. If an event type has a featue flag set then it won't be returned to application access clients that don't have the appropriate event type feature flag claim set in their token.

Organization access tokens can always see all event types.
