### PR TITLE
Add attr macro to generate operation transform

### DIFF
--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -190,7 +190,7 @@ impl From<(application::Model, applicationmetadata::Model)> for ApplicationOut {
 }
 
 /// List all of the organization's applications.
-#[aide_annotate]
+#[aide_annotate(op_id = "list_applications_api_v1_app__get")]
 async fn list_applications(
     State(AppState { ref db, .. }): State<AppState>,
     ValidatedQuery(pagination): ValidatedQuery<Pagination<ReversibleIterator<ApplicationId>>>,
@@ -240,7 +240,7 @@ pub struct CreateApplicationQuery {
 }
 
 /// Create a new application.
-#[aide_annotate]
+#[aide_annotate(op_id = "create_application_api_v1_app__post")]
 async fn create_application(
     State(AppState { ref db, .. }): State<AppState>,
     query: ValidatedQuery<CreateApplicationQuery>,
@@ -279,7 +279,7 @@ async fn create_application(
 }
 
 /// Get an application.
-#[aide_annotate]
+#[aide_annotate(op_id = "get_application_api_v1_app__app_id___get")]
 async fn get_application(
     permissions::ApplicationWithMetadata { app, metadata }: permissions::ApplicationWithMetadata,
 ) -> Result<Json<ApplicationOut>> {
@@ -287,7 +287,7 @@ async fn get_application(
 }
 
 /// Update an application.
-#[aide_annotate]
+#[aide_annotate(op_id = "update_application_api_v1_app__app_id___put")]
 async fn update_application(
     State(AppState { ref db, .. }): State<AppState>,
     Path(ApplicationPath { app_id }): Path<ApplicationPath>,
@@ -350,7 +350,7 @@ async fn patch_application(
 }
 
 /// Delete an application.
-#[aide_annotate]
+#[aide_annotate(op_id = "delete_application_api_v1_app__app_id___delete")]
 async fn delete_application(
     State(AppState { ref db, .. }): State<AppState>,
     permissions::OrganizationWithApplication { app }: permissions::OrganizationWithApplication,

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -130,7 +130,9 @@ pub struct ListAttemptedMessagesQueryParameters {
 /// List messages for a particular endpoint. Additionally includes metadata about the latest message attempt.
 ///
 /// The `before` parameter lets you filter all items created before a certain date and is ignored if an iterator is passed.
-#[aide_annotate]
+#[aide_annotate(
+    op_id = "list_attempted_messages_api_v1_app__app_id__endpoint__endpoint_id__msg__get"
+)]
 async fn list_attempted_messages(
     State(AppState { ref db, .. }): State<AppState>,
     ValidatedQuery(pagination): ValidatedQuery<Pagination<ReversibleIterator<MessageId>>>,
@@ -292,7 +294,9 @@ fn list_attempts_by_endpoint_or_message_filters(
 }
 
 /// List attempts by endpoint id
-#[aide_annotate]
+#[aide_annotate(
+    op_id = "list_attempts_by_endpoint_api_v1_app__app_id__attempt_endpoint__endpoint_id___get"
+)]
 async fn list_attempts_by_endpoint(
     State(AppState { ref db, .. }): State<AppState>,
     ValidatedQuery(pagination): ValidatedQuery<Pagination<ReversibleIterator<MessageAttemptId>>>,
@@ -354,7 +358,7 @@ pub struct ListAttemptsByMsgQueryParameters {
 }
 
 /// List attempts by message id
-#[aide_annotate]
+#[aide_annotate(op_id = "list_attempts_by_msg_api_v1_app__app_id__attempt_msg__msg_id___get")]
 async fn list_attempts_by_msg(
     State(AppState { ref db, .. }): State<AppState>,
     ValidatedQuery(pagination): ValidatedQuery<Pagination<ReversibleIterator<MessageAttemptId>>>,
@@ -446,7 +450,9 @@ impl MessageEndpointOut {
 }
 
 /// `msg_id`: Use a message id or a message `eventId`
-#[aide_annotate]
+#[aide_annotate(
+    op_id = "list_attempted_destinations_api_v1_app__app_id__msg__msg_id__endpoint__get"
+)]
 async fn list_attempted_destinations(
     State(AppState { ref db, .. }): State<AppState>,
     ValidatedQuery(mut pagination): ValidatedQuery<Pagination<EndpointId>>,
@@ -510,7 +516,9 @@ pub struct ListAttemptsForEndpointQueryParameters {
 /// Returning the endpoint.
 ///
 /// The `before` parameter lets you filter all items created before a certain date and is ignored if an iterator is passed.
-#[aide_annotate]
+#[aide_annotate(
+    op_id = "list_attempts_for_endpoint_api_v1_app__app_id__msg__msg_id__endpoint__endpoint_id__attempt__get"
+)]
 async fn list_attempts_for_endpoint(
     state: State<AppState>,
     pagination: ValidatedQuery<Pagination<ReversibleIterator<MessageAttemptId>>>,
@@ -559,7 +567,7 @@ pub struct AttemptListFetchOptions {
 /// Deprecated: Please use "List Attempts by Endpoint" and "List Attempts by Msg" instead.
 ///
 /// `msg_id`: Use a message id or a message `eventId`
-#[aide_annotate]
+#[aide_annotate(op_id = "list_attempts_api_v1_app__app_id__msg__msg_id__attempt__get")]
 async fn list_messageattempts(
     State(AppState { ref db, .. }): State<AppState>,
     ValidatedQuery(pagination): ValidatedQuery<Pagination<ReversibleIterator<MessageAttemptId>>>,
@@ -622,7 +630,7 @@ async fn list_messageattempts(
 }
 
 /// `msg_id`: Use a message id or a message `eventId`
-#[aide_annotate]
+#[aide_annotate(op_id = "get_attempt_api_v1_app__app_id__msg__msg_id__attempt__attempt_id___get")]
 async fn get_messageattempt(
     State(AppState { ref db, .. }): State<AppState>,
     Path(ApplicationMsgAttemptPath {
@@ -648,7 +656,9 @@ async fn get_messageattempt(
 }
 
 /// Resend a message to the specified endpoint.
-#[aide_annotate]
+#[aide_annotate(
+    op_id = "resend_webhook_api_v1_app__app_id__msg__msg_id__endpoint__endpoint_id__resend__post"
+)]
 async fn resend_webhook(
     State(AppState {
         ref db, queue_tx, ..
@@ -706,7 +716,9 @@ async fn resend_webhook(
 }
 
 /// Deletes the given attempt's response body. Useful when an endpoint accidentally returned sensitive content.
-#[aide_annotate]
+#[aide_annotate(
+    op_id = "expunge_attempt_content_api_v1_app__app_id__msg__msg_id__attempt__attempt_id__content__delete"
+)]
 async fn expunge_attempt_content(
     State(AppState { ref db, .. }): State<AppState>,
     Path(ApplicationMsgAttemptPath {

--- a/server/svix-server/src/v1/endpoints/auth.rs
+++ b/server/svix-server/src/v1/endpoints/auth.rs
@@ -2,6 +2,7 @@ use aide::axum::{routing::post_with, ApiRouter};
 use axum::{extract::State, Json};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use svix_server_derive::aide_annotate;
 use validator::Validate;
 
 use crate::{
@@ -27,8 +28,8 @@ pub struct AppPortalAccessIn {
 
 pub type AppPortalAccessOut = DashboardAccessOut;
 
-const APP_PORTAL_ACCESS_DESCRIPTION: &str = "Use this function to get magic links (and authentication codes) for connecting your users to the Consumer Application Portal.";
-
+/// Use this function to get magic links (and authentication codes) for connecting your users to the Consumer Application Portal.
+#[aide_annotate]
 async fn app_portal_access(
     State(AppState { cfg, .. }): State<AppState>,
     permissions::OrganizationWithApplication { app }: permissions::OrganizationWithApplication,
@@ -56,12 +57,10 @@ async fn app_portal_access(
     Ok(Json(DashboardAccessOut { url, token }))
 }
 
-const DASHBOARD_ACCESS_DESCRIPTION: &str = r#"
-DEPRECATED: Please use `app-portal-access` instead.
-
-Use this function to get magic links (and authentication codes) for connecting your users to the Consumer Application Portal.
-"#;
-
+/// DEPRECATED: Please use `app-portal-access` instead.
+///
+/// Use this function to get magic links (and authentication codes) for connecting your users to the Consumer Application Portal.
+#[aide_annotate]
 async fn dashboard_access(
     state: State<AppState>,
     permissions: permissions::OrganizationWithApplication,
@@ -87,7 +86,7 @@ pub fn router() -> ApiRouter<AppState> {
     ApiRouter::new()
         .api_route_with(
             "/auth/dashboard-access/:app_id/",
-            post_with(dashboard_access, openapi_desc(DASHBOARD_ACCESS_DESCRIPTION)),
+            post_with(dashboard_access, dashboard_access_operation),
             &tag,
         )
         .api_route_with(
@@ -97,10 +96,7 @@ pub fn router() -> ApiRouter<AppState> {
         )
         .api_route_with(
             "/auth/app-portal-access/:app_id/",
-            post_with(
-                app_portal_access,
-                openapi_desc(APP_PORTAL_ACCESS_DESCRIPTION),
-            ),
+            post_with(app_portal_access, app_portal_access_operation),
             tag,
         )
 }

--- a/server/svix-server/src/v1/endpoints/endpoint/crud.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/crud.rs
@@ -32,7 +32,7 @@ use crate::{
 use hack::EventTypeNameResult;
 
 /// List the application's endpoints.
-#[aide_annotate]
+#[aide_annotate(op_id = "list_endpoints_api_v1_app__app_id__endpoint__get")]
 pub(super) async fn list_endpoints(
     State(AppState { ref db, .. }): State<AppState>,
     ValidatedQuery(pagination): ValidatedQuery<Pagination<ReversibleIterator<EndpointId>>>,
@@ -105,7 +105,7 @@ async fn create_endp_from_data(
 /// Create a new endpoint for the application.
 ///
 /// When `secret` is `null` the secret is automatically generated (recommended)
-#[aide_annotate]
+#[aide_annotate(op_id = "create_endpoint_api_v1_app__app_id__endpoint__post")]
 pub(super) async fn create_endpoint(
     State(AppState {
         ref db,
@@ -127,7 +127,7 @@ pub(super) async fn create_endpoint(
 }
 
 /// Get an endpoint.
-#[aide_annotate]
+#[aide_annotate(op_id = "get_endpoint_api_v1_app__app_id__endpoint__endpoint_id___get")]
 pub(super) async fn get_endpoint(
     State(AppState { ref db, .. }): State<AppState>,
     Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,
@@ -173,7 +173,7 @@ async fn update_endp_from_data(
 }
 
 /// Update an endpoint.
-#[aide_annotate]
+#[aide_annotate(op_id = "update_endpoint_api_v1_app__app_id__endpoint__endpoint_id___put")]
 pub(super) async fn update_endpoint(
     State(AppState {
         ref db,
@@ -240,7 +240,7 @@ pub(super) async fn patch_endpoint(
 }
 
 /// Delete an endpoint.
-#[aide_annotate]
+#[aide_annotate(op_id = "delete_endpoint_api_v1_app__app_id__endpoint__endpoint_id___delete")]
 pub(super) async fn delete_endpoint(
     State(AppState {
         ref db,

--- a/server/svix-server/src/v1/endpoints/endpoint/crud.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/crud.rs
@@ -7,6 +7,7 @@ use axum::{
 use hyper::StatusCode;
 use sea_orm::{entity::prelude::*, ActiveValue::Set, TransactionTrait};
 use sea_orm::{ActiveModelTrait, DatabaseConnection, QuerySelect};
+use svix_server_derive::aide_annotate;
 use url::Url;
 
 use super::{EndpointIn, EndpointOut, EndpointPatch};
@@ -30,8 +31,8 @@ use crate::{
 };
 use hack::EventTypeNameResult;
 
-pub(super) const LIST_ENDPOINTS_DESCRIPTION: &str = "List the application's endpoints.";
-
+/// List the application's endpoints.
+#[aide_annotate]
 pub(super) async fn list_endpoints(
     State(AppState { ref db, .. }): State<AppState>,
     ValidatedQuery(pagination): ValidatedQuery<Pagination<ReversibleIterator<EndpointId>>>,
@@ -101,12 +102,10 @@ async fn create_endp_from_data(
     Ok((endp, metadata))
 }
 
-pub(super) const CREATE_ENDPOINT_DESCRIPTION: &str = r#"
-Create a new endpoint for the application.
-
-When `secret` is `null` the secret is automatically generated (recommended)
-"#;
-
+/// Create a new endpoint for the application.
+///
+/// When `secret` is `null` the secret is automatically generated (recommended)
+#[aide_annotate]
 pub(super) async fn create_endpoint(
     State(AppState {
         ref db,
@@ -127,8 +126,8 @@ pub(super) async fn create_endpoint(
     Ok((StatusCode::CREATED, Json((endp, metadata.data).into())))
 }
 
-pub(super) const GET_ENDPOINT_DESCRIPTION: &str = "Get an endpoint.";
-
+/// Get an endpoint.
+#[aide_annotate]
 pub(super) async fn get_endpoint(
     State(AppState { ref db, .. }): State<AppState>,
     Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,
@@ -173,8 +172,8 @@ async fn update_endp_from_data(
     Ok((endp, metadata))
 }
 
-pub(super) const UPDATE_ENDPOINT_DESCRIPTION: &str = "Update an endpoint.";
-
+/// Update an endpoint.
+#[aide_annotate]
 pub(super) async fn update_endpoint(
     State(AppState {
         ref db,
@@ -206,8 +205,8 @@ pub(super) async fn update_endpoint(
     }
 }
 
-pub(super) const PATCH_ENDPOINT_DESCRIPTION: &str = "Partially update an endpoint.";
-
+/// Partially update an endpoint.
+#[aide_annotate]
 pub(super) async fn patch_endpoint(
     State(AppState {
         ref db,
@@ -240,8 +239,8 @@ pub(super) async fn patch_endpoint(
     Ok(Json((endp, metadata.data).into()))
 }
 
-pub(super) const DELETE_ENDPOINT_DESCRIPTION: &str = "Delete an endpoint.";
-
+/// Delete an endpoint.
+#[aide_annotate]
 pub(super) async fn delete_endpoint(
     State(AppState {
         ref db,

--- a/server/svix-server/src/v1/endpoints/endpoint/headers.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/headers.rs
@@ -17,7 +17,9 @@ use crate::{
 };
 
 /// Get the additional headers to be sent with the webhook
-#[aide_annotate]
+#[aide_annotate(
+    op_id = "get_endpoint_headers_api_v1_app__app_id__endpoint__endpoint_id__headers__get"
+)]
 pub(super) async fn get_endpoint_headers(
     State(AppState { ref db, .. }): State<AppState>,
     Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,
@@ -37,7 +39,9 @@ pub(super) async fn get_endpoint_headers(
 }
 
 /// Set the additional headers to be sent with the webhook
-#[aide_annotate]
+#[aide_annotate(
+    op_id = "update_endpoint_headers_api_v1_app__app_id__endpoint__endpoint_id__headers__put"
+)]
 pub(super) async fn update_endpoint_headers(
     State(AppState { ref db, .. }): State<AppState>,
     Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,
@@ -59,7 +63,9 @@ pub(super) async fn update_endpoint_headers(
 }
 
 /// Partially set the additional headers to be sent with the webhook
-#[aide_annotate]
+#[aide_annotate(
+    op_id = "patch_endpoint_headers_api_v1_app__app_id__endpoint__endpoint_id__headers__patch"
+)]
 pub(super) async fn patch_endpoint_headers(
     State(AppState { ref db, .. }): State<AppState>,
     Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,

--- a/server/svix-server/src/v1/endpoints/endpoint/headers.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/headers.rs
@@ -4,6 +4,7 @@ use axum::{
 };
 use hyper::StatusCode;
 use sea_orm::ActiveModelTrait;
+use svix_server_derive::aide_annotate;
 
 use super::{EndpointHeadersIn, EndpointHeadersOut, EndpointHeadersPatchIn};
 use crate::{
@@ -15,9 +16,8 @@ use crate::{
     AppState,
 };
 
-pub(super) const GET_ENDPOINT_HEADERS_DESCRIPTION: &str =
-    "Get the additional headers to be sent with the webhook";
-
+/// Get the additional headers to be sent with the webhook
+#[aide_annotate]
 pub(super) async fn get_endpoint_headers(
     State(AppState { ref db, .. }): State<AppState>,
     Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,
@@ -36,9 +36,8 @@ pub(super) async fn get_endpoint_headers(
     }
 }
 
-pub(super) const UPDATE_ENDPOINT_HEADERS_DESCRIPTION: &str =
-    "Set the additional headers to be sent with the webhook";
-
+/// Set the additional headers to be sent with the webhook
+#[aide_annotate]
 pub(super) async fn update_endpoint_headers(
     State(AppState { ref db, .. }): State<AppState>,
     Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,
@@ -59,9 +58,8 @@ pub(super) async fn update_endpoint_headers(
     Ok((StatusCode::NO_CONTENT, Json(EmptyResponse {})))
 }
 
-pub(super) const PATCH_ENDPOINT_HEADERS_DESCRIPTION: &str =
-    "Partially set the additional headers to be sent with the webhook";
-
+/// Partially set the additional headers to be sent with the webhook
+#[aide_annotate]
 pub(super) async fn patch_endpoint_headers(
     State(AppState { ref db, .. }): State<AppState>,
     Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,

--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -45,7 +45,7 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, collections::HashSet};
 use url::Url;
 
-use svix_server_derive::{ModelIn, ModelOut};
+use svix_server_derive::{aide_annotate, ModelIn, ModelOut};
 use validator::{Validate, ValidationError};
 
 use crate::core::types::{EndpointHeaders, EndpointHeadersPatch, EndpointSecret};
@@ -523,8 +523,8 @@ pub struct EndpointStatsQueryOut {
     count: i64,
 }
 
-const ENDPOINT_STATS_DESCRIPTION: &str = "Get basic statistics for the endpoint.";
-
+/// Get basic statistics for the endpoint.
+#[aide_annotate]
 async fn endpoint_stats(
     State(AppState { ref db, .. }): State<AppState>,
     Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,
@@ -573,41 +573,23 @@ pub fn router() -> ApiRouter<AppState> {
     ApiRouter::new()
         .api_route_with(
             "/app/:app_id/endpoint/",
-            post_with(
-                crud::create_endpoint,
-                openapi_desc(crud::CREATE_ENDPOINT_DESCRIPTION),
-            )
-            .get_with(
-                crud::list_endpoints,
-                openapi_desc(crud::LIST_ENDPOINTS_DESCRIPTION),
-            ),
+            post_with(crud::create_endpoint, crud::create_endpoint_operation)
+                .get_with(crud::list_endpoints, crud::list_endpoints_operation),
             &tag,
         )
         .api_route_with(
             "/app/:app_id/endpoint/:endpoint_id/",
-            get_with(
-                crud::get_endpoint,
-                openapi_desc(crud::GET_ENDPOINT_DESCRIPTION),
-            )
-            .put_with(
-                crud::update_endpoint,
-                openapi_desc(crud::UPDATE_ENDPOINT_DESCRIPTION),
-            )
-            .patch_with(
-                crud::patch_endpoint,
-                openapi_desc(crud::PATCH_ENDPOINT_DESCRIPTION),
-            )
-            .delete_with(
-                crud::delete_endpoint,
-                openapi_desc(crud::DELETE_ENDPOINT_DESCRIPTION),
-            ),
+            get_with(crud::get_endpoint, crud::get_endpoint_operation)
+                .put_with(crud::update_endpoint, crud::update_endpoint_operation)
+                .patch_with(crud::patch_endpoint, crud::patch_endpoint_operation)
+                .delete_with(crud::delete_endpoint, crud::delete_endpoint_operation),
             &tag,
         )
         .api_route_with(
             "/app/:app_id/endpoint/:endpoint_id/secret/",
             get_with(
                 secrets::get_endpoint_secret,
-                openapi_desc(secrets::GET_ENDPOINT_SECRET_DESCRIPTION),
+                secrets::get_endpoint_secret_operation,
             ),
             &tag,
         )
@@ -615,13 +597,13 @@ pub fn router() -> ApiRouter<AppState> {
             "/app/:app_id/endpoint/:endpoint_id/secret/rotate/",
             post_with(
                 secrets::rotate_endpoint_secret,
-                openapi_desc(secrets::ROTATE_ENDPOINT_SECRET_DESCRIPTION),
+                secrets::rotate_endpoint_secret_operation,
             ),
             &tag,
         )
         .api_route_with(
             "/app/:app_id/endpoint/:endpoint_id/stats/",
-            get_with(endpoint_stats, openapi_desc(ENDPOINT_STATS_DESCRIPTION)),
+            get_with(endpoint_stats, endpoint_stats_operation),
             &tag,
         )
         .api_route_with(
@@ -633,7 +615,7 @@ pub fn router() -> ApiRouter<AppState> {
             "/app/:app_id/endpoint/:endpoint_id/recover/",
             post_with(
                 recovery::recover_failed_webhooks,
-                openapi_desc(recovery::RECOVER_FAILED_WEBHOOKS_DESCRIPTION),
+                recovery::recover_failed_webhooks_operation,
             ),
             &tag,
         )
@@ -641,15 +623,15 @@ pub fn router() -> ApiRouter<AppState> {
             "/app/:app_id/endpoint/:endpoint_id/headers/",
             get_with(
                 headers::get_endpoint_headers,
-                openapi_desc(headers::GET_ENDPOINT_HEADERS_DESCRIPTION),
+                headers::get_endpoint_headers_operation,
             )
             .patch_with(
                 headers::patch_endpoint_headers,
-                openapi_desc(headers::PATCH_ENDPOINT_HEADERS_DESCRIPTION),
+                headers::patch_endpoint_headers_operation,
             )
             .put_with(
                 headers::update_endpoint_headers,
-                openapi_desc(headers::UPDATE_ENDPOINT_HEADERS_DESCRIPTION),
+                headers::update_endpoint_headers_operation,
             ),
             tag,
         )

--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -524,7 +524,7 @@ pub struct EndpointStatsQueryOut {
 }
 
 /// Get basic statistics for the endpoint.
-#[aide_annotate]
+#[aide_annotate(op_id = "get_endpoint_stats_api_v1_app__app_id__endpoint__endpoint_id__stats__get")]
 async fn endpoint_stats(
     State(AppState { ref db, .. }): State<AppState>,
     Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,

--- a/server/svix-server/src/v1/endpoints/endpoint/recovery.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/recovery.rs
@@ -73,7 +73,9 @@ async fn bulk_recover_failed_messages(
 }
 
 /// Resend all failed messages since a given time.
-#[aide_annotate]
+#[aide_annotate(
+    op_id = "recover_failed_webhooks_api_v1_app__app_id__endpoint__endpoint_id__recover__post"
+)]
 pub(super) async fn recover_failed_webhooks(
     State(AppState {
         ref db, queue_tx, ..

--- a/server/svix-server/src/v1/endpoints/endpoint/recovery.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/recovery.rs
@@ -6,6 +6,7 @@ use chrono::{DateTime, Utc};
 use hyper::StatusCode;
 use sea_orm::{entity::prelude::*, QueryOrder};
 use sea_orm::{DatabaseConnection, QuerySelect};
+use svix_server_derive::aide_annotate;
 
 use super::RecoverIn;
 use crate::{
@@ -71,9 +72,8 @@ async fn bulk_recover_failed_messages(
     Ok(())
 }
 
-pub(super) const RECOVER_FAILED_WEBHOOKS_DESCRIPTION: &str =
-    "Resend all failed messages since a given time.";
-
+/// Resend all failed messages since a given time.
+#[aide_annotate]
 pub(super) async fn recover_failed_webhooks(
     State(AppState {
         ref db, queue_tx, ..

--- a/server/svix-server/src/v1/endpoints/endpoint/secrets.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/secrets.rs
@@ -7,6 +7,7 @@ use hyper::StatusCode;
 use sea_orm::ActiveModelTrait;
 use sea_orm::ActiveValue::Set;
 use std::iter;
+use svix_server_derive::aide_annotate;
 
 use super::{EndpointSecretOut, EndpointSecretRotateIn};
 use crate::{
@@ -34,13 +35,11 @@ pub(super) fn generate_secret(
     }
 }
 
-pub(super) const GET_ENDPOINT_SECRET_DESCRIPTION: &str = r#"
-Get the endpoint's signing secret.
-
-This is used to verify the authenticity of the webhook.
-For more information please refer to [the consuming webhooks docs](https://docs.svix.com/consuming-webhooks/).
-"#;
-
+/// Get the endpoint's signing secret.
+///
+/// This is used to verify the authenticity of the webhook.
+/// For more information please refer to [the consuming webhooks docs](https://docs.svix.com/consuming-webhooks/).
+#[aide_annotate]
 pub(super) async fn get_endpoint_secret(
     State(AppState { ref db, cfg, .. }): State<AppState>,
     Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,
@@ -57,8 +56,8 @@ pub(super) async fn get_endpoint_secret(
     }))
 }
 
-pub(super) const ROTATE_ENDPOINT_SECRET_DESCRIPTION: &str = "Rotates the endpoint's signing secret.  The previous secret will be valid for the next 24 hours.";
-
+/// Rotates the endpoint's signing secret.  The previous secret will be valid for the next 24 hours.
+#[aide_annotate]
 pub(super) async fn rotate_endpoint_secret(
     State(AppState {
         ref db,

--- a/server/svix-server/src/v1/endpoints/endpoint/secrets.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/secrets.rs
@@ -39,7 +39,9 @@ pub(super) fn generate_secret(
 ///
 /// This is used to verify the authenticity of the webhook.
 /// For more information please refer to [the consuming webhooks docs](https://docs.svix.com/consuming-webhooks/).
-#[aide_annotate]
+#[aide_annotate(
+    op_id = "get_endpoint_secret_api_v1_app__app_id__endpoint__endpoint_id__secret__get"
+)]
 pub(super) async fn get_endpoint_secret(
     State(AppState { ref db, cfg, .. }): State<AppState>,
     Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,
@@ -57,7 +59,9 @@ pub(super) async fn get_endpoint_secret(
 }
 
 /// Rotates the endpoint's signing secret.  The previous secret will be valid for the next 24 hours.
-#[aide_annotate]
+#[aide_annotate(
+    op_id = "rotate_endpoint_secret_api_v1_app__app_id__endpoint__endpoint_id__secret_rotate__post"
+)]
 pub(super) async fn rotate_endpoint_secret(
     State(AppState {
         ref db,

--- a/server/svix-server/src/v1/endpoints/event_type.rs
+++ b/server/svix-server/src/v1/endpoints/event_type.rs
@@ -189,7 +189,7 @@ pub struct ListFetchOptions {
 }
 
 /// Return the list of event types.
-#[aide_annotate]
+#[aide_annotate(op_id = "list_event_types_api_v1_event_type__get")]
 async fn list_event_types(
     State(AppState { ref db, .. }): State<AppState>,
     ValidatedQuery(pagination): ValidatedQuery<Pagination<ReversibleIterator<EventTypeName>>>,
@@ -243,7 +243,7 @@ async fn list_event_types(
 /// Unarchiving an event type will allow endpoints to filter on it and messages to be sent with it.
 /// Endpoints filtering on the event type before archival will continue to filter on it.
 /// This operation does not preserve the description and schemas.
-#[aide_annotate]
+#[aide_annotate(op_id = "create_event_type_api_v1_event_type__post")]
 async fn create_event_type(
     State(AppState { ref db, .. }): State<AppState>,
     permissions::Organization { org_id }: permissions::Organization,
@@ -281,7 +281,7 @@ async fn create_event_type(
 }
 
 /// Get an event type.
-#[aide_annotate]
+#[aide_annotate(op_id = "get_event_type_api_v1_event_type__event_type_name___get")]
 async fn get_event_type(
     State(AppState { ref db, .. }): State<AppState>,
     Path(EventTypeNamePath { event_type_name }): Path<EventTypeNamePath>,
@@ -301,7 +301,7 @@ async fn get_event_type(
 }
 
 /// Update an event type.
-#[aide_annotate]
+#[aide_annotate(op_id = "update_event_type_api_v1_event_type__event_type_name___put")]
 async fn update_event_type(
     State(AppState { ref db, .. }): State<AppState>,
     Path(EventTypeNamePath { event_type_name }): Path<EventTypeNamePath>,
@@ -365,7 +365,7 @@ async fn patch_event_type(
 /// However, new messages can not be sent with it and endpoints can not filter on it.
 /// An event type can be unarchived with the
 /// [create operation](#operation/create_event_type_api_v1_event_type__post).
-#[aide_annotate]
+#[aide_annotate(op_id = "delete_event_type_api_v1_event_type__event_type_name___delete")]
 async fn delete_event_type(
     State(AppState { ref db, .. }): State<AppState>,
     Path(EventTypeNamePath { event_type_name }): Path<EventTypeNamePath>,

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -174,7 +174,7 @@ pub struct ListMessagesQueryParams {
 /// The `before` parameter lets you filter all items created before a certain date and is ignored if an iterator is passed.
 /// The `after` parameter lets you filter all items created after a certain date and is ignored if an iterator is passed.
 /// `before` and `after` cannot be used simultaneously.
-#[aide_annotate]
+#[aide_annotate(op_id = "list_messages_api_v1_app__app_id__msg__get")]
 async fn list_messages(
     State(AppState { ref db, .. }): State<AppState>,
     ValidatedQuery(pagination): ValidatedQuery<Pagination<ReversibleIterator<MessageId>>>,
@@ -301,7 +301,7 @@ pub struct GetMessageQueryParams {
 }
 
 /// Get a message by its ID or eventID.
-#[aide_annotate]
+#[aide_annotate(op_id = "get_message_api_v1_app__app_id__msg__msg_id___get")]
 async fn get_message(
     State(AppState { ref db, .. }): State<AppState>,
     Path(ApplicationMsgPath { msg_id, .. }): Path<ApplicationMsgPath>,
@@ -325,7 +325,7 @@ async fn get_message(
 /// Delete the given message's payload. Useful in cases when a message was accidentally sent with sensitive content.
 ///
 /// The message can't be replayed or resent once its payload has been deleted or expired.
-#[aide_annotate]
+#[aide_annotate(op_id = "expunge_message_payload_api_v1_app__app_id__msg__msg_id__content__delete")]
 async fn expunge_message_content(
     State(AppState { ref db, .. }): State<AppState>,
     Path(ApplicationMsgPath { msg_id, .. }): Path<ApplicationMsgPath>,

--- a/server/svix-server_derive/src/lib.rs
+++ b/server/svix-server_derive/src/lib.rs
@@ -83,7 +83,7 @@ fn doc_comment_from_attributes(attributes: &Vec<syn::Attribute>) -> Option<Strin
         }
     }
 
-    if doc_comment_lines.len() == 0 {
+    if doc_comment_lines.is_empty() {
         return None;
     }
     Some(doc_comment_lines.join("\n"))
@@ -128,8 +128,7 @@ pub fn aide_annotate(
     // The operation summary is the title-cased version of the original
     // function name.
     let mut operation_summary = operation_id
-        .clone()
-        .split("_")
+        .split('_')
         .map(title_case)
         .collect::<Vec<String>>()
         .join(" ");
@@ -156,10 +155,8 @@ pub fn aide_annotate(
                 "op_summary" => operation_summary = value,
                 _ => {
                     let path = meta.path.to_token_stream().to_string();
-                    let msg = format!(
-                        "Unknown argument `{}`, expected `op_id` or `op_summary`",
-                        path
-                    );
+                    let msg =
+                        format!("Unknown argument `{path}`, expected `op_id` or `op_summary`",);
                     return syn::Error::new_spanned(meta.path, msg)
                         .into_compile_error()
                         .into();

--- a/server/svix-server_derive/src/lib.rs
+++ b/server/svix-server_derive/src/lib.rs
@@ -1,6 +1,9 @@
-use quote::quote;
+use quote::{format_ident, quote, ToTokens};
 
-use syn::{parse_macro_input, parse_quote, DeriveInput, GenericParam, Generics};
+use syn::{
+    parse_macro_input, parse_quote, AttributeArgs, DeriveInput, GenericParam, Generics, ItemFn,
+    NestedMeta,
+};
 
 #[proc_macro_derive(ModelIn)]
 pub fn derive_model_in(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -60,6 +63,137 @@ pub fn derive_model_out(input: proc_macro::TokenStream) -> proc_macro::TokenStre
 
     // Hand the output tokens back to the compiler.
     proc_macro::TokenStream::from(expanded)
+}
+
+fn doc_comment_from_attributes(attributes: &Vec<syn::Attribute>) -> Option<String> {
+    let mut doc_comment_lines = Vec::new();
+
+    for attr in attributes {
+        let meta = attr
+            .parse_meta()
+            .expect("Failed to parse fn attribute as Meta");
+
+        if let syn::Meta::NameValue(meta) = meta {
+            if meta.path.to_token_stream().to_string() != "doc" {
+                continue;
+            }
+            if let syn::Lit::Str(doc) = meta.lit {
+                doc_comment_lines.push(doc.value().trim().to_string());
+            }
+        }
+    }
+
+    if doc_comment_lines.len() == 0 {
+        return None;
+    }
+    Some(doc_comment_lines.join("\n"))
+}
+
+fn title_case(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+    }
+}
+
+#[proc_macro_attribute]
+/// Attribute macro for axum/aide handler functions that creates a new function
+/// with the same name as the handler, suffixed with `_operation`, that acts as
+/// an operation transformation function, automatically setting the operation
+/// ID, summary and description.
+///
+/// # Example
+/// ```
+/// /// This is foo!
+/// #[aide_annotate]
+/// fn foo() {
+/// }
+///
+/// /// This is bar, with a custom op ID and summary
+/// #[aide_annotate(op_id = "custom_id", op_summary = "Bar Operation!")]
+/// fn bar() {
+/// }
+/// ```
+pub fn aide_annotate(
+    args: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let args = parse_macro_input!(args as AttributeArgs);
+
+    let item = parse_macro_input!(input as ItemFn);
+
+    // By default, use the function's name as the operation id.
+    let mut operation_id = item.sig.ident.to_string();
+    // The operation summary is the title-cased version of the original
+    // function name.
+    let mut operation_summary = operation_id
+        .clone()
+        .split("_")
+        .map(title_case)
+        .collect::<Vec<String>>()
+        .join(" ");
+    // The documentation function's name will always be the name of the
+    // original function suffixed with `_operation`.
+    let operation_ident = format_ident!("{}_operation", item.sig.ident);
+    let visibility = item.vis.clone();
+
+    // Allow overriding operation ID and summary via arguments
+    for arg in args {
+        if let NestedMeta::Meta(syn::Meta::NameValue(meta)) = arg {
+            let arg_id = meta.path.to_token_stream().to_string();
+
+            let value = if let syn::Lit::Str(s) = meta.lit {
+                s.value()
+            } else {
+                return syn::Error::new_spanned(meta.lit, "Unexpected literal, expected a string")
+                    .into_compile_error()
+                    .into();
+            };
+
+            match arg_id.as_str() {
+                "op_id" => operation_id = value,
+                "op_summary" => operation_summary = value,
+                _ => {
+                    let path = meta.path.to_token_stream().to_string();
+                    let msg = format!(
+                        "Unknown argument `{}`, expected `op_id` or `op_summary`",
+                        path
+                    );
+                    return syn::Error::new_spanned(meta.path, msg)
+                        .into_compile_error()
+                        .into();
+                }
+            }
+        } else {
+            return syn::Error::new_spanned(arg, "Unexpected argument")
+                .into_compile_error()
+                .into();
+        }
+    }
+
+    let description = doc_comment_from_attributes(&item.attrs);
+
+    if description.is_none() {
+        let msg = "An annotated handler must have a doc comment for its description.";
+        return syn::Error::new(item.sig.ident.span(), msg)
+            .into_compile_error()
+            .into();
+    }
+
+    let f = item.into_token_stream();
+
+    let out = quote! {
+        #f
+
+        #visibility fn #operation_ident(op: ::aide::transform::TransformOperation) -> ::aide::transform::TransformOperation {
+            op
+                .id(#operation_id)
+                .summary(#operation_summary)
+                .description(#description)
+        }
+    };
+    proc_macro::TokenStream::from(out)
 }
 
 // Add a bound `T: HeapSize` to every type parameter T.


### PR DESCRIPTION
This macro can be used to annotate axum handler functions to automatically generate an operation transformation that adds an operation ID, summary, and description.

Here's how to use it:

```rust
/// Doc comment
#[aide_annotate]
async fn some_handler(/* some params */) -> impl IntoResponse {

}
```

This generates a new function `some_handler_operation` which has the signature `fn(TransformOperation) -> TransformOperation`, i.e. what's needed for aide. This function sets the following in OpenAPI:
1. Operation ID becomes the name of the function, or can be optionally overridden with an `#[aide_annotate(op_id = "foobar")]`.
2. Operation summary becomes the title cased name of the function, e.g. `create_message` becomes `Create Message`. This can also be overridden, with `op_summary = "summary here"`.
3. Operation description becomes the doc comment of the function. This macro makes setting a doc comment mandatory.

Part of #717 