### PR TITLE
Remove unnecessary Clone trait bounds

### DIFF
--- a/server/svix-server/src/v1/utils/mod.rs
+++ b/server/svix-server/src/v1/utils/mod.rs
@@ -223,7 +223,7 @@ pub struct EmptyResponse {}
 
 #[derive(Serialize, Deserialize, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct ListResponse<T: Clone> {
+pub struct ListResponse<T> {
     pub data: Vec<T>,
     pub iterator: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -285,7 +285,7 @@ fn list_response_inner<T: ModelOut>(
     }
 }
 
-pub trait ModelOut: Clone {
+pub trait ModelOut: Sized {
     fn id_copy(&self) -> String;
 
     fn list_response(data: Vec<Self>, limit: usize, is_prev_iter: bool) -> ListResponse<Self> {
@@ -555,7 +555,7 @@ pub struct ApplicationMsgAttemptPath {
     pub attempt_id: MessageAttemptId,
 }
 
-#[derive(Clone, Deserialize, JsonSchema)]
+#[derive(Deserialize, JsonSchema)]
 pub struct EventTypeNamePath {
     pub event_type_name: EventTypeName,
 }

--- a/server/svix-server/tests/utils/common_calls.rs
+++ b/server/svix-server/tests/utils/common_calls.rs
@@ -186,7 +186,7 @@ pub fn event_type_in(
 
 // Common tests
 pub async fn common_test_list<
-    ModelOut: DeserializeOwned + Clone + PartialEq + std::fmt::Debug,
+    ModelOut: DeserializeOwned + PartialEq + std::fmt::Debug,
     ModelIn: Serialize,
 >(
     client: &TestClient,


### PR DESCRIPTION
## Motivation

While working on some new endpoints, I was surprised/annoyed that I needed to implement `Clone` for the various structs used in the axum handler.

Turns out, we don't need it at all. So I'm removing the unnecessary trait bound. We can probably remove `#[derive(Clone)]` from a bunch of structs in our `v1` folder, but that's for another day.

## Solution

Remove the unnecessary trait bound.
