### PR TITLE
Return CONFLICT on UID constraint breached on app creation

### DIFF
--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -270,7 +270,7 @@ async fn create_application(
     let (app, metadata) = model;
 
     let (app, metadata) = transaction!(db, |txn| async move {
-        let app_result = ctx!(app.insert(txn).await)?;
+        let app_result = ctx!(app.insert(txn).await.map_err(http_error_on_conflict))?;
         let metadata = ctx!(metadata.upsert_or_delete(txn).await)?;
         Ok((app_result, metadata))
     })?;


### PR DESCRIPTION
Followup to #835 which adds a missing explicit conversion from conflict `DbErr`s during message creation.