### PR TITLE
Fire operational webhook on endpoint secret rotation

### DIFF
--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -374,7 +374,7 @@ impl From<(endpoint::Model, Metadata)> for EndpointOut {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Validate, Deserialize, JsonSchema)]
+#[derive(Default, Clone, Debug, PartialEq, Eq, Validate, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct EndpointSecretRotateIn {
     #[validate]

--- a/server/svix-server/tests/e2e_operational_webhooks.rs
+++ b/server/svix-server/tests/e2e_operational_webhooks.rs
@@ -20,7 +20,7 @@ use svix_server::{
     },
     v1::endpoints::{
         application::{ApplicationIn, ApplicationOut},
-        endpoint::{EndpointIn, EndpointOut},
+        endpoint::{EndpointIn, EndpointOut, EndpointSecretRotateIn},
     },
 };
 
@@ -235,6 +235,25 @@ async fn test_endpoint_create_update_and_delete() {
         }
         _ => panic!("Got wrong type"),
     };
+
+    // Rotate secrets
+    let _: IgnoredResponse = client_regular
+        .post(
+            &format!(
+                "api/v1/app/{}/endpoint/{}/secret/rotate/",
+                regular_app.id, regular_endp.id
+            ),
+            EndpointSecretRotateIn::default(),
+            StatusCode::NO_CONTENT,
+        )
+        .await
+        .unwrap();
+
+    let op_webhook_out = receiver.data_recv.recv().await.unwrap();
+    assert_eq!(
+        op_webhook_out.get("type").unwrap().as_str().unwrap(),
+        "endpoint.updated"
+    );
 
     // And finally delete the endpoint
     let _: IgnoredResponse = client_regular


### PR DESCRIPTION
As per title, rotating the secrets of an endpoint is an update to the endpoint, therefore it should fire the corresponding operational webhook.