### PR TITLE
Add new endpoint for app portal access

### DIFF
--- a/server/svix-server/src/v1/endpoints/auth.rs
+++ b/server/svix-server/src/v1/endpoints/auth.rs
@@ -18,19 +18,25 @@ pub struct DashboardAccessOut {
 }
 
 #[derive(Deserialize, Serialize, Validate, JsonSchema)]
-pub struct DashboardAccessIn {
+pub struct AppPortalAccessIn {
     /// The set of feature flags the created token will have access to.
     #[serde(default, skip_serializing_if = "FeatureFlagSet::is_empty")]
     pub feature_flags: FeatureFlagSet,
 }
 
-async fn dashboard_access(
+pub type AppPortalAccessOut = DashboardAccessOut;
+
+async fn app_portal_access(
     State(AppState { cfg, .. }): State<AppState>,
     permissions::OrganizationWithApplication { app }: permissions::OrganizationWithApplication,
-    data: Option<ValidatedJson<DashboardAccessIn>>,
-) -> Result<Json<DashboardAccessOut>> {
-    let feature_flags = data.map(|data| data.0.feature_flags).unwrap_or_default();
-    let token = generate_app_token(&cfg.jwt_secret, app.org_id, app.id.clone(), feature_flags)?;
+    ValidatedJson(data): ValidatedJson<AppPortalAccessIn>,
+) -> Result<Json<AppPortalAccessOut>> {
+    let token = generate_app_token(
+        &cfg.jwt_secret,
+        app.org_id,
+        app.id.clone(),
+        data.feature_flags,
+    )?;
 
     let login_key = serde_json::to_vec(&serde_json::json!({
         "appId": app.id,
@@ -47,6 +53,20 @@ async fn dashboard_access(
     Ok(Json(DashboardAccessOut { url, token }))
 }
 
+async fn dashboard_access(
+    state: State<AppState>,
+    permissions: permissions::OrganizationWithApplication,
+) -> Result<Json<DashboardAccessOut>> {
+    app_portal_access(
+        state,
+        permissions,
+        ValidatedJson(AppPortalAccessIn {
+            feature_flags: FeatureFlagSet::default(),
+        }),
+    )
+    .await
+}
+
 pub fn router() -> ApiRouter<AppState> {
     ApiRouter::new()
         .api_route_with(
@@ -57,6 +77,11 @@ pub fn router() -> ApiRouter<AppState> {
         .api_route_with(
             "/auth/logout/",
             post(api_not_implemented),
+            openapi_tag("Authentication"),
+        )
+        .api_route_with(
+            "/auth/app-portal-access/:app_id/",
+            post(app_portal_access),
             openapi_tag("Authentication"),
         )
 }

--- a/server/svix-server/tests/e2e_auth.rs
+++ b/server/svix-server/tests/e2e_auth.rs
@@ -8,7 +8,7 @@ use svix_server::{core::types::ApplicationId, v1::endpoints::application::Applic
 
 mod utils;
 use utils::{
-    common_calls::{application_in, dashboard_access},
+    common_calls::{app_portal_access, application_in},
     start_svix_server, IgnoredResponse,
 };
 
@@ -37,7 +37,7 @@ async fn test_restricted_application_access() {
         .unwrap()
         .id;
 
-    let client = dashboard_access(&client, &app_id, Default::default()).await;
+    let client = app_portal_access(&client, &app_id, Default::default()).await;
 
     // CREATE, UPDATE, DELETE, and LIST ops
     let _: IgnoredResponse = client

--- a/server/svix-server/tests/e2e_event_type.rs
+++ b/server/svix-server/tests/e2e_event_type.rs
@@ -20,7 +20,7 @@ use svix_server::{
 mod utils;
 
 use utils::{
-    common_calls::{application_in, common_test_list, dashboard_access, event_type_in},
+    common_calls::{app_portal_access, application_in, common_test_list, event_type_in},
     start_svix_server, IgnoredResponse,
 };
 
@@ -239,13 +239,13 @@ async fn test_event_type_feature_flags() {
         .id;
 
     // Client with no feature flags set
-    let client1 = dashboard_access(&client, &app, FeatureFlagSet::default()).await;
+    let client1 = app_portal_access(&client, &app, FeatureFlagSet::default()).await;
     // Client with a different set of feature flags than needed
-    let client2 = dashboard_access(&client, &app, other_features).await;
+    let client2 = app_portal_access(&client, &app, other_features).await;
     // Client with the right flag, plus extras
-    let client3 = dashboard_access(&client, &app, union.clone()).await;
+    let client3 = app_portal_access(&client, &app, union.clone()).await;
     // Client with only the right flag
-    let client4 = dashboard_access(&client, &app, features.clone()).await;
+    let client4 = app_portal_access(&client, &app, features.clone()).await;
 
     // Clients which don't have the right flag shouldn't see it
     let list: ListResponse<EventTypeOut> = client1

--- a/server/svix-server/tests/utils/common_calls.rs
+++ b/server/svix-server/tests/utils/common_calls.rs
@@ -15,7 +15,7 @@ use svix_server::{
         endpoints::{
             application::{ApplicationIn, ApplicationOut},
             attempt::MessageAttemptOut,
-            auth::DashboardAccessIn,
+            auth::AppPortalAccessIn,
             endpoint::{EndpointIn, EndpointOut, RecoverIn},
             event_type::EventTypeIn,
             message::{MessageIn, MessageOut},
@@ -312,17 +312,17 @@ pub fn metadata(s: &str) -> Metadata {
     serde_json::from_str::<Metadata>(s).unwrap()
 }
 
-/// Accesses the dashboard-access endpoint and returns a new [`TestClient`] with an auth header set
+/// Accesses the app-portal-access endpoint and returns a new [`TestClient`] with an auth header set
 /// to the returned token.
-pub async fn dashboard_access(
+pub async fn app_portal_access(
     org_client: &TestClient,
     application_id: &ApplicationId,
     feature_flags: FeatureFlagSet,
 ) -> TestClient {
     let resp: DashboardAccessOut = org_client
         .post(
-            &format!("api/v1/auth/dashboard-access/{application_id}/"),
-            DashboardAccessIn { feature_flags },
+            &format!("api/v1/auth/app-portal-access/{application_id}/"),
+            AppPortalAccessIn { feature_flags },
             StatusCode::OK,
         )
         .await


### PR DESCRIPTION
## Motivation
2 reasons for this endpoint:
* Better naming than current "dashboard access"
* This one requires a body, even if it's just an empty JSON object with no keys. This way we can add body parameters later without breaking existing clients.

## Solution
Functionally the same as the existing `/dashboard-access/` endpoint but we require a request body on this endpoint.
