### PR TITLE
rename bridge ci

### DIFF
--- a/.github/workflows/bridge-ci.yml
+++ b/.github/workflows/bridge-ci.yml
@@ -1,4 +1,4 @@
-name: Webhook Bridge CI
+name: Bridge CI
 
 on:
   push:

--- a/bridge/svix-bridge.example.receivers.yaml
+++ b/bridge/svix-bridge.example.receivers.yaml
@@ -1,4 +1,4 @@
-# Svix Webhook Bridge Example Configuration
+# Svix Bridge Example Configuration
 
 # Set the log level for the service. Supported: error, info, warn, debug, trace. Default: info
 #log_level: "debug"

--- a/bridge/svix-bridge.example.senders.yaml
+++ b/bridge/svix-bridge.example.senders.yaml
@@ -1,4 +1,4 @@
-# Svix Webhook Bridge Example Configuration
+# Svix Bridge Example Configuration
 
 # Set the log level for the service. Supported: error, info, warn, debug, trace. Default: info
 #log_level: "debug"

--- a/bridge/svix-bridge/src/config/tests.rs
+++ b/bridge/svix-bridge/src/config/tests.rs
@@ -5,7 +5,7 @@ use crate::config::{LogFormat, LogLevel, SenderConfig};
 /// configuration options as possible to ensure they parse correctly.
 // FIXME: today, largely based on the examples. Should instead focus on coverage.
 const OMNIBUS: &str = r#"
-# Svix Webhook Bridge Example Configuration
+# Svix Bridge Example Configuration
 
 # Set the log level for the service. Supported: error, info, warn, debug, trace. Default: info
 #log_level: "debug"


### PR DESCRIPTION
At one point bridge was being called "webhook bridge" and during the renaming some references to the old name were missed.

Most of these omissions are harmless but in the case of the CI workflow name, it mismatched with the updated name used in the badge on the readme.

This should fix the broken link for the badge.

Superseeds #948 