### PR TITLE
Clarify error message and documentation around filtered IP addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ There are two configuration variables `db_pool_max_size` and `redis_pool_max_siz
 
 They default to a max size of 20, but higher values can significantly increase performance if your database can handle it.
 
+### SSRF Attacks and Internal IP Addresses
+To prevent SSRF attacks, message dispatches to internal IP addresses are blocked by default. However we understand that this doesn't meet the needs of every user say, for example, the service can only be accessed internally. To bypass these restrictions, see the `whitelist_subnets` configuration option, which accepts an array of CIDR-notation subnets to allow messages to be dispatched to.
 
 ### Webhook signature scheme (symmetric vs asymmetric)
 


### PR DESCRIPTION
Solves #792 by clarifying the error message surrounding a filtered internal IP address, making it clear that this can be configured. Additionally this changes the  README to include a short paragraph on how to add subnets to the whitelist.