### PR TITLE
Alias types from internal dir / openapi package

### DIFF
--- a/go/messageattempt.go
+++ b/go/messageattempt.go
@@ -18,8 +18,11 @@ type (
 	ListResponseMessageAttemptOut         openapi.ListResponseMessageAttemptOut
 	MessageAttemptOut                     openapi.MessageAttemptOut
 	ListResponseEndpointMessageOut        openapi.ListResponseEndpointMessageOut
+	EndpointMessageOut                    openapi.EndpointMessageOut
 	ListResponseMessageEndpointOut        openapi.ListResponseMessageEndpointOut
+	MessageEndpointOut                    openapi.MessageEndpointOut
 	ListResponseMessageAttemptEndpointOut openapi.ListResponseMessageAttemptEndpointOut
+	MessageAttemptEndpointOut             openapi.MessageAttemptEndpointOut
 )
 
 type MessageAttemptListOptions struct {


### PR DESCRIPTION
When these ListResponse* types are aliased in the svix package, the struct type they're returning in the Data array should also be aliased.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

If the user would like to, say, make a helper function that cycles through all the iterators for this, and returns the structs on a channel, they cannot do that without the types being available (or defining their own struct types that mimic the openapi ones).

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Simply alias the struct types that are used in each of these ListReponse* type's Data array field.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
