### PR TITLE
bridge: reduce duplicate consumer code as much as possible

### DIFF
--- a/webhook-bridge/svix-webhook-bridge-plugin-queue-consumer/src/gcp_pubsub/mod.rs
+++ b/webhook-bridge/svix-webhook-bridge-plugin-queue-consumer/src/gcp_pubsub/mod.rs
@@ -1,16 +1,11 @@
 use crate::config::{GCPPubSubConsumerConfig, GCPPubSubInputOpts};
 use crate::error::Error;
-use crate::PLUGIN_VERS;
-use crate::{create_svix_message, CreateMessageRequest};
-use crate::{run_inner, Consumer, PLUGIN_NAME};
-use generic_queue::gcp_pubsub::{
-    GCPPubSubConfig, GCPPubSubDelivery, GCPPubSubQueueBackend, GCPPubSubQueueConsumer,
-};
-use generic_queue::{Delivery, TaskQueueBackend, TaskQueueReceive};
-use std::time::Duration;
+use crate::ConsumerWrapper;
+use crate::{run_inner, Consumer};
+use generic_queue::gcp_pubsub::{GCPPubSubConfig, GCPPubSubQueueBackend};
+use generic_queue::TaskQueueBackend;
 use svix::api::Svix;
 use svix_webhook_bridge_types::{async_trait, JsObject, Plugin, TransformerTx};
-use tracing::instrument;
 
 pub struct GCPPubSubConsumerPlugin {
     input_options: GCPPubSubInputOpts,
@@ -34,95 +29,42 @@ impl GCPPubSubConsumerPlugin {
             transformation,
         }
     }
-
-    /// Pulls N messages off the queue and feeds them to [`Self::process`].
-    #[instrument(skip_all,
-        fields(
-            otel.kind = "CONSUMER",
-            messaging.system = "gcp-pubsub",
-            messaging.operation = "receive",
-            messaging.source = &self.input_options.subscription_id,
-            svixagent_plugin.name = PLUGIN_NAME,
-            svixagent_plugin.vers = PLUGIN_VERS,
-        )
-    )]
-    async fn receive(&self, consumer: &mut GCPPubSubQueueConsumer) -> std::io::Result<()> {
-        let deliveries = consumer
-            .receive_all(1, Duration::from_millis(10))
-            .await
-            .map_err(Error::from)?;
-        tracing::trace!("received: {}", deliveries.len());
-        for delivery in deliveries {
-            self.process(delivery).await?;
-        }
-        Ok(())
-    }
-
-    /// Parses the delivery as JSON and feeds it into [`create_svix_message`].
-    /// Will nack the delivery if either the JSON parse, transformation, or the request to svix fails.
-    #[instrument(skip_all, fields(messaging.operation = "process"))]
-    async fn process(&self, delivery: GCPPubSubDelivery<JsObject>) -> std::io::Result<()> {
-        let payload = match Delivery::<JsObject>::payload(&delivery) {
-            Ok(p) => p,
-            Err(e) => {
-                tracing::warn!("{e}");
-                delivery.nack().await.map_err(Error::from)?;
-                return Ok(());
-            }
-        };
-
-        let payload = if let Some(script) = &self.transformation {
-            match self.transform(script.clone(), payload).await {
-                Err(e) => {
-                    tracing::error!("nack: {e}");
-                    delivery.nack().await.map_err(Error::from)?;
-                    return Ok(());
-                }
-                Ok(x) => x,
-            }
-        } else {
-            payload
-        };
-
-        match create_svix_message(&self.svix_client, payload).await {
-            Ok(_) => {
-                tracing::trace!("ack");
-                delivery.ack().await.map_err(Error::from)?
-            }
-            Err(e) => {
-                tracing::error!("nack: {e}");
-                delivery.nack().await.map_err(Error::from)?
-            }
-        }
-        Ok(())
-    }
 }
 
 #[async_trait]
 impl Consumer for GCPPubSubConsumerPlugin {
-    fn transformer_tx(&self) -> Option<&TransformerTx> {
-        self.transformer_tx.as_ref()
+    fn source(&self) -> &str {
+        &self.input_options.subscription_id
     }
-    async fn consume(&self) -> std::io::Result<()> {
-        let mut consumer =
-            <GCPPubSubQueueBackend as TaskQueueBackend<CreateMessageRequest>>::consuming_half(
-                GCPPubSubConfig {
-                    subscription_id: self.input_options.subscription_id.clone(),
-                    credentials_file: self.input_options.credentials_file.clone(),
-                    // Topics are for producers so we don't care
-                    topic: String::new(),
-                },
-            )
-            .await
-            .map_err(Error::from)?;
-        tracing::debug!(
-            "gcp pubsub consuming: {}",
-            &self.input_options.subscription_id
-        );
 
-        loop {
-            self.receive(&mut consumer).await?;
-        }
+    fn system(&self) -> &str {
+        "gcp-pubsub"
+    }
+
+    fn transformer_tx(&self) -> &Option<TransformerTx> {
+        &self.transformer_tx
+    }
+
+    fn transformation(&self) -> &Option<String> {
+        &self.transformation
+    }
+
+    fn svix_client(&self) -> &Svix {
+        &self.svix_client
+    }
+
+    async fn consumer(&self) -> std::io::Result<ConsumerWrapper> {
+        let consumer = <GCPPubSubQueueBackend as TaskQueueBackend<JsObject>>::consuming_half(
+            GCPPubSubConfig {
+                subscription_id: self.input_options.subscription_id.clone(),
+                credentials_file: self.input_options.credentials_file.clone(),
+                // Topics are for producers so we don't care
+                topic: String::new(),
+            },
+        )
+        .await
+        .map_err(Error::from)?;
+        Ok(ConsumerWrapper::GCPPubSub(consumer))
     }
 }
 
@@ -139,6 +81,6 @@ impl Plugin for GCPPubSubConsumerPlugin {
         self.transformer_tx = tx;
     }
     async fn run(&self) -> std::io::Result<()> {
-        run_inner(self, "gcp subsub", &self.input_options.subscription_id).await
+        run_inner(self).await
     }
 }

--- a/webhook-bridge/svix-webhook-bridge-plugin-queue-consumer/src/rabbitmq/mod.rs
+++ b/webhook-bridge/svix-webhook-bridge-plugin-queue-consumer/src/rabbitmq/mod.rs
@@ -1,0 +1,98 @@
+use crate::config::{RabbitMqConsumerConfig, RabbitMqInputOpts};
+use crate::error::Error;
+use crate::run_inner;
+use crate::Consumer;
+use crate::ConsumerWrapper;
+use generic_queue::{
+    rabbitmq::{
+        BasicProperties, BasicPublishOptions, ConnectionProperties, RabbitMqBackend, RabbitMqConfig,
+    },
+    TaskQueueBackend,
+};
+use svix::api::Svix;
+use svix_webhook_bridge_types::{async_trait, JsObject, Plugin, TransformerTx};
+
+pub struct RabbitMqConsumerPlugin {
+    input_options: RabbitMqInputOpts,
+    svix_client: Svix,
+    transformer_tx: Option<TransformerTx>,
+    transformation: Option<String>,
+}
+
+impl RabbitMqConsumerPlugin {
+    pub fn new(
+        RabbitMqConsumerConfig {
+            input,
+            transformation,
+            output,
+        }: RabbitMqConsumerConfig,
+    ) -> Self {
+        Self {
+            input_options: input,
+            svix_client: Svix::new(output.token, output.svix_options.map(Into::into)),
+            transformer_tx: None,
+            transformation,
+        }
+    }
+}
+
+impl TryInto<Box<dyn Plugin>> for RabbitMqConsumerConfig {
+    type Error = &'static str;
+
+    fn try_into(self) -> Result<Box<dyn Plugin>, Self::Error> {
+        Ok(Box::new(RabbitMqConsumerPlugin::new(self)))
+    }
+}
+
+#[async_trait]
+impl Consumer for RabbitMqConsumerPlugin {
+    fn source(&self) -> &str {
+        &self.input_options.queue_name
+    }
+
+    fn system(&self) -> &str {
+        "rabbitmq"
+    }
+
+    fn transformer_tx(&self) -> &Option<TransformerTx> {
+        &self.transformer_tx
+    }
+
+    fn transformation(&self) -> &Option<String> {
+        &self.transformation
+    }
+
+    fn svix_client(&self) -> &Svix {
+        &self.svix_client
+    }
+
+    async fn consumer(&self) -> std::io::Result<ConsumerWrapper> {
+        let consumer =
+            <RabbitMqBackend as TaskQueueBackend<JsObject>>::consuming_half(RabbitMqConfig {
+                uri: self.input_options.uri.clone(),
+                connection_properties: ConnectionProperties::default(),
+                publish_exchange: String::new(),
+                publish_routing_key: String::new(),
+                publish_options: BasicPublishOptions::default(),
+                publish_properites: BasicProperties::default(),
+                consume_queue: self.input_options.queue_name.clone(),
+                consumer_tag: self.input_options.consumer_tag.clone().unwrap_or_default(),
+                consume_options: self.input_options.consume_opts.unwrap_or_default(),
+                consume_arguments: self.input_options.consume_args.clone().unwrap_or_default(),
+                requeue_on_nack: self.input_options.requeue_on_nack,
+            })
+            .await
+            .map_err(Error::from)?;
+        Ok(ConsumerWrapper::RabbitMQ(consumer))
+    }
+}
+
+#[async_trait]
+impl Plugin for RabbitMqConsumerPlugin {
+    fn set_transformer(&mut self, tx: Option<TransformerTx>) {
+        self.transformer_tx = tx;
+    }
+    async fn run(&self) -> std::io::Result<()> {
+        run_inner(self).await
+    }
+}

--- a/webhook-bridge/svix-webhook-bridge-plugin-queue-consumer/src/redis/mod.rs
+++ b/webhook-bridge/svix-webhook-bridge-plugin-queue-consumer/src/redis/mod.rs
@@ -1,0 +1,89 @@
+use crate::config::{RedisConsumerConfig, RedisInputOpts};
+use crate::error::Error;
+use crate::run_inner;
+use crate::Consumer;
+use crate::ConsumerWrapper;
+use generic_queue::redis::RedisConfig;
+use generic_queue::{redis::RedisQueueBackend, TaskQueueBackend};
+use svix::api::Svix;
+use svix_webhook_bridge_types::{async_trait, JsObject, Plugin, TransformerTx};
+
+pub struct RedisConsumerPlugin {
+    input_options: RedisInputOpts,
+    svix_client: Svix,
+    transformer_tx: Option<TransformerTx>,
+    transformation: Option<String>,
+}
+
+impl RedisConsumerPlugin {
+    pub fn new(
+        RedisConsumerConfig {
+            input,
+            transformation,
+            output,
+        }: RedisConsumerConfig,
+    ) -> Self {
+        Self {
+            input_options: input,
+            svix_client: Svix::new(output.token, output.svix_options.map(Into::into)),
+            transformer_tx: None,
+            transformation,
+        }
+    }
+}
+
+impl TryInto<Box<dyn Plugin>> for RedisConsumerConfig {
+    type Error = &'static str;
+
+    fn try_into(self) -> Result<Box<dyn Plugin>, Self::Error> {
+        Ok(Box::new(RedisConsumerPlugin::new(self)))
+    }
+}
+
+#[async_trait]
+impl Consumer for RedisConsumerPlugin {
+    fn source(&self) -> &str {
+        &self.input_options.queue_key
+    }
+
+    fn system(&self) -> &str {
+        "redis"
+    }
+
+    fn transformer_tx(&self) -> &Option<TransformerTx> {
+        &self.transformer_tx
+    }
+
+    fn transformation(&self) -> &Option<String> {
+        &self.transformation
+    }
+
+    fn svix_client(&self) -> &Svix {
+        &self.svix_client
+    }
+
+    async fn consumer(&self) -> std::io::Result<ConsumerWrapper> {
+        let consumer =
+            <RedisQueueBackend as TaskQueueBackend<JsObject>>::consuming_half(RedisConfig {
+                dsn: self.input_options.dsn.clone(),
+                max_connections: self.input_options.max_connections,
+                reinsert_on_nack: self.input_options.reinsert_on_nack,
+                queue_key: self.input_options.queue_key.clone(),
+                consumer_group: self.input_options.consumer_group.clone(),
+                consumer_name: self.input_options.consumer_name.clone(),
+            })
+            .await
+            .map_err(Error::from)?;
+        Ok(ConsumerWrapper::Redis(consumer))
+    }
+}
+
+#[async_trait]
+impl Plugin for RedisConsumerPlugin {
+    fn set_transformer(&mut self, tx: Option<TransformerTx>) {
+        self.transformer_tx = tx;
+    }
+    async fn run(&self) -> std::io::Result<()> {
+        run_inner(self).await
+    }
+}

--- a/webhook-bridge/svix-webhook-bridge-plugin-queue-consumer/src/sqs/mod.rs
+++ b/webhook-bridge/svix-webhook-bridge-plugin-queue-consumer/src/sqs/mod.rs
@@ -1,0 +1,84 @@
+use crate::config::{SqsConsumerConfig, SqsInputOpts};
+use crate::error::Error;
+use crate::{run_inner, Consumer, ConsumerWrapper};
+use generic_queue::{
+    sqs::{SqsConfig, SqsQueueBackend},
+    TaskQueueBackend,
+};
+use svix::api::Svix;
+use svix_webhook_bridge_types::{async_trait, JsObject, Plugin, TransformerTx};
+
+pub struct SqsConsumerPlugin {
+    input_options: SqsInputOpts,
+    svix_client: Svix,
+    transformer_tx: Option<TransformerTx>,
+    transformation: Option<String>,
+}
+
+impl TryInto<Box<dyn Plugin>> for SqsConsumerConfig {
+    type Error = &'static str;
+
+    fn try_into(self) -> Result<Box<dyn Plugin>, Self::Error> {
+        Ok(Box::new(SqsConsumerPlugin::new(self)))
+    }
+}
+
+impl SqsConsumerPlugin {
+    pub fn new(
+        SqsConsumerConfig {
+            input,
+            transformation,
+            output,
+        }: SqsConsumerConfig,
+    ) -> Self {
+        Self {
+            input_options: input,
+            svix_client: Svix::new(output.token, output.svix_options.map(Into::into)),
+            transformer_tx: None,
+            transformation,
+        }
+    }
+}
+
+#[async_trait]
+impl Consumer for SqsConsumerPlugin {
+    fn source(&self) -> &str {
+        &self.input_options.queue_dsn
+    }
+
+    fn system(&self) -> &str {
+        "sqs"
+    }
+
+    fn transformer_tx(&self) -> &Option<TransformerTx> {
+        &self.transformer_tx
+    }
+
+    fn transformation(&self) -> &Option<String> {
+        &self.transformation
+    }
+
+    fn svix_client(&self) -> &Svix {
+        &self.svix_client
+    }
+
+    async fn consumer(&self) -> std::io::Result<ConsumerWrapper> {
+        let consumer = <SqsQueueBackend as TaskQueueBackend<JsObject>>::consuming_half(SqsConfig {
+            queue_dsn: self.input_options.queue_dsn.clone(),
+            override_endpoint: self.input_options.override_endpoint,
+        })
+        .await
+        .map_err(Error::from)?;
+        Ok(ConsumerWrapper::SQS(consumer))
+    }
+}
+
+#[async_trait]
+impl Plugin for SqsConsumerPlugin {
+    fn set_transformer(&mut self, tx: Option<TransformerTx>) {
+        self.transformer_tx = tx;
+    }
+    async fn run(&self) -> std::io::Result<()> {
+        run_inner(self).await
+    }
+}

--- a/webhook-bridge/svix-webhook-bridge-plugin-queue-consumer/tests/gcp_pubsub_consumer.rs
+++ b/webhook-bridge/svix-webhook-bridge-plugin-queue-consumer/tests/gcp_pubsub_consumer.rs
@@ -11,10 +11,9 @@ use std::time::Duration;
 
 use serde_json::json;
 use svix::api::MessageIn;
-use svix_webhook_bridge_plugin_queue_consumer::config::GCPPubSubInputOpts;
 use svix_webhook_bridge_plugin_queue_consumer::{
-    config::{OutputOpts, SvixOptions},
-    CreateMessageRequest, GCPPubSubConsumerConfig, GCPPubSubConsumerPlugin,
+    config::{GCPPubSubConsumerConfig, GCPPubSubInputOpts, OutputOpts, SvixOptions},
+    CreateMessageRequest, GCPPubSubConsumerPlugin,
 };
 use svix_webhook_bridge_types::{JsReturn, Plugin, TransformerJob};
 use wiremock::matchers::{body_partial_json, method};

--- a/webhook-bridge/svix-webhook-bridge-plugin-queue-consumer/tests/rabbitmq_consumer.rs
+++ b/webhook-bridge/svix-webhook-bridge-plugin-queue-consumer/tests/rabbitmq_consumer.rs
@@ -8,8 +8,8 @@ use serde_json::json;
 use std::time::Duration;
 use svix::api::MessageIn;
 use svix_webhook_bridge_plugin_queue_consumer::{
-    config::{OutputOpts, RabbitMqInputOpts, SvixOptions},
-    CreateMessageRequest, RabbitMqConsumerConfig, RabbitMqConsumerPlugin,
+    config::{OutputOpts, RabbitMqConsumerConfig, RabbitMqInputOpts, SvixOptions},
+    CreateMessageRequest, RabbitMqConsumerPlugin,
 };
 use svix_webhook_bridge_types::{JsReturn, Plugin, TransformerJob};
 use wiremock::matchers::{body_partial_json, method};

--- a/webhook-bridge/svix-webhook-bridge-plugin-queue-consumer/tests/redis_stream_consumer.rs
+++ b/webhook-bridge/svix-webhook-bridge-plugin-queue-consumer/tests/redis_stream_consumer.rs
@@ -7,8 +7,8 @@ use redis::{AsyncCommands, Client};
 use serde_json::json;
 use svix::api::MessageIn;
 use svix_webhook_bridge_plugin_queue_consumer::{
-    config::{OutputOpts, SvixOptions},
-    CreateMessageRequest, RedisConsumerConfig, RedisConsumerPlugin, RedisInputOpts,
+    config::{OutputOpts, RedisConsumerConfig, RedisInputOpts, SvixOptions},
+    CreateMessageRequest, RedisConsumerPlugin,
 };
 use svix_webhook_bridge_types::{JsReturn, Plugin, TransformerJob};
 use wiremock::matchers::{body_partial_json, method};

--- a/webhook-bridge/svix-webhook-bridge-plugin-queue-consumer/tests/sqs_consumer.rs
+++ b/webhook-bridge/svix-webhook-bridge-plugin-queue-consumer/tests/sqs_consumer.rs
@@ -9,8 +9,8 @@ use aws_sdk_sqs::Client;
 use serde_json::json;
 use svix::api::MessageIn;
 use svix_webhook_bridge_plugin_queue_consumer::{
-    config::{OutputOpts, SvixOptions},
-    CreateMessageRequest, SqsConsumerConfig, SqsConsumerPlugin, SqsInputOpts,
+    config::{OutputOpts, SqsConsumerConfig, SqsInputOpts, SvixOptions},
+    CreateMessageRequest, SqsConsumerPlugin,
 };
 use svix_webhook_bridge_types::{JsReturn, Plugin, TransformerJob};
 use wiremock::matchers::{body_partial_json, method};

--- a/webhook-bridge/svix-webhook-bridge/src/config/mod.rs
+++ b/webhook-bridge/svix-webhook-bridge/src/config/mod.rs
@@ -1,4 +1,7 @@
 use serde::Deserialize;
+use svix_webhook_bridge_plugin_queue_consumer::config::{
+    GCPPubSubConsumerConfig, RabbitMqConsumerConfig, RedisConsumerConfig, SqsConsumerConfig,
+};
 use svix_webhook_bridge_types::Plugin;
 use tracing::Level;
 
@@ -57,16 +60,16 @@ pub enum LogFormat {
 #[serde(rename_all = "lowercase")]
 pub enum PluginConfig {
     #[cfg(feature = "gcp-pubsub")]
-    GCPPubSubConsumer(svix_webhook_bridge_plugin_queue_consumer::GCPPubSubConsumerConfig),
+    GCPPubSubConsumer(GCPPubSubConsumerConfig),
 
     #[cfg(feature = "rabbitmq")]
-    RabbitMQConsumer(svix_webhook_bridge_plugin_queue_consumer::RabbitMqConsumerConfig),
+    RabbitMQConsumer(RabbitMqConsumerConfig),
 
     #[cfg(feature = "redis")]
-    RedisConsumer(svix_webhook_bridge_plugin_queue_consumer::RedisConsumerConfig),
+    RedisConsumer(RedisConsumerConfig),
 
     #[cfg(feature = "sqs")]
-    SqsConsumer(svix_webhook_bridge_plugin_queue_consumer::SqsConsumerConfig),
+    SqsConsumer(SqsConsumerConfig),
 
     #[cfg(feature = "webhook-receiver")]
     WebhookReceiver(svix_webhook_bridge_plugin_webhook_receiver::WebhookReceiverPluginConfig),


### PR DESCRIPTION
Adds wrapper types around the backend-specific types we get from generic-queue.

## Motivation

Adding new backends to the consumer bridge plugin today is a bit of a chore, encouraging parts of the ack/nack and consumer loop flow to be duplicated. The generics exposed in the signatures of items from `generic-queue` tend to make code reuse tricky.

## Solution


This is mostly focused on moving the decision-making bits of the flow up to the trait's default implementation for methods like `receive` and `process` since these were essentially duplicate from backend to backend.

New wrapper types are used to hide/erase the distinct backend typing from the consumer flow.

Additionally, the code related to each backend has been relegated to a dedicated module (which should help when adding new backends since you can copy the module entirely as a starting point).

More refactoring could be done, perhaps adding `enum_dispatch` to reduce runtime cost and improve the layout of the code generally, but even without this seems like a good first step.
