### PR TITLE
Fix event type filtering involving feature flags

### DIFF
--- a/server/svix-server/src/db/models/eventtype.rs
+++ b/server/svix-server/src/db/models/eventtype.rs
@@ -4,7 +4,9 @@
 use std::collections::HashMap;
 
 use crate::{
-    core::types::{BaseId, EventTypeId, EventTypeName, FeatureFlag, OrganizationId},
+    core::types::{
+        BaseId, EventTypeId, EventTypeName, FeatureFlag, FeatureFlagSet, OrganizationId,
+    },
     json_wrapper,
 };
 use chrono::Utc;
@@ -63,6 +65,14 @@ impl Entity {
 
     pub fn secure_find_by_name(org_id: OrganizationId, name: EventTypeName) -> Select<Entity> {
         Self::secure_find(org_id).filter(Column::Name.eq(name))
+    }
+
+    pub fn filter_feature_flags(query: Select<Self>, flags: FeatureFlagSet) -> Select<Self> {
+        query.filter(
+            sea_orm::Condition::any()
+                .add(Column::FeatureFlag.is_in(flags.into_iter()))
+                .add(Column::FeatureFlag.is_null()),
+        )
     }
 }
 

--- a/server/svix-server/src/v1/endpoints/event_type.rs
+++ b/server/svix-server/src/v1/endpoints/event_type.rs
@@ -215,7 +215,7 @@ async fn list_event_types(
     }
 
     if let permissions::AllowedFeatureFlags::Some(flags) = feature_flags {
-        query = query.filter(eventtype::Column::FeatureFlag.is_in(flags.into_iter()));
+        query = eventtype::Entity::filter_feature_flags(query, flags);
     }
 
     Ok(Json(EventTypeOut::list_response_no_prev(
@@ -280,7 +280,7 @@ async fn get_event_type(
 ) -> Result<Json<EventTypeOut>> {
     let mut query = eventtype::Entity::secure_find_by_name(org_id, evtype_name);
     if let permissions::AllowedFeatureFlags::Some(flags) = feature_flags {
-        query = query.filter(eventtype::Column::FeatureFlag.is_in(flags.into_iter()));
+        query = eventtype::Entity::filter_feature_flags(query, flags);
     }
     let evtype = ctx!(query.one(db).await)?.ok_or_else(|| HttpError::not_found(None, None))?;
 


### PR DESCRIPTION
## Motivation
The previous logic was incorrectly filtering out event types with no feature flag set.


## Solution
Apply the correct condition to the database query.
