### PR TITLE
[JavaScript] add missing `withContent` field to `MessageListOptions`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## Next
 * Libs/Go: add missing `endpoint_id` option to list attempts by msg.
+* Libs/JavaScript: add missing `withContent` field to `MessageListOptions`.
 
 ## Version 0.85.1
 * Libs: update OpenAPI spec

--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -199,6 +199,7 @@ export interface MessageListOptions extends ListOptions {
   before?: Date;
   after?: Date;
   channel?: string;
+  withContent?: boolean;
 }
 
 export interface MessageAttemptListOptions extends ListOptions {


### PR DESCRIPTION
Helps with #942 but to fix we need to update the spec and regenerate the openapi client code.