### PR TITLE
Server: Centralize header sanitize logic

### DIFF
--- a/server/svix-server/src/core/message_app.rs
+++ b/server/svix-server/src/core/message_app.rs
@@ -202,7 +202,7 @@ impl TryFrom<endpoint::Model> for CreateMessageEndpoint {
                 .transpose()
                 .map_err(|_| err_validation!("Endpoint rate limit out of bounds"))?,
             first_failure_at: m.first_failure_at,
-            headers: m.headers,
+            headers: m.headers_dangerous,
             disabled: m.disabled,
             deleted: m.deleted,
         })

--- a/server/svix-server/src/db/models/endpoint.rs
+++ b/server/svix-server/src/db/models/endpoint.rs
@@ -3,7 +3,7 @@
 
 use crate::core::types::{
     ApplicationId, BaseId, EndpointHeaders, EndpointId, EndpointIdOrUid, EndpointSecretInternal,
-    EndpointUid, EventChannelSet, EventTypeNameSet, ExpiringSigningKeys,
+    EndpointUid, EventChannelSet, EventTypeNameSet, ExpiringSigningKeys, SanitizedHeaders,
 };
 use crate::{ctx, error};
 use chrono::Utc;
@@ -33,7 +33,18 @@ pub struct Model {
     pub uid: Option<EndpointUid>,
     pub old_keys: Option<ExpiringSigningKeys>,
     pub channels: Option<EventChannelSet>,
-    pub headers: Option<EndpointHeaders>,
+    #[sea_orm(column_name = "headers")]
+    // This field could contain sensitive information and should
+    // not be exposed or accessed casually:
+    pub headers_dangerous: Option<EndpointHeaders>,
+}
+
+impl Model {
+    pub fn sanitized_headers(&self) -> Option<SanitizedHeaders> {
+        self.headers_dangerous
+            .as_ref()
+            .map(|hdrs| hdrs.clone().into())
+    }
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]


### PR DESCRIPTION
We will need to reuse the current header sanitizing logic in a future PR, so 
introduce `SanitizedHeaders` as a type, use it where appropriate, and 
rename the non-sanitized field to indicate clearly that it could contain 
sensitive information.
