### PR TITLE
Add query flag to insert evt type into payload

### DIFF
--- a/server/svix-server/tests/e2e_message.rs
+++ b/server/svix-server/tests/e2e_message.rs
@@ -458,7 +458,7 @@ async fn test_expunge_message_payload() {
 }
 
 #[tokio::test]
-async fn test_insert_event_type_into_payload() {
+async fn test_inject_event_type_into_payload() {
     let (client, _jh) = start_svix_server().await;
     let app_id = create_test_app(&client, "testApp").await.unwrap().id;
     let mut receiver = TestReceiver::start(axum::http::StatusCode::OK);
@@ -483,10 +483,10 @@ async fn test_insert_event_type_into_payload() {
     let data = receiver.data_recv.recv().await.unwrap();
     assert_eq!(payload, data);
 
-    // If flag is set, insert event type into payload
+    // If flag is set, inject event type into payload
     let _: IgnoredResponse = client
         .post(
-            &format!("api/v1/app/{}/msg/?insert_event_type=true", &app_id),
+            &format!("api/v1/app/{}/msg/?inject_event_type=true", &app_id),
             message_in("foo", payload.clone()).unwrap(),
             StatusCode::ACCEPTED,
         )
@@ -501,7 +501,7 @@ async fn test_insert_event_type_into_payload() {
 
     let _: IgnoredResponse = client
         .post(
-            &format!("api/v1/app/{}/msg/?insert_event_type=true", &app_id),
+            &format!("api/v1/app/{}/msg/?inject_event_type=true", &app_id),
             message_in("foo", payload.clone()).unwrap(),
             StatusCode::ACCEPTED,
         )


### PR DESCRIPTION
Some users use one endpoint to consume different kinds of event types. In these cases it can be useful to have a discriminant in the payload itself to determine the type of event being sent. This PR adds a flag which automates this.

The flag defaults to false (don't insert). If set, it checks if the payload is a JSON object. If not then there's nothing sensible to do. If it is, it checks if there's already a field with the name `"event"`. If yes, nothing is done. If no, it creates a new field with this name and sets its value to the event type name.