### PR TITLE
Add Since/Until for endpoint stats to libs

### DIFF
--- a/csharp/Svix/Endpoint.cs
+++ b/csharp/Svix/Endpoint.cs
@@ -531,13 +531,38 @@ namespace Svix
             {
                 var lStats = _endpointApi.V1EndpointGetStats(
                     appId,
-                    endpointId);
+                    endpointId,
+                    null,
+                    null);
 
                 return lStats;
             }
             catch (ApiException e)
             {
                 Logger?.LogError(e, $"{nameof(GetStats)} failed");
+
+                if (Throw)
+                    throw;
+
+                return null;
+            }
+        }
+
+        public EndpointStats GetStatsWithOptions(string appId, string endpointId, EndpointStatsOptions options = null, string idempotencyKey = default)
+        {
+            try
+            {
+                var lStats = _endpointApi.V1EndpointGetStats(
+                    appId,
+                    endpointId,
+                    options?.Since,
+                    options?.Until);
+
+                return lStats;
+            }
+            catch (ApiException e)
+            {
+                Logger?.LogError(e, $"{nameof(GetStatsWithOptions)} failed");
 
                 if (Throw)
                     throw;
@@ -563,6 +588,31 @@ namespace Svix
             catch (ApiException e)
             {
                 Logger?.LogError(e, $"{nameof(GetStatsAsync)} failed");
+
+                if (Throw)
+                    throw;
+
+                return null;
+            }
+        }
+
+        public async Task<EndpointStats> GetStatsWithOptionsAsync(string appId, string endpointId, EndpointStatsOptions options = null, string idempotencyKey = default,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var lStats = await _endpointApi.V1EndpointGetStatsAsync(
+                    appId,
+                    endpointId,
+                    options?.Since,
+                    options?.Until,
+                    cancellationToken);
+
+                return lStats;
+            }
+            catch (ApiException e)
+            {
+                Logger?.LogError(e, $"{nameof(GetStatsWithOptionsAsync)} failed");
 
                 if (Throw)
                     throw;

--- a/csharp/Svix/Models/EndpointStatsOptions.cs
+++ b/csharp/Svix/Models/EndpointStatsOptions.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+
+namespace Svix.Models
+{
+    public sealed class EndpointStatsOptions
+    {
+        public DateTime? Since { get; set; }
+
+        public DateTime? Until { get; set; }
+    }
+}

--- a/go/endpoint.go
+++ b/go/endpoint.go
@@ -2,6 +2,7 @@ package svix
 
 import (
 	"context"
+	"time"
 
 	"github.com/svix/svix-webhooks/go/internal/openapi"
 )
@@ -33,6 +34,11 @@ type EndpointListOptions struct {
 	Iterator *string
 	Limit    *int32
 	Order    *Ordering
+}
+
+type EndpointStatsOptions struct {
+	Since *time.Time
+	Until *time.Time
 }
 
 func (e *Endpoint) List(ctx context.Context, appId string, options *EndpointListOptions) (*ListResponseEndpointOut, error) {
@@ -182,7 +188,11 @@ func (e *Endpoint) PatchHeaders(ctx context.Context, appId string, endpointId st
 }
 
 func (e *Endpoint) GetStats(ctx context.Context, appId string, endpointId string) (*EndpointStats, error) {
-	req := e.api.EndpointApi.V1EndpointGetStats(ctx, appId, endpointId)
+	return e.GetStatsWithOptions(ctx, appId, endpointId, EndpointStatsOptions{})
+}
+
+func (e *Endpoint) GetStatsWithOptions(ctx context.Context, appId string, endpointId string, options EndpointStatsOptions) (*EndpointStats, error) {
+	req := e.api.EndpointApi.V1EndpointGetStats(ctx, appId, endpointId, options.Since, options.Until)
 	out, res, err := req.Execute()
 	if err != nil {
 		return nil, wrapError(err, res)

--- a/go/internal/openapi/api_endpoint.go
+++ b/go/internal/openapi/api_endpoint.go
@@ -1156,12 +1156,14 @@ func (r ApiV1EndpointGetStatsRequest) Execute() (EndpointStats, *_nethttp.Respon
  * @param endpointId The ep's ID or UID
  * @return ApiV1EndpointGetStatsRequest
  */
-func (a *EndpointApiService) V1EndpointGetStats(ctx _context.Context, appId string, endpointId string) ApiV1EndpointGetStatsRequest {
+func (a *EndpointApiService) V1EndpointGetStats(ctx _context.Context, appId string, endpointId string, since *time.Time, until *time.Time) ApiV1EndpointGetStatsRequest {
 	return ApiV1EndpointGetStatsRequest{
 		ApiService: a,
 		ctx: ctx,
 		appId: appId,
 		endpointId: endpointId,
+		since: since,
+		until: until,
 	}
 }
 

--- a/java/lib/src/main/java/com/svix/Endpoint.java
+++ b/java/lib/src/main/java/com/svix/Endpoint.java
@@ -38,7 +38,8 @@ public final class Endpoint {
 		return this.create(appId, endpointIn, new PostOptions());
 	}
 
-	public EndpointOut create(final String appId, final EndpointIn endpointIn, final PostOptions options) throws ApiException {
+	public EndpointOut create(final String appId, final EndpointIn endpointIn, final PostOptions options)
+			throws ApiException {
 		try {
 			return api.v1EndpointCreate(appId, endpointIn, options.getIdempotencyKey());
 		} catch (com.svix.internal.ApiException e) {
@@ -54,7 +55,8 @@ public final class Endpoint {
 		}
 	}
 
-	public EndpointOut update(final String appId, final String endpointId, final EndpointUpdate endpointUpdate) throws ApiException {
+	public EndpointOut update(final String appId, final String endpointId, final EndpointUpdate endpointUpdate)
+			throws ApiException {
 		try {
 			return api.v1EndpointUpdate(appId, endpointId, endpointUpdate);
 		} catch (com.svix.internal.ApiException e) {
@@ -78,11 +80,13 @@ public final class Endpoint {
 		}
 	}
 
-	public void rotateSecret(final String appId, final String endpointId, final EndpointSecretRotateIn endpointSecretRotateIn) throws ApiException {
+	public void rotateSecret(final String appId, final String endpointId,
+			final EndpointSecretRotateIn endpointSecretRotateIn) throws ApiException {
 		this.rotateSecret(appId, endpointId, endpointSecretRotateIn, new PostOptions());
 	}
 
-	public void rotateSecret(final String appId, final String endpointId, final EndpointSecretRotateIn endpointSecretRotateIn, final PostOptions options) throws ApiException {
+	public void rotateSecret(final String appId, final String endpointId,
+			final EndpointSecretRotateIn endpointSecretRotateIn, final PostOptions options) throws ApiException {
 		try {
 			api.v1EndpointRotateSecret(appId, endpointId, endpointSecretRotateIn, options.getIdempotencyKey());
 		} catch (com.svix.internal.ApiException e) {
@@ -94,7 +98,8 @@ public final class Endpoint {
 		this.recover(appId, endpointId, recoverIn, new PostOptions());
 	}
 
-	public void recover(final String appId, final String endpointId, final RecoverIn recoverIn, final PostOptions options) throws ApiException {
+	public void recover(final String appId, final String endpointId, final RecoverIn recoverIn,
+			final PostOptions options) throws ApiException {
 		try {
 			api.v1EndpointRecover(appId, endpointId, recoverIn, options.getIdempotencyKey());
 		} catch (com.svix.internal.ApiException e) {
@@ -110,7 +115,8 @@ public final class Endpoint {
 		}
 	}
 
-	public void updateHeaders(final String appId, final String endpointId, final EndpointHeadersIn endpointHeadersIn) throws ApiException {
+	public void updateHeaders(final String appId, final String endpointId, final EndpointHeadersIn endpointHeadersIn)
+			throws ApiException {
 		try {
 			api.v1EndpointUpdateHeaders(appId, endpointId, endpointHeadersIn);
 		} catch (com.svix.internal.ApiException e) {
@@ -118,7 +124,8 @@ public final class Endpoint {
 		}
 	}
 
-	public void patchHeaders(final String appId, final String endpointId, final EndpointHeadersPatchIn endpointHeadersIn) throws ApiException {
+	public void patchHeaders(final String appId, final String endpointId,
+			final EndpointHeadersPatchIn endpointHeadersIn) throws ApiException {
 		try {
 			api.v1EndpointPatchHeaders(appId, endpointId, endpointHeadersIn);
 		} catch (com.svix.internal.ApiException e) {
@@ -127,18 +134,25 @@ public final class Endpoint {
 	}
 
 	public EndpointStats getStats(final String appId, final String endpointId) throws ApiException {
+		return getStats(appId, endpointId, new EndpointStatsOptions());
+	}
+
+	public EndpointStats getStats(final String appId, final String endpointId, final EndpointStatsOptions options)
+			throws ApiException {
 		try {
-			return api.v1EndpointGetStats(appId, endpointId, null, null);
+			return api.v1EndpointGetStats(appId, endpointId, options.getSince(), options.getUntil());
 		} catch (com.svix.internal.ApiException e) {
 			throw Utils.wrapInternalApiException(e);
 		}
 	}
 
-	public void replayMissing(final String appId, final String endpointId, final ReplayIn replayIn) throws ApiException {
+	public void replayMissing(final String appId, final String endpointId, final ReplayIn replayIn)
+			throws ApiException {
 		this.replayMissing(appId, endpointId, replayIn, new PostOptions());
 	}
 
-	public void replayMissing(final String appId, final String endpointId, final ReplayIn replayIn, final PostOptions options) throws ApiException {
+	public void replayMissing(final String appId, final String endpointId, final ReplayIn replayIn,
+			final PostOptions options) throws ApiException {
 		try {
 			api.v1EndpointReplay(appId, endpointId, replayIn, options.getIdempotencyKey());
 		} catch (com.svix.internal.ApiException e) {
@@ -146,7 +160,8 @@ public final class Endpoint {
 		}
 	}
 
-	public EndpointTransformationOut transformationGet(final String appId, final String endpointId) throws ApiException {
+	public EndpointTransformationOut transformationGet(final String appId, final String endpointId)
+			throws ApiException {
 		try {
 			return api.v1EndpointTransformationGet(appId, endpointId);
 		} catch (com.svix.internal.ApiException e) {
@@ -154,7 +169,8 @@ public final class Endpoint {
 		}
 	}
 
-	public void transformationPartialUpdate(final String appId, final String endpointId, final EndpointTransformationIn transformationIn) throws ApiException {
+	public void transformationPartialUpdate(final String appId, final String endpointId,
+			final EndpointTransformationIn transformationIn) throws ApiException {
 		try {
 			api.v1EndpointTransformationPartialUpdate(appId, endpointId, transformationIn);
 		} catch (com.svix.internal.ApiException e) {
@@ -162,11 +178,13 @@ public final class Endpoint {
 		}
 	}
 
-	public MessageOut sendExample(final String appId, final String endpointId, final EventExampleIn eventExampleIn) throws ApiException {
+	public MessageOut sendExample(final String appId, final String endpointId, final EventExampleIn eventExampleIn)
+			throws ApiException {
 		return this.sendExample(appId, endpointId, eventExampleIn, new PostOptions());
 	}
 
-	public MessageOut sendExample(final String appId, final String endpointId, final EventExampleIn eventExampleIn, final PostOptions options) throws ApiException {
+	public MessageOut sendExample(final String appId, final String endpointId, final EventExampleIn eventExampleIn,
+			final PostOptions options) throws ApiException {
 		try {
 			return api.v1EndpointSendExample(appId, endpointId, eventExampleIn, options.getIdempotencyKey());
 		} catch (com.svix.internal.ApiException e) {

--- a/java/lib/src/main/java/com/svix/EndpointStatsOptions.java
+++ b/java/lib/src/main/java/com/svix/EndpointStatsOptions.java
@@ -1,0 +1,24 @@
+package com.svix;
+
+import org.threeten.bp.OffsetDateTime;
+
+public class EndpointStatsOptions {
+    private OffsetDateTime since;
+    private OffsetDateTime until;
+
+    public void setSince(final OffsetDateTime since) {
+        this.since = since;
+    }
+
+    public OffsetDateTime getSince() {
+        return since;
+    }
+
+    public void setUntil(final OffsetDateTime until) {
+        this.until = until;
+    }
+
+    public OffsetDateTime getUntil() {
+        return until;
+    }
+}

--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -182,6 +182,11 @@ export interface EndpointListOptions extends ListOptions {
   order?: Ordering;
 }
 
+export interface EndpointStatsOptions {
+  since?: Date;
+  until?: Date;
+}
+
 export type IntegrationListOptions = ListOptions;
 
 export interface EventTypeListOptions extends ListOptions {
@@ -385,10 +390,11 @@ class Endpoint {
     });
   }
 
-  public getStats(appId: string, endpointId: string): Promise<EndpointStats> {
+  public getStats(appId: string, endpointId: string, options?: EndpointStatsOptions): Promise<EndpointStats> {
     return this.api.v1EndpointGetStats({
       appId,
       endpointId,
+      ...options
     });
   }
 

--- a/kotlin/lib/src/main/kotlin/Endpoint.kt
+++ b/kotlin/lib/src/main/kotlin/Endpoint.kt
@@ -182,13 +182,17 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun getStats(appId: String, endpointId: String): EndpointStats {
+    suspend fun getStats(
+        appId: String,
+        endpointId: String,
+        options: EndpointStatsOptions = EndpointStatsOptions()
+    ): EndpointStats {
         try {
             return api.v1EndpointGetStats(
                 appId,
                 endpointId,
-                null,
-                null
+                options.since,
+                options.until
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)

--- a/kotlin/lib/src/main/kotlin/EndpointStatsOptions.kt
+++ b/kotlin/lib/src/main/kotlin/EndpointStatsOptions.kt
@@ -1,0 +1,8 @@
+package com.svix.kotlin
+
+import java.time.OffsetDateTime
+
+class EndpointStatsOptions {
+    var since: OffsetDateTime? = null
+    var until: OffsetDateTime? = null
+}

--- a/python/svix/api.py
+++ b/python/svix/api.py
@@ -172,6 +172,12 @@ class EndpointListOptions(ListOptions):
 
 
 @dataclass
+class EndpointStatsOptions:
+    since: t.Optional[datetime] = None
+    until: t.Optional[datetime] = None
+
+
+@dataclass
 class IntegrationListOptions(ListOptions):
     pass
 
@@ -486,11 +492,15 @@ class Endpoint(ApiBase):
             json_body=endpoint_headers_in,
         )
 
-    def get_stats(self, app_id: str, endpoint_id: str) -> EndpointStats:
+    def get_stats(
+        self, app_id: str, endpoint_id: str, options: EndpointStatsOptions = EndpointStatsOptions()
+    ) -> EndpointStats:
         return v1_endpoint_get_stats.sync(
             client=self._client,
             app_id=app_id,
             endpoint_id=endpoint_id,
+            since=options.since,
+            until=options.until,
         )
 
     def replay_missing(

--- a/ruby/lib/svix/endpoint_api.rb
+++ b/ruby/lib/svix/endpoint_api.rb
@@ -51,8 +51,8 @@ module Svix
       return @api.v1_endpoint_patch_headers(app_id, endpoint_id, endpoint_headers_in)
     end
 
-    def get_stats(app_id, endpoint_id)
-      return @api.v1_endpoint_get_stats(app_id, endpoint_id)
+    def get_stats(app_id, endpoint_id, options = {})
+      return @api.v1_endpoint_get_stats(app_id, endpoint_id, options)
     end
 
     def replay_missing(app_id, endpoint_id, replay_in, options = {})

--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -246,6 +246,12 @@ pub struct Endpoint<'a> {
     cfg: &'a Configuration,
 }
 
+#[derive(Default)]
+pub struct EndpointStatsOptions {
+    pub since: Option<String>,
+    pub until: Option<String>,
+}
+
 impl<'a> Endpoint<'a> {
     fn new(cfg: &'a Configuration) -> Self {
         Self { cfg }
@@ -432,14 +438,20 @@ impl<'a> Endpoint<'a> {
         .await?)
     }
 
-    pub async fn get_stats(&self, app_id: String, endpoint_id: String) -> Result<EndpointStats> {
+    pub async fn get_stats(
+        &self,
+        app_id: String,
+        endpoint_id: String,
+        options: Option<EndpointStatsOptions>,
+    ) -> Result<EndpointStats> {
+        let EndpointStatsOptions { since, until } = options.unwrap_or_default();
         Ok(endpoint_api::v1_endpoint_get_stats(
             self.cfg,
             endpoint_api::V1EndpointGetStatsParams {
                 app_id,
                 endpoint_id,
-                since: None,
-                until: None,
+                since,
+                until,
             },
         )
         .await?)


### PR DESCRIPTION
## Motivation

We added this feature to our API a while ago (see [here](https://api.svix.com/docs#tag/Endpoint/operation/v1.endpoint.get-stats)), but never updated the libs.

This PR corrects that.

## Solution

Update the libs.
