### PR TITLE
Add endpoints to erase payload and response

### DIFF
--- a/server/svix-server/tests/e2e_endpoint.rs
+++ b/server/svix-server/tests/e2e_endpoint.rs
@@ -1887,7 +1887,7 @@ async fn test_msg_channels_filter() {
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
-    let _receiver = TestReceiver::start(StatusCode::OK);
+    let receiver = TestReceiver::start(StatusCode::OK);
 
     let ec = EventChannelSet(HashSet::from([EventChannel("tag1".to_owned())]));
 
@@ -1897,6 +1897,7 @@ async fn test_msg_channels_filter() {
             &app_id,
             EndpointIn {
                 channels,
+                url: Url::parse(&receiver.endpoint).unwrap(),
                 ..default_test_endpoint()
             },
         )
@@ -1919,8 +1920,6 @@ async fn test_msg_channels_filter() {
             )
             .await
             .unwrap();
-
-        tokio::time::sleep(Duration::from_millis(100)).await;
 
         let _list =
             get_msg_attempt_list_and_assert_count(&client, &app_id, &msg.id, expected_count)


### PR DESCRIPTION
These endpoints can be used to erase the payload of a message, and the response body of attempts. They can be useful in cases where a message was inadvertently sent with sensitive data that it shouldn't have contained, or an endpoint returned a response body with something of the same sort.

Erasing message payloads is technically OK, the worker already handles the case where there's no payload (due to payload expiration) and the response body is not currently used by svix, it is only retained for troubleshooting purposes.