### PR TITLE
Add JSON response type wrapper with response code

### DIFF
--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -20,7 +20,7 @@ use crate::{
         utils::{
             apply_pagination_desc, iterator_from_before_or_after, openapi_tag,
             ApplicationEndpointPath, ApplicationMsgAttemptPath, ApplicationMsgEndpointPath,
-            ApplicationMsgPath, EmptyResponse, EventTypesQuery, ListResponse, ModelOut,
+            ApplicationMsgPath, EmptyResponse, EventTypesQuery, JsonStatus, ListResponse, ModelOut,
             PaginationLimit, ReversibleIterator, ValidatedQuery,
         },
     },
@@ -669,7 +669,7 @@ async fn resend_webhook(
         ..
     }): Path<ApplicationMsgEndpointPath>,
     permissions::Application { app }: permissions::Application,
-) -> Result<(StatusCode, Json<EmptyResponse>)> {
+) -> Result<JsonStatus<202, EmptyResponse>> {
     let msg = ctx!(
         message::Entity::secure_find_by_id_or_uid(app.id.clone(), msg_id)
             .one(db)
@@ -712,7 +712,7 @@ async fn resend_webhook(
             None,
         )
         .await?;
-    Ok((StatusCode::ACCEPTED, Json(EmptyResponse {})))
+    Ok(JsonStatus(EmptyResponse {}))
 }
 
 /// Deletes the given attempt's response body. Useful when an endpoint accidentally returned sensitive content.

--- a/server/svix-server/src/v1/endpoints/endpoint/headers.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/headers.rs
@@ -2,7 +2,6 @@ use axum::{
     extract::{Path, State},
     Json,
 };
-use hyper::StatusCode;
 use sea_orm::ActiveModelTrait;
 use svix_server_derive::aide_annotate;
 
@@ -12,7 +11,7 @@ use crate::{
     ctx,
     db::models::endpoint,
     error::{HttpError, Result},
-    v1::utils::{ApplicationEndpointPath, EmptyResponse, ModelIn, ValidatedJson},
+    v1::utils::{ApplicationEndpointPath, EmptyResponse, JsonStatus, ModelIn, ValidatedJson},
     AppState,
 };
 
@@ -47,7 +46,7 @@ pub(super) async fn update_endpoint_headers(
     Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,
     permissions::Application { app }: permissions::Application,
     ValidatedJson(data): ValidatedJson<EndpointHeadersIn>,
-) -> Result<(StatusCode, Json<EmptyResponse>)> {
+) -> Result<JsonStatus<204, EmptyResponse>> {
     let endp = ctx!(
         endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endpoint_id)
             .one(db)
@@ -59,7 +58,7 @@ pub(super) async fn update_endpoint_headers(
     data.update_model(&mut endp);
     ctx!(endp.update(db).await)?;
 
-    Ok((StatusCode::NO_CONTENT, Json(EmptyResponse {})))
+    Ok(JsonStatus(EmptyResponse {}))
 }
 
 /// Partially set the additional headers to be sent with the webhook
@@ -71,7 +70,7 @@ pub(super) async fn patch_endpoint_headers(
     Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,
     permissions::Application { app }: permissions::Application,
     ValidatedJson(data): ValidatedJson<EndpointHeadersPatchIn>,
-) -> Result<(StatusCode, Json<EmptyResponse>)> {
+) -> Result<JsonStatus<204, EmptyResponse>> {
     let endp = ctx!(
         endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endpoint_id)
             .one(db)
@@ -83,7 +82,7 @@ pub(super) async fn patch_endpoint_headers(
     data.update_model(&mut endp);
     ctx!(endp.update(db).await)?;
 
-    Ok((StatusCode::NO_CONTENT, Json(EmptyResponse {})))
+    Ok(JsonStatus(EmptyResponse {}))
 }
 
 #[cfg(test)]

--- a/server/svix-server/src/v1/endpoints/endpoint/recovery.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/recovery.rs
@@ -1,9 +1,5 @@
-use axum::{
-    extract::{Path, State},
-    Json,
-};
+use axum::extract::{Path, State};
 use chrono::{DateTime, Utc};
-use hyper::StatusCode;
 use sea_orm::{entity::prelude::*, QueryOrder};
 use sea_orm::{DatabaseConnection, QuerySelect};
 use svix_server_derive::aide_annotate;
@@ -18,7 +14,7 @@ use crate::{
     db::models::{application, endpoint, messagedestination},
     error::{HttpError, Result, ValidationErrorItem},
     queue::{MessageTask, TaskQueueProducer},
-    v1::utils::{ApplicationEndpointPath, EmptyResponse, ValidatedJson},
+    v1::utils::{ApplicationEndpointPath, EmptyResponse, JsonStatus, ValidatedJson},
     AppState,
 };
 
@@ -83,7 +79,7 @@ pub(super) async fn recover_failed_webhooks(
     Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,
     permissions::Application { app }: permissions::Application,
     ValidatedJson(data): ValidatedJson<RecoverIn>,
-) -> Result<(StatusCode, Json<EmptyResponse>)> {
+) -> Result<JsonStatus<202, EmptyResponse>> {
     // Add five minutes so that people can easily just do `now() - two_weeks` without having to worry about clock sync
     let timeframe = chrono::Duration::days(14);
     let timeframe = timeframe + chrono::Duration::minutes(5);
@@ -110,5 +106,5 @@ pub(super) async fn recover_failed_webhooks(
         async move { bulk_recover_failed_messages(db, queue_tx, app, endp, data.since).await },
     );
 
-    Ok((StatusCode::ACCEPTED, Json(EmptyResponse {})))
+    Ok(JsonStatus(EmptyResponse {}))
 }

--- a/server/svix-server/src/v1/endpoints/endpoint/secrets.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/secrets.rs
@@ -3,7 +3,6 @@ use axum::{
     Json,
 };
 use chrono::{Duration, Utc};
-use hyper::StatusCode;
 use sea_orm::ActiveModelTrait;
 use sea_orm::ActiveValue::Set;
 use std::iter;
@@ -21,7 +20,7 @@ use crate::{
     ctx,
     db::models::endpoint,
     error::{HttpError, Result},
-    v1::utils::{ApplicationEndpointPath, EmptyResponse, ValidatedJson},
+    v1::utils::{ApplicationEndpointPath, EmptyResponse, JsonStatus, ValidatedJson},
     AppState,
 };
 
@@ -72,7 +71,7 @@ pub(super) async fn rotate_endpoint_secret(
     Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,
     permissions::Application { app }: permissions::Application,
     ValidatedJson(data): ValidatedJson<EndpointSecretRotateIn>,
-) -> Result<(StatusCode, Json<EmptyResponse>)> {
+) -> Result<JsonStatus<204, EmptyResponse>> {
     let mut endp = ctx!(
         endpoint::Entity::secure_find_by_id_or_uid(app.id, endpoint_id)
             .one(db)
@@ -129,5 +128,5 @@ pub(super) async fn rotate_endpoint_secret(
         )
         .await?;
 
-    Ok((StatusCode::NO_CONTENT, Json(EmptyResponse {})))
+    Ok(JsonStatus(EmptyResponse {}))
 }

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -15,8 +15,8 @@ use crate::{
     queue::MessageTaskBatch,
     v1::utils::{
         apply_pagination_desc, iterator_from_before_or_after, openapi_tag, validation_error,
-        ApplicationMsgPath, EventTypesQuery, ListResponse, ModelIn, ModelOut, PaginationLimit,
-        ReversibleIterator, ValidatedJson, ValidatedQuery,
+        ApplicationMsgPath, EventTypesQuery, JsonStatus, ListResponse, ModelIn, ModelOut,
+        PaginationLimit, ReversibleIterator, ValidatedJson, ValidatedQuery,
     },
     AppState,
 };
@@ -248,7 +248,7 @@ async fn create_message(
     >,
     permissions::OrganizationWithApplication { app }: permissions::OrganizationWithApplication,
     ValidatedJson(data): ValidatedJson<MessageIn>,
-) -> Result<(StatusCode, Json<MessageOut>)> {
+) -> Result<JsonStatus<202, MessageOut>> {
     let create_message_app = CreateMessageApp::layered_fetch(
         &cache,
         db,
@@ -291,7 +291,7 @@ async fn create_message(
         MessageOut::without_payload(msg)
     };
 
-    Ok((StatusCode::ACCEPTED, Json(msg_out)))
+    Ok(JsonStatus(msg_out))
 }
 
 #[derive(Debug, Deserialize, Validate, JsonSchema)]


### PR DESCRIPTION
This way the response code can be correctly inferred by aide for endpoints where we were previously returning `(StatusCode, Json<T>)` style responses. With the tuple style aide had no way of knowing what was the response like that's being returned. This way the response code is known statically at compile time which we can use to inform aide.

There are two structs, `JsonStatus`, for endpoints that always return the same status code on success, and `JsonStatusUpsert`, which is appropriate for endpoints that do upsert-style operations, e.g. where you have two status codes to distinguish between what happened internally, e.g. create versus update, but the output is the same. There's a fair number of endpoints that follow this pattern so it seemed worthwhile to add this.

Unfortunately custom types, i.e. `http::StatusCode` can't be used as a const generic in Rust currently, so I used `u16` which is essentially what `StatusCode` is on the inside, which I just quasi-cast into `StatusCode` with `from_u16(v).unwrap()`, but this _can_ panic because `from_u16` validates that the value passed is `100 <= n < 1000`. Therefore, some vigilance must be exercised with this, because `JsonStatus<1234, Foo>` will compile but blow up at runtime/test time.