### PR TITLE
Centralize the handling of deleted flags in CreateMessageApp

### DIFF
--- a/server/svix-server/src/core/message_app.rs
+++ b/server/svix-server/src/core/message_app.rs
@@ -33,8 +33,8 @@ pub struct CreateMessageApp {
     pub uid: Option<ApplicationUid>,
     pub org_id: OrganizationId,
     pub rate_limit: Option<u16>,
-    pub endpoints: Vec<CreateMessageEndpoint>,
-    pub deleted: bool,
+    endpoints: Vec<CreateMessageEndpoint>,
+    deleted: bool,
 }
 
 impl CreateMessageApp {
@@ -77,8 +77,12 @@ impl CreateMessageApp {
         let cache_key = AppEndpointKey::new(&org_id, &app_id);
 
         // First check Redis
-        if let Ok(Some(cma)) = cache.get(&cache_key).await {
-            return Ok(Some(cma));
+        if let Ok(Some(cma)) = cache.get::<CreateMessageApp>(&cache_key).await {
+            if cma.deleted {
+                return Ok(None);
+            } else {
+                return Ok(Some(cma));
+            }
         }
 
         // Then check PostgreSQL
@@ -101,6 +105,10 @@ impl CreateMessageApp {
 
         // Insert it into Redis
         let _ = cache.set(&cache_key, &out, ttl).await;
+
+        if out.deleted {
+            return Ok(None);
+        }
 
         Ok(Some(out))
     }

--- a/server/svix-server/tests/message_app.rs
+++ b/server/svix-server/tests/message_app.rs
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: © 2022 Svix Authors
+// SPDX-License-Identifier: MIT
+
+//! Tests related to the [`CreateMessageApp`] and the [`CreateMessageEndpoint`]s structs.
+use std::time::Duration;
+
+use http::StatusCode;
+
+mod utils;
+
+use svix_server::{
+    cfg::{CacheBackend, CacheType, Configuration},
+    core::{
+        cache::{self, CacheBehavior},
+        message_app::AppEndpointKey,
+        types::{BaseId, OrganizationId},
+    },
+    redis::{new_redis_pool, new_redis_pool_clustered, RedisPool},
+};
+use utils::{
+    common_calls::{create_test_app, create_test_endpoint, create_test_message, message_in},
+    get_default_test_config, start_svix_server_with_cfg_and_org_id, IgnoredResponse, TestReceiver,
+};
+
+pub async fn get_pool(cfg: Configuration) -> RedisPool {
+    match cfg.cache_type {
+        CacheType::RedisCluster => {
+            new_redis_pool_clustered(cfg.redis_dsn.as_ref().unwrap().as_str(), &cfg).await
+        }
+        _ => new_redis_pool(cfg.redis_dsn.as_ref().unwrap().as_str(), &cfg).await,
+    }
+}
+
+/// Ensures that a deleted application returns `None` when using [`layered_fetch`]
+#[tokio::test]
+async fn test_app_deletion() {
+    dotenv::dotenv().ok();
+    let cfg = svix_server::cfg::load().expect("Error loading Configuration");
+    let org_id = OrganizationId::new(None, None);
+    let (client, _jh) =
+        start_svix_server_with_cfg_and_org_id(&get_default_test_config(), org_id.clone()).await;
+
+    // Cannot run test using an in-memory cache as we can't invalidate a key from within the test.
+    // Ie. the Redis backends all share the same memory when a cache is created in this test. The
+    // same is not true for an in-memory map.
+    if matches!(cfg.cache_backend(), CacheBackend::Memory) {
+        return;
+    }
+
+    let mut test_receiver = TestReceiver::start(axum::http::StatusCode::OK);
+
+    let app_id = create_test_app(&client, "TestAppDeletion")
+        .await
+        .unwrap()
+        .id;
+    let _ = create_test_endpoint(&client, &app_id, &test_receiver.endpoint)
+        .await
+        .unwrap();
+
+    let payload = serde_json::json!({"test": "value"});
+
+    create_test_message(&client, &app_id, payload.clone())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        tokio::time::timeout(Duration::from_millis(250), test_receiver.data_recv.recv()).await,
+        Ok(Some(payload.clone()))
+    );
+
+    client
+        .delete::<IgnoredResponse>(&format!("api/v1/app/{app_id}/"), StatusCode::NO_CONTENT)
+        .await
+        .unwrap();
+
+    // Delete the cached [`CreateMessageApp`] here instead of waiting 30s for it to expire
+    let cache = match cfg.cache_backend() {
+        CacheBackend::None => cache::none::new(),
+        CacheBackend::Redis(dsn) => {
+            let mgr = new_redis_pool(dsn, &cfg).await;
+            cache::redis::new(mgr)
+        }
+        CacheBackend::RedisCluster(dsn) => {
+            let mgr = new_redis_pool_clustered(dsn, &cfg).await;
+            cache::redis::new(mgr)
+        }
+
+        // Cannot use memory cache for this test. See the above check.
+        CacheBackend::Memory => unreachable!(),
+    };
+
+    cache
+        .delete(&AppEndpointKey::new(&org_id, &app_id))
+        .await
+        .unwrap();
+
+    // Assert message creation return a 404 with a deleted application
+    client
+        .post::<_, IgnoredResponse>(
+            &format!("api/v1/app/{app_id}/msg/"),
+            message_in("test.event", payload).unwrap(),
+            StatusCode::NOT_FOUND,
+        )
+        .await
+        .unwrap();
+
+    // And assert that no message is sent even if it 404s
+    assert!(
+        tokio::time::timeout(Duration::from_millis(250), test_receiver.data_recv.recv())
+            .await
+            .is_err()
+    );
+}
+
+#[tokio::test]
+async fn test_endp_deletion() {
+    dotenv::dotenv().ok();
+    let cfg = svix_server::cfg::load().expect("Error loading Configuration");
+    let org_id = OrganizationId::new(None, None);
+    let (client, _jh) =
+        start_svix_server_with_cfg_and_org_id(&get_default_test_config(), org_id.clone()).await;
+
+    // Cannot run test using an in-memory cache as we can't invalidate a key from within the test.
+    // Ie. the Redis backends all share the same memory when a cache is created in this test. The
+    // same is not true for an in-memory map.
+    if matches!(cfg.cache_backend(), CacheBackend::Memory) {
+        return;
+    }
+
+    let mut test_receiver = TestReceiver::start(axum::http::StatusCode::OK);
+
+    let app_id = create_test_app(&client, "TestAppDeletion")
+        .await
+        .unwrap()
+        .id;
+    let endp_id = create_test_endpoint(&client, &app_id, &test_receiver.endpoint)
+        .await
+        .unwrap()
+        .id;
+
+    let payload = serde_json::json!({"test": "value"});
+
+    create_test_message(&client, &app_id, payload.clone())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        tokio::time::timeout(Duration::from_millis(250), test_receiver.data_recv.recv()).await,
+        Ok(Some(payload.clone()))
+    );
+
+    client
+        .delete::<IgnoredResponse>(
+            &format!("api/v1/app/{app_id}/endpoint/{endp_id}/"),
+            StatusCode::NO_CONTENT,
+        )
+        .await
+        .unwrap();
+
+    // Delete the cached [`CreateMessageApp`] here instead of waiting 30s for it to expire
+    let cache = match cfg.cache_backend() {
+        CacheBackend::None => cache::none::new(),
+        CacheBackend::Redis(dsn) => {
+            let mgr = new_redis_pool(dsn, &cfg).await;
+            cache::redis::new(mgr)
+        }
+        CacheBackend::RedisCluster(dsn) => {
+            let mgr = new_redis_pool_clustered(dsn, &cfg).await;
+            cache::redis::new(mgr)
+        }
+
+        // Cannot use memory cache for this test. See the above check.
+        CacheBackend::Memory => unreachable!(),
+    };
+
+    cache
+        .delete(&AppEndpointKey::new(&org_id, &app_id))
+        .await
+        .unwrap();
+
+    // Assert message creation return a 202 with a deleted endpoint
+    client
+        .post::<_, IgnoredResponse>(
+            &format!("api/v1/app/{app_id}/msg/"),
+            message_in("test.event", payload).unwrap(),
+            StatusCode::ACCEPTED,
+        )
+        .await
+        .unwrap();
+
+    // But assert that no message is sent as the endpoint no longer exists
+    assert!(
+        tokio::time::timeout(Duration::from_millis(250), test_receiver.data_recv.recv())
+            .await
+            .is_err()
+    );
+}


### PR DESCRIPTION
It was discovered that deleted applications could still be improperly handled if a `CreateMessageApp` 's deleted fields (either on the `struct`  itself or via the `endpoints` field which each could be deleted) was not respected. These changes ensure that deleted application models return `Ok(None)` instead of `Some` `CreateMessageApp`, centralizing the logic to the only constructor of the `struct`. 

Additionally, to prevent such issues from ever occurring the `CreateMessageApp` has been changed slightly such that the `endpoints` and `deleted` fields are private. This means that the struct must be always be constructed via the `layered_fetch` which now filters for deleted applications. And it  means that endpoints must be fetched through the `filtered_endpoints` method, which filters disabled and deleted endpoints from the `Vec` of associated `CreateMessageEndpoint`s.

Finally, these changes introduce two  tests ensuring the soundness of this logic.

Do note that the `CreateMessageApp` is cached for 30 seconds, so it will take at most that long for deletion of applications or endpoints to be respected. This is bypassed in the aforementioned tests by manually deleting the key for the `CreateMessageApp`. 