### PR TITLE
Handle previous iterator on descending ordering

### DIFF
--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -204,20 +204,12 @@ async fn list_attempted_messages(
         Ok(AttemptedMessageOut::from_dest_and_msg(dest, msg))
     };
 
-    let out = if is_prev {
-        ctx!(dests_and_msgs.all(db).await)?
-            .into_iter()
-            .rev()
-            .map(into)
-            .collect::<Result<_>>()?
-    } else {
-        ctx!(dests_and_msgs.all(db).await)?
-            .into_iter()
-            .map(into)
-            .collect::<Result<_>>()?
-    };
+    let out = ctx!(dests_and_msgs.all(db).await)?
+        .into_iter()
+        .map(into)
+        .collect::<Result<_>>()?;
 
-    Ok(Json(AttemptedMessageOut::list_response_desc(
+    Ok(Json(AttemptedMessageOut::list_response(
         out,
         limit as usize,
         is_prev,
@@ -340,20 +332,12 @@ async fn list_attempts_by_endpoint(
     let is_prev = matches!(iterator, Some(ReversibleIterator::Prev(_)));
     let query = apply_pagination_desc(query, messageattempt::Column::Id, limit, iterator);
 
-    let out = if is_prev {
-        ctx!(query.all(db).await)?
-            .into_iter()
-            .rev()
-            .map(Into::into)
-            .collect()
-    } else {
-        ctx!(query.all(db).await)?
-            .into_iter()
-            .map(Into::into)
-            .collect()
-    };
+    let out = ctx!(query.all(db).await)?
+        .into_iter()
+        .map(Into::into)
+        .collect();
 
-    Ok(Json(MessageAttemptOut::list_response_desc(
+    Ok(Json(MessageAttemptOut::list_response(
         out,
         limit as usize,
         is_prev,
@@ -425,20 +409,12 @@ async fn list_attempts_by_msg(
     let iterator = iterator_from_before_or_after(pagination.iterator, before, after);
     let is_prev = matches!(iterator, Some(ReversibleIterator::Prev(_)));
     let query = apply_pagination_desc(query, messageattempt::Column::Id, limit, iterator);
-    let out = if is_prev {
-        ctx!(query.all(db).await)?
-            .into_iter()
-            .rev()
-            .map(Into::into)
-            .collect()
-    } else {
-        ctx!(query.all(db).await)?
-            .into_iter()
-            .map(Into::into)
-            .collect()
-    };
+    let out = ctx!(query.all(db).await)?
+        .into_iter()
+        .map(Into::into)
+        .collect();
 
-    Ok(Json(MessageAttemptOut::list_response_desc(
+    Ok(Json(MessageAttemptOut::list_response(
         out,
         limit as usize,
         is_prev,
@@ -643,23 +619,15 @@ async fn list_messageattempts(
     let iterator = iterator_from_before_or_after(pagination.iterator, before, after);
     let is_prev = matches!(iterator, Some(ReversibleIterator::Prev(_)));
     let query = apply_pagination_desc(query, messageattempt::Column::Id, limit, iterator);
-    let out = if is_prev {
-        ctx!(query.all(db).await)?
-            .into_iter()
-            .rev()
-            .map(Into::into)
-            .collect()
-    } else {
-        ctx!(query.all(db).await)?
-            .into_iter()
-            .map(Into::into)
-            .collect()
-    };
+    let out = ctx!(query.all(db).await)?
+        .into_iter()
+        .map(Into::into)
+        .collect();
 
-    Ok(Json(MessageAttemptOut::list_response_desc(
+    Ok(Json(MessageAttemptOut::list_response(
         out,
         limit as usize,
-        false,
+        is_prev,
     )))
 }
 

--- a/server/svix-server/src/v1/endpoints/endpoint/crud.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/crud.rs
@@ -68,7 +68,6 @@ pub(super) async fn list_endpoints(
         results,
         limit as usize,
         is_prev,
-        order,
     )))
 }
 

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -212,20 +212,12 @@ async fn list_messages(
         }
     };
 
-    let out = if is_prev {
-        ctx!(query.all(db).await)?
-            .into_iter()
-            .rev()
-            .map(into)
-            .collect()
-    } else {
-        ctx!(query.all(db).await)?.into_iter().map(into).collect()
-    };
+    let out = ctx!(query.all(db).await)?.into_iter().map(into).collect();
 
-    Ok(Json(MessageOut::list_response_desc(
+    Ok(Json(MessageOut::list_response(
         out,
         limit as usize,
-        false,
+        is_prev,
     )))
 }
 

--- a/server/svix-server/tests/e2e_endpoint.rs
+++ b/server/svix-server/tests/e2e_endpoint.rs
@@ -671,6 +671,7 @@ async fn test_endpoint_list_ordering() {
         .await
         .unwrap();
 
+    // First iterate through in order
     assert_eq!(
         first_list.data.first().unwrap().ep.url,
         "https://test.url/0"
@@ -694,6 +695,7 @@ async fn test_endpoint_list_ordering() {
     assert_eq!(list.data.last().unwrap().ep.url, "https://test.url/3");
     assert!(!list.done);
 
+    // Iterate with previous iterator
     let list: ListResponse<EndpointOut> = client
         .get(
             &format!(
@@ -710,6 +712,7 @@ async fn test_endpoint_list_ordering() {
     assert_eq!(list.data.last().unwrap().ep.url, "https://test.url/1");
     assert!(list.done);
 
+    // Iterate in descending order
     let list: ListResponse<EndpointOut> = client
         .get(
             &format!("api/v1/app/{}/endpoint/?limit=3&order=descending", &app_id),
@@ -737,6 +740,21 @@ async fn test_endpoint_list_ordering() {
     assert_eq!(list.data.first().unwrap().ep.url, "https://test.url/1");
     assert_eq!(list.data.last().unwrap().ep.url, "https://test.url/0");
     assert!(list.done);
+
+    // Previous iterator on descending order
+    let list: ListResponse<EndpointOut> = client
+        .get(
+            &format!(
+                "api/v1/app/{}/endpoint/?limit=2&order=descending&iterator={}",
+                &app_id,
+                list.prev_iterator.unwrap(),
+            ),
+            StatusCode::OK,
+        )
+        .await
+        .unwrap();
+    assert_eq!(list.data.first().unwrap().ep.url, "https://test.url/3");
+    assert_eq!(list.data.last().unwrap().ep.url, "https://test.url/2");
 }
 
 /// Tests that there is at most one endpoint with a single UID for all endpoints associated with


### PR DESCRIPTION
After the last change, a "previous" iterator for descending sorting was not handled correctly. This fixes that.