### PR TITLE
Fix 5xx responses during concurrent UID updates

### DIFF
--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -341,7 +341,7 @@ async fn patch_application(
     let (app, metadata) = model;
 
     let (app, metadata) = transaction!(db, |txn| async move {
-        let app = ctx!(app.update(txn).await)?;
+        let app = ctx!(app.update(txn).await.map_err(http_error_on_conflict))?;
         let metadata = ctx!(metadata.upsert_or_delete(txn).await)?;
         Ok((app, metadata))
     })?;

--- a/server/svix-server/src/v1/endpoints/event_type.rs
+++ b/server/svix-server/src/v1/endpoints/event_type.rs
@@ -276,7 +276,7 @@ async fn create_event_type(
                 org_id: Set(org_id),
                 ..data.into()
             };
-            ctx!(evtype.insert(db).await)?
+            ctx!(evtype.insert(db).await.map_err(http_error_on_conflict))?
         }
     };
     Ok((StatusCode::CREATED, Json(ret.into())))
@@ -325,15 +325,14 @@ async fn update_event_type(
             Ok((StatusCode::OK, Json(ret.into())))
         }
         None => {
-            let ret = ctx!(
-                eventtype::ActiveModel {
-                    org_id: Set(org_id),
-                    name: Set(event_type_name),
-                    ..data.into()
-                }
-                .insert(db)
-                .await
-            )?;
+            let ret = ctx!(eventtype::ActiveModel {
+                org_id: Set(org_id),
+                name: Set(event_type_name),
+                ..data.into()
+            }
+            .insert(db)
+            .await
+            .map_err(http_error_on_conflict))?;
 
             Ok((StatusCode::CREATED, Json(ret.into())))
         }


### PR DESCRIPTION
Followup to #846 which identifies and fixes the same problem in other parts of the code. In brief, with unluckily timed concurrent PUT/PATCH requests to the same object, the checks for UID conflicts done during the start of the request would become stale as one request processed. This leads to a specific `DbErr` which the changes now manually map to a HTTP CONFLICT response.