### PR TITLE
add changelog entry for expired message cleaner refactor

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Next
-* 
+* Server: refactor expired message cleaner to be incremental
 
 ## Version 0.81.0
 * Libs: add support for creating application when creating a message


### PR DESCRIPTION
Neglected to update the changelog with the initial work on #869. This diff adds the missing entry.