### PR TITLE
Server: Support sending example event

### DIFF
--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1091,6 +1091,20 @@
                 },
                 "type": "object"
             },
+            "EventExampleIn": {
+                "properties": {
+                    "event_type": {
+                        "example": "user.signup",
+                        "maxLength": 256,
+                        "pattern": "^[a-zA-Z0-9\\-_.]+$",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "event_type"
+                ],
+                "type": "object"
+            },
             "EventTypeIn": {
                 "properties": {
                     "archived": {
@@ -4763,7 +4777,34 @@
         "/api/v1/app/{app_id}/endpoint/{endpoint_id}/send-example/": {
             "post": {
                 "description": "Send an example message for event",
+                "operationId": "v1.endpoint.send-example",
                 "parameters": [
+                    {
+                        "in": "path",
+                        "name": "app_id",
+                        "required": true,
+                        "schema": {
+                            "example": "unique-app-identifier",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+                            "type": "string"
+                        },
+                        "style": "simple"
+                    },
+                    {
+                        "in": "path",
+                        "name": "endpoint_id",
+                        "required": true,
+                        "schema": {
+                            "example": "unique-ep-identifier",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+                            "type": "string"
+                        },
+                        "style": "simple"
+                    },
                     {
                         "description": "The request's idempotency key",
                         "in": "header",
@@ -4774,11 +4815,89 @@
                         "style": "simple"
                     }
                 ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EventExampleIn"
+                            }
+                        }
+                    },
+                    "required": true
+                },
                 "responses": {
-                    "204": {
-                        "description": "no content"
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MessageOut"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Forbidden"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "409": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Conflict"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                        "description": "Validation Error"
+                    },
+                    "429": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Too Many Requests"
                     }
                 },
+                "summary": "Send Event Type Example Message",
                 "tags": [
                     "Endpoint"
                 ]

--- a/server/svix-server/src/db/models/eventtype.rs
+++ b/server/svix-server/src/db/models/eventtype.rs
@@ -101,8 +101,25 @@ pub fn schema_example() -> serde_json::Value {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Default)]
-pub struct Schema(HashMap<String, Json>);
+pub struct Schema(pub HashMap<String, Json>);
 json_wrapper!(Schema);
+
+impl Schema {
+    // Return the first example found for a particular schema,
+    // if one exists:
+    pub fn example(&self) -> Option<&serde_json::Value> {
+        self.0
+            .get("1")
+            .and_then(|version| match version {
+                serde_json::Value::Object(obj) => obj.get("examples"),
+                _ => None,
+            })
+            .and_then(|examples| match examples {
+                serde_json::Value::Array(arr) => arr.iter().next(),
+                _ => None,
+            })
+    }
+}
 
 impl JsonSchema for Schema {
     fn schema_name() -> String {

--- a/server/svix-server/src/queue/mod.rs
+++ b/server/svix-server/src/queue/mod.rs
@@ -94,6 +94,7 @@ impl MessageTask {
 pub struct MessageTaskBatch {
     pub msg_id: MessageId,
     pub app_id: ApplicationId,
+    pub force_endpoint: Option<EndpointId>,
     pub trigger_type: MessageAttemptTriggerType,
 }
 
@@ -101,11 +102,13 @@ impl MessageTaskBatch {
     pub fn new_task(
         msg_id: MessageId,
         app_id: ApplicationId,
+        force_endpoint: Option<EndpointId>,
         trigger_type: MessageAttemptTriggerType,
     ) -> QueueTask {
         QueueTask::MessageBatch(Self {
             msg_id,
             app_id,
+            force_endpoint,
             trigger_type,
         })
     }

--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -12,20 +12,24 @@ use crate::{
         permissions,
         types::{
             metadata::Metadata, BaseId, EndpointId, EndpointSecretInternal, EndpointUid,
-            EventChannelSet, EventTypeNameSet, MessageEndpointId, MessageStatus, SanitizedHeaders,
+            EventChannelSet, EventTypeName, EventTypeNameSet, MessageEndpointId, MessageStatus,
+            SanitizedHeaders,
         },
     },
     ctx,
-    db::models::messagedestination,
+    db::models::{
+        eventtype::{self},
+        messagedestination,
+    },
     error::{self, HttpError},
     v1::utils::{
-        api_not_implemented, openapi_desc, openapi_tag,
+        openapi_tag,
         patch::{
             patch_field_non_nullable, patch_field_nullable, UnrequiredField,
             UnrequiredNullableField,
         },
         validate_no_control_characters, validate_no_control_characters_unrequired,
-        validation_error, ApplicationEndpointPath, ModelIn,
+        validation_error, ApplicationEndpointPath, ModelIn, ValidatedJson,
     },
     AppState,
 };
@@ -52,6 +56,8 @@ use crate::core::types::{EndpointHeaders, EndpointHeadersPatch, EndpointSecret};
 use crate::db::models::endpoint;
 
 use self::secrets::generate_secret;
+
+use super::message::{create_message_inner, MessageIn, MessageOut, RawPayload};
 
 pub fn validate_event_types_ids(
     event_types_ids: &EventTypeNameSet,
@@ -715,7 +721,74 @@ async fn endpoint_stats(
     }))
 }
 
-const SEND_EXAMPLE_DESCRIPTION: &str = "Send an example message for event";
+#[derive(Deserialize, JsonSchema, Validate)]
+struct EventExampleIn {
+    event_type: EventTypeName,
+}
+
+const SVIX_PING_EVENT_TYPE_NAME: &str = "svix.ping";
+const SVIX_PING_EVENT_TYPE_PAYLOAD: &str = r#"{"success": true}"#;
+
+/// Send an example message for event
+#[aide_annotate(
+    op_id = "v1.endpoint.send-example",
+    op_summary = "Send Event Type Example Message"
+)]
+async fn send_example(
+    state: State<AppState>,
+    Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,
+    permissions::OrganizationWithApplication { app }: permissions::OrganizationWithApplication,
+    ValidatedJson(data): ValidatedJson<EventExampleIn>,
+) -> error::Result<Json<MessageOut>> {
+    let State(AppState { ref db, .. }) = state;
+
+    let endpoint = ctx!(
+        endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endpoint_id)
+            .one(db)
+            .await
+    )?
+    .ok_or_else(|| HttpError::not_found(None, None))?;
+
+    let example = if data.event_type == EventTypeName(SVIX_PING_EVENT_TYPE_NAME.to_owned()) {
+        SVIX_PING_EVENT_TYPE_PAYLOAD.to_string()
+    } else {
+        let event_type = ctx!(
+            eventtype::Entity::secure_find_by_name(app.org_id.clone(), data.event_type.clone())
+                .one(db)
+                .await
+        )?
+        .ok_or_else(|| HttpError::not_found(None, None))?;
+
+        let example = event_type.schemas.and_then(|schema| {
+            schema
+                .example()
+                .and_then(|ex| serde_json::to_string(ex).ok())
+        });
+
+        match example {
+            Some(example) => example,
+            None => {
+                return Err(HttpError::bad_request(
+                    Some("invalid_schema".to_owned()),
+                    Some("Unable to generate example message from event-type schema.".to_owned()),
+                )
+                .into());
+            }
+        }
+    };
+
+    let msg_in = MessageIn {
+        channels: None,
+        event_type: data.event_type,
+        payload: RawPayload::from_string(example).unwrap(),
+        uid: None,
+        payload_retention_period: 90,
+    };
+
+    let create_message = create_message_inner(state, app, msg_in, Some(endpoint.id), false).await?;
+
+    Ok(Json(create_message))
+}
 
 pub fn router() -> ApiRouter<AppState> {
     let tag = openapi_tag("Endpoint");
@@ -757,7 +830,7 @@ pub fn router() -> ApiRouter<AppState> {
         )
         .api_route_with(
             "/app/:app_id/endpoint/:endpoint_id/send-example/",
-            post_with(api_not_implemented, openapi_desc(SEND_EXAMPLE_DESCRIPTION)),
+            post_with(send_example, send_example_operation),
             &tag,
         )
         .api_route_with(

--- a/server/svix-server/src/worker.rs
+++ b/server/svix-server/src/worker.rs
@@ -825,7 +825,7 @@ async fn process_queue_task_inner(
         QueueTask::MessageBatch(task) => {
             let msg = ctx!(message::Entity::find_by_id(task.msg_id).one(db).await)?
                 .ok_or_else(|| err_generic!("Unexpected: message doesn't exist"))?;
-            (msg, None, None, task.trigger_type, 0)
+            (msg, task.force_endpoint, None, task.trigger_type, 0)
         }
     };
 


### PR DESCRIPTION
Support sending example events to given endpoints.
This works out-of-the-box for `svix.ping` events and 
for user-defined events with an example defined.

This also makes slight modification to `MessageTaskBatch`
to support optional endpoint overrides. 