### PR TITLE
Add operation descriptions to generated OpenAPI

### DIFF
--- a/server/svix-server/src/v1/endpoints/endpoint/crud.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/crud.rs
@@ -30,6 +30,8 @@ use crate::{
 };
 use hack::EventTypeNameResult;
 
+pub(super) const LIST_ENDPOINTS_DESCRIPTION: &str = "List the application's endpoints.";
+
 pub(super) async fn list_endpoints(
     State(AppState { ref db, .. }): State<AppState>,
     ValidatedQuery(pagination): ValidatedQuery<Pagination<ReversibleIterator<EndpointId>>>,
@@ -98,6 +100,12 @@ async fn create_endp_from_data(
     Ok((endp, metadata))
 }
 
+pub(super) const CREATE_ENDPOINT_DESCRIPTION: &str = r#"
+Create a new endpoint for the application.
+
+When `secret` is `null` the secret is automatically generated (recommended)
+"#;
+
 pub(super) async fn create_endpoint(
     State(AppState {
         ref db,
@@ -117,6 +125,8 @@ pub(super) async fn create_endpoint(
 
     Ok((StatusCode::CREATED, Json((endp, metadata.data).into())))
 }
+
+pub(super) const GET_ENDPOINT_DESCRIPTION: &str = "Get an endpoint.";
 
 pub(super) async fn get_endpoint(
     State(AppState { ref db, .. }): State<AppState>,
@@ -162,6 +172,8 @@ async fn update_endp_from_data(
     Ok((endp, metadata))
 }
 
+pub(super) const UPDATE_ENDPOINT_DESCRIPTION: &str = "Update an endpoint.";
+
 pub(super) async fn update_endpoint(
     State(AppState {
         ref db,
@@ -192,6 +204,8 @@ pub(super) async fn update_endpoint(
         Ok((StatusCode::CREATED, Json((endp, metadata.data).into())))
     }
 }
+
+pub(super) const PATCH_ENDPOINT_DESCRIPTION: &str = "Partially update an endpoint.";
 
 pub(super) async fn patch_endpoint(
     State(AppState {
@@ -224,6 +238,8 @@ pub(super) async fn patch_endpoint(
 
     Ok(Json((endp, metadata.data).into()))
 }
+
+pub(super) const DELETE_ENDPOINT_DESCRIPTION: &str = "Delete an endpoint.";
 
 pub(super) async fn delete_endpoint(
     State(AppState {

--- a/server/svix-server/src/v1/endpoints/endpoint/headers.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/headers.rs
@@ -15,6 +15,9 @@ use crate::{
     AppState,
 };
 
+pub(super) const GET_ENDPOINT_HEADERS_DESCRIPTION: &str =
+    "Get the additional headers to be sent with the webhook";
+
 pub(super) async fn get_endpoint_headers(
     State(AppState { ref db, .. }): State<AppState>,
     Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,
@@ -32,6 +35,9 @@ pub(super) async fn get_endpoint_headers(
         None => Ok(Json(EndpointHeadersOut::default())),
     }
 }
+
+pub(super) const UPDATE_ENDPOINT_HEADERS_DESCRIPTION: &str =
+    "Set the additional headers to be sent with the webhook";
 
 pub(super) async fn update_endpoint_headers(
     State(AppState { ref db, .. }): State<AppState>,
@@ -52,6 +58,9 @@ pub(super) async fn update_endpoint_headers(
 
     Ok((StatusCode::NO_CONTENT, Json(EmptyResponse {})))
 }
+
+pub(super) const PATCH_ENDPOINT_HEADERS_DESCRIPTION: &str =
+    "Partially set the additional headers to be sent with the webhook";
 
 pub(super) async fn patch_endpoint_headers(
     State(AppState { ref db, .. }): State<AppState>,

--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -19,7 +19,7 @@ use crate::{
     db::models::messagedestination,
     error::{self, HttpError},
     v1::utils::{
-        api_not_implemented, openapi_tag,
+        api_not_implemented, openapi_desc, openapi_tag,
         patch::{
             patch_field_non_nullable, patch_field_nullable, UnrequiredField,
             UnrequiredNullableField,
@@ -31,7 +31,7 @@ use crate::{
 };
 
 use aide::axum::{
-    routing::{get, post},
+    routing::{get_with, post_with},
     ApiRouter,
 };
 use axum::{
@@ -523,6 +523,8 @@ pub struct EndpointStatsQueryOut {
     count: i64,
 }
 
+const ENDPOINT_STATS_DESCRIPTION: &str = "Get basic statistics for the endpoint.";
+
 async fn endpoint_stats(
     State(AppState { ref db, .. }): State<AppState>,
     Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,
@@ -564,52 +566,92 @@ async fn endpoint_stats(
     }))
 }
 
+const SEND_EXAMPLE_DESCRIPTION: &str = "Send an example message for event";
+
 pub fn router() -> ApiRouter<AppState> {
+    let tag = openapi_tag("Endpoint");
     ApiRouter::new()
         .api_route_with(
             "/app/:app_id/endpoint/",
-            post(crud::create_endpoint).get(crud::list_endpoints),
-            openapi_tag("Endpoint"),
+            post_with(
+                crud::create_endpoint,
+                openapi_desc(crud::CREATE_ENDPOINT_DESCRIPTION),
+            )
+            .get_with(
+                crud::list_endpoints,
+                openapi_desc(crud::LIST_ENDPOINTS_DESCRIPTION),
+            ),
+            &tag,
         )
         .api_route_with(
             "/app/:app_id/endpoint/:endpoint_id/",
-            get(crud::get_endpoint)
-                .put(crud::update_endpoint)
-                .patch(crud::patch_endpoint)
-                .delete(crud::delete_endpoint),
-            openapi_tag("Endpoint"),
+            get_with(
+                crud::get_endpoint,
+                openapi_desc(crud::GET_ENDPOINT_DESCRIPTION),
+            )
+            .put_with(
+                crud::update_endpoint,
+                openapi_desc(crud::UPDATE_ENDPOINT_DESCRIPTION),
+            )
+            .patch_with(
+                crud::patch_endpoint,
+                openapi_desc(crud::PATCH_ENDPOINT_DESCRIPTION),
+            )
+            .delete_with(
+                crud::delete_endpoint,
+                openapi_desc(crud::DELETE_ENDPOINT_DESCRIPTION),
+            ),
+            &tag,
         )
         .api_route_with(
             "/app/:app_id/endpoint/:endpoint_id/secret/",
-            get(secrets::get_endpoint_secret),
-            openapi_tag("Endpoint"),
+            get_with(
+                secrets::get_endpoint_secret,
+                openapi_desc(secrets::GET_ENDPOINT_SECRET_DESCRIPTION),
+            ),
+            &tag,
         )
         .api_route_with(
             "/app/:app_id/endpoint/:endpoint_id/secret/rotate/",
-            post(secrets::rotate_endpoint_secret),
-            openapi_tag("Endpoint"),
+            post_with(
+                secrets::rotate_endpoint_secret,
+                openapi_desc(secrets::ROTATE_ENDPOINT_SECRET_DESCRIPTION),
+            ),
+            &tag,
         )
         .api_route_with(
             "/app/:app_id/endpoint/:endpoint_id/stats/",
-            get(endpoint_stats),
-            openapi_tag("Endpoint"),
+            get_with(endpoint_stats, openapi_desc(ENDPOINT_STATS_DESCRIPTION)),
+            &tag,
         )
         .api_route_with(
             "/app/:app_id/endpoint/:endpoint_id/send-example/",
-            post(api_not_implemented),
-            openapi_tag("Endpoint"),
+            post_with(api_not_implemented, openapi_desc(SEND_EXAMPLE_DESCRIPTION)),
+            &tag,
         )
         .api_route_with(
             "/app/:app_id/endpoint/:endpoint_id/recover/",
-            post(recovery::recover_failed_webhooks),
-            openapi_tag("Endpoint"),
+            post_with(
+                recovery::recover_failed_webhooks,
+                openapi_desc(recovery::RECOVER_FAILED_WEBHOOKS_DESCRIPTION),
+            ),
+            &tag,
         )
         .api_route_with(
             "/app/:app_id/endpoint/:endpoint_id/headers/",
-            get(headers::get_endpoint_headers)
-                .patch(headers::patch_endpoint_headers)
-                .put(headers::update_endpoint_headers),
-            openapi_tag("Endpoint"),
+            get_with(
+                headers::get_endpoint_headers,
+                openapi_desc(headers::GET_ENDPOINT_HEADERS_DESCRIPTION),
+            )
+            .patch_with(
+                headers::patch_endpoint_headers,
+                openapi_desc(headers::PATCH_ENDPOINT_HEADERS_DESCRIPTION),
+            )
+            .put_with(
+                headers::update_endpoint_headers,
+                openapi_desc(headers::UPDATE_ENDPOINT_HEADERS_DESCRIPTION),
+            ),
+            tag,
         )
 }
 

--- a/server/svix-server/src/v1/endpoints/endpoint/recovery.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/recovery.rs
@@ -71,6 +71,9 @@ async fn bulk_recover_failed_messages(
     Ok(())
 }
 
+pub(super) const RECOVER_FAILED_WEBHOOKS_DESCRIPTION: &str =
+    "Resend all failed messages since a given time.";
+
 pub(super) async fn recover_failed_webhooks(
     State(AppState {
         ref db, queue_tx, ..

--- a/server/svix-server/src/v1/endpoints/endpoint/secrets.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/secrets.rs
@@ -34,6 +34,13 @@ pub(super) fn generate_secret(
     }
 }
 
+pub(super) const GET_ENDPOINT_SECRET_DESCRIPTION: &str = r#"
+Get the endpoint's signing secret.
+
+This is used to verify the authenticity of the webhook.
+For more information please refer to [the consuming webhooks docs](https://docs.svix.com/consuming-webhooks/).
+"#;
+
 pub(super) async fn get_endpoint_secret(
     State(AppState { ref db, cfg, .. }): State<AppState>,
     Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,
@@ -49,6 +56,8 @@ pub(super) async fn get_endpoint_secret(
         key: endp.key.into_endpoint_secret(&cfg.encryption)?,
     }))
 }
+
+pub(super) const ROTATE_ENDPOINT_SECRET_DESCRIPTION: &str = "Rotates the endpoint's signing secret.  The previous secret will be valid for the next 24 hours.";
 
 pub(super) async fn rotate_endpoint_secret(
     State(AppState {

--- a/server/svix-server/src/v1/utils/mod.rs
+++ b/server/svix-server/src/v1/utils/mod.rs
@@ -9,7 +9,10 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use aide::{transform::TransformPathItem, OperationInput, OperationIo};
+use aide::{
+    transform::{TransformOperation, TransformPathItem},
+    OperationInput, OperationIo,
+};
 use axum::{
     async_trait,
     body::HttpBody,
@@ -509,8 +512,12 @@ pub fn validate_no_control_characters_unrequired(
     }
 }
 
-pub fn openapi_tag(tag: &'static str) -> impl FnOnce(TransformPathItem) -> TransformPathItem {
-    |op| op.tag(tag)
+pub fn openapi_tag<T: AsRef<str>>(tag: T) -> impl Fn(TransformPathItem) -> TransformPathItem {
+    move |op| op.tag(tag.as_ref())
+}
+
+pub fn openapi_desc<T: AsRef<str>>(desc: T) -> impl Fn(TransformOperation) -> TransformOperation {
+    move |op| op.description(desc.as_ref())
 }
 
 pub fn get_unix_timestamp() -> u64 {


### PR DESCRIPTION
This change just copy-pastes the description from the existing spec, except for fixing obvious mistakes (e.g. get_endpoint says "gets an application" in the current spec)
