### PR TITLE
Include transformations API in the libs

### DIFF
--- a/csharp/Svix/Endpoint.cs
+++ b/csharp/Svix/Endpoint.cs
@@ -633,5 +633,97 @@ namespace Svix
                 return false;
             }
         }
+
+        public EndpointTransformationOut TransformationGet(string appId, string endpointId, string idempotencyKey = default)
+        {
+            try
+            {
+                var lTransformation = _endpointApi.GetEndpointTransformationApiV1AppAppIdEndpointEndpointIdTransformationGet(
+                    appId,
+                    endpointId,
+                    idempotencyKey);
+
+                return lTransformation;
+            }
+            catch (ApiException e)
+            {
+                Logger?.LogError(e, $"{nameof(TransformationGet)} failed");
+
+                if (Throw)
+                    throw;
+
+                return null;
+            }
+        }
+
+        public async Task<EndpointTransformationOut> TransformationGetAsync(string appId, string endpointId, string idempotencyKey = default, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var lTransformation = await _endpointApi.GetEndpointTransformationApiV1AppAppIdEndpointEndpointIdTransformationGetAsync(
+                    appId,
+                    endpointId,
+                    idempotencyKey,
+                    cancellationToken);
+
+                return lTransformation;
+            }
+            catch (ApiException e)
+            {
+                Logger?.LogError(e, $"{nameof(TransformationGetAsync)} failed");
+
+                if (Throw)
+                    throw;
+
+                return null;
+            }
+        }
+
+        public bool TransformationPartialUpdate(string appId, string endpointId, EndpointTransformationIn endpointTransformationIn, string idempotencyKey = default)
+        {
+            try
+            {
+                var response = _endpointApi.SetEndpointTransformationApiV1AppAppIdEndpointEndpointIdTransformationPatchWithHttpInfo(
+                    appId,
+                    endpointId,
+                    endpointTransformationIn,
+                    idempotencyKey);
+
+                return response.StatusCode == HttpStatusCode.NoContent;
+            }
+            catch (ApiException e)
+            {
+                Logger?.LogError(e, $"{nameof(TransformationGet)} failed");
+
+                if (Throw)
+                    throw;
+
+                return false;
+            }
+        }
+
+        public async Task<bool> TransformationPartialUpdateAsync(string appId, string endpointId, EndpointTransformationIn endpointTransformationIn, string idempotencyKey = default, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var response = await _endpointApi.SetEndpointTransformationApiV1AppAppIdEndpointEndpointIdTransformationPatchWithHttpInfoAsync(
+                    appId,
+                    endpointId,
+                    endpointTransformationIn,
+                    idempotencyKey,
+                    cancellationToken);
+
+                return response.StatusCode == HttpStatusCode.NoContent;
+            }
+            catch (ApiException e)
+            {
+                Logger?.LogError(e, $"{nameof(TransformationPartialUpdateAsync)} failed");
+
+                if (Throw)
+                    throw;
+
+                return false;
+            }
+        }
     }
 }

--- a/go/endpoint.go
+++ b/go/endpoint.go
@@ -7,18 +7,20 @@ import (
 )
 
 type (
-	ListResponseEndpointOut openapi.ListResponseEndpointOut
-	EndpointIn              openapi.EndpointIn
-	EndpointUpdate          openapi.EndpointUpdate
-	EndpointOut             openapi.EndpointOut
-	EndpointSecretOut       openapi.EndpointSecretOut
-	EndpointSecretRotateIn  openapi.EndpointSecretRotateIn
-	RecoverIn               openapi.RecoverIn
-	ReplayIn                openapi.ReplayIn
-	EndpointHeadersIn       openapi.EndpointHeadersIn
-	EndpointHeadersPatchIn  openapi.EndpointHeadersPatchIn
-	EndpointHeadersOut      openapi.EndpointHeadersOut
-	EndpointStats           openapi.EndpointStats
+	ListResponseEndpointOut   openapi.ListResponseEndpointOut
+	EndpointIn                openapi.EndpointIn
+	EndpointUpdate            openapi.EndpointUpdate
+	EndpointOut               openapi.EndpointOut
+	EndpointSecretOut         openapi.EndpointSecretOut
+	EndpointSecretRotateIn    openapi.EndpointSecretRotateIn
+	EndpointTransformationIn  openapi.EndpointTransformationIn
+	RecoverIn                 openapi.RecoverIn
+	ReplayIn                  openapi.ReplayIn
+	EndpointHeadersIn         openapi.EndpointHeadersIn
+	EndpointHeadersPatchIn    openapi.EndpointHeadersPatchIn
+	EndpointHeadersOut        openapi.EndpointHeadersOut
+	EndpointStats             openapi.EndpointStats
+	EndpointTransformationOut openapi.EndpointTransformationOut
 )
 
 type Endpoint struct {
@@ -204,5 +206,29 @@ func (e *Endpoint) ReplayWithOptions(
 	if err != nil {
 		return wrapError(err, res)
 	}
+	return nil
+}
+
+func (e *Endpoint) TransformationGet(appId string, endpointId string) (*EndpointTransformationOut, error) {
+	req := e.api.EndpointApi.GetEndpointTransformationApiV1AppAppIdEndpointEndpointIdTransformationGet(context.Background(), endpointId, appId)
+
+	out, res, err := req.Execute()
+	if err != nil {
+		return nil, wrapError(err, res)
+	}
+
+	ret := EndpointTransformationOut(out)
+	return &ret, nil
+}
+
+func (e *Endpoint) TransformatioPartialUpdate(appId string, endpointId string, transformation *EndpointTransformationIn) error {
+	req := e.api.EndpointApi.SetEndpointTransformationApiV1AppAppIdEndpointEndpointIdTransformationPatch(context.Background(), appId, endpointId)
+	req.EndpointTransformationIn(openapi.EndpointTransformationIn(*transformation))
+
+	res, err := req.Execute()
+	if err != nil {
+		return wrapError(err, res)
+	}
+
 	return nil
 }

--- a/go/internal/openapi/api_authentication.go
+++ b/go/internal/openapi/api_authentication.go
@@ -411,7 +411,7 @@ func (r ApiGetDashboardAccessApiV1AuthDashboardAccessAppIdPostRequest) Execute()
 }
 
 /*
- * GetDashboardAccessApiV1AuthDashboardAccessAppIdPost Get Consumer App Portal Access
+ * GetDashboardAccessApiV1AuthDashboardAccessAppIdPost Get Dashboard Access
  * DEPRECATED: Please use `app-portal-access` instead.
 
 Use this function to get magic links (and authentication codes) for connecting your users to the Consumer Application Portal.

--- a/go/internal/openapi/api_message.go
+++ b/go/internal/openapi/api_message.go
@@ -244,6 +244,186 @@ func (a *MessageApiService) CreateMessageApiV1AppAppIdMsgPostExecute(r ApiCreate
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
+type ApiExpungeMessagePayloadApiV1AppAppIdMsgMsgIdContentDeleteRequest struct {
+	ctx _context.Context
+	ApiService *MessageApiService
+	msgId string
+	appId string
+	idempotencyKey *string
+}
+
+func (r ApiExpungeMessagePayloadApiV1AppAppIdMsgMsgIdContentDeleteRequest) IdempotencyKey(idempotencyKey string) ApiExpungeMessagePayloadApiV1AppAppIdMsgMsgIdContentDeleteRequest {
+	r.idempotencyKey = &idempotencyKey
+	return r
+}
+
+func (r ApiExpungeMessagePayloadApiV1AppAppIdMsgMsgIdContentDeleteRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.ExpungeMessagePayloadApiV1AppAppIdMsgMsgIdContentDeleteExecute(r)
+}
+
+/*
+ * ExpungeMessagePayloadApiV1AppAppIdMsgMsgIdContentDelete Delete message payload
+ * Delete the given message's payload. Useful in cases when a message was accidentally sent with sensitive content.
+
+The message can't be replayed or resent once its payload has been deleted or expired.
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param msgId
+ * @param appId
+ * @return ApiExpungeMessagePayloadApiV1AppAppIdMsgMsgIdContentDeleteRequest
+ */
+func (a *MessageApiService) ExpungeMessagePayloadApiV1AppAppIdMsgMsgIdContentDelete(ctx _context.Context, msgId string, appId string) ApiExpungeMessagePayloadApiV1AppAppIdMsgMsgIdContentDeleteRequest {
+	return ApiExpungeMessagePayloadApiV1AppAppIdMsgMsgIdContentDeleteRequest{
+		ApiService: a,
+		ctx: ctx,
+		msgId: msgId,
+		appId: appId,
+	}
+}
+
+/*
+ * Execute executes the request
+ */
+func (a *MessageApiService) ExpungeMessagePayloadApiV1AppAppIdMsgMsgIdContentDeleteExecute(r ApiExpungeMessagePayloadApiV1AppAppIdMsgMsgIdContentDeleteRequest) (*_nethttp.Response, error) {
+	var (
+		localVarHTTPMethod   = _nethttp.MethodDelete
+		localVarPostBody     interface{}
+		localVarFormFileName string
+		localVarFileName     string
+		localVarFileBytes    []byte
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "MessageApiService.ExpungeMessagePayloadApiV1AppAppIdMsgMsgIdContentDelete")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/api/v1/app/{app_id}/msg/{msg_id}/content/"
+	localVarPath = strings.Replace(localVarPath, "{"+"msg_id"+"}", _neturl.PathEscape(parameterToString(r.msgId, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"app_id"+"}", _neturl.PathEscape(parameterToString(r.appId, "")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := _neturl.Values{}
+	localVarFormParams := _neturl.Values{}
+	if strlen(r.msgId) < 1 {
+		return nil, reportError("msgId must have at least 1 elements")
+	}
+	if strlen(r.msgId) > 256 {
+		return nil, reportError("msgId must have less than 256 elements")
+	}
+	if strlen(r.appId) < 1 {
+		return nil, reportError("appId must have at least 1 elements")
+	}
+	if strlen(r.appId) > 256 {
+		return nil, reportError("appId must have less than 256 elements")
+	}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	if r.idempotencyKey != nil {
+		localVarHeaderParams["idempotency-key"] = parameterToString(*r.idempotencyKey, "")
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarHTTPResponse, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 401 {
+			var v HttpErrorOut
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 403 {
+			var v HttpErrorOut
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 404 {
+			var v HttpErrorOut
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 409 {
+			var v HttpErrorOut
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 422 {
+			var v HTTPValidationError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 429 {
+			var v HttpErrorOut
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+		}
+		return localVarHTTPResponse, newErr
+	}
+
+	return localVarHTTPResponse, nil
+}
+
 type ApiGetMessageApiV1AppAppIdMsgMsgIdGetRequest struct {
 	ctx _context.Context
 	ApiService *MessageApiService

--- a/go/internal/openapi/api_message_attempt.go
+++ b/go/internal/openapi/api_message_attempt.go
@@ -29,6 +29,188 @@ var (
 // MessageAttemptApiService MessageAttemptApi service
 type MessageAttemptApiService service
 
+type ApiExpungeAttemptContentApiV1AppAppIdMsgMsgIdAttemptAttemptIdContentDeleteRequest struct {
+	ctx _context.Context
+	ApiService *MessageAttemptApiService
+	attemptId string
+	msgId string
+	appId string
+	idempotencyKey *string
+}
+
+func (r ApiExpungeAttemptContentApiV1AppAppIdMsgMsgIdAttemptAttemptIdContentDeleteRequest) IdempotencyKey(idempotencyKey string) ApiExpungeAttemptContentApiV1AppAppIdMsgMsgIdAttemptAttemptIdContentDeleteRequest {
+	r.idempotencyKey = &idempotencyKey
+	return r
+}
+
+func (r ApiExpungeAttemptContentApiV1AppAppIdMsgMsgIdAttemptAttemptIdContentDeleteRequest) Execute() (*_nethttp.Response, error) {
+	return r.ApiService.ExpungeAttemptContentApiV1AppAppIdMsgMsgIdAttemptAttemptIdContentDeleteExecute(r)
+}
+
+/*
+ * ExpungeAttemptContentApiV1AppAppIdMsgMsgIdAttemptAttemptIdContentDelete Delete attempt response body
+ * Deletes the given attempt's repsonse body. Useful when an endpoint accidentally returned sensitive content.
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param attemptId
+ * @param msgId
+ * @param appId
+ * @return ApiExpungeAttemptContentApiV1AppAppIdMsgMsgIdAttemptAttemptIdContentDeleteRequest
+ */
+func (a *MessageAttemptApiService) ExpungeAttemptContentApiV1AppAppIdMsgMsgIdAttemptAttemptIdContentDelete(ctx _context.Context, attemptId string, msgId string, appId string) ApiExpungeAttemptContentApiV1AppAppIdMsgMsgIdAttemptAttemptIdContentDeleteRequest {
+	return ApiExpungeAttemptContentApiV1AppAppIdMsgMsgIdAttemptAttemptIdContentDeleteRequest{
+		ApiService: a,
+		ctx: ctx,
+		attemptId: attemptId,
+		msgId: msgId,
+		appId: appId,
+	}
+}
+
+/*
+ * Execute executes the request
+ */
+func (a *MessageAttemptApiService) ExpungeAttemptContentApiV1AppAppIdMsgMsgIdAttemptAttemptIdContentDeleteExecute(r ApiExpungeAttemptContentApiV1AppAppIdMsgMsgIdAttemptAttemptIdContentDeleteRequest) (*_nethttp.Response, error) {
+	var (
+		localVarHTTPMethod   = _nethttp.MethodDelete
+		localVarPostBody     interface{}
+		localVarFormFileName string
+		localVarFileName     string
+		localVarFileBytes    []byte
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "MessageAttemptApiService.ExpungeAttemptContentApiV1AppAppIdMsgMsgIdAttemptAttemptIdContentDelete")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/api/v1/app/{app_id}/msg/{msg_id}/attempt/{attempt_id}/content/"
+	localVarPath = strings.Replace(localVarPath, "{"+"attempt_id"+"}", _neturl.PathEscape(parameterToString(r.attemptId, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"msg_id"+"}", _neturl.PathEscape(parameterToString(r.msgId, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"app_id"+"}", _neturl.PathEscape(parameterToString(r.appId, "")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := _neturl.Values{}
+	localVarFormParams := _neturl.Values{}
+	if strlen(r.msgId) < 1 {
+		return nil, reportError("msgId must have at least 1 elements")
+	}
+	if strlen(r.msgId) > 256 {
+		return nil, reportError("msgId must have less than 256 elements")
+	}
+	if strlen(r.appId) < 1 {
+		return nil, reportError("appId must have at least 1 elements")
+	}
+	if strlen(r.appId) > 256 {
+		return nil, reportError("appId must have less than 256 elements")
+	}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	if r.idempotencyKey != nil {
+		localVarHeaderParams["idempotency-key"] = parameterToString(*r.idempotencyKey, "")
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarHTTPResponse, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 401 {
+			var v HttpErrorOut
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 403 {
+			var v HttpErrorOut
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 404 {
+			var v HttpErrorOut
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 409 {
+			var v HttpErrorOut
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 422 {
+			var v HTTPValidationError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 429 {
+			var v HttpErrorOut
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+		}
+		return localVarHTTPResponse, newErr
+	}
+
+	return localVarHTTPResponse, nil
+}
+
 type ApiGetAttemptApiV1AppAppIdMsgMsgIdAttemptAttemptIdGetRequest struct {
 	ctx _context.Context
 	ApiService *MessageAttemptApiService

--- a/go/internal/openapi/model_app_portal_access_in.go
+++ b/go/internal/openapi/model_app_portal_access_in.go
@@ -16,7 +16,7 @@ import (
 
 // AppPortalAccessIn struct for AppPortalAccessIn
 type AppPortalAccessIn struct {
-	FeatureFlags []string `json:"featureFlags,omitempty"`
+	FeatureFlags *[]string `json:"featureFlags,omitempty"`
 }
 
 // NewAppPortalAccessIn instantiates a new AppPortalAccessIn object
@@ -36,23 +36,22 @@ func NewAppPortalAccessInWithDefaults() *AppPortalAccessIn {
 	return &this
 }
 
-// GetFeatureFlags returns the FeatureFlags field value if set, zero value otherwise (both if not set or set to explicit null).
+// GetFeatureFlags returns the FeatureFlags field value if set, zero value otherwise.
 func (o *AppPortalAccessIn) GetFeatureFlags() []string {
-	if o == nil  {
+	if o == nil || o.FeatureFlags == nil {
 		var ret []string
 		return ret
 	}
-	return o.FeatureFlags
+	return *o.FeatureFlags
 }
 
 // GetFeatureFlagsOk returns a tuple with the FeatureFlags field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-// NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *AppPortalAccessIn) GetFeatureFlagsOk() (*[]string, bool) {
 	if o == nil || o.FeatureFlags == nil {
 		return nil, false
 	}
-	return &o.FeatureFlags, true
+	return o.FeatureFlags, true
 }
 
 // HasFeatureFlags returns a boolean if a field has been set.
@@ -66,7 +65,7 @@ func (o *AppPortalAccessIn) HasFeatureFlags() bool {
 
 // SetFeatureFlags gets a reference to the given []string and assigns it to the FeatureFlags field.
 func (o *AppPortalAccessIn) SetFeatureFlags(v []string) {
-	o.FeatureFlags = v
+	o.FeatureFlags = &v
 }
 
 func (o AppPortalAccessIn) MarshalJSON() ([]byte, error) {

--- a/go/webhook.go
+++ b/go/webhook.go
@@ -40,7 +40,7 @@ func NewWebhook(secret string) (*Webhook, error) {
 }
 
 func NewWebhookRaw(secret []byte) (*Webhook, error) {
-	return &Webhook {
+	return &Webhook{
 		key: secret,
 	}, nil
 }

--- a/java/lib/src/main/java/com/svix/Endpoint.java
+++ b/java/lib/src/main/java/com/svix/Endpoint.java
@@ -10,6 +10,8 @@ import com.svix.models.EndpointOut;
 import com.svix.models.EndpointUpdate;
 import com.svix.models.EndpointSecretOut;
 import com.svix.models.EndpointSecretRotateIn;
+import com.svix.models.EndpointTransformationIn;
+import com.svix.models.EndpointTransformationOut;
 import com.svix.models.ListResponseEndpointOut;
 import com.svix.models.RecoverIn;
 import com.svix.models.ReplayIn;
@@ -137,6 +139,22 @@ public final class Endpoint {
 	public void replay(final String appId, final String endpointId, final ReplayIn replayIn, final PostOptions options) throws ApiException {
 		try {
 			api.replayMissingWebhooksApiV1AppAppIdEndpointEndpointIdReplayMissingPostWithHttpInfo(appId, endpointId, replayIn, options.getIdempotencyKey());
+		} catch (com.svix.internal.ApiException e) {
+			throw Utils.wrapInternalApiException(e);
+		}
+	}
+
+	public EndpointTransformationOut transformationGet(final String appId, final String endpointId) throws ApiException {
+		try {
+			return api.getEndpointTransformationApiV1AppAppIdEndpointEndpointIdTransformationGet(endpointId, appId, null);
+		} catch (com.svix.internal.ApiException e) {
+			throw Utils.wrapInternalApiException(e);
+		}
+	}
+
+	public void transformationPartialUpdate(final String appId, final String endpointId, final EndpointTransformationIn transformationIn) throws ApiException {
+		try {
+			api.setEndpointTransformationApiV1AppAppIdEndpointEndpointIdTransformationPatch(appId, endpointId, transformationIn, null);
 		} catch (com.svix.internal.ApiException e) {
 			throw Utils.wrapInternalApiException(e);
 		}

--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -14,6 +14,8 @@ import {
   EndpointUpdate,
   EndpointSecretOut,
   EndpointSecretRotateIn,
+  EndpointTransformationIn,
+  EndpointTransformationOut,
   EndpointHeadersIn,
   EndpointHeadersPatchIn,
   EndpointHeadersOut,
@@ -370,6 +372,25 @@ class Endpoint {
       appId,
       endpointId,
     });
+  }
+
+  public transformationGet(
+    appId: string,
+    endpointId: string
+  ): Promise<EndpointTransformationOut> {
+    return this.api.getEndpointTransformationApiV1AppAppIdEndpointEndpointIdTransformationGet(
+      { endpointId, appId }
+    );
+  }
+
+  public transformationPartialUpdate(
+    appId: string,
+    endpointId: string,
+    endpointTransformationIn: EndpointTransformationIn
+  ): Promise<void> {
+    return this.api.setEndpointTransformationApiV1AppAppIdEndpointEndpointIdTransformationPatch(
+      { appId, endpointId, endpointTransformationIn }
+    );
   }
 }
 

--- a/kotlin/lib/src/main/kotlin/Endpoint.kt
+++ b/kotlin/lib/src/main/kotlin/Endpoint.kt
@@ -10,6 +10,8 @@ import com.svix.kotlin.models.EndpointOut
 import com.svix.kotlin.models.EndpointSecretOut
 import com.svix.kotlin.models.EndpointSecretRotateIn
 import com.svix.kotlin.models.EndpointStats
+import com.svix.kotlin.models.EndpointTransformationIn
+import com.svix.kotlin.models.EndpointTransformationOut
 import com.svix.kotlin.models.EndpointUpdate
 import com.svix.kotlin.models.ListResponseEndpointOut
 import com.svix.kotlin.models.RecoverIn
@@ -208,6 +210,31 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
                 endpointId,
                 replayIn,
                 options.idempotencyKey
+            )
+        } catch (e: Exception) {
+            throw ApiException.wrap(e)
+        }
+    }
+
+    suspend fun transformationGet(appId: String, endpointId: String): EndpointTransformationOut {
+        try {
+            return api.getEndpointTransformationApiV1AppAppIdEndpointEndpointIdTransformationGet(
+                endpointId,
+                appId,
+                null
+            )
+        } catch (e: Exception) {
+            throw ApiException.wrap(e)
+        }
+    }
+
+    suspend fun transformationPartialUpdate(appId: String, endpointId: String, endpointTransformationIn: EndpointTransformationIn) {
+        try {
+            api.setEndpointTransformationApiV1AppAppIdEndpointEndpointIdTransformationPatch(
+                endpointId,
+                appId,
+                endpointTransformationIn,
+                null
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)

--- a/openapi.json
+++ b/openapi.json
@@ -4,13 +4,14 @@
             "AppPortalAccessIn": {
                 "properties": {
                     "featureFlags": {
+                        "default": [],
+                        "example": [],
                         "items": {
                             "example": "cool-new-feature",
                             "maxLength": 256,
                             "pattern": "^[a-zA-Z0-9\\-_.]+$",
                             "type": "string"
                         },
-                        "nullable": true,
                         "title": "Featureflags",
                         "type": "array",
                         "uniqueItems": true
@@ -7730,57 +7731,57 @@
                     {
                         "label": "JavaScript",
                         "lang": "JavaScript",
-                        "source": "const endpointTransformationOut = await svix.endpoint.get('app_id', 'endpoint_id');"
+                        "source": "const endpointTransformationOut = await svix.endpoint.transformationGet('app_id', 'endpoint_id');"
                     },
                     {
                         "label": "TypeScript",
                         "lang": "JavaScript",
-                        "source": "const endpointTransformationOut = await svix.endpoint.get('app_id', 'endpoint_id');"
+                        "source": "const endpointTransformationOut = await svix.endpoint.transformationGet('app_id', 'endpoint_id');"
                     },
                     {
                         "label": "Python",
                         "lang": "Python",
-                        "source": "endpoint_transformation_out = svix.endpoint.get('app_id', 'endpoint_id')"
+                        "source": "endpoint_transformation_out = svix.endpoint.transformation_get('app_id', 'endpoint_id')"
                     },
                     {
                         "label": "Python (Async)",
                         "lang": "Python",
-                        "source": "endpoint_transformation_out = await svix.endpoint.get('app_id', 'endpoint_id')"
+                        "source": "endpoint_transformation_out = await svix.endpoint.transformation_get('app_id', 'endpoint_id')"
                     },
                     {
                         "label": "Go",
                         "lang": "Go",
-                        "source": "endpointTransformationOut, err := svixClient.Endpoint.Get(\"app_id\", \"endpoint_id\")"
+                        "source": "endpointTransformationOut, err := svixClient.Endpoint.TransformationGet(\"app_id\", \"endpoint_id\")"
                     },
                     {
                         "label": "Kotlin",
                         "lang": "Kotlin",
-                        "source": "val endpointTransformationOut = svix.endpoint.get('app_id', 'endpoint_id')"
+                        "source": "val endpointTransformationOut = svix.endpoint.transformationGet('app_id', 'endpoint_id')"
                     },
                     {
                         "label": "Java",
                         "lang": "Java",
-                        "source": "EndpointTransformationOut endpointTransformationOut = svix.getEndpoint().get('app_id', 'endpoint_id')"
+                        "source": "EndpointTransformationOut endpointTransformationOut = svix.getEndpoint().transformationGet('app_id', 'endpoint_id')"
                     },
                     {
                         "label": "Ruby",
                         "lang": "Ruby",
-                        "source": "endpoint_transformation_out = svix.endpoint.get('app_id', 'endpoint_id')"
+                        "source": "endpoint_transformation_out = svix.endpoint.transformation_get('app_id', 'endpoint_id')"
                     },
                     {
                         "label": "Rust",
                         "lang": "Rust",
-                        "source": "let endpoint_transformation_out = svix.endpoint().get(\"app_id\", \"endpoint_id\").await?;"
+                        "source": "let endpoint_transformation_out = svix.endpoint().transformation_get(\"app_id\", \"endpoint_id\").await?;"
                     },
                     {
                         "label": "C#",
                         "lang": "C#",
-                        "source": "var endpointTransformationOut = await svix.Endpoint.GetAsync(\"app_id\", \"endpoint_id\")"
+                        "source": "var endpointTransformationOut = await svix.Endpoint.TransformationGetAsync(\"app_id\", \"endpoint_id\")"
                     },
                     {
                         "label": "CLI",
                         "lang": "Shell",
-                        "source": "svix endpoint get 'app_id' 'endpoint_id'"
+                        "source": "svix endpoint transformation-get 'app_id' 'endpoint_id'"
                     },
                     {
                         "label": "cURL",
@@ -7922,57 +7923,57 @@
                     {
                         "label": "JavaScript",
                         "lang": "JavaScript",
-                        "source": "await svix.endpoint.set('app_id', 'endpoint_id', {\n    code: None,\n    enabled: None\n});"
+                        "source": "await svix.endpoint.transformationPartialUpdate('app_id', 'endpoint_id', {\n    code: None,\n    enabled: None\n});"
                     },
                     {
                         "label": "TypeScript",
                         "lang": "JavaScript",
-                        "source": "await svix.endpoint.set('app_id', 'endpoint_id', {\n    code: None,\n    enabled: None\n});"
+                        "source": "await svix.endpoint.transformationPartialUpdate('app_id', 'endpoint_id', {\n    code: None,\n    enabled: None\n});"
                     },
                     {
                         "label": "Python",
                         "lang": "Python",
-                        "source": "svix.endpoint.set('app_id', 'endpoint_id', EndpointTransformationIn(\n    code=None,\n    enabled=None\n))"
+                        "source": "svix.endpoint.transformation_partial_update('app_id', 'endpoint_id', EndpointTransformationIn(\n    code=None,\n    enabled=None\n))"
                     },
                     {
                         "label": "Python (Async)",
                         "lang": "Python",
-                        "source": "await svix.endpoint.set('app_id', 'endpoint_id', EndpointTransformationIn(\n    code=None,\n    enabled=None\n))"
+                        "source": "await svix.endpoint.transformation_partial_update('app_id', 'endpoint_id', EndpointTransformationIn(\n    code=None,\n    enabled=None\n))"
                     },
                     {
                         "label": "Go",
                         "lang": "Go",
-                        "source": "err := svixClient.Endpoint.Set(\"app_id\", \"endpoint_id\", &svix.EndpointTransformationIn{\n    Code: None,\n    Enabled: None\n})"
+                        "source": "err := svixClient.Endpoint.TransformationPartialUpdate(\"app_id\", \"endpoint_id\", &svix.EndpointTransformationIn{\n    Code: None,\n    Enabled: None\n})"
                     },
                     {
                         "label": "Kotlin",
                         "lang": "Kotlin",
-                        "source": "svix.endpoint.set('app_id', 'endpoint_id', EndpointTransformationIn()\n    .code(None),\n    .enabled(None)\n)"
+                        "source": "svix.endpoint.transformationPartialUpdate('app_id', 'endpoint_id', EndpointTransformationIn()\n    .code(None),\n    .enabled(None)\n)"
                     },
                     {
                         "label": "Java",
                         "lang": "Java",
-                        "source": "svix.getEndpoint().set('app_id', 'endpoint_id', new EndpointTransformationIn()\n    .code(None),\n    .enabled(None)\n)"
+                        "source": "svix.getEndpoint().transformationPartialUpdate('app_id', 'endpoint_id', new EndpointTransformationIn()\n    .code(None),\n    .enabled(None)\n)"
                     },
                     {
                         "label": "Ruby",
                         "lang": "Ruby",
-                        "source": "svix.endpoint.set('app_id', 'endpoint_id', Svix::EndpointTransformationIn.new({\n    \"code\": null,\n    \"enabled\": null\n}))"
+                        "source": "svix.endpoint.transformation_partial_update('app_id', 'endpoint_id', Svix::EndpointTransformationIn.new({\n    \"code\": null,\n    \"enabled\": null\n}))"
                     },
                     {
                         "label": "Rust",
                         "lang": "Rust",
-                        "source": "svix.endpoint().set(\"app_id\", \"endpoint_id\", EndpointTransformationIn {\n    code: None,\n    enabled: None\n}).await?;"
+                        "source": "svix.endpoint().transformation_partial_update(\"app_id\", \"endpoint_id\", EndpointTransformationIn {\n    code: None,\n    enabled: None\n}).await?;"
                     },
                     {
                         "label": "C#",
                         "lang": "C#",
-                        "source": "await svix.Endpoint.SetAsync(\"app_id\", \"endpoint_id\", new EndpointTransformationIn{\n    code: None,\n    enabled: None\n})"
+                        "source": "await svix.Endpoint.TransformationPartialUpdateAsync(\"app_id\", \"endpoint_id\", new EndpointTransformationIn{\n    code: None,\n    enabled: None\n})"
                     },
                     {
                         "label": "CLI",
                         "lang": "Shell",
-                        "source": "svix endpoint set 'app_id' 'endpoint_id' '{\n    \"code\": null,\n    \"enabled\": null\n}'"
+                        "source": "svix endpoint transformation-partial-update 'app_id' 'endpoint_id' '{\n    \"code\": null,\n    \"enabled\": null\n}'"
                     },
                     {
                         "label": "cURL",
@@ -10646,6 +10647,145 @@
                 ]
             }
         },
+        "/api/v1/app/{app_id}/msg/{msg_id}/attempt/{attempt_id}/content/": {
+            "delete": {
+                "description": "Deletes the given attempt's repsonse body. Useful when an endpoint accidentally returned sensitive content.",
+                "operationId": "expunge_attempt_content_api_v1_app__app_id__msg__msg_id__attempt__attempt_id__content__delete",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "attempt_id",
+                        "required": true,
+                        "schema": {
+                            "example": "atmpt_1srOrx2ZWZBpBUvZwXKQmoEYga2",
+                            "title": "Attempt Id",
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "msg_id",
+                        "required": true,
+                        "schema": {
+                            "description": "The message's ID or eventID",
+                            "example": "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+                            "title": "Msg Id",
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "app_id",
+                        "required": true,
+                        "schema": {
+                            "description": "The application's ID or UID",
+                            "example": "app_1srOrx2ZWZBpBUvZwXKQmoEYga2",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+                            "title": "App Id",
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "The request's idempotency key",
+                        "in": "header",
+                        "name": "idempotency-key",
+                        "required": false,
+                        "schema": {
+                            "description": "The request's idempotency key",
+                            "nullable": true,
+                            "title": "Idempotency-Key",
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successful Response"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Forbidden"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "409": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Conflict"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                        "description": "Validation Error"
+                    },
+                    "429": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Too Many Requests"
+                    }
+                },
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "summary": "Delete attempt response body",
+                "tags": [
+                    "Message Attempt"
+                ],
+                "x-codeSamples": [
+                    {
+                        "label": "cURL",
+                        "lang": "Shell",
+                        "source": "curl -X 'DELETE' \\\n  'https://api.svix.com/api/v1/app/{app_id}/msg/{msg_id}/attempt/{attempt_id}/content/' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'accept: application/json' \\\n  -H 'Content-Type: application/json'"
+                    }
+                ]
+            }
+        },
         "/api/v1/app/{app_id}/msg/{msg_id}/attempt/{attempt_id}/headers/": {
             "get": {
                 "description": "Calculate and return headers used on a given message attempt",
@@ -10843,6 +10983,135 @@
                         "label": "cURL",
                         "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.svix.com/api/v1/app/{app_id}/msg/{msg_id}/attempt/{attempt_id}/headers/' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'accept: application/json' \\\n  -H 'Content-Type: application/json'"
+                    }
+                ]
+            }
+        },
+        "/api/v1/app/{app_id}/msg/{msg_id}/content/": {
+            "delete": {
+                "description": "Delete the given message's payload. Useful in cases when a message was accidentally sent with sensitive content.\n\nThe message can't be replayed or resent once its payload has been deleted or expired.",
+                "operationId": "expunge_message_payload_api_v1_app__app_id__msg__msg_id__content__delete",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "msg_id",
+                        "required": true,
+                        "schema": {
+                            "description": "The message's ID or eventID",
+                            "example": "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+                            "title": "Msg Id",
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "app_id",
+                        "required": true,
+                        "schema": {
+                            "description": "The application's ID or UID",
+                            "example": "app_1srOrx2ZWZBpBUvZwXKQmoEYga2",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+                            "title": "App Id",
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "The request's idempotency key",
+                        "in": "header",
+                        "name": "idempotency-key",
+                        "required": false,
+                        "schema": {
+                            "description": "The request's idempotency key",
+                            "nullable": true,
+                            "title": "Idempotency-Key",
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successful Response"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Forbidden"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "409": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Conflict"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                        "description": "Validation Error"
+                    },
+                    "429": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Too Many Requests"
+                    }
+                },
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "summary": "Delete message payload",
+                "tags": [
+                    "Message"
+                ],
+                "x-codeSamples": [
+                    {
+                        "label": "cURL",
+                        "lang": "Shell",
+                        "source": "curl -X 'DELETE' \\\n  'https://api.svix.com/api/v1/app/{app_id}/msg/{msg_id}/content/' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'accept: application/json' \\\n  -H 'Content-Type: application/json'"
                     }
                 ]
             }
@@ -11715,62 +11984,62 @@
                     {
                         "label": "JavaScript",
                         "lang": "JavaScript",
-                        "source": "const appPortalAccessOut = await svix.authentication.appPortalAccess('app_id', {\n    featureFlags: None\n});"
+                        "source": "const appPortalAccessOut = await svix.authentication.appPortalAccess('app_id', {\n    featureFlags: [    ]\n});"
                     },
                     {
                         "label": "TypeScript",
                         "lang": "JavaScript",
-                        "source": "const appPortalAccessOut = await svix.authentication.appPortalAccess('app_id', {\n    featureFlags: None\n});"
+                        "source": "const appPortalAccessOut = await svix.authentication.appPortalAccess('app_id', {\n    featureFlags: [    ]\n});"
                     },
                     {
                         "label": "Python",
                         "lang": "Python",
-                        "source": "app_portal_access_out = svix.authentication.app_portal_access('app_id', AppPortalAccessIn(\n    feature_flags=None\n))"
+                        "source": "app_portal_access_out = svix.authentication.app_portal_access('app_id', AppPortalAccessIn(\n    feature_flags=[]\n))"
                     },
                     {
                         "label": "Python (Async)",
                         "lang": "Python",
-                        "source": "app_portal_access_out = await svix.authentication.app_portal_access('app_id', AppPortalAccessIn(\n    feature_flags=None\n))"
+                        "source": "app_portal_access_out = await svix.authentication.app_portal_access('app_id', AppPortalAccessIn(\n    feature_flags=[]\n))"
                     },
                     {
                         "label": "Go",
                         "lang": "Go",
-                        "source": "appPortalAccessOut, err := svixClient.Authentication.AppPortalAccess(\"app_id\", &svix.AppPortalAccessIn{\n    FeatureFlags: None\n})"
+                        "source": "appPortalAccessOut, err := svixClient.Authentication.AppPortalAccess(\"app_id\", &svix.AppPortalAccessIn{\n    FeatureFlags: [...]string{}\n})"
                     },
                     {
                         "label": "Kotlin",
                         "lang": "Kotlin",
-                        "source": "val appPortalAccessOut = svix.authentication.appPortalAccess('app_id', AppPortalAccessIn()\n    .featureFlags(None)\n)"
+                        "source": "val appPortalAccessOut = svix.authentication.appPortalAccess('app_id', AppPortalAccessIn()\n    .featureFlags(arrayOf())\n)"
                     },
                     {
                         "label": "Java",
                         "lang": "Java",
-                        "source": "AppPortalAccessOut appPortalAccessOut = svix.getAuthentication().appPortalAccess('app_id', new AppPortalAccessIn()\n    .featureFlags(None)\n)"
+                        "source": "AppPortalAccessOut appPortalAccessOut = svix.getAuthentication().appPortalAccess('app_id', new AppPortalAccessIn()\n    .featureFlags(new String[]{})\n)"
                     },
                     {
                         "label": "Ruby",
                         "lang": "Ruby",
-                        "source": "app_portal_access_out = svix.authentication.app_portal_access('app_id', Svix::AppPortalAccessIn.new({\n    \"feature_flags\": null\n}))"
+                        "source": "app_portal_access_out = svix.authentication.app_portal_access('app_id', Svix::AppPortalAccessIn.new({\n    \"feature_flags\": []\n}))"
                     },
                     {
                         "label": "Rust",
                         "lang": "Rust",
-                        "source": "let app_portal_access_out = svix.authentication().app_portal_access(\"app_id\", AppPortalAccessIn {\n    feature_flags: None\n}).await?;"
+                        "source": "let app_portal_access_out = svix.authentication().app_portal_access(\"app_id\", AppPortalAccessIn {\n    feature_flags: Some(vec![])\n}).await?;"
                     },
                     {
                         "label": "C#",
                         "lang": "C#",
-                        "source": "var appPortalAccessOut = await svix.Authentication.AppPortalAccessAsync(\"app_id\", new AppPortalAccessIn{\n    featureFlags: None\n})"
+                        "source": "var appPortalAccessOut = await svix.Authentication.AppPortalAccessAsync(\"app_id\", new AppPortalAccessIn{\n    featureFlags: new string[] {}\n})"
                     },
                     {
                         "label": "CLI",
                         "lang": "Shell",
-                        "source": "svix authentication app-portal-access 'app_id' '{\n    \"featureFlags\": null\n}'"
+                        "source": "svix authentication app-portal-access 'app_id' '{\n    \"featureFlags\": []\n}'"
                     },
                     {
                         "label": "cURL",
                         "lang": "Shell",
-                        "source": "curl -X 'POST' \\\n  'https://api.svix.com/api/v1/auth/app-portal-access/{app_id}/' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"featureFlags\": null\n}'"
+                        "source": "curl -X 'POST' \\\n  'https://api.svix.com/api/v1/auth/app-portal-access/{app_id}/' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"featureFlags\": []\n}'"
                     }
                 ]
             }
@@ -12065,7 +12334,7 @@
                         "HTTPBearer": []
                     }
                 ],
-                "summary": "Get Consumer App Portal Access",
+                "summary": "Get Dashboard Access",
                 "tags": [
                     "Authentication"
                 ],

--- a/python/svix/api.py
+++ b/python/svix/api.py
@@ -23,11 +23,13 @@ from .internal.openapi_client.api.endpoint import (
     get_endpoint_headers_api_v1_app_app_id_endpoint_endpoint_id_headers_get,
     get_endpoint_secret_api_v1_app_app_id_endpoint_endpoint_id_secret_get,
     get_endpoint_stats_api_v1_app_app_id_endpoint_endpoint_id_stats_get,
+    get_endpoint_transformation_api_v1_app_app_id_endpoint_endpoint_id_transformation_get,
     list_endpoints_api_v1_app_app_id_endpoint_get,
     patch_endpoint_headers_api_v1_app_app_id_endpoint_endpoint_id_headers_patch,
     recover_failed_webhooks_api_v1_app_app_id_endpoint_endpoint_id_recover_post,
     replay_missing_webhooks_api_v1_app_app_id_endpoint_endpoint_id_replay_missing_post,
     rotate_endpoint_secret_api_v1_app_app_id_endpoint_endpoint_id_secret_rotate_post,
+    set_endpoint_transformation_api_v1_app_app_id_endpoint_endpoint_id_transformation_patch,
     update_endpoint_api_v1_app_app_id_endpoint_endpoint_id_put,
     update_endpoint_headers_api_v1_app_app_id_endpoint_endpoint_id_headers_put,
 )
@@ -76,6 +78,8 @@ from .internal.openapi_client.models.endpoint_out import EndpointOut
 from .internal.openapi_client.models.endpoint_secret_out import EndpointSecretOut
 from .internal.openapi_client.models.endpoint_secret_rotate_in import EndpointSecretRotateIn
 from .internal.openapi_client.models.endpoint_stats import EndpointStats
+from .internal.openapi_client.models.endpoint_transformation_in import EndpointTransformationIn
+from .internal.openapi_client.models.endpoint_transformation_out import EndpointTransformationOut
 from .internal.openapi_client.models.endpoint_update import EndpointUpdate
 from .internal.openapi_client.models.event_type_in import EventTypeIn
 from .internal.openapi_client.models.event_type_out import EventTypeOut
@@ -366,6 +370,21 @@ class EndpointAsync(ApiBase):
             client=self._client, app_id=app_id, endpoint_id=endpoint_id, json_body=replay_in, **options.to_dict()
         )
 
+    async def transformations_get(self, app_id: str, endpoint_id: str) -> EndpointTransformationOut:
+        return await get_endpoint_transformation_api_v1_app_app_id_endpoint_endpoint_id_transformation_get.asyncio(
+            client=self._client, app_id=app_id, endpoint_id=endpoint_id
+        )
+
+    async def transformation_partial_update(
+        self, app_id: str, endpoint_id: str, endpoint_transformation_in: EndpointTransformationIn
+    ) -> None:
+        await set_endpoint_transformation_api_v1_app_app_id_endpoint_endpoint_id_transformation_patch.asyncio(
+            client=self._client,
+            app_id=app_id,
+            endpoint_id=endpoint_id,
+            json_body=endpoint_transformation_in,
+        )
+
 
 class Endpoint(ApiBase):
     def list(self, app_id: str, options: EndpointListOptions = EndpointListOptions()) -> ListResponseEndpointOut:
@@ -471,6 +490,21 @@ class Endpoint(ApiBase):
     ) -> ReplayOut:
         return replay_missing_webhooks_api_v1_app_app_id_endpoint_endpoint_id_replay_missing_post.sync(
             client=self._client, app_id=app_id, endpoint_id=endpoint_id, json_body=replay_in, **options.to_dict()
+        )
+
+    def transformations_get(self, app_id: str, endpoint_id: str) -> EndpointTransformationOut:
+        return get_endpoint_transformation_api_v1_app_app_id_endpoint_endpoint_id_transformation_get.sync(
+            client=self._client, app_id=app_id, endpoint_id=endpoint_id
+        )
+
+    def transformation_partial_update(
+        self, app_id: str, endpoint_id: str, endpoint_transformation_in: EndpointTransformationIn
+    ) -> None:
+        set_endpoint_transformation_api_v1_app_app_id_endpoint_endpoint_id_transformation_patch.sync(
+            client=self._client,
+            app_id=app_id,
+            endpoint_id=endpoint_id,
+            json_body=endpoint_transformation_in,
         )
 
 

--- a/ruby/lib/svix/endpoint_api.rb
+++ b/ruby/lib/svix/endpoint_api.rb
@@ -60,5 +60,13 @@ module Svix
       nil
     end
 
+    def transformation_get(app_id, endpoint_id, options = {})
+      return @api.get_endpoint_transformation_api_v1_app_app_id_endpoint_endpoint_id_transformation_get(endpoint_id, app_id, options)
+    end
+
+    def transformation_partial_update(app_id, endpoint_id, endpoint_transformation_in, options = {})
+      @api.set_endpoint_transformation_api_v1_app_app_id_endpoint_endpoint_id_transformation_patch(app_id, endpoint_id, endpoint_transformation_in, options)
+      nil
+    end
   end
 end

--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -5,8 +5,9 @@ use crate::apis::{
 };
 use crate::error::Result;
 use crate::models::{
-    AppPortalAccessIn, AppPortalAccessOut, IntegrationIn, IntegrationKeyOut, IntegrationOut,
-    IntegrationUpdate, ListResponseIntegrationOut, ReplayIn,
+    AppPortalAccessIn, AppPortalAccessOut, EndpointTransformationIn, EndpointTransformationOut,
+    IntegrationIn, IntegrationKeyOut, IntegrationOut, IntegrationUpdate,
+    ListResponseIntegrationOut, ReplayIn,
 };
 pub use crate::models::{
     ApplicationIn, ApplicationOut, DashboardAccessOut, EndpointHeadersIn, EndpointHeadersOut,
@@ -498,6 +499,37 @@ impl<'a> Endpoint<'a> {
             },
         )
         .await?;
+        Ok(())
+    }
+
+    pub async fn transformation_get(
+        &self,
+        app_id: String,
+        endpoint_id: String,
+    ) -> Result<EndpointTransformationOut> {
+        Ok(endpoint_api::get_endpoint_transformation_api_v1_app_app_id_endpoint_endpoint_id_transformation_get(
+            self.cfg,
+            endpoint_api::GetEndpointTransformationApiV1AppAppIdEndpointEndpointIdTransformationGetParams {
+                app_id,
+                endpoint_id,
+                idempotency_key: None,
+            }
+        )
+        .await?)
+    }
+
+    pub async fn transformation_partial_update(
+        &self,
+        app_id: String,
+        endpoint_id: String,
+        endpoint_transformation_in: EndpointTransformationIn,
+    ) -> Result<()> {
+        endpoint_api::set_endpoint_transformation_api_v1_app_app_id_endpoint_endpoint_id_transformation_patch(self.cfg, endpoint_api::SetEndpointTransformationApiV1AppAppIdEndpointEndpointIdTransformationPatchParams {
+            app_id,
+            endpoint_id,
+            endpoint_transformation_in,
+            idempotency_key: None,
+        }).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
These changes introduce methods for interfacing with the transformations API in the libraries. In the process it updates the `openapi.json` file to the most recent version, meaning some of the unrelated Go generated code is updated by proxy.