### PR TITLE
Server: Disable clustered-redis lib retries

### DIFF
--- a/server/svix-server/src/redis/cluster.rs
+++ b/server/svix-server/src/redis/cluster.rs
@@ -17,7 +17,7 @@ impl RedisClusterConnectionManager {
         info: T,
     ) -> Result<RedisClusterConnectionManager, RedisError> {
         Ok(RedisClusterConnectionManager {
-            client: ClusterClientBuilder::new(vec![info]).build()?,
+            client: ClusterClientBuilder::new(vec![info]).retries(0).build()?,
         })
     }
 }


### PR DESCRIPTION
Because we already have our own generic retry implementation that we use for queuing and caching, we should disable the clustered redis client's own default retry mechanism, which defaults to 16(!) retries if none are specified. For certain classes of errors, this limit includes exponental backoffs, so if we add our own layer of retries on top of this, we could potentially spend minutes in an endless retry loop. Let's ensure that doesn't happen!
