### PR TITLE
Bump tower-http version

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -199,7 +199,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.3.5",
  "tower-layer",
  "tower-service",
 ]
@@ -3304,7 +3304,7 @@ dependencies = [
  "time 0.3.20",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.4.0",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -3684,6 +3684,24 @@ dependencies = [
  "http-range-header",
  "pin-project-lite",
  "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -27,7 +27,7 @@ hyper-openssl = "0.9.2"
 openssl = "0.10.45"
 tokio = { version = "1.24.2", features = ["full"] }
 tower = "0.4.11"
-tower-http = { version = "0.3.4", features = ["trace", "cors", "request-id"] }
+tower-http = { version = "0.4.0", features = ["trace", "cors", "request-id"] }
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = { version = "1.0.74", features = ["arbitrary_precision"] }
 serde_urlencoded = "0.7.1"


### PR DESCRIPTION
## Motivation

This just bumps `tower-http` to the latest version. We use some of the crate's services for limiting request bodies.

This isn't motivated by anything specific, I just saw we were behind versions when looking at adjacent code.

## Solution

Bumping the version. That's it.

