### PR TITLE
Change app portal access request body casing to camel case

### DIFF
--- a/server/svix-server/src/v1/endpoints/auth.rs
+++ b/server/svix-server/src/v1/endpoints/auth.rs
@@ -18,6 +18,7 @@ pub struct DashboardAccessOut {
 }
 
 #[derive(Deserialize, Serialize, Validate, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct AppPortalAccessIn {
     /// The set of feature flags the created token will have access to.
     #[serde(default, skip_serializing_if = "FeatureFlagSet::is_empty")]


### PR DESCRIPTION
## Motivation
Svix's API uses camel casing across the board; this was missed when implementing this endpoint.


## Solution
Apply serde `rename_all` attribute.