### PR TITLE
Add support for ordering and prev_iter in app list

### DIFF
--- a/server/svix-server/src/v1/endpoints/endpoint/crud.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/crud.rs
@@ -24,7 +24,7 @@ use crate::{
         apply_pagination,
         patch::{patch_field_non_nullable, UnrequiredField, UnrequiredNullableField},
         ApplicationEndpointPath, EmptyResponse, ListOrdering, ListResponse, ModelIn, ModelOut,
-        Ordering, Pagination, PaginationLimit, ReversibleIterator, ValidatedJson, ValidatedQuery,
+        Pagination, PaginationLimit, ReversibleIterator, ValidatedJson, ValidatedQuery,
     },
     AppState,
 };
@@ -35,20 +35,18 @@ pub(super) const LIST_ENDPOINTS_DESCRIPTION: &str = "List the application's endp
 pub(super) async fn list_endpoints(
     State(AppState { ref db, .. }): State<AppState>,
     ValidatedQuery(pagination): ValidatedQuery<Pagination<ReversibleIterator<EndpointId>>>,
-    ValidatedQuery(Ordering { order }): ValidatedQuery<Ordering>,
     permissions::Application { app }: permissions::Application,
 ) -> Result<Json<ListResponse<EndpointOut>>> {
     let PaginationLimit(limit) = pagination.limit;
     let iterator = pagination.iterator;
     let is_prev = matches!(iterator, Some(ReversibleIterator::Prev(_)));
 
-    let order = order.unwrap_or(ListOrdering::Descending);
     let query = apply_pagination(
         endpoint::Entity::secure_find(app.id),
         endpoint::Column::Id,
         limit,
         iterator,
-        order.clone(),
+        pagination.order.unwrap_or(ListOrdering::Descending),
     );
 
     let results = ctx!(

--- a/server/svix-server/src/v1/utils/mod.rs
+++ b/server/svix-server/src/v1/utils/mod.rs
@@ -56,6 +56,7 @@ pub struct Pagination<T: Validate + JsonSchema> {
     pub limit: PaginationLimit,
     #[validate]
     pub iterator: Option<T>,
+    pub order: Option<ListOrdering>,
 }
 
 #[derive(Debug, JsonSchema)]
@@ -94,11 +95,6 @@ impl Validate for PaginationLimit {
             Err(errs)
         }
     }
-}
-
-#[derive(Deserialize, Validate, JsonSchema)]
-pub struct Ordering {
-    pub order: Option<ListOrdering>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -237,7 +233,7 @@ pub trait ModelIn {
     fn update_model(self, model: &mut Self::ActiveModel);
 }
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum ListOrdering {
     Ascending,

--- a/server/svix-server/tests/e2e_application.rs
+++ b/server/svix-server/tests/e2e_application.rs
@@ -348,6 +348,7 @@ async fn test_list() {
         "api/v1/app/",
         |i| application_in(&format!("App {i}")),
         true,
+        true,
     )
     .await
     .unwrap();

--- a/server/svix-server/tests/e2e_endpoint.rs
+++ b/server/svix-server/tests/e2e_endpoint.rs
@@ -644,6 +644,7 @@ async fn test_list() {
         &format!("api/v1/app/{app_id}/endpoint/"),
         |i| endpoint_in(&format!("https://localhost/{i}")),
         false,
+        true,
     )
     .await
     .unwrap();

--- a/server/svix-server/tests/e2e_event_type.rs
+++ b/server/svix-server/tests/e2e_event_type.rs
@@ -296,6 +296,7 @@ async fn test_list() {
         "api/v1/event-type/",
         |i| event_type_in(&format!("test-event-type-{i}"), None).unwrap(),
         true,
+        false,
     )
     .await
     .unwrap();

--- a/server/svix-server/tests/utils/common_calls.rs
+++ b/server/svix-server/tests/utils/common_calls.rs
@@ -193,6 +193,7 @@ pub async fn common_test_list<
     path: &str,
     create_model: fn(usize) -> ModelIn,
     sort_asc: bool,
+    supports_reverse: bool,
 ) -> Result<()> {
     let mut items = Vec::new();
     for i in 0..10 {
@@ -205,7 +206,7 @@ pub async fn common_test_list<
         items.push(item);
     }
 
-    let list = run_with_retries(|| async {
+    let original_list = run_with_retries(|| async {
         let list = client
             .get::<ListResponse<ModelOut>>(&format!("{path}?with_content=true"), StatusCode::OK)
             .await
@@ -220,11 +221,11 @@ pub async fn common_test_list<
 
     if sort_asc {
         for i in 0..10 {
-            assert_eq!(items.get(i), list.data.get(i));
+            assert_eq!(items.get(i), original_list.data.get(i));
         }
     } else {
         for i in 0..10 {
-            assert_eq!(items.get(9 - i), list.data.get(i));
+            assert_eq!(items.get(9 - i), original_list.data.get(i));
         }
     }
 
@@ -279,6 +280,46 @@ pub async fn common_test_list<
         )
         .await
         .unwrap();
+
+    if supports_reverse {
+        let opposite_order = if sort_asc { "descending" } else { "ascending" };
+
+        let opposite_1 = client
+            .get::<ListResponse<ModelOut>>(
+                &format!("{path}?limit=3&order={opposite_order}"),
+                StatusCode::OK,
+            )
+            .await
+            .unwrap();
+
+        let opposite_2 = client
+            .get::<ListResponse<ModelOut>>(
+                &format!(
+                    "{path}?limit=3&order={opposite_order}&iterator={}",
+                    opposite_1.iterator.unwrap()
+                ),
+                StatusCode::OK,
+            )
+            .await
+            .unwrap();
+
+        let opposite_prev = client
+            .get::<ListResponse<ModelOut>>(
+                &format!(
+                    "{path}?limit=3&order={opposite_order}&iterator={}",
+                    opposite_2.prev_iterator.unwrap()
+                ),
+                StatusCode::OK,
+            )
+            .await
+            .unwrap();
+
+        for i in 0..3 {
+            assert_eq!(original_list.data.get(9 - i), opposite_1.data.get(i));
+            assert_eq!(original_list.data.get(6 - i), opposite_2.data.get(i));
+            assert_eq!(original_list.data.get(9 - i), opposite_prev.data.get(i));
+        }
+    }
 
     // Test limits -- ten models were created previously and the default hard/soft cap is 250 so
     // 10..251 is the sane range here.


### PR DESCRIPTION
It also extends the `common_test_list` function to test for reverse ordering, where supported.