### PR TITLE
Rust: Enable `reqwest` default-tls

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,4 +25,5 @@ serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"
 url = "^2.2"
-reqwest = { version = "^0.11", features = ["json", "multipart"], default-features = false }
+reqwest = { version = "^0.11", features = ["json", "multipart", "default-tls"], default-features = false }
+


### PR DESCRIPTION
Ensure that Rust Svix Client can properly
connect to https endpoints out of the box
by enabling `default-tls` feature in `reqwest`.