### PR TITLE
Add flag to ignore missing app on msg creation

### DIFF
--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -17,8 +17,9 @@ use crate::{
     queue::MessageTaskBatch,
     v1::utils::{
         apply_pagination_desc, iterator_from_before_or_after, openapi_tag,
-        validation_error, ApplicationMsgPath, ApplicationPath, EventTypesQuery, ListResponse,
-        ModelIn, ModelOut, PaginationLimit, ReversibleIterator, ValidatedJson, ValidatedQuery,
+        validation_error, ApplicationMsgPath, ApplicationPath, EmptyResponse, EventTypesQuery,
+        ListResponse, ModelIn, ModelOut, PaginationLimit, ReversibleIterator, ValidatedJson,
+        ValidatedQuery,
     },
     AppState,
 };
@@ -244,7 +245,7 @@ impl IntoResponse for CreateMessageOut {
     fn into_response(self) -> axum::response::Response {
         match self {
             Self::Accepted(msg) => Json(msg).into_response(),
-            Self::NoContent => ().into_response(),
+            Self::NoContent => Json(EmptyResponse {}).into_response(),
         }
     }
 }
@@ -388,8 +389,9 @@ pub fn router() -> ApiRouter<AppState> {
     let tag = openapi_tag("Message");
 
     fn document_create_message(op: TransformOperation) -> TransformOperation {
-        let op = op.response::<202, Json<MessageOut>>()
-            .response_with::<200, (), _>(|r| {
+        let op = op
+            .response::<202, Json<MessageOut>>()
+            .response_with::<200, Json<EmptyResponse>, _>(|r| {
                 r.description("Response given when `ignore_missing_app=true` is passed and the specified app does not exist")
             });
         create_message_operation(op)

--- a/server/svix-server/src/v1/utils/mod.rs
+++ b/server/svix-server/src/v1/utils/mod.rs
@@ -221,7 +221,7 @@ pub fn apply_pagination<
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, JsonSchema)]
 pub struct EmptyResponse {}
 
 #[derive(Serialize, Deserialize, Clone, JsonSchema)]

--- a/server/svix-server/tests/e2e_message.rs
+++ b/server/svix-server/tests/e2e_message.rs
@@ -111,7 +111,7 @@ async fn test_message_create_read_list() {
 
     let _: IgnoredResponse = client
         .post(
-            "api/v1/app/nonexistent_app/msg/?ignore_missing_app=true",
+            "api/v1/app/nonexistent_app/msg/?skip_missing_app=true",
             message_in(&app_id, serde_json::json!({"test": "value"})).unwrap(),
             StatusCode::OK,
         )

--- a/server/svix-server/tests/e2e_message.rs
+++ b/server/svix-server/tests/e2e_message.rs
@@ -99,6 +99,24 @@ async fn test_message_create_read_list() {
         .unwrap();
     assert_eq!(list.data.len(), 1);
     assert!(list.data.contains(&message_3));
+
+    let _: IgnoredResponse = client
+        .post(
+            "api/v1/app/nonexistent_app/msg/",
+            message_in(&app_id, serde_json::json!({"test": "value"})).unwrap(),
+            StatusCode::NOT_FOUND,
+        )
+        .await
+        .unwrap();
+
+    let _: IgnoredResponse = client
+        .post(
+            "api/v1/app/nonexistent_app/msg/?ignore_missing_app=true",
+            message_in(&app_id, serde_json::json!({"test": "value"})).unwrap(),
+            StatusCode::OK,
+        )
+        .await
+        .unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
Some users use Svix in a stateless mode where they do not know if an app (consumer) exists or not when they send a message. These users just want to ignore the error when an app does not exist when a message is sent.

This change adds a new query parameter `ignore_missing_app`, which can be set to `true` to return 200 OK on `create_message` when the app does not exist.