### PR TITLE
Bump Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,12 @@
 module github.com/svix/svix-webhooks
 
-go 1.16
+go 1.20
 
 require golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c
+
+require (
+	github.com/golang/protobuf v1.4.2 // indirect
+	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
+)


### PR DESCRIPTION
## Motivation

We are quite a few # of Go versions behind. Also, this should fix
* https://github.com/svix/svix-webhooks/security/dependabot/35
* https://github.com/svix/svix-webhooks/security/dependabot/32
* https://github.com/svix/svix-webhooks/security/dependabot/34

## Solution

Bump to latest go version, and ran `go mod tidy`