### PR TITLE
Add new endpoint for app portal access with a body

### DIFF
--- a/server/svix-server/tests/e2e_event_type.rs
+++ b/server/svix-server/tests/e2e_event_type.rs
@@ -20,7 +20,7 @@ use svix_server::{
 mod utils;
 
 use utils::{
-    common_calls::{application_in, common_test_list, dashboard_access, event_type_in},
+    common_calls::{app_portal_access, application_in, common_test_list, event_type_in},
     start_svix_server, IgnoredResponse,
 };
 
@@ -239,13 +239,13 @@ async fn test_event_type_feature_flags() {
         .id;
 
     // Client with no feature flags set
-    let client1 = dashboard_access(&client, &app, FeatureFlagSet::default()).await;
+    let client1 = app_portal_access(&client, &app, FeatureFlagSet::default()).await;
     // Client with a different set of feature flags than needed
-    let client2 = dashboard_access(&client, &app, other_features).await;
+    let client2 = app_portal_access(&client, &app, other_features).await;
     // Client with the right flag, plus extras
-    let client3 = dashboard_access(&client, &app, union.clone()).await;
+    let client3 = app_portal_access(&client, &app, union.clone()).await;
     // Client with only the right flag
-    let client4 = dashboard_access(&client, &app, features.clone()).await;
+    let client4 = app_portal_access(&client, &app, features.clone()).await;
 
     // Clients which don't have the right flag shouldn't see it
     let list: ListResponse<EventTypeOut> = client1

--- a/server/svix-server/tests/utils/common_calls.rs
+++ b/server/svix-server/tests/utils/common_calls.rs
@@ -15,7 +15,7 @@ use svix_server::{
         endpoints::{
             application::{ApplicationIn, ApplicationOut},
             attempt::MessageAttemptOut,
-            auth::DashboardAccessIn,
+            auth::AppPortalAccessIn,
             endpoint::{EndpointIn, EndpointOut, RecoverIn},
             event_type::EventTypeIn,
             message::{MessageIn, MessageOut},
@@ -314,15 +314,15 @@ pub fn metadata(s: &str) -> Metadata {
 
 /// Accesses the dashboard-access endpoint and returns a new [`TestClient`] with an auth header set
 /// to the returned token.
-pub async fn dashboard_access(
+pub async fn app_portal_access(
     org_client: &TestClient,
     application_id: &ApplicationId,
     feature_flags: FeatureFlagSet,
 ) -> TestClient {
     let resp: DashboardAccessOut = org_client
         .post(
-            &format!("api/v1/auth/dashboard-access/{application_id}/"),
-            DashboardAccessIn { feature_flags },
+            &format!("api/v1/auth/app-portal-access/{application_id}/"),
+            AppPortalAccessIn { feature_flags },
             StatusCode::OK,
         )
         .await


### PR DESCRIPTION
## Motivation
PR #765 added support for attaching feature flags to auth tokens. A request body requirement was added to the dashboard access endpoint, but this makes it incompatible with existing client libraries because they do not send a request body.

## Solution
This change essentially revets that by changing `/dashboard-access/` back to its old behaviour of not accepting a body, and adds a new endpoint, `/app-portal-access/`, which does.