### PR TITLE
bump pytest, removes dep on py

### DIFF
--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -7,9 +7,7 @@
 anyio==3.5.0
     # via httpcore
 attrs==21.4.0
-    # via
-    #   openapi-python-client
-    #   pytest
+    # via openapi-python-client
 autoflake==1.4
     # via
     #   -r requirements.in/development.txt
@@ -29,6 +27,8 @@ click==8.0.1
     #   black
     #   pip-tools
     #   typer
+exceptiongroup==1.1.1
+    # via pytest
 flake8==3.9.2
     # via
     #   -r requirements.in/development.txt
@@ -85,8 +85,6 @@ platformdirs==3.5.1
     # via black
 pluggy==0.13.1
     # via pytest
-py==1.10.0
-    # via pytest
 pycodestyle==2.7.0
     # via
     #   flake8
@@ -99,7 +97,7 @@ pyflakes==2.3.1
     #   flake8
 pyproject-hooks==1.0.0
     # via build
-pytest==6.2.4
+pytest==7.3.1
     # via -r requirements.in/development.txt
 python-dateutil==2.8.2
     # via openapi-python-client
@@ -118,14 +116,13 @@ sniffio==1.2.0
     #   anyio
     #   httpcore
     #   httpx
-toml==0.10.2
-    # via pytest
 tomli==2.0.0
     # via
     #   black
     #   build
     #   mypy
     #   pyproject-hooks
+    #   pytest
 typer==0.7.0
     # via openapi-python-client
 typing-extensions==3.10.0.0

--- a/python/requirements.in/development.txt
+++ b/python/requirements.in/development.txt
@@ -6,6 +6,6 @@ flake8-print
 pep8-naming
 mypy
 pip-tools>=6.13.0
-pytest
+pytest>=7.2.0
 httpx>=0.23.0
 openapi-python-client>=0.14.0


### PR DESCRIPTION
The `py` package has a CVE open, which does not actually apply to us since we don't use subversion (`svn`) for version control.

However! The fix to remove the vulnerable dep from our repo entirely is really just updating `pytest` which is trivial to do, so why not?

`pytest>=7.2.0` removes its dependency on `py` so there's no problem, even if we decide to switch to svn for some wild reason.

Helps avoid <https://github.com/advisories/GHSA-w596-4wvx-j9j6>
