### PR TITLE
Run library linting on OpenAPI change

### DIFF
--- a/.github/workflows/csharp-lint.yml
+++ b/.github/workflows/csharp-lint.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "csharp/**"
+      - "openapi.json"
 
 jobs:
   dotnet:

--- a/.github/workflows/java-lint.yml
+++ b/.github/workflows/java-lint.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - "java/**"
+      - "openapi.json"
 jobs:
   dotnet:
     name: Java Lint

--- a/.github/workflows/javascript-lint.yml
+++ b/.github/workflows/javascript-lint.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - "javascript/**"
+      - "openapi.json"
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/kotlin-lint.yml
+++ b/.github/workflows/kotlin-lint.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - "kotlin/**"
+      - "openapi.json"
 jobs:
   kotlin:
     name: Kotlin Lint

--- a/.github/workflows/other-lint.yml
+++ b/.github/workflows/other-lint.yml
@@ -6,6 +6,7 @@ on:
       - "go/**"
       - "javascript/**"
       - "python/**"
+      - "openapi.json"
 
 jobs:
   build:

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - "python/**"
+      - "openapi.json"
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ruby-lint.yml
+++ b/.github/workflows/ruby-lint.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "ruby/**"
+      - "openapi.json"
 
 jobs:
   dotnet:

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - 'rust/**'
       - '.github/workflows/rust-lint.yml'
+      - "openapi.json"
 
 jobs:
   test-versions:


### PR DESCRIPTION
Changing OpenAPI means the generated parts of the codebase may change. We need to run linting in this case to ensure the libraries are still valid after a change.