### PR TITLE
Implement bidirectional pagination for endpoints

### DIFF
--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -18,10 +18,10 @@ use crate::{
     v1::{
         endpoints::message::MessageOut,
         utils::{
-            apply_pagination, iterator_from_before_or_after, openapi_tag, ApplicationEndpointPath,
-            ApplicationMsgAttemptPath, ApplicationMsgEndpointPath, ApplicationMsgPath,
-            EmptyResponse, EventTypesQuery, ListResponse, ModelOut, PaginationLimit,
-            ReversibleIterator, ValidatedQuery,
+            apply_pagination_desc, iterator_from_before_or_after, openapi_tag,
+            ApplicationEndpointPath, ApplicationMsgAttemptPath, ApplicationMsgEndpointPath,
+            ApplicationMsgPath, EmptyResponse, EventTypesQuery, ListResponse, ModelOut,
+            PaginationLimit, ReversibleIterator, ValidatedQuery,
         },
     },
     AppState,
@@ -185,7 +185,7 @@ async fn list_attempted_messages(
     let iterator = iterator_from_before_or_after(msg_dest_iterator, before, after);
     let is_prev = matches!(iterator, Some(ReversibleIterator::Prev(_)));
 
-    let dests_and_msgs = apply_pagination(
+    let dests_and_msgs = apply_pagination_desc(
         dests_and_msgs,
         messagedestination::Column::Id,
         limit,
@@ -211,7 +211,7 @@ async fn list_attempted_messages(
             .collect::<Result<_>>()?
     };
 
-    Ok(Json(AttemptedMessageOut::list_response(
+    Ok(Json(AttemptedMessageOut::list_response_desc(
         out,
         limit as usize,
         is_prev,
@@ -330,7 +330,7 @@ async fn list_attempts_by_endpoint(
 
     let iterator = iterator_from_before_or_after(pagination.iterator, before, after);
     let is_prev = matches!(iterator, Some(ReversibleIterator::Prev(_)));
-    let query = apply_pagination(query, messageattempt::Column::Id, limit, iterator);
+    let query = apply_pagination_desc(query, messageattempt::Column::Id, limit, iterator);
 
     let out = if is_prev {
         ctx!(query.all(db).await)?
@@ -345,7 +345,7 @@ async fn list_attempts_by_endpoint(
             .collect()
     };
 
-    Ok(Json(MessageAttemptOut::list_response(
+    Ok(Json(MessageAttemptOut::list_response_desc(
         out,
         limit as usize,
         is_prev,
@@ -414,7 +414,7 @@ async fn list_attempts_by_msg(
 
     let iterator = iterator_from_before_or_after(pagination.iterator, before, after);
     let is_prev = matches!(iterator, Some(ReversibleIterator::Prev(_)));
-    let query = apply_pagination(query, messageattempt::Column::Id, limit, iterator);
+    let query = apply_pagination_desc(query, messageattempt::Column::Id, limit, iterator);
     let out = if is_prev {
         ctx!(query.all(db).await)?
             .into_iter()
@@ -428,7 +428,7 @@ async fn list_attempts_by_msg(
             .collect()
     };
 
-    Ok(Json(MessageAttemptOut::list_response(
+    Ok(Json(MessageAttemptOut::list_response_desc(
         out,
         limit as usize,
         is_prev,
@@ -613,7 +613,7 @@ async fn list_messageattempts(
 
     let iterator = iterator_from_before_or_after(pagination.iterator, before, after);
     let is_prev = matches!(iterator, Some(ReversibleIterator::Prev(_)));
-    let query = apply_pagination(query, messageattempt::Column::Id, limit, iterator);
+    let query = apply_pagination_desc(query, messageattempt::Column::Id, limit, iterator);
     let out = if is_prev {
         ctx!(query.all(db).await)?
             .into_iter()
@@ -627,7 +627,7 @@ async fn list_messageattempts(
             .collect()
     };
 
-    Ok(Json(MessageAttemptOut::list_response(
+    Ok(Json(MessageAttemptOut::list_response_desc(
         out,
         limit as usize,
         false,

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -14,7 +14,7 @@ use crate::{
     error::{HttpError, Result},
     queue::MessageTaskBatch,
     v1::utils::{
-        apply_pagination, iterator_from_before_or_after, openapi_tag, validation_error,
+        apply_pagination_desc, iterator_from_before_or_after, openapi_tag, validation_error,
         ApplicationMsgPath, EventTypesQuery, ListResponse, ModelIn, ModelOut, PaginationLimit,
         ReversibleIterator, ValidatedJson, ValidatedQuery,
     },
@@ -196,7 +196,7 @@ async fn list_messages(
     let iterator = iterator_from_before_or_after(pagination.iterator, before, after);
     let is_prev = matches!(iterator, Some(ReversibleIterator::Prev(_)));
 
-    let query = apply_pagination(query, message::Column::Id, limit, iterator);
+    let query = apply_pagination_desc(query, message::Column::Id, limit, iterator);
     let into = |x: message::Model| {
         if with_content {
             x.into()
@@ -215,7 +215,11 @@ async fn list_messages(
         ctx!(query.all(db).await)?.into_iter().map(into).collect()
     };
 
-    Ok(Json(MessageOut::list_response(out, limit as usize, false)))
+    Ok(Json(MessageOut::list_response_desc(
+        out,
+        limit as usize,
+        false,
+    )))
 }
 
 #[derive(Debug, Deserialize, Validate, JsonSchema)]


### PR DESCRIPTION
With this change `Endpoint` also returns a `prev_iterator` in its list response, and accepts such an iterator.