### PR TITLE
Fix `/attempt/endpoint`'s broken `?channel=` query

### DIFF
--- a/server/svix-server/src/core/types/mod.rs
+++ b/server/svix-server/src/core/types/mod.rs
@@ -254,6 +254,13 @@ macro_rules! string_wrapper {
 
 macro_rules! string_wrapper_impl {
     ($name_id:ident) => {
+        impl $name_id {
+            /// Wraps the type as JSONB. Useful when doing comparisons in a jsonb container w/sea_orm|postgres.
+            pub fn jsonb(self) -> sea_orm::Value {
+                sea_orm::Value::Json(Some(Box::new(serde_json::Value::String(self.0))))
+            }
+        }
+
         impl Deref for $name_id {
             type Target = String;
 


### PR DESCRIPTION
## Motivation

`/attempt/endpoint` is borked.

When `?channel=` is specified, an improper join happens which causes the Endpoint to fail with a 500 error.

Also, the actual query on a specific channel just straight up doesn't work. `channel ?? ?` is neither the proper operation, nor is `?` even used for params in postgres. You need a `$N`.

## Solution

Fix the damn queries! And update the tests so we catch this in the future.