### PR TITLE
Server: Support comma-separated array query params

### DIFF
--- a/server/svix-server/src/v1/utils/mod.rs
+++ b/server/svix-server/src/v1/utils/mod.rs
@@ -563,13 +563,14 @@ where
         let pairs = form_urlencoded::parse(parts.uri.query().unwrap_or_default().as_bytes());
 
         let event_types: HashSet<EventTypeName> = pairs
-            .filter_map(|(key, value)| {
+            .filter(|(key, _)|
                 // want to handle both `?event_types=`, `?event_types[]=`, and `?event_types[1]=`
-                if key == "event_types" || (key.starts_with("event_types[") && key.ends_with(']')) {
-                    Some(EventTypeName(value.into_owned()))
-                } else {
-                    None
-                }
+                key == "event_types" || (key.starts_with("event_types[") && key.ends_with(']')))
+            .flat_map(|(_, value)| {
+                value
+                    .split(',')
+                    .map(|x| EventTypeName(x.to_owned()))
+                    .collect::<Vec<_>>()
             })
             .collect();
 

--- a/server/svix-server/tests/e2e_attempt.rs
+++ b/server/svix-server/tests/e2e_attempt.rs
@@ -295,14 +295,23 @@ async fn test_list_attempts_by_endpoint() {
         .unwrap();
     assert_eq!(regular_attempts.data.len(), 2);
 
-    let all_attempts: ListResponse<MessageAttemptOut> = client
+    let all_attempts_1: ListResponse<MessageAttemptOut> = client
     .get(
         &format!("api/v1/app/{app_id}/attempt/endpoint/{endp_id_2}/?event_types[0]=event.type&event_types[1]=user.exploded"),
         StatusCode::OK,
     )
     .await
     .unwrap();
-    assert_eq!(all_attempts.data.len(), 3);
+    assert_eq!(all_attempts_1.data.len(), 3);
+
+    let all_attempts_2: ListResponse<MessageAttemptOut> = client
+    .get(
+        &format!("api/v1/app/{app_id}/attempt/endpoint/{endp_id_2}/?event_types=event.type,user.exploded"),
+        StatusCode::OK,
+    )
+    .await
+    .unwrap();
+    assert_eq!(all_attempts_2.data.len(), 3);
 
     receiver_1.jh.abort();
     receiver_2.jh.abort();


### PR DESCRIPTION
Our Rust lib generates query params in comma-separated syntax.
This is technically not what our API expects, but frankly it's easy to
support it and seems reasonable to do so. Added and updated tests
accordingly.

Fixes #921 