### PR TITLE
Add new event type and endpoint params to libs

### DIFF
--- a/csharp/Svix/Endpoint.cs
+++ b/csharp/Svix/Endpoint.cs
@@ -260,6 +260,7 @@ namespace Svix
                     appId,
                     options?.Iterator,
                     options?.Limit,
+                    options?.Order,
                     idempotencyKey);
 
                 return lEndpoints?.Data;
@@ -284,6 +285,7 @@ namespace Svix
                     appId,
                     options?.Iterator,
                     options?.Limit,
+                    options?.Order,
                     idempotencyKey,
                     cancellationToken);
 

--- a/csharp/Svix/EventType.cs
+++ b/csharp/Svix/EventType.cs
@@ -28,6 +28,7 @@ namespace Svix
             {
                 var lResponse = _eventTypeApi.DeleteEventTypeApiV1EventTypeEventTypeNameDeleteWithHttpInfo(
                     eventType,
+                    null,
                     idempotencyKey);
 
                 return lResponse.StatusCode == HttpStatusCode.NoContent;
@@ -49,6 +50,7 @@ namespace Svix
             {
                 var lResponse = await _eventTypeApi.DeleteEventTypeApiV1EventTypeEventTypeNameDeleteWithHttpInfoAsync(
                     eventType,
+                    null,
                     idempotencyKey,
                     cancellationToken);
 

--- a/csharp/Svix/Models/ListOptions.cs
+++ b/csharp/Svix/Models/ListOptions.cs
@@ -1,9 +1,13 @@
-﻿namespace Svix.Models
+﻿using Svix.Model;
+
+namespace Svix.Models
 {
     public class ListOptions
     {
         public string? Iterator { get; set; }
 
         public int? Limit { get; set; }
+
+        public Ordering? Order { get; set; }
     }
 }

--- a/go/endpoint.go
+++ b/go/endpoint.go
@@ -21,6 +21,7 @@ type (
 	EndpointHeadersOut        openapi.EndpointHeadersOut
 	EndpointStats             openapi.EndpointStats
 	EndpointTransformationOut openapi.EndpointTransformationOut
+	Ordering                  openapi.Ordering
 )
 
 type Endpoint struct {
@@ -30,6 +31,7 @@ type Endpoint struct {
 type EndpointListOptions struct {
 	Iterator *string
 	Limit    *int32
+	Order    *Ordering
 }
 
 func (e *Endpoint) List(ctx context.Context, appId string, options *EndpointListOptions) (*ListResponseEndpointOut, error) {
@@ -40,6 +42,9 @@ func (e *Endpoint) List(ctx context.Context, appId string, options *EndpointList
 		}
 		if options.Limit != nil {
 			req = req.Limit(*options.Limit)
+		}
+		if options.Order != nil {
+			req = req.Order(openapi.Ordering(*options.Order))
 		}
 	}
 	out, res, err := req.Execute()

--- a/java/lib/src/main/java/com/svix/Endpoint.java
+++ b/java/lib/src/main/java/com/svix/Endpoint.java
@@ -26,7 +26,7 @@ public final class Endpoint {
 
 	public ListResponseEndpointOut list(final String appId, final EndpointListOptions options) throws ApiException {
 		try {
-			return api.listEndpointsApiV1AppAppIdEndpointGet(appId, options.getIterator(), options.getLimit(), null);
+			return api.listEndpointsApiV1AppAppIdEndpointGet(appId, options.getIterator(), options.getLimit(), options.getOrder(), null);
 		} catch (com.svix.internal.ApiException e) {
 			throw Utils.wrapInternalApiException(e);
 		}

--- a/java/lib/src/main/java/com/svix/EndpointListOptions.java
+++ b/java/lib/src/main/java/com/svix/EndpointListOptions.java
@@ -1,4 +1,15 @@
 package com.svix;
 
+import com.svix.models.Ordering;
+
 public class EndpointListOptions extends ListOptions {
+    private Ordering order;
+
+    public void setOrder(final Ordering order) {
+        this.order = order;
+    }
+
+    public Ordering getOrder() {
+        return this.order;
+    }
 }

--- a/java/lib/src/main/java/com/svix/EventType.java
+++ b/java/lib/src/main/java/com/svix/EventType.java
@@ -52,7 +52,7 @@ public final class EventType {
 
 	public void delete(final String eventTypeName) throws ApiException {
 		try {
-			api.deleteEventTypeApiV1EventTypeEventTypeNameDelete(eventTypeName, null);
+			api.deleteEventTypeApiV1EventTypeEventTypeNameDelete(eventTypeName, null, null);
 		} catch (com.svix.internal.ApiException e) {
 			throw Utils.wrapInternalApiException(e);
 		}

--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -52,6 +52,7 @@ import {
   ResponseContext,
   AppPortalAccessOut,
   AppPortalAccessIn,
+  Ordering,
 } from "./openapi/index";
 export * from "./openapi/models/all";
 export * from "./openapi/apis/exception";
@@ -167,7 +168,9 @@ interface ListOptions {
 
 export type ApplicationListOptions = ListOptions;
 
-export type EndpointListOptions = ListOptions;
+export interface EndpointListOptions extends ListOptions {
+  order?: Ordering;
+}
 
 export type IntegrationListOptions = ListOptions;
 

--- a/kotlin/lib/src/main/kotlin/Endpoint.kt
+++ b/kotlin/lib/src/main/kotlin/Endpoint.kt
@@ -36,6 +36,7 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
                 appId,
                 options.iterator,
                 options.limit,
+                options.order,
                 null
             )
         } catch (e: Exception) {

--- a/kotlin/lib/src/main/kotlin/EndpointListOptions.kt
+++ b/kotlin/lib/src/main/kotlin/EndpointListOptions.kt
@@ -1,6 +1,12 @@
 package com.svix.kotlin
 
+import com.svix.kotlin.models.Ordering
+
 class EndpointListOptions : ListOptions() {
+    var order: Ordering? = null
+
+    fun order(order: Ordering) = apply { this.order = order }
+
     override fun iterator(iterator: String) = apply { super.iterator(iterator) }
 
     override fun limit(limit: Int) = apply { super.limit(limit) }

--- a/kotlin/lib/src/main/kotlin/EventType.kt
+++ b/kotlin/lib/src/main/kotlin/EventType.kt
@@ -51,7 +51,7 @@ class EventType internal constructor(token: String, options: SvixOptions) {
 
     suspend fun delete(eventTypeName: String) {
         try {
-            api.deleteEventTypeApiV1EventTypeEventTypeNameDelete(eventTypeName, null)
+            api.deleteEventTypeApiV1EventTypeEventTypeNameDelete(eventTypeName, null, null)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }

--- a/python/svix/api.py
+++ b/python/svix/api.py
@@ -107,6 +107,7 @@ from .internal.openapi_client.models.message_in_payload import MessageInPayload
 from .internal.openapi_client.models.message_out import MessageOut
 from .internal.openapi_client.models.message_out_payload import MessageOutPayload
 from .internal.openapi_client.models.message_status import MessageStatus
+from .internal.openapi_client.models.ordering import Ordering
 from .internal.openapi_client.models.recover_in import RecoverIn
 from .internal.openapi_client.models.recover_out import RecoverOut
 from .internal.openapi_client.models.replay_in import ReplayIn
@@ -160,7 +161,7 @@ class EventTypeListOptions(ListOptions):
 
 @dataclass
 class EndpointListOptions(ListOptions):
-    pass
+    order: t.Optional[Ordering] = None
 
 
 @dataclass

--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -240,7 +240,12 @@ impl<'a> Application<'a> {
     }
 }
 
-pub type EndpointListOptions = ListOptions;
+#[derive(Default)]
+pub struct EndpointListOptions {
+    pub iterator: Option<String>,
+    pub limit: Option<i32>,
+    pub order: Option<Ordering>,
+}
 
 pub struct Endpoint<'a> {
     cfg: &'a Configuration,
@@ -256,11 +261,16 @@ impl<'a> Endpoint<'a> {
         app_id: String,
         options: Option<EndpointListOptions>,
     ) -> Result<ListResponseEndpointOut> {
-        let EndpointListOptions { iterator, limit } = options.unwrap_or_default();
+        let EndpointListOptions {
+            iterator,
+            limit,
+            order,
+        } = options.unwrap_or_default();
         Ok(endpoint_api::list_endpoints_api_v1_app_app_id_endpoint_get(
             self.cfg,
             endpoint_api::ListEndpointsApiV1AppAppIdEndpointGetParams {
                 app_id,
+                order,
                 iterator,
                 limit,
                 idempotency_key: None,
@@ -746,6 +756,7 @@ impl<'a> EventType<'a> {
                 self.cfg,
                 event_type_api::DeleteEventTypeApiV1EventTypeEventTypeNameDeleteParams {
                     event_type_name,
+                    expunge: None,
                     idempotency_key: None,
                 },
             )


### PR DESCRIPTION
These were missed when the OpenAPI spec was updated, so fixing that here.