### PR TITLE
pin redis images to 7.0.10

### DIFF
--- a/server/testing-docker-compose.yml
+++ b/server/testing-docker-compose.yml
@@ -10,13 +10,13 @@ services:
       - "5432:5432"
 
   redis:
-    image: "redis:7-alpine"
+    image: "redis:7.0.10-alpine"
     ports:
       - "6379:6379"
 
   # Redis cluster
   redis-cluster:
-    image: "bitnami/redis-cluster:7.0"
+    image: "bitnami/redis-cluster:7.0.10"
     environment:
       ALLOW_EMPTY_PASSWORD: "yes"
       REDIS_NODES: "redis-cluster redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4"
@@ -32,7 +32,7 @@ services:
       - redis-cluster-node-4
 
   redis-cluster-node-0:
-    image: "bitnami/redis-cluster:7.0"
+    image: "bitnami/redis-cluster:7.0.10"
     ports:
       - "6381:6379"
     environment:
@@ -40,7 +40,7 @@ services:
       REDIS_NODES: "redis-cluster redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4"
 
   redis-cluster-node-1:
-    image: "bitnami/redis-cluster:7.0"
+    image: "bitnami/redis-cluster:7.0.10"
     ports:
       - "6382:6379"
     environment:
@@ -48,7 +48,7 @@ services:
       REDIS_NODES: "redis-cluster redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4"
 
   redis-cluster-node-2:
-    image: "bitnami/redis-cluster:7.0"
+    image: "bitnami/redis-cluster:7.0.10"
     ports:
       - "6383:6379"
     environment:
@@ -56,7 +56,7 @@ services:
       REDIS_NODES: "redis-cluster redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4"
 
   redis-cluster-node-3:
-    image: "bitnami/redis-cluster:7.0"
+    image: "bitnami/redis-cluster:7.0.10"
     ports:
       - "6384:6379"
     environment:
@@ -64,7 +64,7 @@ services:
       REDIS_NODES: "redis-cluster redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4"
 
   redis-cluster-node-4:
-    image: "bitnami/redis-cluster:7.0"
+    image: "bitnami/redis-cluster:7.0.10"
     ports:
       - "6385:6379"
     environment:


### PR DESCRIPTION
## Motivation

CI is failing for rediscluster configurations as of the 7.0.11 release that just came out.

## Solution

Pin the redis containers we use in CI to 7.0.10 instead so the tests can actually run cleanly.