### PR TITLE
Change all path extractors to use structs

### DIFF
--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -4,7 +4,7 @@
 use crate::{
     core::{
         permissions,
-        types::{metadata::Metadata, ApplicationId, ApplicationIdOrUid, ApplicationUid},
+        types::{metadata::Metadata, ApplicationId, ApplicationUid},
     },
     ctx,
     db::models::{application, applicationmetadata},
@@ -17,8 +17,8 @@ use crate::{
             UnrequiredNullableField,
         },
         validate_no_control_characters, validate_no_control_characters_unrequired,
-        validation_error, EmptyResponse, ListResponse, ModelIn, ModelOut, Pagination,
-        PaginationLimit, ValidatedJson, ValidatedQuery,
+        validation_error, ApplicationPath, EmptyResponse, ListResponse, ModelIn, ModelOut,
+        Pagination, PaginationLimit, ValidatedJson, ValidatedQuery,
     },
     AppState,
 };
@@ -263,7 +263,7 @@ async fn get_application(
 
 async fn update_application(
     State(AppState { ref db, .. }): State<AppState>,
-    Path(app_id): Path<ApplicationIdOrUid>,
+    Path(ApplicationPath { app_id }): Path<ApplicationPath>,
     permissions::Organization { org_id }: permissions::Organization,
     ValidatedJson(data): ValidatedJson<ApplicationIn>,
 ) -> Result<(StatusCode, Json<ApplicationOut>)> {

--- a/server/svix-server/src/v1/endpoints/endpoint/headers.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/headers.rs
@@ -7,24 +7,21 @@ use sea_orm::ActiveModelTrait;
 
 use super::{EndpointHeadersIn, EndpointHeadersOut, EndpointHeadersPatchIn};
 use crate::{
-    core::{
-        permissions,
-        types::{ApplicationIdOrUid, EndpointIdOrUid},
-    },
+    core::permissions,
     ctx,
     db::models::endpoint,
     error::{HttpError, Result},
-    v1::utils::{EmptyResponse, ModelIn, ValidatedJson},
+    v1::utils::{ApplicationEndpointPath, EmptyResponse, ModelIn, ValidatedJson},
     AppState,
 };
 
 pub(super) async fn get_endpoint_headers(
     State(AppState { ref db, .. }): State<AppState>,
-    Path((_app_id, endp_id)): Path<(ApplicationIdOrUid, EndpointIdOrUid)>,
+    Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,
     permissions::Application { app }: permissions::Application,
 ) -> Result<Json<EndpointHeadersOut>> {
     let endp = ctx!(
-        endpoint::Entity::secure_find_by_id_or_uid(app.id, endp_id)
+        endpoint::Entity::secure_find_by_id_or_uid(app.id, endpoint_id)
             .one(db)
             .await
     )?
@@ -38,12 +35,12 @@ pub(super) async fn get_endpoint_headers(
 
 pub(super) async fn update_endpoint_headers(
     State(AppState { ref db, .. }): State<AppState>,
-    Path((_app_id, endp_id)): Path<(ApplicationIdOrUid, EndpointIdOrUid)>,
+    Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,
     permissions::Application { app }: permissions::Application,
     ValidatedJson(data): ValidatedJson<EndpointHeadersIn>,
 ) -> Result<(StatusCode, Json<EmptyResponse>)> {
     let endp = ctx!(
-        endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endp_id)
+        endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endpoint_id)
             .one(db)
             .await
     )?
@@ -58,12 +55,12 @@ pub(super) async fn update_endpoint_headers(
 
 pub(super) async fn patch_endpoint_headers(
     State(AppState { ref db, .. }): State<AppState>,
-    Path((_app_id, endp_id)): Path<(ApplicationIdOrUid, EndpointIdOrUid)>,
+    Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,
     permissions::Application { app }: permissions::Application,
     ValidatedJson(data): ValidatedJson<EndpointHeadersPatchIn>,
 ) -> Result<(StatusCode, Json<EmptyResponse>)> {
     let endp = ctx!(
-        endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endp_id)
+        endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endpoint_id)
             .one(db)
             .await
     )?

--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -11,9 +11,8 @@ use crate::{
         cryptography::Encryption,
         permissions,
         types::{
-            metadata::Metadata, ApplicationIdOrUid, BaseId, EndpointId, EndpointIdOrUid,
-            EndpointSecretInternal, EndpointUid, EventChannelSet, EventTypeNameSet,
-            MessageEndpointId, MessageStatus,
+            metadata::Metadata, BaseId, EndpointId, EndpointSecretInternal, EndpointUid,
+            EventChannelSet, EventTypeNameSet, MessageEndpointId, MessageStatus,
         },
     },
     ctx,
@@ -26,7 +25,7 @@ use crate::{
             UnrequiredNullableField,
         },
         validate_no_control_characters, validate_no_control_characters_unrequired,
-        validation_error, ModelIn,
+        validation_error, ApplicationEndpointPath, ModelIn,
     },
     AppState,
 };
@@ -526,14 +525,14 @@ pub struct EndpointStatsQueryOut {
 
 async fn endpoint_stats(
     State(AppState { ref db, .. }): State<AppState>,
-    Path((_app_id, endp_id)): Path<(ApplicationIdOrUid, EndpointIdOrUid)>,
+    Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,
     Query(range): Query<EndpointStatsRange>,
     permissions::Application { app }: permissions::Application,
 ) -> error::Result<Json<EndpointStatsOut>> {
     let (since, until) = range.validate_unwrap_or_default()?;
 
     let endpoint = ctx!(
-        crate::db::models::endpoint::Entity::secure_find_by_id_or_uid(app.id, endp_id)
+        crate::db::models::endpoint::Entity::secure_find_by_id_or_uid(app.id, endpoint_id)
             .one(db)
             .await
     )?

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -6,8 +6,8 @@ use crate::{
         message_app::CreateMessageApp,
         permissions,
         types::{
-            ApplicationIdOrUid, EventChannel, EventChannelSet, EventTypeName, EventTypeNameSet,
-            MessageAttemptTriggerType, MessageId, MessageIdOrUid, MessageUid,
+            EventChannel, EventChannelSet, EventTypeName, EventTypeNameSet,
+            MessageAttemptTriggerType, MessageId, MessageUid,
         },
     },
     ctx, err_generic,
@@ -15,8 +15,8 @@ use crate::{
     queue::MessageTaskBatch,
     v1::utils::{
         apply_pagination, iterator_from_before_or_after, openapi_tag, validation_error,
-        ListResponse, MessageListFetchOptions, ModelIn, ModelOut, PaginationLimit,
-        ReversibleIterator, ValidatedJson, ValidatedQuery,
+        ApplicationMsgPath, ListResponse, MessageListFetchOptions, ModelIn, ModelOut,
+        PaginationLimit, ReversibleIterator, ValidatedJson, ValidatedQuery,
     },
     AppState,
 };
@@ -287,7 +287,7 @@ pub struct GetMessageQueryParams {
 }
 async fn get_message(
     State(AppState { ref db, .. }): State<AppState>,
-    Path((_app_id, msg_id)): Path<(ApplicationIdOrUid, MessageIdOrUid)>,
+    Path(ApplicationMsgPath { msg_id, .. }): Path<ApplicationMsgPath>,
     ValidatedQuery(GetMessageQueryParams { with_content }): ValidatedQuery<GetMessageQueryParams>,
     permissions::Application { app }: permissions::Application,
 ) -> Result<Json<MessageOut>> {
@@ -307,7 +307,7 @@ async fn get_message(
 
 async fn expunge_message_content(
     State(AppState { ref db, .. }): State<AppState>,
-    Path((_app_id, msg_id)): Path<(ApplicationIdOrUid, MessageIdOrUid)>,
+    Path(ApplicationMsgPath { msg_id, .. }): Path<ApplicationMsgPath>,
     permissions::OrganizationWithApplication { app }: permissions::OrganizationWithApplication,
 ) -> Result<StatusCode> {
     let mut msg = ctx!(

--- a/server/svix-server/src/v1/utils/mod.rs
+++ b/server/svix-server/src/v1/utils/mod.rs
@@ -27,7 +27,10 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use validator::{Validate, ValidationError};
 
 use crate::{
-    core::types::{BaseId, EventTypeName, EventTypeNameSet},
+    core::types::{
+        ApplicationIdOrUid, BaseId, EndpointIdOrUid, EventTypeName, EventTypeNameSet,
+        MessageAttemptId, MessageIdOrUid,
+    },
     error::{Error, HttpError, Result, ValidationErrorItem},
 };
 
@@ -460,6 +463,42 @@ pub fn get_unix_timestamp() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_secs()
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct ApplicationPath {
+    pub app_id: ApplicationIdOrUid,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct ApplicationEndpointPath {
+    pub app_id: ApplicationIdOrUid,
+    pub endpoint_id: EndpointIdOrUid,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct ApplicationMsgPath {
+    pub app_id: ApplicationIdOrUid,
+    pub msg_id: MessageIdOrUid,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct ApplicationMsgEndpointPath {
+    pub app_id: ApplicationIdOrUid,
+    pub msg_id: MessageIdOrUid,
+    pub endpoint_id: EndpointIdOrUid,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct ApplicationMsgAttemptPath {
+    pub app_id: ApplicationIdOrUid,
+    pub msg_id: MessageIdOrUid,
+    pub attempt_id: MessageAttemptId,
+}
+
+#[derive(Clone, Deserialize, JsonSchema)]
+pub struct EventTypeNamePath {
+    pub event_type_name: EventTypeName,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This has 2 benefits:
1. It is a little safer because tuple params are extracted based simply on position so it's possible to make a mistake simply by putting the types in the wrong order. It still doesn't check that the path placeholders match the extractors at compile-time, though.
2. Aide can match field names to URL placeholder names this way, as a result including the path parameters in the OpenAPI params section.