### PR TITLE
[CSharp] change `SvixOptions.Throw` default to `true`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Next
-* 
+* Libs/C#: **[Breaking]** change default value for `SvixOptions.Throw` to `true`
+*
 
 ## Version 0.79.0
 * Server: support prev_iterator for application and event type listing

--- a/csharp/Svix/Models/SvixOptions.cs
+++ b/csharp/Svix/Models/SvixOptions.cs
@@ -13,7 +13,7 @@ namespace Svix.Models
             // empty
         }
 
-        public SvixOptions(string serverUrl, bool bThrow = false)
+        public SvixOptions(string serverUrl, bool bThrow = true)
         {
             ServerUrl = serverUrl;
             Throw = bThrow;


### PR DESCRIPTION
## Motivation

Today, the default behavior for the C# client is to swallow exceptions and return a `null` in the event of a failed HTTP request.

In addition to being surprising, this hides the HTTP status code for the response since this is exposed via the exception being swallowed.

Refs: <https://github.com/svix/svix-webhooks/issues/823>

## Solution

This diff changes the default for `Throw` from `false` to `true` so that callers need to opt-in to the swallowing behavior rather than opt-out.