### PR TITLE
Create message: change to RawValue instead of Value

### DIFF
--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -29,7 +29,7 @@ tokio = { version = "1.24.2", features = ["full"] }
 tower = "0.4.11"
 tower-http = { version = "0.4.0", features = ["trace", "cors", "request-id"] }
 serde = { version = "1.0.133", features = ["derive"] }
-serde_json = { version = "1.0.74", features = ["arbitrary_precision"] }
+serde_json = { version = "1.0.74", features = ["arbitrary_precision", "raw_value"] }
 serde_urlencoded = "0.7.1"
 serde_path_to_error = "0.1.7"
 num_enum = "0.5.6"

--- a/server/svix-server/tests/e2e_endpoint.rs
+++ b/server/svix-server/tests/e2e_endpoint.rs
@@ -17,6 +17,7 @@ use std::{
 };
 use svix_server::db::models::{message, messagedestination};
 use svix_server::v1::endpoints::endpoint::EndpointStatsOut;
+use svix_server::v1::endpoints::message::RawPayload;
 
 use serde::Deserialize;
 use svix::webhooks::Webhook;
@@ -1972,7 +1973,7 @@ async fn test_msg_event_types_filter() {
                 MessageIn {
                     channels: None,
                     event_type: event_name,
-                    payload: serde_json::json!({}),
+                    payload: RawPayload::from_string("{}".to_string()).unwrap(),
                     uid: None,
                     payload_retention_period: 5,
                 },
@@ -2021,7 +2022,7 @@ async fn test_msg_channels_filter() {
                 MessageIn {
                     channels: channels.clone(),
                     event_type: EventTypeName("et1".to_owned()),
-                    payload: serde_json::json!({}),
+                    payload: RawPayload::from_string("{}".to_string()).unwrap(),
                     uid: None,
                     payload_retention_period: 5,
                 },

--- a/server/svix-server/tests/utils/common_calls.rs
+++ b/server/svix-server/tests/utils/common_calls.rs
@@ -21,7 +21,7 @@ use svix_server::{
             auth::AppPortalAccessIn,
             endpoint::{EndpointIn, EndpointOut, RecoverIn},
             event_type::EventTypeIn,
-            message::{MessageIn, MessageOut},
+            message::{MessageIn, MessageOut, RawPayload},
         },
         utils::ListResponse,
     },
@@ -116,7 +116,7 @@ pub async fn put_endpoint(
 pub fn message_in<T: Serialize>(event_type: &str, payload: T) -> Result<MessageIn> {
     Ok(MessageIn {
         event_type: EventTypeName(event_type.to_owned()),
-        payload: serde_json::to_value(payload)?,
+        payload: RawPayload::from_string(serde_json::to_string(&payload)?)?,
         payload_retention_period: 5,
         channels: None,
         uid: None,
@@ -160,7 +160,7 @@ pub async fn create_test_msg_with(
             &format!("api/v1/app/{}/msg/", &app_id),
             MessageIn {
                 event_type: EventTypeName(event_type.to_owned()),
-                payload,
+                payload: RawPayload::from_string(serde_json::to_string(&payload).unwrap()).unwrap(),
                 payload_retention_period: 5,
                 channels,
                 uid: None,


### PR DESCRIPTION
We were using the `serde_json::Value` for the message payload which resulted in a lot of allocations when the payload was complex, and was causing high memory usage and fragmentation. With this, we don't actually parse this part of the json, but rather just treat it as a string (serde verifies it's valid json though). We unfortunately turn it into a `Value` when persisting to PG, we should fix this extra thing that diminishes the point of this change a bit.

Includes a hack to workaround the serde_json flatten issue with RawValue: https://github.com/serde-rs/json/issues/599