### PR TITLE
Fix event_type array query parsing

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -3323,6 +3323,7 @@ dependencies = [
  "ed25519-compact",
  "enum_dispatch",
  "figment",
+ "form_urlencoded",
  "futures",
  "hmac-sha256",
  "http",

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -73,6 +73,7 @@ ipnet = { version = "2.5", features = ["serde"] }
 urlencoding = "2.1.2"
 strum_macros = "0.24"
 strum = { version = "0.24", features = ["derive"] }
+form_urlencoded = "1.1.0"
 
 [dev-dependencies]
 anyhow = "1.0.56"

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -15,8 +15,8 @@ use crate::{
     queue::MessageTaskBatch,
     v1::utils::{
         apply_pagination, iterator_from_before_or_after, openapi_tag, validation_error,
-        ApplicationMsgPath, ListResponse, MessageListFetchOptions, ModelIn, ModelOut,
-        PaginationLimit, ReversibleIterator, ValidatedJson, ValidatedQuery,
+        ApplicationMsgPath, EventTypesQuery, ListResponse, ModelIn, ModelOut, PaginationLimit,
+        ReversibleIterator, ValidatedJson, ValidatedQuery,
     },
     AppState,
 };
@@ -165,6 +165,7 @@ pub struct ListMessagesQueryParams {
     #[serde(default = "default_true")]
     with_content: bool,
 
+    before: Option<DateTime<Utc>>,
     after: Option<DateTime<Utc>>,
 }
 
@@ -174,16 +175,17 @@ async fn list_messages(
     ValidatedQuery(ListMessagesQueryParams {
         channel,
         with_content,
+        before,
         after,
     }): ValidatedQuery<ListMessagesQueryParams>,
-    list_filter: MessageListFetchOptions,
+    EventTypesQuery(event_types): EventTypesQuery,
     permissions::Application { app }: permissions::Application,
 ) -> Result<Json<ListResponse<MessageOut>>> {
     let PaginationLimit(limit) = pagination.limit;
 
     let mut query = message::Entity::secure_find(app.id);
 
-    if let Some(EventTypeNameSet(event_types)) = list_filter.event_types {
+    if let Some(EventTypeNameSet(event_types)) = event_types {
         query = query.filter(message::Column::EventType.is_in(event_types));
     }
 
@@ -191,7 +193,7 @@ async fn list_messages(
         query = query.filter(Expr::cust_with_values("channels ?? ?", vec![channel]));
     }
 
-    let iterator = iterator_from_before_or_after(pagination.iterator, list_filter.before, after);
+    let iterator = iterator_from_before_or_after(pagination.iterator, before, after);
     let is_prev = matches!(iterator, Some(ReversibleIterator::Prev(_)));
 
     let query = apply_pagination(query, message::Column::Id, limit, iterator);

--- a/server/svix-server/tests/e2e_attempt.rs
+++ b/server/svix-server/tests/e2e_attempt.rs
@@ -262,6 +262,33 @@ async fn test_list_attempts_by_endpoint() {
         .unwrap();
     assert_eq!(obits_attempts.data.len(), 1);
 
+    let exploded_attempts: ListResponse<MessageAttemptOut> = client
+        .get(
+            &format!("api/v1/app/{app_id}/attempt/endpoint/{endp_id_2}/?event_types=user.exploded"),
+            StatusCode::OK,
+        )
+        .await
+        .unwrap();
+    assert_eq!(exploded_attempts.data.len(), 1);
+
+    let regular_attempts: ListResponse<MessageAttemptOut> = client
+        .get(
+            &format!("api/v1/app/{app_id}/attempt/endpoint/{endp_id_2}/?event_types[]=event.type"),
+            StatusCode::OK,
+        )
+        .await
+        .unwrap();
+    assert_eq!(regular_attempts.data.len(), 2);
+
+    let all_attempts: ListResponse<MessageAttemptOut> = client
+    .get(
+        &format!("api/v1/app/{app_id}/attempt/endpoint/{endp_id_2}/?event_types[0]=event.type&event_types[1]=user.exploded"),
+        StatusCode::OK,
+    )
+    .await
+    .unwrap();
+    assert_eq!(all_attempts.data.len(), 3);
+
     receiver_1.jh.abort();
     receiver_2.jh.abort();
 }


### PR DESCRIPTION
This fixes how `?event_types` query parameters are parsed in `*/attempt/endpoint/*`, in addition to some adjacent refactors.

## Motivation

`axum::Query` doesn't support URL query array parameter parsing very well. For example,
- `?a=1&a=2` gets rejected
- `?a[]=1&a[]=2` also gets rejected
- `?a[0]=1&a[1]=2` _also_ gets rejected

This is largely because `serde::urlencoded` doesn't support any of these formats. See https://github.com/nox/serde_urlencoded/issues/75

There is `serde_qs`, which supports the last two. But not the first format. See https://github.com/samscott89/serde_qs/issues/16

Unfortunately, we _need_ to support the first format because that is what our internal API has supported up to today.

However, our OSS has been inconsistent. Specifically with `?event_types`.

Most endpoints that took in `?event_types` used `MessageListFetchOptions`, which manually parsed `?event_types` only using the first format. Ideally, we'd like to support all 3.

In addition, `*/attempts/endpoint/` didn't use `MessageListFetchOptions`. Instead it relied on `axum::Query` deserialization, so `?event_types` outright didn't work as expected with this endpoint.

## Solution

This PR does a couple small things to fix these issues

1) `MessageListFetchOptions` is axed in favor of a more explicit `EventTypesQuery`. `MessageListFetchOptions` had an extra timestamp parameter, `before`, that is already parsed just fine by `axum::Query`.
2) `EventTypesQuery` is _similar_ to `MessageListFetchOptions`, in respect to how `event_types` are parsed. With a few exceptions
    * `EventTypesQuery` validates the input.
    * `EventTypesQuery` handles all 3 formats, not just the first one
    * `EventTypesQuery` should be a bit more performant, since it uses `form_urlencode`, which parses pairs as `Cow<str>`, so fewer allocations. (Note that `form_urlencode` is what `serde_urlencoded` uses under the hood)
3) Updates `*/attempts/endpoint/` to use `EventTypesQuery`, so that `?event_types` are parsed correctly. Tests are added to demonstrate and validate this behavior.