### PR TITLE
Add prev_iter support for event type list

### DIFF
--- a/server/svix-server/src/core/types/mod.rs
+++ b/server/svix-server/src/core/types/mod.rs
@@ -320,6 +320,12 @@ macro_rules! string_wrapper_impl {
                 self.0.fmt(f)
             }
         }
+
+        impl From<String> for $name_id {
+            fn from(s: String) -> Self {
+                $name_id(s)
+            }
+        }
     };
 }
 
@@ -347,12 +353,6 @@ macro_rules! create_id_type {
                 Err(sea_orm::DbErr::Exec(sea_orm::error::RuntimeErr::Internal(
                     format!("{} cannot be converted from u64", stringify!($type)),
                 )))
-            }
-        }
-
-        impl From<String> for $name_id {
-            fn from(s: String) -> Self {
-                $name_id(s)
             }
         }
     };

--- a/server/svix-server/src/v1/utils/mod.rs
+++ b/server/svix-server/src/v1/utils/mod.rs
@@ -179,10 +179,17 @@ pub fn apply_pagination_desc<
     }
 }
 
+/// Marker trait for any type that is used for iterating through results
+/// in the public API.
+pub trait IdIterator: Validate + Into<sea_orm::Value> {}
+
+impl<T: BaseId + Validate + Into<sea_orm::Value>> IdIterator for T {}
+impl IdIterator for EventTypeName {}
+
 pub fn apply_pagination<
     Q: QuerySelect + QueryOrder + QueryFilter,
     C: ColumnTrait,
-    I: BaseId<Output = I> + Validate + Into<sea_orm::Value>,
+    I: IdIterator,
 >(
     query: Q,
     sort_column: C,

--- a/server/svix-server/tests/utils/common_calls.rs
+++ b/server/svix-server/tests/utils/common_calls.rs
@@ -273,6 +273,19 @@ pub async fn common_test_list<
     assert_eq!(list.data.len(), 4);
     assert!(list.done);
 
+    let prev = client
+        .get::<ListResponse<ModelOut>>(
+            &format!("{}?limit=3&iterator={}", path, list.prev_iterator.unwrap()),
+            StatusCode::OK,
+        )
+        .await
+        .unwrap();
+    assert_eq!(prev.data.len(), 3);
+    assert_eq!(
+        prev.data.first().unwrap(),
+        original_list.data.get(3).unwrap()
+    );
+
     let _list = client
         .get::<IgnoredResponse>(
             &format!("{path}?limit=6&iterator=BAD-$$$ITERATOR"),


### PR DESCRIPTION
Two noteworthy changes:
* Introduce a new `IdIterator` trait to represent all identifier-like things we use for iteration in the API. These are generally the `BaseId` types but there are some exceptions, like `EventTypeName` in this change's case.
* Move `From<String>` impl from the `create_id_type` macro to the `string_wrapper_impl` macro since all string wrappers will want this, and it's needed for `EventTypeName` to function as a `ReversibleIterator`.