### PR TITLE
refactor expired message cleaner to be incremental to avoid db deadlocks

### DIFF
--- a/server/svix-server/src/expired_message_cleaner.rs
+++ b/server/svix-server/src/expired_message_cleaner.rs
@@ -3,33 +3,72 @@
 
 use std::sync::atomic::Ordering;
 
-use crate::db::models::message;
 use crate::error::Result;
-use chrono::Utc;
-use sea_orm::{
-    entity::prelude::*, sea_query::Expr, DatabaseConnection, DbErr, EntityTrait, UpdateResult,
-};
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbErr, Statement, UpdateResult};
+use std::time::Duration;
 use tokio::time::sleep;
 
-/// Nullifies the payload column for expired messages
+/// Nullifies the payload column for expired messages,
+/// `limit` sets how many rows to update at a time.
 pub async fn clean_expired_messages(
     pool: &DatabaseConnection,
+    limit: u32,
 ) -> std::result::Result<UpdateResult, DbErr> {
-    message::Entity::update_many()
-        .col_expr(message::Column::Payload, Expr::value(Value::Json(None)))
-        .filter(message::Column::Expiration.lte(Utc::now()))
-        .filter(message::Column::Payload.is_not_null())
-        .exec(pool)
-        .await
+    let stmt = Statement::from_sql_and_values(
+        pool.get_database_backend(),
+        r#"
+        UPDATE message SET payload = NULL WHERE id IN (
+            SELECT id FROM message
+            WHERE
+                expiration <= now()
+                AND payload IS NOT NULL
+            LIMIT $1
+            FOR UPDATE SKIP LOCKED
+        )
+    "#,
+        [limit.into()],
+    );
+    let res = pool.execute(stmt).await?;
+    Ok(UpdateResult {
+        rows_affected: res.rows_affected(),
+    })
 }
 
-/// Runs every 10 seconds
+/// Polls the database for expired messages to nullify payloads for.
+///
+/// Uses a variable polling schedule, based on affected row counts each iteration of the loop.
 pub async fn expired_message_cleaner_loop(pool: &DatabaseConnection) -> Result<()> {
+    // When no rows have been updated, widen the interval.
+    const IDLE: Duration = Duration::from_secs(10);
+    // When the affected row count dips below this, switch to the `SLOWING` interval.
+    const SLOWING_THRESHOLD: u64 = 1_000;
+    const SLOWING: Duration = Duration::from_secs(3);
+    const BATCH_SIZE: u32 = 5_000;
+    let mut sleep_time = Some(IDLE);
     loop {
-        sleep(std::time::Duration::from_secs(10)).await;
+        if let Some(duration) = sleep_time {
+            sleep(duration).await;
+        }
         let pool = pool.clone();
-        if let Err(err) = clean_expired_messages(&pool).await {
-            tracing::error!("{}", err)
+        match clean_expired_messages(&pool, BATCH_SIZE).await {
+            Err(err) => {
+                tracing::error!("{}", err);
+            }
+            Ok(UpdateResult { rows_affected }) => {
+                if rows_affected > 0 {
+                    tracing::trace!("expired {} payloads", rows_affected);
+                }
+
+                sleep_time = match rows_affected {
+                    0 => Some(IDLE),
+                    count if count <= SLOWING_THRESHOLD => {
+                        tracing::trace!("slowing down...");
+                        Some(SLOWING)
+                    }
+                    // Any non-zero count above the slowing threshold gets no sleep.
+                    _ => None,
+                };
+            }
         }
 
         if crate::SHUTTING_DOWN.load(Ordering::SeqCst) {

--- a/server/svix-server/tests/e2e_message.rs
+++ b/server/svix-server/tests/e2e_message.rs
@@ -399,7 +399,7 @@ async fn test_payload_retention_period() {
         .await
         .unwrap();
 
-    expired_message_cleaner::clean_expired_messages(&pool)
+    expired_message_cleaner::clean_expired_messages(&pool, 5000)
         .await
         .unwrap();
 


### PR DESCRIPTION
## Motivation

In cases where a large number of messages expire within a short period, and multiple instances of svix-server are running in concert, it's possible to see postgres deadlocks.

## Solution

This diff adjusts the cleaner to make it more cooperative by using row-locks to incrementally remove the payloads a batch at a time.

The polling schedule has been updated as well. When the backlog of expired messages is small or zero, we poll every 3 or 10 seconds respectively. In other cases (where there are many rows processed) there will be no sleep at all; the loop will "go hot" as it works through the backlog.

With this, we should no longer see deadlocks related to the cleaner but at the cost of (possibly) a delay in payload expiry.