### PR TITLE
Server: add  support for one time token auth

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -3732,6 +3732,7 @@ dependencies = [
  "figment",
  "form_urlencoded",
  "futures",
+ "getrandom",
  "hmac-sha256",
  "http",
  "hyper",

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -2111,6 +2111,28 @@
                     "Sending"
                 ]
             },
+            "OneTimeTokenIn": {
+                "properties": {
+                    "oneTimeToken": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "oneTimeToken"
+                ],
+                "type": "object"
+            },
+            "OneTimeTokenOut": {
+                "properties": {
+                    "token": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "token"
+                ],
+                "type": "object"
+            },
             "Ordering": {
                 "description": "Defines the ordering in a listing of results.",
                 "enum": [

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -56,6 +56,7 @@ thiserror = "1.0.30"
 bytes = "1.1.0"
 blake2 = "0.10.4"
 chacha20poly1305 = "0.9.0"
+getrandom = "0.2.4"
 # sea orm
 sea-orm = { version = "0.10.2", features = [ "sqlx-postgres", "runtime-tokio-rustls", "macros", "with-chrono", "with-json" ], default-features = false }
 sqlx = { version = "0.6.2", features = [ "runtime-tokio-rustls", "postgres", "migrate" ] }

--- a/server/svix-server/src/v1/mod.rs
+++ b/server/svix-server/src/v1/mod.rs
@@ -13,8 +13,14 @@ pub mod endpoints;
 pub mod utils;
 
 pub fn router() -> ApiRouter<AppState> {
-    let ret: ApiRouter<AppState> = ApiRouter::new()
+    // These routes should not have auth/permissions middleware applied.
+    // We don't currently have any layers for this, so for now we merge these in with the rest.
+    let authless: ApiRouter<AppState> = ApiRouter::new()
         .merge(endpoints::health::router())
+        .merge(endpoints::auth::authless_router(true));
+
+    let ret: ApiRouter<AppState> = ApiRouter::new()
+        .merge(authless)
         .merge(endpoints::auth::router())
         .merge(endpoints::application::router())
         .merge(endpoints::endpoint::router())


### PR DESCRIPTION
Support for one time tokens depends on cache.

A JWT and one-time token are generated in `app_portal_access`, and the
one-time token is used as a part of the cache key where the value is the
JWT itself.

The cache entry has a 7 day TTL.