### PR TITLE
implement clone derive macro for Sivx client

### DIFF
--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -25,6 +25,7 @@ pub struct SvixOptions {
     pub server_url: Option<String>,
 }
 
+#[derive(Clone)]
 pub struct Svix {
     cfg: Configuration,
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Configuration struct derives clone macro so Sivx struct can also derive it. This would be helpful to clone Sivx client when sharing it between threads without wrapping it in Arc.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Add Clone derive macro
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
