### PR TITLE
Publicly reexport types in the `api` pkg in rust

### DIFF
--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -4,19 +4,16 @@ use crate::apis::{
     message_api, message_attempt_api,
 };
 use crate::error::Result;
-use crate::models::{
-    AppPortalAccessIn, AppPortalAccessOut, EndpointTransformationIn, EndpointTransformationOut,
-    IntegrationIn, IntegrationKeyOut, IntegrationOut, IntegrationUpdate,
-    ListResponseIntegrationOut, ReplayIn,
-};
 pub use crate::models::{
-    ApplicationIn, ApplicationOut, DashboardAccessOut, EndpointHeadersIn, EndpointHeadersOut,
-    EndpointHeadersPatchIn, EndpointIn, EndpointOut, EndpointSecretOut, EndpointSecretRotateIn,
-    EndpointStats, EndpointUpdate, EventTypeIn, EventTypeOut, EventTypeUpdate,
+    AppPortalAccessIn, AppPortalAccessOut, ApplicationIn, ApplicationOut, DashboardAccessOut,
+    EndpointHeadersIn, EndpointHeadersOut, EndpointHeadersPatchIn, EndpointIn, EndpointOut,
+    EndpointSecretOut, EndpointSecretRotateIn, EndpointStats, EndpointTransformationIn,
+    EndpointTransformationOut, EndpointUpdate, EventTypeIn, EventTypeOut, EventTypeUpdate,
+    IntegrationIn, IntegrationKeyOut, IntegrationOut, IntegrationUpdate,
     ListResponseApplicationOut, ListResponseEndpointMessageOut, ListResponseEndpointOut,
-    ListResponseEventTypeOut, ListResponseMessageAttemptEndpointOut, ListResponseMessageAttemptOut,
-    ListResponseMessageEndpointOut, ListResponseMessageOut, MessageAttemptOut, MessageIn,
-    MessageOut, MessageStatus, RecoverIn, StatusCodeClass,
+    ListResponseEventTypeOut, ListResponseIntegrationOut, ListResponseMessageAttemptEndpointOut,
+    ListResponseMessageAttemptOut, ListResponseMessageEndpointOut, ListResponseMessageOut,
+    MessageAttemptOut, MessageIn, MessageOut, MessageStatus, RecoverIn, ReplayIn, StatusCodeClass,
 };
 
 const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");


### PR DESCRIPTION
The main `api` package has so far reexported the types used in the functions it wraps, with a few exceptions. This PR moves these types from the private `use` statement to the publicly reexporting one. 

Fixes #805 