### PR TITLE
Accept a context parameter in all Go lib methods

### DIFF
--- a/go/application.go
+++ b/go/application.go
@@ -21,8 +21,8 @@ type ApplicationListOptions struct {
 	Limit    *int32
 }
 
-func (a *Application) List(options *ApplicationListOptions) (*ListResponseApplicationOut, error) {
-	req := a.api.ApplicationApi.ListApplicationsApiV1AppGet(context.Background())
+func (a *Application) List(ctx context.Context, options *ApplicationListOptions) (*ListResponseApplicationOut, error) {
+	req := a.api.ApplicationApi.ListApplicationsApiV1AppGet(ctx)
 	if options != nil {
 		if options.Iterator != nil {
 			req = req.Iterator(*options.Iterator)
@@ -39,12 +39,12 @@ func (a *Application) List(options *ApplicationListOptions) (*ListResponseApplic
 	return &ret, nil
 }
 
-func (a *Application) Create(applicationIn *ApplicationIn) (*ApplicationOut, error) {
-	return a.CreateWithOptions(applicationIn, nil)
+func (a *Application) Create(ctx context.Context, applicationIn *ApplicationIn) (*ApplicationOut, error) {
+	return a.CreateWithOptions(ctx, applicationIn, nil)
 }
 
-func (a *Application) CreateWithOptions(applicationIn *ApplicationIn, options *PostOptions) (*ApplicationOut, error) {
-	req := a.api.ApplicationApi.CreateApplicationApiV1AppPost(context.Background())
+func (a *Application) CreateWithOptions(ctx context.Context, applicationIn *ApplicationIn, options *PostOptions) (*ApplicationOut, error) {
+	req := a.api.ApplicationApi.CreateApplicationApiV1AppPost(ctx)
 	req = req.ApplicationIn(openapi.ApplicationIn(*applicationIn))
 	if options != nil {
 		if options.IdempotencyKey != nil {
@@ -59,12 +59,12 @@ func (a *Application) CreateWithOptions(applicationIn *ApplicationIn, options *P
 	return &ret, nil
 }
 
-func (a *Application) GetOrCreate(applicationIn *ApplicationIn) (*ApplicationOut, error) {
-	return a.GetOrCreateWithOptions(applicationIn, nil)
+func (a *Application) GetOrCreate(ctx context.Context, applicationIn *ApplicationIn) (*ApplicationOut, error) {
+	return a.GetOrCreateWithOptions(ctx, applicationIn, nil)
 }
 
-func (a *Application) GetOrCreateWithOptions(applicationIn *ApplicationIn, options *PostOptions) (*ApplicationOut, error) {
-	req := a.api.ApplicationApi.CreateApplicationApiV1AppPost(context.Background())
+func (a *Application) GetOrCreateWithOptions(ctx context.Context, applicationIn *ApplicationIn, options *PostOptions) (*ApplicationOut, error) {
+	req := a.api.ApplicationApi.CreateApplicationApiV1AppPost(ctx)
 	req = req.ApplicationIn(openapi.ApplicationIn(*applicationIn))
 	req = req.GetIfExists(true)
 	if options != nil {
@@ -80,8 +80,8 @@ func (a *Application) GetOrCreateWithOptions(applicationIn *ApplicationIn, optio
 	return &ret, nil
 }
 
-func (a *Application) Get(appId string) (*ApplicationOut, error) {
-	req := a.api.ApplicationApi.GetApplicationApiV1AppAppIdGet(context.Background(), appId)
+func (a *Application) Get(ctx context.Context, appId string) (*ApplicationOut, error) {
+	req := a.api.ApplicationApi.GetApplicationApiV1AppAppIdGet(ctx, appId)
 	resp, res, err := req.Execute()
 	if err != nil {
 		return nil, wrapError(err, res)
@@ -90,8 +90,8 @@ func (a *Application) Get(appId string) (*ApplicationOut, error) {
 	return &ret, nil
 }
 
-func (a *Application) Update(appId string, applicationIn *ApplicationIn) (*ApplicationOut, error) {
-	req := a.api.ApplicationApi.UpdateApplicationApiV1AppAppIdPut(context.Background(), appId)
+func (a *Application) Update(ctx context.Context, appId string, applicationIn *ApplicationIn) (*ApplicationOut, error) {
+	req := a.api.ApplicationApi.UpdateApplicationApiV1AppAppIdPut(ctx, appId)
 	req = req.ApplicationIn(openapi.ApplicationIn(*applicationIn))
 	resp, res, err := req.Execute()
 	if err != nil {
@@ -101,8 +101,8 @@ func (a *Application) Update(appId string, applicationIn *ApplicationIn) (*Appli
 	return &ret, nil
 }
 
-func (a *Application) Delete(appId string) error {
-	req := a.api.ApplicationApi.DeleteApplicationApiV1AppAppIdDelete(context.Background(), appId)
+func (a *Application) Delete(ctx context.Context, appId string) error {
+	req := a.api.ApplicationApi.DeleteApplicationApiV1AppAppIdDelete(ctx, appId)
 	res, err := req.Execute()
 	return wrapError(err, res)
 }

--- a/go/authentication.go
+++ b/go/authentication.go
@@ -16,12 +16,12 @@ type (
 	DashboardAccessOut openapi.DashboardAccessOut
 )
 
-func (a *Authentication) AppPortalAccess(appId string, appPortalAccessIn *AppPortalAccessIn) (*AppPortalAccessOut, error) {
-	return a.AppPortalAccessWithOptions(appId, appPortalAccessIn, nil)
+func (a *Authentication) AppPortalAccess(ctx context.Context, appId string, appPortalAccessIn *AppPortalAccessIn) (*AppPortalAccessOut, error) {
+	return a.AppPortalAccessWithOptions(ctx, appId, appPortalAccessIn, nil)
 }
 
-func (a *Authentication) AppPortalAccessWithOptions(appId string, appPortalAccessIn *AppPortalAccessIn, options *PostOptions) (*AppPortalAccessOut, error) {
-	req := a.api.AuthenticationApi.GetAppPortalAccessApiV1AuthAppPortalAccessAppIdPost(context.Background(), appId)
+func (a *Authentication) AppPortalAccessWithOptions(ctx context.Context, appId string, appPortalAccessIn *AppPortalAccessIn, options *PostOptions) (*AppPortalAccessOut, error) {
+	req := a.api.AuthenticationApi.GetAppPortalAccessApiV1AuthAppPortalAccessAppIdPost(ctx, appId)
 	req = req.AppPortalAccessIn(openapi.AppPortalAccessIn(*appPortalAccessIn))
 	if options != nil {
 		if options.IdempotencyKey != nil {
@@ -36,12 +36,12 @@ func (a *Authentication) AppPortalAccessWithOptions(appId string, appPortalAcces
 	return &ret, nil
 }
 
-func (a *Authentication) DashboardAccess(appId string) (*DashboardAccessOut, error) {
-	return a.DashboardAccessWithOptions(appId, nil)
+func (a *Authentication) DashboardAccess(ctx context.Context, appId string) (*DashboardAccessOut, error) {
+	return a.DashboardAccessWithOptions(ctx, appId, nil)
 }
 
-func (a *Authentication) DashboardAccessWithOptions(appId string, options *PostOptions) (*DashboardAccessOut, error) {
-	req := a.api.AuthenticationApi.GetDashboardAccessApiV1AuthDashboardAccessAppIdPost(context.Background(), appId)
+func (a *Authentication) DashboardAccessWithOptions(ctx context.Context, appId string, options *PostOptions) (*DashboardAccessOut, error) {
+	req := a.api.AuthenticationApi.GetDashboardAccessApiV1AuthDashboardAccessAppIdPost(ctx, appId)
 	if options != nil {
 		if options.IdempotencyKey != nil {
 			req = req.IdempotencyKey(*options.IdempotencyKey)
@@ -55,12 +55,12 @@ func (a *Authentication) DashboardAccessWithOptions(appId string, options *PostO
 	return &ret, nil
 }
 
-func (a *Authentication) Logout() error {
-	return a.LogoutWithOptions(nil)
+func (a *Authentication) Logout(ctx context.Context) error {
+	return a.LogoutWithOptions(ctx, nil)
 }
 
-func (a *Authentication) LogoutWithOptions(options *PostOptions) error {
-	req := a.api.AuthenticationApi.LogoutApiV1AuthLogoutPost(context.Background())
+func (a *Authentication) LogoutWithOptions(ctx context.Context, options *PostOptions) error {
+	req := a.api.AuthenticationApi.LogoutApiV1AuthLogoutPost(ctx)
 	if options != nil {
 		if options.IdempotencyKey != nil {
 			req = req.IdempotencyKey(*options.IdempotencyKey)

--- a/go/endpoint.go
+++ b/go/endpoint.go
@@ -32,8 +32,8 @@ type EndpointListOptions struct {
 	Limit    *int32
 }
 
-func (e *Endpoint) List(appId string, options *EndpointListOptions) (*ListResponseEndpointOut, error) {
-	req := e.api.EndpointApi.ListEndpointsApiV1AppAppIdEndpointGet(context.Background(), appId)
+func (e *Endpoint) List(ctx context.Context, appId string, options *EndpointListOptions) (*ListResponseEndpointOut, error) {
+	req := e.api.EndpointApi.ListEndpointsApiV1AppAppIdEndpointGet(ctx, appId)
 	if options != nil {
 		if options.Iterator != nil {
 			req = req.Iterator(*options.Iterator)
@@ -50,12 +50,12 @@ func (e *Endpoint) List(appId string, options *EndpointListOptions) (*ListRespon
 	return &ret, nil
 }
 
-func (e *Endpoint) Create(appId string, endpointIn *EndpointIn) (*EndpointOut, error) {
-	return e.CreateWithOptions(appId, endpointIn, nil)
+func (e *Endpoint) Create(ctx context.Context, appId string, endpointIn *EndpointIn) (*EndpointOut, error) {
+	return e.CreateWithOptions(ctx, appId, endpointIn, nil)
 }
 
-func (e *Endpoint) CreateWithOptions(appId string, endpointIn *EndpointIn, options *PostOptions) (*EndpointOut, error) {
-	req := e.api.EndpointApi.CreateEndpointApiV1AppAppIdEndpointPost(context.Background(), appId)
+func (e *Endpoint) CreateWithOptions(ctx context.Context, appId string, endpointIn *EndpointIn, options *PostOptions) (*EndpointOut, error) {
+	req := e.api.EndpointApi.CreateEndpointApiV1AppAppIdEndpointPost(ctx, appId)
 	req = req.EndpointIn(openapi.EndpointIn(*endpointIn))
 	if options != nil {
 		if options.IdempotencyKey != nil {
@@ -70,8 +70,8 @@ func (e *Endpoint) CreateWithOptions(appId string, endpointIn *EndpointIn, optio
 	return &ret, nil
 }
 
-func (e *Endpoint) Get(appId string, endpointId string) (*EndpointOut, error) {
-	req := e.api.EndpointApi.GetEndpointApiV1AppAppIdEndpointEndpointIdGet(context.Background(), endpointId, appId)
+func (e *Endpoint) Get(ctx context.Context, appId string, endpointId string) (*EndpointOut, error) {
+	req := e.api.EndpointApi.GetEndpointApiV1AppAppIdEndpointEndpointIdGet(ctx, endpointId, appId)
 	out, res, err := req.Execute()
 	if err != nil {
 		return nil, wrapError(err, res)
@@ -80,8 +80,8 @@ func (e *Endpoint) Get(appId string, endpointId string) (*EndpointOut, error) {
 	return &ret, nil
 }
 
-func (e *Endpoint) Update(appId string, endpointId string, endpointUpdate *EndpointUpdate) (*EndpointOut, error) {
-	req := e.api.EndpointApi.UpdateEndpointApiV1AppAppIdEndpointEndpointIdPut(context.Background(), endpointId, appId)
+func (e *Endpoint) Update(ctx context.Context, appId string, endpointId string, endpointUpdate *EndpointUpdate) (*EndpointOut, error) {
+	req := e.api.EndpointApi.UpdateEndpointApiV1AppAppIdEndpointEndpointIdPut(ctx, endpointId, appId)
 	req = req.EndpointUpdate(openapi.EndpointUpdate(*endpointUpdate))
 	out, res, err := req.Execute()
 	if err != nil {
@@ -91,14 +91,14 @@ func (e *Endpoint) Update(appId string, endpointId string, endpointUpdate *Endpo
 	return &ret, nil
 }
 
-func (e *Endpoint) Delete(appId string, endpointId string) error {
-	req := e.api.EndpointApi.DeleteEndpointApiV1AppAppIdEndpointEndpointIdDelete(context.Background(), endpointId, appId)
+func (e *Endpoint) Delete(ctx context.Context, appId string, endpointId string) error {
+	req := e.api.EndpointApi.DeleteEndpointApiV1AppAppIdEndpointEndpointIdDelete(ctx, endpointId, appId)
 	res, err := req.Execute()
 	return wrapError(err, res)
 }
 
-func (e *Endpoint) GetSecret(appId string, endpointId string) (*EndpointSecretOut, error) {
-	req := e.api.EndpointApi.GetEndpointSecretApiV1AppAppIdEndpointEndpointIdSecretGet(context.Background(), endpointId, appId)
+func (e *Endpoint) GetSecret(ctx context.Context, appId string, endpointId string) (*EndpointSecretOut, error) {
+	req := e.api.EndpointApi.GetEndpointSecretApiV1AppAppIdEndpointEndpointIdSecretGet(ctx, endpointId, appId)
 	out, res, err := req.Execute()
 	if err != nil {
 		return nil, wrapError(err, res)
@@ -107,12 +107,12 @@ func (e *Endpoint) GetSecret(appId string, endpointId string) (*EndpointSecretOu
 	return &ret, nil
 }
 
-func (e *Endpoint) RotateSecret(appId string, endpointId string, endpointSecretRotateIn *EndpointSecretRotateIn) error {
-	return e.RotateSecretWithOptions(appId, endpointId, endpointSecretRotateIn, nil)
+func (e *Endpoint) RotateSecret(ctx context.Context, appId string, endpointId string, endpointSecretRotateIn *EndpointSecretRotateIn) error {
+	return e.RotateSecretWithOptions(ctx, appId, endpointId, endpointSecretRotateIn, nil)
 }
 
-func (e *Endpoint) RotateSecretWithOptions(appId string, endpointId string, endpointSecretRotateIn *EndpointSecretRotateIn, options *PostOptions) error {
-	req := e.api.EndpointApi.RotateEndpointSecretApiV1AppAppIdEndpointEndpointIdSecretRotatePost(context.Background(), endpointId, appId)
+func (e *Endpoint) RotateSecretWithOptions(ctx context.Context, appId string, endpointId string, endpointSecretRotateIn *EndpointSecretRotateIn, options *PostOptions) error {
+	req := e.api.EndpointApi.RotateEndpointSecretApiV1AppAppIdEndpointEndpointIdSecretRotatePost(ctx, endpointId, appId)
 	req = req.EndpointSecretRotateIn(openapi.EndpointSecretRotateIn(*endpointSecretRotateIn))
 	if options != nil {
 		if options.IdempotencyKey != nil {
@@ -126,12 +126,12 @@ func (e *Endpoint) RotateSecretWithOptions(appId string, endpointId string, endp
 	return nil
 }
 
-func (e *Endpoint) Recover(appId string, endpointId string, recoverIn *RecoverIn) error {
-	return e.RecoverWithOptions(appId, endpointId, recoverIn, nil)
+func (e *Endpoint) Recover(ctx context.Context, appId string, endpointId string, recoverIn *RecoverIn) error {
+	return e.RecoverWithOptions(ctx, appId, endpointId, recoverIn, nil)
 }
 
-func (e *Endpoint) RecoverWithOptions(appId string, endpointId string, recoverIn *RecoverIn, options *PostOptions) error {
-	req := e.api.EndpointApi.RecoverFailedWebhooksApiV1AppAppIdEndpointEndpointIdRecoverPost(context.Background(), appId, endpointId)
+func (e *Endpoint) RecoverWithOptions(ctx context.Context, appId string, endpointId string, recoverIn *RecoverIn, options *PostOptions) error {
+	req := e.api.EndpointApi.RecoverFailedWebhooksApiV1AppAppIdEndpointEndpointIdRecoverPost(ctx, appId, endpointId)
 	req = req.RecoverIn(openapi.RecoverIn(*recoverIn))
 	if options != nil {
 		if options.IdempotencyKey != nil {
@@ -145,8 +145,8 @@ func (e *Endpoint) RecoverWithOptions(appId string, endpointId string, recoverIn
 	return nil
 }
 
-func (e *Endpoint) GetHeaders(appId string, endpointId string) (*EndpointHeadersOut, error) {
-	req := e.api.EndpointApi.GetEndpointHeadersApiV1AppAppIdEndpointEndpointIdHeadersGet(context.Background(), endpointId, appId)
+func (e *Endpoint) GetHeaders(ctx context.Context, appId string, endpointId string) (*EndpointHeadersOut, error) {
+	req := e.api.EndpointApi.GetEndpointHeadersApiV1AppAppIdEndpointEndpointIdHeadersGet(ctx, endpointId, appId)
 	out, res, err := req.Execute()
 	if err != nil {
 		return nil, wrapError(err, res)
@@ -155,8 +155,8 @@ func (e *Endpoint) GetHeaders(appId string, endpointId string) (*EndpointHeaders
 	return &ret, nil
 }
 
-func (e *Endpoint) UpdateHeaders(appId string, endpointId string, endpointHeadersIn *EndpointHeadersIn) error {
-	req := e.api.EndpointApi.UpdateEndpointHeadersApiV1AppAppIdEndpointEndpointIdHeadersPut(context.Background(), appId, endpointId)
+func (e *Endpoint) UpdateHeaders(ctx context.Context, appId string, endpointId string, endpointHeadersIn *EndpointHeadersIn) error {
+	req := e.api.EndpointApi.UpdateEndpointHeadersApiV1AppAppIdEndpointEndpointIdHeadersPut(ctx, appId, endpointId)
 	req = req.EndpointHeadersIn(openapi.EndpointHeadersIn(*endpointHeadersIn))
 	res, err := req.Execute()
 	if err != nil {
@@ -165,8 +165,8 @@ func (e *Endpoint) UpdateHeaders(appId string, endpointId string, endpointHeader
 	return nil
 }
 
-func (e *Endpoint) PatchHeaders(appId string, endpointId string, endpointHeadersIn *EndpointHeadersPatchIn) error {
-	req := e.api.EndpointApi.PatchEndpointHeadersApiV1AppAppIdEndpointEndpointIdHeadersPatch(context.Background(), appId, endpointId)
+func (e *Endpoint) PatchHeaders(ctx context.Context, appId string, endpointId string, endpointHeadersIn *EndpointHeadersPatchIn) error {
+	req := e.api.EndpointApi.PatchEndpointHeadersApiV1AppAppIdEndpointEndpointIdHeadersPatch(ctx, appId, endpointId)
 	req = req.EndpointHeadersPatchIn(openapi.EndpointHeadersPatchIn(*endpointHeadersIn))
 	res, err := req.Execute()
 	if err != nil {
@@ -175,8 +175,8 @@ func (e *Endpoint) PatchHeaders(appId string, endpointId string, endpointHeaders
 	return nil
 }
 
-func (e *Endpoint) GetStats(appId string, endpointId string) (*EndpointStats, error) {
-	req := e.api.EndpointApi.GetEndpointStatsApiV1AppAppIdEndpointEndpointIdStatsGet(context.Background(), endpointId, appId)
+func (e *Endpoint) GetStats(ctx context.Context, appId string, endpointId string) (*EndpointStats, error) {
+	req := e.api.EndpointApi.GetEndpointStatsApiV1AppAppIdEndpointEndpointIdStatsGet(ctx, endpointId, appId)
 	out, res, err := req.Execute()
 	if err != nil {
 		return nil, wrapError(err, res)
@@ -185,17 +185,18 @@ func (e *Endpoint) GetStats(appId string, endpointId string) (*EndpointStats, er
 	return &ret, nil
 }
 
-func (e *Endpoint) ReplayMissing(appId string, endpointId string, replayIn *ReplayIn) error {
-	return e.ReplayMissingWithOptions(appId, endpointId, replayIn, nil)
+func (e *Endpoint) ReplayMissing(ctx context.Context, appId string, endpointId string, replayIn *ReplayIn) error {
+	return e.ReplayMissingWithOptions(ctx, appId, endpointId, replayIn, nil)
 }
 
 func (e *Endpoint) ReplayMissingWithOptions(
+	ctx context.Context,
 	appId string,
 	endpointId string,
 	replayIn *ReplayIn,
 	options *PostOptions,
 ) error {
-	req := e.api.EndpointApi.ReplayMissingWebhooksApiV1AppAppIdEndpointEndpointIdReplayMissingPost(context.Background(), appId, endpointId)
+	req := e.api.EndpointApi.ReplayMissingWebhooksApiV1AppAppIdEndpointEndpointIdReplayMissingPost(ctx, appId, endpointId)
 	req.ReplayIn(openapi.ReplayIn(*replayIn))
 	if options != nil {
 		if options.IdempotencyKey != nil {
@@ -209,8 +210,8 @@ func (e *Endpoint) ReplayMissingWithOptions(
 	return nil
 }
 
-func (e *Endpoint) TransformationGet(appId string, endpointId string) (*EndpointTransformationOut, error) {
-	req := e.api.EndpointApi.GetEndpointTransformationApiV1AppAppIdEndpointEndpointIdTransformationGet(context.Background(), endpointId, appId)
+func (e *Endpoint) TransformationGet(ctx context.Context, appId string, endpointId string) (*EndpointTransformationOut, error) {
+	req := e.api.EndpointApi.GetEndpointTransformationApiV1AppAppIdEndpointEndpointIdTransformationGet(ctx, endpointId, appId)
 
 	out, res, err := req.Execute()
 	if err != nil {
@@ -221,8 +222,8 @@ func (e *Endpoint) TransformationGet(appId string, endpointId string) (*Endpoint
 	return &ret, nil
 }
 
-func (e *Endpoint) TransformatioPartialUpdate(appId string, endpointId string, transformation *EndpointTransformationIn) error {
-	req := e.api.EndpointApi.SetEndpointTransformationApiV1AppAppIdEndpointEndpointIdTransformationPatch(context.Background(), appId, endpointId)
+func (e *Endpoint) TransformatioPartialUpdate(ctx context.Context, appId string, endpointId string, transformation *EndpointTransformationIn) error {
+	req := e.api.EndpointApi.SetEndpointTransformationApiV1AppAppIdEndpointEndpointIdTransformationPatch(ctx, appId, endpointId)
 	req.EndpointTransformationIn(openapi.EndpointTransformationIn(*transformation))
 
 	res, err := req.Execute()

--- a/go/eventtype.go
+++ b/go/eventtype.go
@@ -24,8 +24,8 @@ type EventTypeListOptions struct {
 	IncludeArchived *bool
 }
 
-func (e *EventType) List(options *EventTypeListOptions) (*ListResponseEventTypeOut, error) {
-	req := e.api.EventTypeApi.ListEventTypesApiV1EventTypeGet(context.Background())
+func (e *EventType) List(ctx context.Context, options *EventTypeListOptions) (*ListResponseEventTypeOut, error) {
+	req := e.api.EventTypeApi.ListEventTypesApiV1EventTypeGet(ctx)
 	if options != nil {
 		if options.Iterator != nil {
 			req = req.Iterator(*options.Iterator)
@@ -48,12 +48,12 @@ func (e *EventType) List(options *EventTypeListOptions) (*ListResponseEventTypeO
 	return &ret, nil
 }
 
-func (e *EventType) Create(eventTypeIn *EventTypeIn) (*EventTypeOut, error) {
-	return e.CreateWithOptions(eventTypeIn, nil)
+func (e *EventType) Create(ctx context.Context, eventTypeIn *EventTypeIn) (*EventTypeOut, error) {
+	return e.CreateWithOptions(ctx, eventTypeIn, nil)
 }
 
-func (e *EventType) CreateWithOptions(eventTypeIn *EventTypeIn, options *PostOptions) (*EventTypeOut, error) {
-	req := e.api.EventTypeApi.CreateEventTypeApiV1EventTypePost(context.Background())
+func (e *EventType) CreateWithOptions(ctx context.Context, eventTypeIn *EventTypeIn, options *PostOptions) (*EventTypeOut, error) {
+	req := e.api.EventTypeApi.CreateEventTypeApiV1EventTypePost(ctx)
 	req = req.EventTypeIn(openapi.EventTypeIn(*eventTypeIn))
 	if options != nil {
 		if options.IdempotencyKey != nil {
@@ -68,8 +68,8 @@ func (e *EventType) CreateWithOptions(eventTypeIn *EventTypeIn, options *PostOpt
 	return &ret, nil
 }
 
-func (e *EventType) Get(eventTypeName string) (*EventTypeOut, error) {
-	req := e.api.EventTypeApi.GetEventTypeApiV1EventTypeEventTypeNameGet(context.Background(), eventTypeName)
+func (e *EventType) Get(ctx context.Context, eventTypeName string) (*EventTypeOut, error) {
+	req := e.api.EventTypeApi.GetEventTypeApiV1EventTypeEventTypeNameGet(ctx, eventTypeName)
 	out, res, err := req.Execute()
 	if err != nil {
 		return nil, wrapError(err, res)
@@ -78,8 +78,8 @@ func (e *EventType) Get(eventTypeName string) (*EventTypeOut, error) {
 	return &ret, nil
 }
 
-func (e *EventType) Update(eventTypeName string, eventTypeUpdate *EventTypeUpdate) (*EventTypeOut, error) {
-	req := e.api.EventTypeApi.UpdateEventTypeApiV1EventTypeEventTypeNamePut(context.Background(), eventTypeName)
+func (e *EventType) Update(ctx context.Context, eventTypeName string, eventTypeUpdate *EventTypeUpdate) (*EventTypeOut, error) {
+	req := e.api.EventTypeApi.UpdateEventTypeApiV1EventTypeEventTypeNamePut(ctx, eventTypeName)
 	req = req.EventTypeUpdate(openapi.EventTypeUpdate(*eventTypeUpdate))
 	out, res, err := req.Execute()
 	if err != nil {
@@ -89,8 +89,8 @@ func (e *EventType) Update(eventTypeName string, eventTypeUpdate *EventTypeUpdat
 	return &ret, nil
 }
 
-func (e *EventType) Delete(eventTypeName string) error {
-	req := e.api.EventTypeApi.DeleteEventTypeApiV1EventTypeEventTypeNameDelete(context.Background(), eventTypeName)
+func (e *EventType) Delete(ctx context.Context, eventTypeName string) error {
+	req := e.api.EventTypeApi.DeleteEventTypeApiV1EventTypeEventTypeNameDelete(ctx, eventTypeName)
 	res, err := req.Execute()
 	return wrapError(err, res)
 }

--- a/go/integration.go
+++ b/go/integration.go
@@ -23,8 +23,8 @@ type IntegrationListOptions struct {
 	Limit    *int32
 }
 
-func (e *Integration) List(appId string, options *IntegrationListOptions) (*ListResponseIntegrationOut, error) {
-	req := e.api.IntegrationApi.ListIntegrationsApiV1AppAppIdIntegrationGet(context.Background(), appId)
+func (e *Integration) List(ctx context.Context, appId string, options *IntegrationListOptions) (*ListResponseIntegrationOut, error) {
+	req := e.api.IntegrationApi.ListIntegrationsApiV1AppAppIdIntegrationGet(ctx, appId)
 	if options != nil {
 		if options.Iterator != nil {
 			req = req.Iterator(*options.Iterator)
@@ -41,12 +41,12 @@ func (e *Integration) List(appId string, options *IntegrationListOptions) (*List
 	return &ret, nil
 }
 
-func (e *Integration) Create(appId string, endpointIn *IntegrationIn) (*IntegrationOut, error) {
-	return e.CreateWithOptions(appId, endpointIn, nil)
+func (e *Integration) Create(ctx context.Context, appId string, endpointIn *IntegrationIn) (*IntegrationOut, error) {
+	return e.CreateWithOptions(ctx, appId, endpointIn, nil)
 }
 
-func (e *Integration) CreateWithOptions(appId string, endpointIn *IntegrationIn, options *PostOptions) (*IntegrationOut, error) {
-	req := e.api.IntegrationApi.CreateIntegrationApiV1AppAppIdIntegrationPost(context.Background(), appId)
+func (e *Integration) CreateWithOptions(ctx context.Context, appId string, endpointIn *IntegrationIn, options *PostOptions) (*IntegrationOut, error) {
+	req := e.api.IntegrationApi.CreateIntegrationApiV1AppAppIdIntegrationPost(ctx, appId)
 	req = req.IntegrationIn(openapi.IntegrationIn(*endpointIn))
 	if options != nil {
 		if options.IdempotencyKey != nil {
@@ -61,8 +61,8 @@ func (e *Integration) CreateWithOptions(appId string, endpointIn *IntegrationIn,
 	return &ret, nil
 }
 
-func (e *Integration) Get(appId string, integId string) (*IntegrationOut, error) {
-	req := e.api.IntegrationApi.GetIntegrationApiV1AppAppIdIntegrationIntegIdGet(context.Background(), integId, appId)
+func (e *Integration) Get(ctx context.Context, appId string, integId string) (*IntegrationOut, error) {
+	req := e.api.IntegrationApi.GetIntegrationApiV1AppAppIdIntegrationIntegIdGet(ctx, integId, appId)
 	out, res, err := req.Execute()
 	if err != nil {
 		return nil, wrapError(err, res)
@@ -71,8 +71,8 @@ func (e *Integration) Get(appId string, integId string) (*IntegrationOut, error)
 	return &ret, nil
 }
 
-func (e *Integration) Update(appId string, integId string, endpointUpdate *IntegrationUpdate) (*IntegrationOut, error) {
-	req := e.api.IntegrationApi.UpdateIntegrationApiV1AppAppIdIntegrationIntegIdPut(context.Background(), integId, appId)
+func (e *Integration) Update(ctx context.Context, appId string, integId string, endpointUpdate *IntegrationUpdate) (*IntegrationOut, error) {
+	req := e.api.IntegrationApi.UpdateIntegrationApiV1AppAppIdIntegrationIntegIdPut(ctx, integId, appId)
 	req = req.IntegrationUpdate(openapi.IntegrationUpdate(*endpointUpdate))
 	out, res, err := req.Execute()
 	if err != nil {
@@ -82,14 +82,14 @@ func (e *Integration) Update(appId string, integId string, endpointUpdate *Integ
 	return &ret, nil
 }
 
-func (e *Integration) Delete(appId string, integId string) error {
-	req := e.api.IntegrationApi.DeleteIntegrationApiV1AppAppIdIntegrationIntegIdDelete(context.Background(), integId, appId)
+func (e *Integration) Delete(ctx context.Context, appId string, integId string) error {
+	req := e.api.IntegrationApi.DeleteIntegrationApiV1AppAppIdIntegrationIntegIdDelete(ctx, integId, appId)
 	res, err := req.Execute()
 	return wrapError(err, res)
 }
 
-func (e *Integration) GetKey(appId string, integId string) (*IntegrationKeyOut, error) {
-	req := e.api.IntegrationApi.GetIntegrationKeyApiV1AppAppIdIntegrationIntegIdKeyGet(context.Background(), integId, appId)
+func (e *Integration) GetKey(ctx context.Context, appId string, integId string) (*IntegrationKeyOut, error) {
+	req := e.api.IntegrationApi.GetIntegrationKeyApiV1AppAppIdIntegrationIntegIdKeyGet(ctx, integId, appId)
 	out, res, err := req.Execute()
 	if err != nil {
 		return nil, wrapError(err, res)
@@ -98,12 +98,12 @@ func (e *Integration) GetKey(appId string, integId string) (*IntegrationKeyOut, 
 	return &ret, nil
 }
 
-func (e *Integration) RotateKey(appId string, integId string) (*IntegrationKeyOut, error) {
-	return e.RotateKeyWithOptions(appId, integId, nil)
+func (e *Integration) RotateKey(ctx context.Context, appId string, integId string) (*IntegrationKeyOut, error) {
+	return e.RotateKeyWithOptions(ctx, appId, integId, nil)
 }
 
-func (e *Integration) RotateKeyWithOptions(appId string, integId string, options *PostOptions) (*IntegrationKeyOut, error) {
-	req := e.api.IntegrationApi.RotateIntegrationKeyApiV1AppAppIdIntegrationIntegIdKeyRotatePost(context.Background(), integId, appId)
+func (e *Integration) RotateKeyWithOptions(ctx context.Context, appId string, integId string, options *PostOptions) (*IntegrationKeyOut, error) {
+	req := e.api.IntegrationApi.RotateIntegrationKeyApiV1AppAppIdIntegrationIntegIdKeyRotatePost(ctx, integId, appId)
 	if options != nil {
 		if options.IdempotencyKey != nil {
 			req = req.IdempotencyKey(*options.IdempotencyKey)

--- a/go/message.go
+++ b/go/message.go
@@ -26,8 +26,8 @@ type MessageListOptions struct {
 	Channel    *string
 }
 
-func (m *Message) List(appId string, options *MessageListOptions) (*ListResponseMessageOut, error) {
-	req := m.api.MessageApi.ListMessagesApiV1AppAppIdMsgGet(context.Background(), appId)
+func (m *Message) List(ctx context.Context, appId string, options *MessageListOptions) (*ListResponseMessageOut, error) {
+	req := m.api.MessageApi.ListMessagesApiV1AppAppIdMsgGet(ctx, appId)
 	if options != nil {
 		if options.Iterator != nil {
 			req = req.Iterator(*options.Iterator)
@@ -56,12 +56,12 @@ func (m *Message) List(appId string, options *MessageListOptions) (*ListResponse
 	return &ret, nil
 }
 
-func (m *Message) Create(appId string, messageIn *MessageIn) (*MessageOut, error) {
-	return m.CreateWithOptions(appId, messageIn, nil)
+func (m *Message) Create(ctx context.Context, appId string, messageIn *MessageIn) (*MessageOut, error) {
+	return m.CreateWithOptions(ctx, appId, messageIn, nil)
 }
 
-func (m *Message) CreateWithOptions(appId string, messageIn *MessageIn, options *PostOptions) (*MessageOut, error) {
-	req := m.api.MessageApi.CreateMessageApiV1AppAppIdMsgPost(context.Background(), appId)
+func (m *Message) CreateWithOptions(ctx context.Context, appId string, messageIn *MessageIn, options *PostOptions) (*MessageOut, error) {
+	req := m.api.MessageApi.CreateMessageApiV1AppAppIdMsgPost(ctx, appId)
 	req = req.MessageIn(openapi.MessageIn(*messageIn))
 	if options != nil {
 		if options.IdempotencyKey != nil {
@@ -76,8 +76,8 @@ func (m *Message) CreateWithOptions(appId string, messageIn *MessageIn, options 
 	return &ret, nil
 }
 
-func (m *Message) Get(appId string, msgId string) (*MessageOut, error) {
-	req := m.api.MessageApi.GetMessageApiV1AppAppIdMsgMsgIdGet(context.Background(), msgId, appId)
+func (m *Message) Get(ctx context.Context, appId string, msgId string) (*MessageOut, error) {
+	req := m.api.MessageApi.GetMessageApiV1AppAppIdMsgMsgIdGet(ctx, msgId, appId)
 	out, res, err := req.Execute()
 	if err != nil {
 		return nil, wrapError(err, res)
@@ -86,8 +86,8 @@ func (m *Message) Get(appId string, msgId string) (*MessageOut, error) {
 	return &ret, nil
 }
 
-func (m *Message) ExpungeContent(appId string, msgId string) error {
-	req := m.api.MessageApi.ExpungeMessagePayloadApiV1AppAppIdMsgMsgIdContentDelete(context.Background(), msgId, appId)
+func (m *Message) ExpungeContent(ctx context.Context, appId string, msgId string) error {
+	req := m.api.MessageApi.ExpungeMessagePayloadApiV1AppAppIdMsgMsgIdContentDelete(ctx, msgId, appId)
 	res, err := req.Execute()
 	return wrapError(err, res)
 }

--- a/go/messageattempt.go
+++ b/go/messageattempt.go
@@ -34,12 +34,12 @@ type MessageAttemptListOptions struct {
 }
 
 // Deprecated: use `ListByMsg` or `ListByEndpoint` instead
-func (m *MessageAttempt) List(appId string, msgId string, options *MessageAttemptListOptions) (*ListResponseMessageAttemptOut, error) {
-	return m.ListByMsg(appId, msgId, options)
+func (m *MessageAttempt) List(ctx context.Context, appId string, msgId string, options *MessageAttemptListOptions) (*ListResponseMessageAttemptOut, error) {
+	return m.ListByMsg(ctx, appId, msgId, options)
 }
 
-func (m *MessageAttempt) ListByMsg(appId string, msgId string, options *MessageAttemptListOptions) (*ListResponseMessageAttemptOut, error) {
-	req := m.api.MessageAttemptApi.ListAttemptsByMsgApiV1AppAppIdAttemptMsgMsgIdGet(context.Background(), appId, msgId)
+func (m *MessageAttempt) ListByMsg(ctx context.Context, appId string, msgId string, options *MessageAttemptListOptions) (*ListResponseMessageAttemptOut, error) {
+	req := m.api.MessageAttemptApi.ListAttemptsByMsgApiV1AppAppIdAttemptMsgMsgIdGet(ctx, appId, msgId)
 	if options != nil {
 		if options.Iterator != nil {
 			req = req.Iterator(*options.Iterator)
@@ -74,8 +74,8 @@ func (m *MessageAttempt) ListByMsg(appId string, msgId string, options *MessageA
 	return &ret, nil
 }
 
-func (m *MessageAttempt) ListByEndpoint(appId string, endpointId string, options *MessageAttemptListOptions) (*ListResponseMessageAttemptOut, error) {
-	req := m.api.MessageAttemptApi.ListAttemptsByEndpointApiV1AppAppIdAttemptEndpointEndpointIdGet(context.Background(), appId, endpointId)
+func (m *MessageAttempt) ListByEndpoint(ctx context.Context, appId string, endpointId string, options *MessageAttemptListOptions) (*ListResponseMessageAttemptOut, error) {
+	req := m.api.MessageAttemptApi.ListAttemptsByEndpointApiV1AppAppIdAttemptEndpointEndpointIdGet(ctx, appId, endpointId)
 	if options != nil {
 		if options.Iterator != nil {
 			req = req.Iterator(*options.Iterator)
@@ -110,8 +110,8 @@ func (m *MessageAttempt) ListByEndpoint(appId string, endpointId string, options
 	return &ret, nil
 }
 
-func (m *MessageAttempt) Get(appId string, msgId string, attemptID string) (*MessageAttemptOut, error) {
-	req := m.api.MessageAttemptApi.GetAttemptApiV1AppAppIdMsgMsgIdAttemptAttemptIdGet(context.Background(), attemptID, msgId, appId)
+func (m *MessageAttempt) Get(ctx context.Context, appId string, msgId string, attemptID string) (*MessageAttemptOut, error) {
+	req := m.api.MessageAttemptApi.GetAttemptApiV1AppAppIdMsgMsgIdAttemptAttemptIdGet(ctx, attemptID, msgId, appId)
 	out, res, err := req.Execute()
 	if err != nil {
 		return nil, wrapError(err, res)
@@ -120,12 +120,12 @@ func (m *MessageAttempt) Get(appId string, msgId string, attemptID string) (*Mes
 	return &ret, nil
 }
 
-func (m *MessageAttempt) Resend(appId string, msgId string, endpointId string) error {
-	return m.ResendWithOptions(appId, msgId, endpointId, nil)
+func (m *MessageAttempt) Resend(ctx context.Context, appId string, msgId string, endpointId string) error {
+	return m.ResendWithOptions(ctx, appId, msgId, endpointId, nil)
 }
 
-func (m *MessageAttempt) ResendWithOptions(appId string, msgId string, endpointId string, options *PostOptions) error {
-	req := m.api.MessageAttemptApi.ResendWebhookApiV1AppAppIdMsgMsgIdEndpointEndpointIdResendPost(context.Background(), endpointId, msgId, appId)
+func (m *MessageAttempt) ResendWithOptions(ctx context.Context, appId string, msgId string, endpointId string, options *PostOptions) error {
+	req := m.api.MessageAttemptApi.ResendWebhookApiV1AppAppIdMsgMsgIdEndpointEndpointIdResendPost(ctx, endpointId, msgId, appId)
 	if options != nil {
 		if options.IdempotencyKey != nil {
 			req = req.IdempotencyKey(*options.IdempotencyKey)
@@ -135,8 +135,8 @@ func (m *MessageAttempt) ResendWithOptions(appId string, msgId string, endpointI
 	return wrapError(err, res)
 }
 
-func (m *MessageAttempt) ListAttemptedMessages(appId string, endpointId string, options *MessageAttemptListOptions) (*ListResponseEndpointMessageOut, error) {
-	req := m.api.MessageAttemptApi.ListAttemptedMessagesApiV1AppAppIdEndpointEndpointIdMsgGet(context.Background(), endpointId, appId)
+func (m *MessageAttempt) ListAttemptedMessages(ctx context.Context, appId string, endpointId string, options *MessageAttemptListOptions) (*ListResponseEndpointMessageOut, error) {
+	req := m.api.MessageAttemptApi.ListAttemptedMessagesApiV1AppAppIdEndpointEndpointIdMsgGet(ctx, endpointId, appId)
 	if options != nil {
 		if options.Iterator != nil {
 			req = req.Iterator(*options.Iterator)
@@ -165,8 +165,8 @@ func (m *MessageAttempt) ListAttemptedMessages(appId string, endpointId string, 
 	return &ret, nil
 }
 
-func (m *MessageAttempt) ListAttemptedDestinations(appId string, msgId string, options *MessageAttemptListOptions) (*ListResponseMessageEndpointOut, error) {
-	req := m.api.MessageAttemptApi.ListAttemptedDestinationsApiV1AppAppIdMsgMsgIdEndpointGet(context.Background(), msgId, appId)
+func (m *MessageAttempt) ListAttemptedDestinations(ctx context.Context, appId string, msgId string, options *MessageAttemptListOptions) (*ListResponseMessageEndpointOut, error) {
+	req := m.api.MessageAttemptApi.ListAttemptedDestinationsApiV1AppAppIdMsgMsgIdEndpointGet(ctx, msgId, appId)
 	if options != nil {
 		if options.Iterator != nil {
 			req = req.Iterator(*options.Iterator)
@@ -183,8 +183,8 @@ func (m *MessageAttempt) ListAttemptedDestinations(appId string, msgId string, o
 	return &ret, nil
 }
 
-func (m *MessageAttempt) ListAttemptsForEndpoint(appId string, msgId string, endpointId string, options *MessageAttemptListOptions) (*ListResponseMessageAttemptEndpointOut, error) {
-	req := m.api.MessageAttemptApi.ListAttemptsForEndpointApiV1AppAppIdMsgMsgIdEndpointEndpointIdAttemptGet(context.Background(), msgId, appId, endpointId)
+func (m *MessageAttempt) ListAttemptsForEndpoint(ctx context.Context, appId string, msgId string, endpointId string, options *MessageAttemptListOptions) (*ListResponseMessageAttemptEndpointOut, error) {
+	req := m.api.MessageAttemptApi.ListAttemptsForEndpointApiV1AppAppIdMsgMsgIdEndpointEndpointIdAttemptGet(ctx, msgId, appId, endpointId)
 	if options != nil {
 		if options.Iterator != nil {
 			req = req.Iterator(*options.Iterator)
@@ -216,8 +216,8 @@ func (m *MessageAttempt) ListAttemptsForEndpoint(appId string, msgId string, end
 	return &ret, nil
 }
 
-func (m *MessageAttempt) ExpungeContent(appId string, msgId string, attemptId string) error {
-	req := m.api.MessageAttemptApi.ExpungeAttemptContentApiV1AppAppIdMsgMsgIdAttemptAttemptIdContentDelete(context.Background(), attemptId, msgId, appId)
+func (m *MessageAttempt) ExpungeContent(ctx context.Context, appId string, msgId string, attemptId string) error {
+	req := m.api.MessageAttemptApi.ExpungeAttemptContentApiV1AppAppIdMsgMsgIdAttemptAttemptIdContentDelete(ctx, attemptId, msgId, appId)
 	res, err := req.Execute()
 	return wrapError(err, res)
 }


### PR DESCRIPTION
Previously, we were passing `context.Background()` internally on all methods. After this callers can pass a context of their own.