### PR TITLE
Server: improve startup logs to indicate status

### DIFF
--- a/server/svix-server/src/db/mod.rs
+++ b/server/svix-server/src/db/mod.rs
@@ -15,7 +15,6 @@ use models::{application, endpoint, eventtype, message, messageattempt, messaged
 static MIGRATIONS: sqlx::migrate::Migrator = sqlx::migrate!();
 
 async fn connect(dsn: &str, max_pool_size: u16) -> sqlx::Pool<sqlx::Postgres> {
-    tracing::debug!("DB: Initializing pool");
     if DbBackend::Postgres.is_prefix_of(dsn) {
         PgPoolOptions::new()
             .max_connections(max_pool_size.into())

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -124,8 +124,9 @@ async fn main() {
     }
 
     if args.run_migrations {
+        tracing::debug!("Migrations: Running");
         db::run_migrations(&cfg).await;
-        tracing::debug!("Migrations: success");
+        tracing::debug!("Migrations: Success");
     }
 
     match args.command {


### PR DESCRIPTION
We were only logging about initialization starting, and never about the success status. This meant that it wasn't very clear for someone reviewing the logs what is going on exactly.

We've cleaned up the logs to be more consistent, and print for both start of an operation and the end (success).

Reason for the change: this just confused a customer (and me!) when we were trying to figure out what's going on. The issue was with the server not connecting to redis, but it wasn't obvious from the logs.
