### PR TITLE
Server: Update Redis Connection Pooling

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -430,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "bb8-redis"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688ba412f8e9c4a7e131774a94bf5a95df12618d143981b97d2aaf0776815533"
+checksum = "cd456361ba8e4e7f5fe58e1697ce078a149c85ebce13bf9c6b483d3f566fc9c3"
 dependencies = [
  "async-trait",
  "bb8",

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -49,7 +49,7 @@ ed25519-compact = "1.0.11"
 chrono = { version="0.4.19", features = ["serde"] }
 reqwest = { version = "0.11.9", features = ["json", "rustls-tls", "trust-dns"], default-features = false }
 bb8 = "0.8"
-bb8-redis = "0.13"
+bb8-redis = "0.13.1"
 redis = { version = "0.23", features = ["tokio-comp", "tokio-native-tls-comp", "streams", "cluster-async"] }
 thiserror = "1.0.30"
 bytes = "1.1.0"


### PR DESCRIPTION
Update redis connection pooling to use use bb8-redis's `RedisMultiplexedConnectionManager` for non-clustered connections. This uses redis-rs's multiplexed connection type under the hood, which is more secure and more performant than the non-multiplexed connection type used by `RedisConnectionManager`.
