### PR TITLE
[Go] add `endpoint_id` option to List Attempts By Msg

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Next
-* 
+* Libs/Go: add missing `endpoint_id` option to list attempts by msg.
 
 ## Version 0.85.1
 * Libs: update OpenAPI spec

--- a/go/messageattempt.go
+++ b/go/messageattempt.go
@@ -34,6 +34,7 @@ type MessageAttemptListOptions struct {
 	After           *time.Time
 	StatusCodeClass *StatusCodeClass
 	Channel         *string
+	EndpointId      *string
 }
 
 // Deprecated: use `ListByMsg` or `ListByEndpoint` instead
@@ -67,6 +68,9 @@ func (m *MessageAttempt) ListByMsg(ctx context.Context, appId string, msgId stri
 		}
 		if options.Channel != nil {
 			req = req.Channel(*options.Channel)
+		}
+		if options.EndpointId != nil {
+			req = req.EndpointId(*options.EndpointId)
 		}
 	}
 	out, res, err := req.Execute()


### PR DESCRIPTION
Looks like this option was omitted from the public API accidentally.

Fixes #928
