### PR TITLE
Make request body to dashboard-access optional again

### DIFF
--- a/server/svix-server/src/v1/endpoints/auth.rs
+++ b/server/svix-server/src/v1/endpoints/auth.rs
@@ -27,14 +27,10 @@ pub struct DashboardAccessIn {
 async fn dashboard_access(
     State(AppState { cfg, .. }): State<AppState>,
     permissions::OrganizationWithApplication { app }: permissions::OrganizationWithApplication,
-    ValidatedJson(data): ValidatedJson<DashboardAccessIn>,
+    data: Option<ValidatedJson<DashboardAccessIn>>,
 ) -> Result<Json<DashboardAccessOut>> {
-    let token = generate_app_token(
-        &cfg.jwt_secret,
-        app.org_id,
-        app.id.clone(),
-        data.feature_flags,
-    )?;
+    let feature_flags = data.map(|data| data.0.feature_flags).unwrap_or_default();
+    let token = generate_app_token(&cfg.jwt_secret, app.org_id, app.id.clone(), feature_flags)?;
 
     let login_key = serde_json::to_vec(&serde_json::json!({
         "appId": app.id,

--- a/server/svix-server/tests/e2e_auth.rs
+++ b/server/svix-server/tests/e2e_auth.rs
@@ -75,3 +75,28 @@ async fn test_restricted_application_access() {
         .await
         .unwrap();
 }
+
+#[tokio::test]
+async fn test_dashboard_access_without_body() {
+    let (client, _jh) = start_svix_server().await;
+
+    let app_id: ApplicationId = client
+        .post::<_, ApplicationOut>(
+            "api/v1/app/",
+            application_in("TEST_APP_NAME"),
+            StatusCode::CREATED,
+        )
+        .await
+        .unwrap()
+        .id;
+
+    // We just need to ensure we get an OK response without a body.
+    let _: IgnoredResponse = client
+        .post(
+            &format!("api/v1/auth/dashboard-access/{app_id}/"),
+            (),
+            StatusCode::OK,
+        )
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
## Motivation
PR #765 added support for attaching feature flags to auth tokens. This added a request body requirement to the dashboard access endpoint which is a backwards-incompatible change for old client libraries. 

## Solution
Change it back so that a body is optional, keeping backwards compatibility.