### PR TITLE
ref verify_timestamp

### DIFF
--- a/rust/src/webhooks.rs
+++ b/rust/src/webhooks.rs
@@ -129,14 +129,15 @@ impl Webhook {
 
     fn verify_timestamp(ts: i64) -> Result<(), WebhookError> {
         let now = OffsetDateTime::now_utc().unix_timestamp();
-        if now - ts > TOLERANCE_IN_SECONDS {
-            Err(WebhookError::TimestampTooOldError)
-        } else if ts > now + TOLERANCE_IN_SECONDS {
-            Err(WebhookError::FutureTimestampError)
-        } else {
-            Ok(())
+        let timestamp_diff = now - ts;
+
+        match timestamp_diff {
+            diff if diff > TOLERANCE_IN_SECONDS => Err(WebhookError::TimestampTooOldError),
+            diff if diff < -TOLERANCE_IN_SECONDS => Err(WebhookError::FutureTimestampError),
+            _ => Ok(()),
         }
     }
+
 }
 
 #[cfg(test)]


### PR DESCRIPTION
used match Instead of if else 
moved timestamp_diff to variable to improve readability  