### PR TITLE
Server: fix permissions and payload format in send_example endpoint

### DIFF
--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1093,7 +1093,7 @@
             },
             "EventExampleIn": {
                 "properties": {
-                    "event_type": {
+                    "eventType": {
                         "example": "user.signup",
                         "maxLength": 256,
                         "pattern": "^[a-zA-Z0-9\\-_.]+$",
@@ -1101,7 +1101,7 @@
                     }
                 },
                 "required": [
-                    "event_type"
+                    "eventType"
                 ],
                 "type": "object"
             },

--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -722,6 +722,7 @@ async fn endpoint_stats(
 }
 
 #[derive(Deserialize, JsonSchema, Validate)]
+#[serde(rename_all = "camelCase")]
 struct EventExampleIn {
     event_type: EventTypeName,
 }
@@ -737,7 +738,7 @@ const SVIX_PING_EVENT_TYPE_PAYLOAD: &str = r#"{"success": true}"#;
 async fn send_example(
     state: State<AppState>,
     Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,
-    permissions::OrganizationWithApplication { app }: permissions::OrganizationWithApplication,
+    permissions::Application { app }: permissions::Application,
     ValidatedJson(data): ValidatedJson<EventExampleIn>,
 ) -> error::Result<Json<MessageOut>> {
     let State(AppState { ref db, .. }) = state;


### PR DESCRIPTION
- Change permission in /send_example endpoint from `OrganizationWithApplication` to `Application`, so it's accessible with an App Portal one time token.
- Use camelCase in EventTypeIn for /send-example