### PR TITLE
fix deno failure in bridge docker build

### DIFF
--- a/webhook-bridge/Dockerfile
+++ b/webhook-bridge/Dockerfile
@@ -4,10 +4,11 @@ FROM rust:1.69-slim-bullseye AS build
 RUN apt-get update && apt-get install -y \
     build-essential=12.* \
     checkinstall=1.* \
-    zlib1g-dev=1:* \
-    pkg-config=0.29.* \
+    curl=7.* \
     libssl-dev=* \
+    pkg-config=0.29.* \
     protobuf-compiler=* \
+    zlib1g-dev=1:* \
     --no-install-recommends
 
 RUN set -ex ; \


### PR DESCRIPTION
Looks like `deno_core` depends on `rusty_v8` which will try to download prebuilt a binary v8 archive via some python script, and when that fails it'll try again with `curl`.

## Motivation


The Python download was failing. Why? No idea. The curl fallback also failed because curl was not installed.

## Solution

This diff adds `curl` to the list of installed packages for the builder stage of the `Dockerfile` which allows the `cargo build` layer to complete successfully.
