### PR TITLE
Pass `WithContent` option as query parameter to `List Attempted Messages` EP

### DIFF
--- a/go/messageattempt.go
+++ b/go/messageattempt.go
@@ -35,6 +35,7 @@ type MessageAttemptListOptions struct {
 	StatusCodeClass *StatusCodeClass
 	Channel         *string
 	EndpointId      *string
+	WithContent     *bool
 }
 
 // Deprecated: use `ListByMsg` or `ListByEndpoint` instead
@@ -162,6 +163,9 @@ func (m *MessageAttempt) ListAttemptedMessages(ctx context.Context, appId string
 		}
 		if options.Channel != nil {
 			req = req.Channel(*options.Channel)
+		}
+		if options.WithContent != nil {
+			req = req.WithContent(*options.WithContent)
 		}
 	}
 	out, res, err := req.Execute()


### PR DESCRIPTION
## Motivation

The motivation behind this Pull Request is to enhance the Svix Go SDK by expanding the functionality of the List Attempted Messages endpoint. Currently, the SDK lacks the capability to return messages with payload. This limitation poses a challenge for developers who require access to the payload data when retrieving attempted messages. Therefore, this PR aims to introduce an option within the SDK that enables the retrieval of messages along with their payloads. By addressing this limitation, developers will have a more comprehensive and convenient way to access the desired message data.

## Solution

`WithContent` field of type `*bool` has been added to the `MessageAttemptListOptions` type. That value is then passed as query parameter in the request to the List Attempted Messages endpoint.
