### PR TITLE
Ruby: Fix missing dependency

### DIFF
--- a/ruby/lib/svix.rb
+++ b/ruby/lib/svix.rb
@@ -70,7 +70,6 @@ require "svix/models/message_out"
 require "svix/models/message_status"
 require "svix/models/recover_in"
 require "svix/models/validation_error"
-require "svix/models/webhook_types"
 require "svix/models/status_code_class"
 
 # Core

--- a/ruby/lib/svix/internal.rb
+++ b/ruby/lib/svix/internal.rb
@@ -1,17 +1,16 @@
 # frozen_string_literal: true
 
 module Svix
-    private_constant :ApiClient
-    private_constant :Configuration
-    private_constant :ApplicationApi
-    private_constant :AuthenticationApi
-    private_constant :EndpointApi
-    private_constant :HealthApi
-    private_constant :IntegrationApi
-    private_constant :MessageApi
-    private_constant :MessageAttemptApi
-    private_constant :WebhookTypes
-    private_constant :HttpErrorOut
-    private_constant :HTTPValidationError
-    private_constant :ValidationError
+  private_constant :ApiClient
+  private_constant :Configuration
+  private_constant :ApplicationApi
+  private_constant :AuthenticationApi
+  private_constant :EndpointApi
+  private_constant :HealthApi
+  private_constant :IntegrationApi
+  private_constant :MessageApi
+  private_constant :MessageAttemptApi
+  private_constant :HttpErrorOut
+  private_constant :HTTPValidationError
+  private_constant :ValidationError
 end


### PR DESCRIPTION
Current library version fails to load due to a missing dependency. 
This dependency is not really part of the public API, though, so removing.

Fixes #908 