### PR TITLE
Add missing OpenAPI-lint-trigger to go

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - "go/**"
+      - "openapi.json"
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
In #842 I missed adding openapi as a lint trigger to the go workflow. This remedies that.