### PR TITLE
integrate bridge js transformations with webhook-receiver plugin

### DIFF
--- a/webhook-bridge/svix-webhook-bridge-plugin-webhook-receiver/src/config.rs
+++ b/webhook-bridge/svix-webhook-bridge-plugin-webhook-receiver/src/config.rs
@@ -13,6 +13,8 @@ pub struct IntegrationConfig {
     pub name: IntegrationId,
     pub verification: VerificationScheme,
     pub destination: ForwardDestination,
+    #[serde(default)]
+    pub transformation: Option<String>,
 }
 
 /// The [`VerificationScheme`] is an enum with variant for every method for verifying a webhook's

--- a/webhook-bridge/svix-webhook-bridge-plugin-webhook-receiver/src/lib.rs
+++ b/webhook-bridge/svix-webhook-bridge-plugin-webhook-receiver/src/lib.rs
@@ -4,9 +4,12 @@ use axum::{
     routing::post,
     Router,
 };
+use forwarding::ForwardingMethod;
 use serde::Deserialize;
 use std::net::SocketAddr;
-use svix_webhook_bridge_types::{async_trait, Plugin};
+use svix_webhook_bridge_types::{
+    async_trait, JsObject, JsReturn, Plugin, TransformerJob, TransformerTx,
+};
 use tracing::instrument;
 use types::{IntegrationId, IntegrationState, InternalState, SerializableRequest, Unvalidated};
 
@@ -24,14 +27,18 @@ pub struct WebhookReceiverPluginConfig {
     pub routes: Vec<IntegrationConfig>,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct WebhookReceiverPlugin {
     cfg: WebhookReceiverPluginConfig,
+    transformer_tx: Option<TransformerTx>,
 }
 
 impl WebhookReceiverPlugin {
     pub fn new(cfg: WebhookReceiverPluginConfig) -> Self {
-        Self { cfg }
+        Self {
+            cfg,
+            transformer_tx: None,
+        }
     }
 }
 
@@ -45,11 +52,16 @@ impl TryInto<Box<dyn Plugin>> for WebhookReceiverPluginConfig {
 
 #[async_trait]
 impl Plugin for WebhookReceiverPlugin {
+    fn set_transformer(&mut self, tx: Option<TransformerTx>) {
+        self.transformer_tx = tx;
+    }
+
     async fn run(&self) -> std::io::Result<()> {
         let addr = &self.cfg.listen_addr;
-        let state = InternalState::from_routes(self.cfg.routes.as_slice())
-            .await
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        let state =
+            InternalState::from_routes(self.cfg.routes.as_slice(), self.transformer_tx.clone())
+                .await
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
 
         let router = Router::new()
             .route(
@@ -81,18 +93,47 @@ impl Plugin for WebhookReceiverPlugin {
 )]
 async fn route(
     Path(integration_id): Path<IntegrationId>,
-    State(InternalState(id_map)): State<InternalState>,
+    State(InternalState {
+        routes,
+        transformer_tx,
+    }): State<InternalState>,
     req: SerializableRequest<Unvalidated>,
 ) -> http::StatusCode {
     if let Some(IntegrationState {
         verifier,
         forwarder,
-    }) = id_map.get(&integration_id)
+        transformation,
+    }) = routes.get(&integration_id)
     {
         match req.validate(verifier).await {
             Ok(req) => {
+                let payload = match req.payload().as_js_object() {
+                    Ok(payload) => match transformation.clone() {
+                        Some(script) => {
+                            match transform(payload, script, transformer_tx.clone()).await {
+                                Ok(transformed_payload) => transformed_payload,
+                                Err(c) => return c,
+                            }
+                        }
+                        // Keep the original payload as-is if there's no transformation specified.
+                        None => payload,
+                    },
+                    Err(e) => {
+                        tracing::error!("failed to parse payload as json object: {}", e);
+                        return http::StatusCode::BAD_REQUEST;
+                    }
+                };
+
                 tracing::debug!("forwarding request");
-                req.forward(forwarder).await
+                // `forward` method was ambiguous. It looks like there are many traits that offer
+                // this method.
+                match ForwardingMethod::forward(forwarder, payload).await {
+                    Ok(c) => c,
+                    Err(e) => {
+                        tracing::error!("Error forwarding request: {}", e);
+                        http::StatusCode::INTERNAL_SERVER_ERROR
+                    }
+                }
             }
             Err(code) => {
                 tracing::warn!("validation failed: {code}");
@@ -102,5 +143,37 @@ async fn route(
     } else {
         tracing::trace!("integration not found");
         http::StatusCode::NOT_FOUND
+    }
+}
+
+/// Attempts to run the payload through a js transformation.
+async fn transform(
+    payload: JsObject,
+    script: String,
+    tx: Option<TransformerTx>,
+) -> Result<JsObject, http::StatusCode> {
+    let tx = tx.ok_or_else(|| {
+        tracing::error!("transformations are not available");
+        http::StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let (job, callback) = TransformerJob::new(script.clone(), payload);
+    if let Err(e) = tx.send(job) {
+        tracing::error!("transformations are not available: {}", e);
+        return Err(http::StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    match callback.await {
+        // This is the only "good" outcome giving a RHS value for the assignment.
+        // All other match arms should bail with a non-2xx status.
+        Ok(Ok(JsReturn::Object(obj))) => Ok(obj),
+        Ok(Ok(JsReturn::Invalid)) => {
+            tracing::error!("transformation produced invalid payload");
+            Err(http::StatusCode::INTERNAL_SERVER_ERROR)
+        }
+        _ => {
+            tracing::error!("transformation failed");
+            Err(http::StatusCode::INTERNAL_SERVER_ERROR)
+        }
     }
 }


### PR DESCRIPTION
Updates the webhook-receiver plugin to accept a `TransformerTx` so it can leverage the JS Runtime managed by bridge.

This is not the best diff, sadly.

The original webhook-ingester made some design decisions that made this a little awkward. Specifically, the request would accept a forwarder on its `forward` method which took responsibility for payload handling.

When transformations are optionally happening, the payload either needs to transform as a part of the `forward` method, or (my preference) the payload handling needs to be moved up to the handler level.

I went for the latter - The "forward" method now hangs off the forwarder and receives a payload. This means the handler can attempt the transformation before forwarding, which keeps the go/no-go logic all within the handler body. It also avoids having to somehow pass app state down into the forwarder so it could perform the transformation itself.

Unfortunately, the go/no-go logic in the handler is also sort of a mess. In order to tame the additional mess contributed by the transformation, that chunk of the work has been extracted into a helper function.

---

Ideally, we'd have some actual unit tests around the HTTP handler code, and the bits invoked by it, but since we don't yet have anything setup it'd be a bigger lift than I care to tackle right now.

Instead, manual testing was done, noted in the comments below.