### PR TITLE
[rust]: allow specifying TLS flavour to use

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,5 +25,8 @@ serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"
 url = "^2.2"
-reqwest = { version = "^0.11", features = ["json", "multipart", "default-tls"], default-features = false }
+reqwest = { version = "^0.11", features = ["json", "multipart"], default-features = false }
 
+[features]
+default = ["reqwest/default-tls"]
+rustls-tls = ["reqwest/rustls-tls"]

--- a/rust/README.md
+++ b/rust/README.md
@@ -44,3 +44,15 @@ You can find general usage documentation at <https://docs.svix.com>.  For comple
 
 ## Usage
 Please refer to [the documentation](https://docs.svix.com/) or [the API reference](https://api.svix.com/docs) for more usage instructions.
+
+# Optional Cargo Features
+
+## TLS
+
+By default reqwest uses rust-native-tls, which will use the operating system TLS framework if available, meaning Windows and macOS. On Linux, it will use OpenSSL 1.1.
+
+[rustls-tls](https://github.com/rustls/rustls) can also be choosen, eg.:
+```
+svix = { version = "N", features = ["rustls-tls"], default-features = false  }
+```
+


### PR DESCRIPTION
// only the default-tls
cargo tree

// both since features are additive
cargo tree --features rustls-tls

// only rustls-tls
cargo tree --features rustls-tls --no-default-features

closes #889

## Motivation

Bellow is verbatim copy from issue #889 created by @msdinit

We are building our application against musl, cross-compiling it from regular libc Ubuntu. However, we are having issues with svix client, because it depends on system OpenSSL, which in our case would be linked against libc. There https://github.com/sfackler/rust-openssl/issues/603, but they are a bit involved.

## Solution

Added cargo features allowing users to choose which ssl version to use for svix reqwest http client, keeping backwards compatibility.
