### PR TITLE
Bridge: support raw inputs for transformations

### DIFF
--- a/bridge/generic-queue/src/gcp_pubsub.rs
+++ b/bridge/generic-queue/src/gcp_pubsub.rs
@@ -186,6 +186,10 @@ impl<T: DeserializeOwned + Send + Serialize + Sync> Delivery<T> for GCPPubSubDel
         serde_json::from_slice(&self.message.message.data).map_err(Into::into)
     }
 
+    fn raw_payload(&self) -> Result<&str, QueueError> {
+        std::str::from_utf8(&self.message.message.data).map_err(QueueError::generic)
+    }
+
     async fn ack(self) -> Result<(), QueueError> {
         self.message.ack().await.map_err(QueueError::generic)
     }

--- a/bridge/generic-queue/src/lib.rs
+++ b/bridge/generic-queue/src/lib.rs
@@ -98,14 +98,15 @@ pub trait TaskQueueBackend<T: Send + Sync> {
 pub trait Delivery<T: Send + Sync> {
     /// Returns a freshly deserialized instance of the contained payload.
     fn payload(&self) -> Result<T, QueueError>;
+    fn raw_payload(&self) -> Result<&str, QueueError>;
 
     /// ACKs this message, which, depending on what backend you are using, may be a NOOP, or it may
-    /// explicity acknowledge the successful processing the message.
+    /// explicitly acknowledge the successful processing the message.
     ///
     /// When ACKed, consumers will not see this exact message again.
     async fn ack(self) -> Result<(), QueueError>;
     /// NACKs this message, which, depending on what backend you are using, may be a NOOP, it may
-    /// explicitly mark a messaege as not acknowledged, or it may reinsert the message back into the
+    /// explicitly mark a message as not acknowledged, or it may reinsert the message back into the
     /// end of the queue.
     ///
     /// When NACKed, consumers of this queue will process the message again at some point.

--- a/bridge/generic-queue/src/memory_queue.rs
+++ b/bridge/generic-queue/src/memory_queue.rs
@@ -55,6 +55,11 @@ impl<T: 'static + Clone + Debug + DeserializeOwned + Send + Serialize + Sync> De
         Ok(self.payload.clone())
     }
 
+    fn raw_payload(&self) -> Result<&str, QueueError> {
+        // this backend is not used in bridge, and we will migrate to omniqueue anyway...
+        unimplemented!("not supported");
+    }
+
     async fn ack(self) -> Result<(), QueueError> {
         Ok(())
     }

--- a/bridge/generic-queue/src/rabbitmq.rs
+++ b/bridge/generic-queue/src/rabbitmq.rs
@@ -128,6 +128,9 @@ impl<T: DeserializeOwned + Send + Serialize + Sync> Delivery<T> for RabbitMqDeli
         serde_json::from_slice(&self.body).map_err(Into::into)
     }
 
+    fn raw_payload(&self) -> Result<&str, QueueError> {
+        std::str::from_utf8(&self.body).map_err(QueueError::generic)
+    }
     async fn ack(self) -> Result<(), QueueError> {
         self.acker
             .ack(BasicAckOptions { multiple: false })

--- a/bridge/generic-queue/src/redis.rs
+++ b/bridge/generic-queue/src/redis.rs
@@ -180,6 +180,15 @@ impl<
     fn payload(&self) -> Result<T, QueueError> {
         T::from_redis_stream_map(&self.body.map).map_err(Into::into)
     }
+    // FIXME: the redis stream queue impl requires values to be encoded a certain way (eg. inside
+    //   a "payload" key in a map).
+    //   This means producers and consumers need to agree on the encoding.
+    //   This also means we can't just accept raw messages published by other systems (as is the
+    //   expectation with these raw payloads).
+    //   Leaving unsupported until we migrate to `omniqueue`.
+    fn raw_payload(&self) -> Result<&str, QueueError> {
+        unimplemented!("raw payload not supported with redis backend")
+    }
 
     async fn ack(self) -> Result<(), QueueError> {
         let mut conn = self.redis.get().await.map_err(QueueError::generic)?;

--- a/bridge/generic-queue/src/sqs.rs
+++ b/bridge/generic-queue/src/sqs.rs
@@ -106,6 +106,10 @@ impl<T: DeserializeOwned + Send + Serialize + Sync> Delivery<T> for SqsDelivery<
         serde_json::from_str(&self.body).map_err(Into::into)
     }
 
+    fn raw_payload(&self) -> Result<&str, QueueError> {
+        Ok(&self.body)
+    }
+
     async fn ack(self) -> Result<(), QueueError> {
         if let Some(receipt_handle) = self.receipt_handle {
             self.ack_client

--- a/bridge/svix-bridge-plugin-queue/src/config.rs
+++ b/bridge/svix-bridge-plugin-queue/src/config.rs
@@ -7,44 +7,53 @@ use crate::{
     GCPPubSubConsumerPlugin, RabbitMqConsumerPlugin, RedisConsumerPlugin, SqsConsumerPlugin,
 };
 use serde::Deserialize;
-use svix_bridge_types::{ReceiverOutput, SenderInput, SenderOutputOpts};
+use svix_bridge_types::{
+    ReceiverOutput, SenderInput, SenderOutputOpts, TransformationConfig, TransformerInputFormat,
+};
 
 #[derive(Deserialize)]
 pub struct QueueConsumerConfig {
     pub name: String,
     pub input: SenderInputOpts,
     #[serde(default)]
-    pub transformation: Option<String>,
+    pub transformation: Option<TransformationConfig>,
     pub output: SenderOutputOpts,
 }
 
 impl QueueConsumerConfig {
-    pub fn into_sender_input(self) -> Box<dyn SenderInput> {
+    pub fn into_sender_input(self) -> Result<Box<dyn SenderInput>, &'static str> {
         match self.input {
-            SenderInputOpts::GCPPubSub(input) => Box::new(GCPPubSubConsumerPlugin::new(
+            SenderInputOpts::GCPPubSub(input) => Ok(Box::new(GCPPubSubConsumerPlugin::new(
                 self.name,
                 input,
                 self.transformation,
                 self.output,
-            )),
-            SenderInputOpts::RabbitMQ(input) => Box::new(RabbitMqConsumerPlugin::new(
+            ))),
+            SenderInputOpts::RabbitMQ(input) => Ok(Box::new(RabbitMqConsumerPlugin::new(
                 self.name,
                 input,
                 self.transformation,
                 self.output,
-            )),
-            SenderInputOpts::Redis(input) => Box::new(RedisConsumerPlugin::new(
+            ))),
+            SenderInputOpts::Redis(input) => {
+                if let Some(xform) = &self.transformation {
+                    if xform.format() != TransformerInputFormat::Json {
+                        return Err("redis only supports json formatted transformations");
+                    }
+                }
+                Ok(Box::new(RedisConsumerPlugin::new(
+                    self.name,
+                    input,
+                    self.transformation,
+                    self.output,
+                )))
+            }
+            SenderInputOpts::SQS(input) => Ok(Box::new(SqsConsumerPlugin::new(
                 self.name,
                 input,
                 self.transformation,
                 self.output,
-            )),
-            SenderInputOpts::SQS(input) => Box::new(SqsConsumerPlugin::new(
-                self.name,
-                input,
-                self.transformation,
-                self.output,
-            )),
+            ))),
         }
     }
 }
@@ -52,13 +61,24 @@ impl QueueConsumerConfig {
 pub async fn into_receiver_output(
     name: String,
     opts: ReceiverOutputOpts,
+    // Annoying to have to pass this, but certain backends (redis) only work with certain transformations (json).
+    transformation: &Option<TransformationConfig>,
 ) -> Result<Box<dyn ReceiverOutput>, crate::Error> {
     let forwarder = match opts {
         ReceiverOutputOpts::GCPPubSub(opts) => {
             QueueForwarder::from_gcp_pupsub_cfg(name, opts).await?
         }
         ReceiverOutputOpts::RabbitMQ(opts) => QueueForwarder::from_rabbitmq_cfg(name, opts).await?,
-        ReceiverOutputOpts::Redis(opts) => QueueForwarder::from_redis_cfg(name, opts).await?,
+        ReceiverOutputOpts::Redis(opts) => {
+            if let Some(t) = transformation {
+                if t.format() != TransformerInputFormat::Json {
+                    return Err(crate::Error::Generic(
+                        "redis only supports json formatted transformations".to_string(),
+                    ));
+                }
+            }
+            QueueForwarder::from_redis_cfg(name, opts).await?
+        }
         ReceiverOutputOpts::SQS(opts) => QueueForwarder::from_sqs_cfg(name, opts).await?,
     };
     Ok(Box::new(forwarder))
@@ -83,4 +103,74 @@ pub enum ReceiverOutputOpts {
     RabbitMQ(RabbitMqOutputOpts),
     Redis(RedisOutputOpts),
     SQS(SqsOutputOpts),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::into_receiver_output;
+    use super::QueueConsumerConfig;
+    use crate::config::{ReceiverOutputOpts, SenderInputOpts};
+    use crate::redis::{RedisInputOpts, RedisOutputOpts};
+    use svix_bridge_types::{
+        SenderOutputOpts, SvixSenderOutputOpts, TransformationConfig, TransformerInputFormat,
+    };
+
+    // FIXME: can't support raw payload access for redis because it requires JSON internally.
+    //   Revisit after `omniqueue` adoption.
+    #[test]
+    fn redis_sender_with_string_transformation_is_err() {
+        let cfg = QueueConsumerConfig {
+            name: "redis-with-string-transformation".to_string(),
+            input: SenderInputOpts::Redis(RedisInputOpts {
+                dsn: "".to_string(),
+                max_connections: 0,
+                reinsert_on_nack: false,
+                queue_key: "".to_string(),
+                consumer_group: "".to_string(),
+                consumer_name: "".to_string(),
+            }),
+            transformation: Some(TransformationConfig::Explicit {
+                format: TransformerInputFormat::String,
+                src: String::new(),
+            }),
+            output: SenderOutputOpts::Svix(SvixSenderOutputOpts {
+                token: "".to_string(),
+                options: None,
+            }),
+        };
+
+        assert_eq!(
+            cfg.into_sender_input()
+                .err()
+                .expect("invalid config didn't result in error"),
+            "redis only supports json formatted transformations"
+        )
+    }
+
+    // FIXME: can't support raw payload access for redis because it requires JSON internally.
+    //   Revisit after `omniqueue` adoption.
+    #[tokio::test]
+    async fn test_redis_receiver_string_transform_is_err() {
+        let redis_out = ReceiverOutputOpts::Redis(RedisOutputOpts {
+            dsn: "".to_string(),
+            max_connections: 0,
+            queue_key: "".to_string(),
+        });
+
+        // Explicit String fails
+        let res = into_receiver_output(
+            "".to_string(),
+            redis_out,
+            &Some(TransformationConfig::Explicit {
+                src: String::new(),
+                format: TransformerInputFormat::String,
+            }),
+        )
+        .await;
+        assert!(matches!(
+            res.err()
+                .expect("invalid config didn't result in error"),
+            crate::error::Error::Generic(msg) if msg == "redis only supports json formatted transformations"
+        ));
+    }
 }

--- a/bridge/svix-bridge-plugin-queue/src/gcp_pubsub/mod.rs
+++ b/bridge/svix-bridge-plugin-queue/src/gcp_pubsub/mod.rs
@@ -6,7 +6,8 @@ use generic_queue::TaskQueueBackend;
 use serde::Deserialize;
 use std::path::PathBuf;
 use svix_bridge_types::{
-    async_trait, svix::api::Svix, JsObject, SenderInput, SenderOutputOpts, TransformerTx,
+    async_trait, svix::api::Svix, JsObject, SenderInput, SenderOutputOpts, TransformationConfig,
+    TransformerTx,
 };
 
 #[derive(Debug, Default, Deserialize)]
@@ -20,14 +21,14 @@ pub struct GCPPubSubConsumerPlugin {
     input_options: GCPPubSubInputOpts,
     svix_client: Svix,
     transformer_tx: Option<TransformerTx>,
-    transformation: Option<String>,
+    transformation: Option<TransformationConfig>,
 }
 
 impl GCPPubSubConsumerPlugin {
     pub fn new(
         name: String,
         input: GCPPubSubInputOpts,
-        transformation: Option<String>,
+        transformation: Option<TransformationConfig>,
         output: SenderOutputOpts,
     ) -> Self {
         Self {
@@ -58,7 +59,7 @@ impl Consumer for GCPPubSubConsumerPlugin {
         &self.transformer_tx
     }
 
-    fn transformation(&self) -> &Option<String> {
+    fn transformation(&self) -> &Option<TransformationConfig> {
         &self.transformation
     }
 

--- a/bridge/svix-bridge-plugin-queue/src/rabbitmq/mod.rs
+++ b/bridge/svix-bridge-plugin-queue/src/rabbitmq/mod.rs
@@ -11,7 +11,8 @@ use generic_queue::{
 };
 use serde::Deserialize;
 use svix_bridge_types::{
-    async_trait, svix::api::Svix, JsObject, SenderInput, SenderOutputOpts, TransformerTx,
+    async_trait, svix::api::Svix, JsObject, SenderInput, SenderOutputOpts, TransformationConfig,
+    TransformerTx,
 };
 
 #[derive(Debug, Deserialize)]
@@ -41,14 +42,14 @@ pub struct RabbitMqConsumerPlugin {
     input_options: RabbitMqInputOpts,
     svix_client: Svix,
     transformer_tx: Option<TransformerTx>,
-    transformation: Option<String>,
+    transformation: Option<TransformationConfig>,
 }
 
 impl RabbitMqConsumerPlugin {
     pub fn new(
         name: String,
         input: RabbitMqInputOpts,
-        transformation: Option<String>,
+        transformation: Option<TransformationConfig>,
         output: SenderOutputOpts,
     ) -> Self {
         Self {
@@ -79,7 +80,7 @@ impl Consumer for RabbitMqConsumerPlugin {
         &self.transformer_tx
     }
 
-    fn transformation(&self) -> &Option<String> {
+    fn transformation(&self) -> &Option<TransformationConfig> {
         &self.transformation
     }
 

--- a/bridge/svix-bridge-plugin-queue/src/redis/mod.rs
+++ b/bridge/svix-bridge-plugin-queue/src/redis/mod.rs
@@ -6,7 +6,8 @@ use generic_queue::redis::RedisConfig;
 use generic_queue::{redis::RedisQueueBackend, TaskQueueBackend};
 use serde::Deserialize;
 use svix_bridge_types::{
-    async_trait, svix::api::Svix, JsObject, SenderInput, SenderOutputOpts, TransformerTx,
+    async_trait, svix::api::Svix, JsObject, SenderInput, SenderOutputOpts, TransformationConfig,
+    TransformerTx,
 };
 
 #[derive(Debug, Default, Deserialize)]
@@ -29,14 +30,14 @@ pub struct RedisConsumerPlugin {
     input_options: RedisInputOpts,
     svix_client: Svix,
     transformer_tx: Option<TransformerTx>,
-    transformation: Option<String>,
+    transformation: Option<TransformationConfig>,
 }
 
 impl RedisConsumerPlugin {
     pub fn new(
         name: String,
         input: RedisInputOpts,
-        transformation: Option<String>,
+        transformation: Option<TransformationConfig>,
         output: SenderOutputOpts,
     ) -> Self {
         Self {
@@ -67,7 +68,7 @@ impl Consumer for RedisConsumerPlugin {
         &self.transformer_tx
     }
 
-    fn transformation(&self) -> &Option<String> {
+    fn transformation(&self) -> &Option<TransformationConfig> {
         &self.transformation
     }
 

--- a/bridge/svix-bridge-plugin-queue/src/sqs/mod.rs
+++ b/bridge/svix-bridge-plugin-queue/src/sqs/mod.rs
@@ -6,7 +6,8 @@ use generic_queue::{
 };
 use serde::Deserialize;
 use svix_bridge_types::{
-    async_trait, svix::api::Svix, JsObject, SenderInput, SenderOutputOpts, TransformerTx,
+    async_trait, svix::api::Svix, JsObject, SenderInput, SenderOutputOpts, TransformationConfig,
+    TransformerTx,
 };
 
 #[derive(Debug, Default, Deserialize)]
@@ -21,14 +22,14 @@ pub struct SqsConsumerPlugin {
     input_options: SqsInputOpts,
     svix_client: Svix,
     transformer_tx: Option<TransformerTx>,
-    transformation: Option<String>,
+    transformation: Option<TransformationConfig>,
 }
 
 impl SqsConsumerPlugin {
     pub fn new(
         name: String,
         input: SqsInputOpts,
-        transformation: Option<String>,
+        transformation: Option<TransformationConfig>,
         output: SenderOutputOpts,
     ) -> Self {
         Self {
@@ -59,7 +60,7 @@ impl Consumer for SqsConsumerPlugin {
         &self.transformer_tx
     }
 
-    fn transformation(&self) -> &Option<String> {
+    fn transformation(&self) -> &Option<TransformationConfig> {
         &self.transformation
     }
 

--- a/bridge/svix-bridge-plugin-queue/tests/gcp_pubsub_consumer.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/gcp_pubsub_consumer.rs
@@ -14,8 +14,9 @@ use svix_bridge_plugin_queue::{
     config::GCPPubSubInputOpts, CreateMessageRequest, GCPPubSubConsumerPlugin,
 };
 use svix_bridge_types::{
-    svix::api::MessageIn, JsReturn, SenderInput, SenderOutputOpts, SvixOptions,
-    SvixSenderOutputOpts, TransformerJob,
+    svix::api::MessageIn, SenderInput, SenderOutputOpts, SvixOptions, SvixSenderOutputOpts,
+    TransformationConfig, TransformerInput, TransformerInputFormat, TransformerJob,
+    TransformerOutput,
 };
 use wiremock::matchers::{body_partial_json, method};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -25,7 +26,7 @@ const DEFAULT_PUBSUB_EMULATOR_HOST: &str = "localhost:8085";
 fn get_test_plugin(
     svix_url: String,
     subscription_id: String,
-    use_transformation: bool,
+    use_transformation: Option<TransformerInputFormat>,
 ) -> GCPPubSubConsumerPlugin {
     GCPPubSubConsumerPlugin::new(
         "test".into(),
@@ -33,13 +34,10 @@ fn get_test_plugin(
             subscription_id,
             credentials_file: None,
         },
-        if use_transformation {
-            // The actual script doesn't matter since the test case will be performing the
-            // transformation, not the actual JS executor.
-            Some(String::from("function handle(x) { return x; }"))
-        } else {
-            None
-        },
+        use_transformation.map(|format| TransformationConfig::Explicit {
+            format,
+            src: String::from("function handle(x) { return x; }"),
+        }),
         SenderOutputOpts::Svix(SvixSenderOutputOpts {
             token: "xxxx".to_string(),
             options: Some(SvixOptions {
@@ -142,7 +140,7 @@ async fn test_consume_ok() {
         .expect(1);
     mock_server.register(mock).await;
 
-    let plugin = get_test_plugin(mock_server.uri(), subscription.id(), false);
+    let plugin = get_test_plugin(mock_server.uri(), subscription.id(), None);
 
     let handle = tokio::spawn(async move {
         let fut = plugin.run();
@@ -171,7 +169,7 @@ async fn test_consume_ok() {
 /// Push a msg on the queue.
 /// Check to see if the svix server sees a request, but this time transform the payload.
 #[tokio::test]
-async fn test_consume_transformed_ok() {
+async fn test_consume_transformed_json_ok() {
     let client = mq_connection().await;
     let (topic, subscription) = create_test_queue(&client).await;
 
@@ -185,8 +183,6 @@ async fn test_consume_transformed_ok() {
         .respond_with(ResponseTemplate::new(202).set_body_json(json!({
           "eventType": "testing.things",
           "payload": {
-            "_SVIX_APP_ID": "app_1234",
-            "_SVIX_EVENT_TYPE": "testing.things",
             // The adjustment made via the transformation...
             "good": "bye",
           },
@@ -197,12 +193,19 @@ async fn test_consume_transformed_ok() {
         .expect(1);
     mock_server.register(mock).await;
 
-    let mut plugin = get_test_plugin(mock_server.uri(), subscription.id(), true);
+    let mut plugin = get_test_plugin(
+        mock_server.uri(),
+        subscription.id(),
+        Some(TransformerInputFormat::Json),
+    );
     let (transformer_tx, mut transformer_rx) =
         tokio::sync::mpsc::unbounded_channel::<TransformerJob>();
     let _handle = tokio::spawn(async move {
         while let Some(x) = transformer_rx.recv().await {
-            let mut out = x.payload;
+            let mut out = match x.input {
+                TransformerInput::JSON(input) => input.as_object().unwrap().clone(),
+                _ => unreachable!(),
+            };
             // Prune out the "hi" key.
             out["message"]["payload"]
                 .as_object_mut()
@@ -210,7 +213,7 @@ async fn test_consume_transformed_ok() {
                 .remove("hi");
             // Add the "good" key.
             out["message"]["payload"]["good"] = json!("bye");
-            x.callback_tx.send(Ok(JsReturn::Object(out))).ok();
+            x.callback_tx.send(Ok(TransformerOutput::Object(out))).ok();
         }
     });
     plugin.set_transformer(Some(transformer_tx));
@@ -239,6 +242,85 @@ async fn test_consume_transformed_ok() {
     topic.delete(None).await.ok();
 }
 
+/// Push a msg on the queue.
+/// Check to see if the svix server sees a request, but this time transform the payload.
+#[tokio::test]
+async fn test_consume_transformed_string_ok() {
+    let client = mq_connection().await;
+    let (topic, subscription) = create_test_queue(&client).await;
+
+    let mock_server = MockServer::start().await;
+    // The mock will make asserts on drop (i.e. when the body of the test is returning).
+    // The `expect` call should ensure we see exactly 1 POST request.
+    // <https://docs.rs/wiremock/latest/wiremock/struct.Mock.html#method.expect>
+    let mock = Mock::given(method("POST"))
+        // The transformed bit of the payload
+        .and(body_partial_json(
+            json!({ "payload": { "hello": "world" } }),
+        ))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+          "eventType": "testing.things",
+          "payload": {
+            // The adjustment made via the transformation...
+            "good": "bye",
+          },
+          "id": "msg_xxxx",
+          "timestamp": "2023-04-25T00:00:00Z"
+        })))
+        .named("create_message")
+        .expect(1);
+    mock_server.register(mock).await;
+
+    let mut plugin = get_test_plugin(
+        mock_server.uri(),
+        subscription.id(),
+        Some(TransformerInputFormat::String),
+    );
+    let (transformer_tx, mut transformer_rx) =
+        tokio::sync::mpsc::unbounded_channel::<TransformerJob>();
+    let _handle = tokio::spawn(async move {
+        while let Some(x) = transformer_rx.recv().await {
+            let input = match x.input {
+                TransformerInput::String(input) => input,
+                _ => unreachable!(),
+            };
+            // Build a create-message-compatible object, using the string input as a field in the payload.
+            let out = json!({
+                "app_id": "app_1234",
+                "message": {
+                    "eventType": "testing.things",
+                    "payload": {
+                        "hello": input,
+                    }
+                }
+            });
+            x.callback_tx
+                .send(Ok(TransformerOutput::Object(
+                    out.as_object().unwrap().clone(),
+                )))
+                .ok();
+        }
+    });
+    plugin.set_transformer(Some(transformer_tx));
+
+    let handle = tokio::spawn(async move {
+        let fut = plugin.run();
+        fut.await
+    });
+    // Wait for the consumer to connect
+    tokio::time::sleep(Duration::from_millis(WAIT_MS)).await;
+
+    publish(&topic, "world").await;
+
+    // Wait for the consumer to consume.
+    tokio::time::sleep(Duration::from_millis(WAIT_MS)).await;
+
+    handle.abort();
+
+    subscription.delete(None).await.ok();
+    topic.delete(None).await.ok();
+}
+
 #[tokio::test]
 async fn test_missing_app_id_nack() {
     let client = mq_connection().await;
@@ -253,7 +335,7 @@ async fn test_missing_app_id_nack() {
         .expect(0);
     mock_server.register(mock).await;
 
-    let plugin = get_test_plugin(mock_server.uri(), subscription.id(), false);
+    let plugin = get_test_plugin(mock_server.uri(), subscription.id(), None);
 
     let handle = tokio::spawn(async move {
         let fut = plugin.run();
@@ -301,7 +383,7 @@ async fn test_missing_event_type_nack() {
         .expect(0);
     mock_server.register(mock).await;
 
-    let plugin = get_test_plugin(mock_server.uri(), subscription.id(), false);
+    let plugin = get_test_plugin(mock_server.uri(), subscription.id(), None);
 
     let handle = tokio::spawn(async move {
         let fut = plugin.run();
@@ -354,7 +436,7 @@ async fn test_consume_svix_503() {
         .expect(1..);
     mock_server.register(mock).await;
 
-    let plugin = get_test_plugin(mock_server.uri(), subscription.id(), false);
+    let plugin = get_test_plugin(mock_server.uri(), subscription.id(), None);
 
     let handle = tokio::spawn(async move {
         let fut = plugin.run();
@@ -392,7 +474,7 @@ async fn test_consume_svix_offline() {
 
     let mock_server = MockServer::start().await;
 
-    let plugin = get_test_plugin(mock_server.uri(), subscription.id(), false);
+    let plugin = get_test_plugin(mock_server.uri(), subscription.id(), None);
 
     // bye-bye svix...
     drop(mock_server);

--- a/bridge/svix-bridge-plugin-queue/tests/rabbitmq_consumer.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/rabbitmq_consumer.rs
@@ -10,8 +10,9 @@ use svix_bridge_plugin_queue::{
     config::RabbitMqInputOpts, CreateMessageRequest, RabbitMqConsumerPlugin,
 };
 use svix_bridge_types::{
-    svix::api::MessageIn, JsReturn, SenderInput, SenderOutputOpts, SvixOptions,
-    SvixSenderOutputOpts, TransformerJob,
+    svix::api::MessageIn, SenderInput, SenderOutputOpts, SvixOptions, SvixSenderOutputOpts,
+    TransformationConfig, TransformerInput, TransformerInputFormat, TransformerJob,
+    TransformerOutput,
 };
 use wiremock::matchers::{body_partial_json, method};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -20,7 +21,7 @@ fn get_test_plugin(
     svix_url: String,
     mq_uri: &str,
     queue_name: &str,
-    use_transformation: bool,
+    use_transformation: Option<TransformerInputFormat>,
 ) -> RabbitMqConsumerPlugin {
     RabbitMqConsumerPlugin::new(
         "test".into(),
@@ -32,13 +33,10 @@ fn get_test_plugin(
             consume_args: None,
             requeue_on_nack: false,
         },
-        if use_transformation {
-            // The actual script doesn't matter since the test case will be performing the
-            // transformation, not the actual JS executor.
-            Some(String::from("function handle(x) { return x; }"))
-        } else {
-            None
-        },
+        use_transformation.map(|format| TransformationConfig::Explicit {
+            format,
+            src: String::from("function handle(x) { return x; }"),
+        }),
         SenderOutputOpts::Svix(SvixSenderOutputOpts {
             token: "xxxx".to_string(),
             options: Some(SvixOptions {
@@ -119,7 +117,7 @@ async fn test_consume_ok() {
         .expect(1);
     mock_server.register(mock).await;
 
-    let plugin = get_test_plugin(mock_server.uri(), MQ_URI, queue_name, false);
+    let plugin = get_test_plugin(mock_server.uri(), MQ_URI, queue_name, None);
 
     let handle = tokio::spawn(async move {
         let fut = plugin.run();
@@ -148,7 +146,7 @@ async fn test_consume_ok() {
 /// Push a msg on the queue.
 /// Check to see if the svix server sees a request, but this time transform the payload.
 #[tokio::test]
-async fn test_consume_transformed_ok() {
+async fn test_consume_transformed_json_ok() {
     let mq_conn = mq_connection(MQ_URI).await;
     let channel = mq_conn.create_channel().await.unwrap();
     // setup the queue before running the consumer or the consumer will error out
@@ -164,8 +162,6 @@ async fn test_consume_transformed_ok() {
         .respond_with(ResponseTemplate::new(202).set_body_json(json!({
           "eventType": "testing.things",
           "payload": {
-            "_SVIX_APP_ID": "app_1234",
-            "_SVIX_EVENT_TYPE": "testing.things",
             // The adjustment made via the transformation...
             "good": "bye",
           },
@@ -176,12 +172,20 @@ async fn test_consume_transformed_ok() {
         .expect(1);
     mock_server.register(mock).await;
 
-    let mut plugin = get_test_plugin(mock_server.uri(), MQ_URI, queue_name, true);
+    let mut plugin = get_test_plugin(
+        mock_server.uri(),
+        MQ_URI,
+        queue_name,
+        Some(TransformerInputFormat::Json),
+    );
     let (transformer_tx, mut transformer_rx) =
         tokio::sync::mpsc::unbounded_channel::<TransformerJob>();
     let _handle = tokio::spawn(async move {
         while let Some(x) = transformer_rx.recv().await {
-            let mut out = x.payload;
+            let mut out = match x.input {
+                TransformerInput::JSON(input) => input.as_object().unwrap().clone(),
+                _ => unreachable!(),
+            };
             // Prune out the "hi" key.
             out["message"]["payload"]
                 .as_object_mut()
@@ -189,7 +193,7 @@ async fn test_consume_transformed_ok() {
                 .remove("hi");
             // Add the "good" key.
             out["message"]["payload"]["good"] = json!("bye");
-            x.callback_tx.send(Ok(JsReturn::Object(out))).ok();
+            x.callback_tx.send(Ok(TransformerOutput::Object(out))).ok();
         }
     });
     plugin.set_transformer(Some(transformer_tx));
@@ -219,6 +223,89 @@ async fn test_consume_transformed_ok() {
         .ok();
 }
 
+/// Push a msg on the queue.
+/// Check to see if the svix server sees a request, but this time transform the payload.
+#[tokio::test]
+async fn test_consume_transformed_string_ok() {
+    let mq_conn = mq_connection(MQ_URI).await;
+    let channel = mq_conn.create_channel().await.unwrap();
+    // setup the queue before running the consumer or the consumer will error out
+    let queue = declare_queue("", &channel).await;
+    let queue_name = queue.name().as_str();
+
+    let mock_server = MockServer::start().await;
+    // The mock will make asserts on drop (i.e. when the body of the test is returning).
+    // The `expect` call should ensure we see exactly 1 POST request.
+    // <https://docs.rs/wiremock/latest/wiremock/struct.Mock.html#method.expect>
+    let mock = Mock::given(method("POST"))
+        .and(body_partial_json(
+            json!({ "payload": { "hello": "world" } }),
+        ))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+          "eventType": "testing.things",
+          "payload": {
+            // The adjustment made via the transformation...
+            "hello": "world",
+          },
+          "id": "msg_xxxx",
+          "timestamp": "2023-04-25T00:00:00Z"
+        })))
+        .named("create_message")
+        .expect(1);
+    mock_server.register(mock).await;
+
+    let mut plugin = get_test_plugin(
+        mock_server.uri(),
+        MQ_URI,
+        queue_name,
+        Some(TransformerInputFormat::String),
+    );
+    let (transformer_tx, mut transformer_rx) =
+        tokio::sync::mpsc::unbounded_channel::<TransformerJob>();
+    let _handle = tokio::spawn(async move {
+        while let Some(x) = transformer_rx.recv().await {
+            let input = match x.input {
+                TransformerInput::String(input) => input,
+                _ => unreachable!(),
+            };
+            // Build a create-message-compatible object, using the string input as a field in the payload.
+            let out = json!({
+                "app_id": "app_1234",
+                "message": {
+                    "eventType": "testing.things",
+                    "payload": {
+                        "hello": input,
+                    }
+                }
+            });
+            x.callback_tx
+                .send(Ok(TransformerOutput::Object(
+                    out.as_object().unwrap().clone(),
+                )))
+                .ok();
+        }
+    });
+    plugin.set_transformer(Some(transformer_tx));
+
+    let handle = tokio::spawn(async move {
+        let fut = plugin.run();
+        fut.await
+    });
+    // Wait for the consumer to connect
+    tokio::time::sleep(Duration::from_millis(WAIT_MS)).await;
+
+    publish(&channel, queue_name, b"world").await;
+
+    // Wait for the consumer to consume.
+    tokio::time::sleep(Duration::from_millis(WAIT_MS)).await;
+
+    handle.abort();
+    channel
+        .queue_delete(queue_name, Default::default())
+        .await
+        .ok();
+}
+
 #[tokio::test]
 async fn test_missing_app_id_nack() {
     let mq_conn = mq_connection(MQ_URI).await;
@@ -236,7 +323,7 @@ async fn test_missing_app_id_nack() {
         .expect(0);
     mock_server.register(mock).await;
 
-    let plugin = get_test_plugin(mock_server.uri(), MQ_URI, queue_name, false);
+    let plugin = get_test_plugin(mock_server.uri(), MQ_URI, queue_name, None);
 
     let handle = tokio::spawn(async move {
         let fut = plugin.run();
@@ -289,7 +376,7 @@ async fn test_missing_event_type_nack() {
         .expect(0);
     mock_server.register(mock).await;
 
-    let plugin = get_test_plugin(mock_server.uri(), MQ_URI, queue_name, false);
+    let plugin = get_test_plugin(mock_server.uri(), MQ_URI, queue_name, None);
 
     let handle = tokio::spawn(async move {
         let fut = plugin.run();
@@ -343,7 +430,7 @@ async fn test_consume_svix_503() {
         .expect(1);
     mock_server.register(mock).await;
 
-    let plugin = get_test_plugin(mock_server.uri(), MQ_URI, queue_name, false);
+    let plugin = get_test_plugin(mock_server.uri(), MQ_URI, queue_name, None);
 
     let handle = tokio::spawn(async move {
         let fut = plugin.run();
@@ -386,7 +473,7 @@ async fn test_consume_svix_offline() {
 
     let mock_server = MockServer::start().await;
 
-    let plugin = get_test_plugin(mock_server.uri(), MQ_URI, queue_name, false);
+    let plugin = get_test_plugin(mock_server.uri(), MQ_URI, queue_name, None);
 
     // bye-bye svix...
     drop(mock_server);

--- a/bridge/svix-bridge-plugin-queue/tests/redis_stream_consumer.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/redis_stream_consumer.rs
@@ -7,8 +7,9 @@ use redis::{AsyncCommands, Client};
 use serde_json::json;
 use svix_bridge_plugin_queue::{config::RedisInputOpts, CreateMessageRequest, RedisConsumerPlugin};
 use svix_bridge_types::{
-    svix::api::MessageIn, JsReturn, SenderInput, SenderOutputOpts, SvixOptions,
-    SvixSenderOutputOpts, TransformerJob,
+    svix::api::MessageIn, SenderInput, SenderOutputOpts, SvixOptions, SvixSenderOutputOpts,
+    TransformationConfig, TransformerInput, TransformerInputFormat, TransformerJob,
+    TransformerOutput,
 };
 use wiremock::matchers::{body_partial_json, method};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -16,7 +17,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 fn get_test_plugin(
     svix_url: String,
     queue_key: String,
-    use_transformation: bool,
+    use_transformation: Option<TransformerInputFormat>,
 ) -> RedisConsumerPlugin {
     RedisConsumerPlugin::new(
         "test".into(),
@@ -28,13 +29,10 @@ fn get_test_plugin(
             consumer_group: "test_cg".to_owned(),
             consumer_name: "test_cn".to_owned(),
         },
-        if use_transformation {
-            // The actual script doesn't matter since the test case will be performing the
-            // transformation, not the actual JS executor.
-            Some(String::from("function handle(x) { return x; }"))
-        } else {
-            None
-        },
+        use_transformation.map(|format| TransformationConfig::Explicit {
+            format,
+            src: String::from("function handle(x) { return x; }"),
+        }),
         SenderOutputOpts::Svix(SvixSenderOutputOpts {
             token: "xxxx".to_string(),
             options: Some(SvixOptions {
@@ -93,8 +91,6 @@ async fn test_consume_ok() {
         .respond_with(ResponseTemplate::new(202).set_body_json(json!({
           "eventType": "testing.things",
           "payload": {
-            "_SVIX_APP_ID": "app_1234",
-            "_SVIX_EVENT_TYPE": "testing.things",
             "hi": "there",
           },
           "id": "msg_xxxx",
@@ -104,7 +100,7 @@ async fn test_consume_ok() {
         .expect(1);
     mock_server.register(mock).await;
 
-    let plugin = get_test_plugin(mock_server.uri(), key.clone(), false);
+    let plugin = get_test_plugin(mock_server.uri(), key.clone(), None);
 
     let handle = tokio::spawn(async move {
         let fut = plugin.run();
@@ -132,7 +128,7 @@ async fn test_consume_ok() {
 /// Push a msg on the queue.
 /// Check to see if the svix server sees a request, but this time transform the payload.
 #[tokio::test]
-async fn test_consume_transformed_ok() {
+async fn test_consume_transformed_json_ok() {
     let client = redis_connection().await;
     let key = create_test_stream(&client).await;
 
@@ -145,8 +141,6 @@ async fn test_consume_transformed_ok() {
         .respond_with(ResponseTemplate::new(202).set_body_json(json!({
           "eventType": "testing.things",
           "payload": {
-            "_SVIX_APP_ID": "app_1234",
-            "_SVIX_EVENT_TYPE": "testing.things",
             // The adjustment made via the transformation...
             "good": "bye",
           },
@@ -157,12 +151,19 @@ async fn test_consume_transformed_ok() {
         .expect(1);
     mock_server.register(mock).await;
 
-    let mut plugin = get_test_plugin(mock_server.uri(), key.clone(), true);
+    let mut plugin = get_test_plugin(
+        mock_server.uri(),
+        key.clone(),
+        Some(TransformerInputFormat::Json),
+    );
     let (transformer_tx, mut transformer_rx) =
         tokio::sync::mpsc::unbounded_channel::<TransformerJob>();
     let _handle = tokio::spawn(async move {
         while let Some(x) = transformer_rx.recv().await {
-            let mut out = x.payload;
+            let mut out = match x.input {
+                TransformerInput::JSON(input) => input.as_object().unwrap().clone(),
+                _ => unreachable!(),
+            };
             // Prune out the "hi" key.
             out["message"]["payload"]
                 .as_object_mut()
@@ -170,7 +171,7 @@ async fn test_consume_transformed_ok() {
                 .remove("hi");
             // Add the "good" key.
             out["message"]["payload"]["good"] = json!("bye");
-            x.callback_tx.send(Ok(JsReturn::Object(out))).ok();
+            x.callback_tx.send(Ok(TransformerOutput::Object(out))).ok();
         }
     });
     plugin.set_transformer(Some(transformer_tx));
@@ -198,6 +199,84 @@ async fn test_consume_transformed_ok() {
     delete_test_stream(&client, &key).await;
 }
 
+// FIXME: can't support raw payload with the current redis backend impl as it requires json
+//   internally. Try again when we switch to `omniqueue`.
+#[ignore]
+#[tokio::test]
+async fn test_consume_transformed_string_ok() {
+    let client = redis_connection().await;
+    let key = create_test_stream(&client).await;
+
+    let mock_server = MockServer::start().await;
+    // The mock will make asserts on drop (i.e. when the body of the test is returning).
+    // The `expect` call should ensure we see exactly 1 POST request.
+    // <https://docs.rs/wiremock/latest/wiremock/struct.Mock.html#method.expect>
+    let mock = Mock::given(method("POST"))
+        .and(body_partial_json(
+            json!({ "payload": { "hello": "world" } }),
+        ))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+          "eventType": "testing.things",
+          "payload": {
+            // The adjustment made via the transformation...
+            "hello": "world",
+          },
+          "id": "msg_xxxx",
+          "timestamp": "2023-04-25T00:00:00Z"
+        })))
+        .named("create_message")
+        .expect(1);
+    mock_server.register(mock).await;
+
+    let mut plugin = get_test_plugin(
+        mock_server.uri(),
+        key.clone(),
+        Some(TransformerInputFormat::String),
+    );
+    let (transformer_tx, mut transformer_rx) =
+        tokio::sync::mpsc::unbounded_channel::<TransformerJob>();
+    let _handle = tokio::spawn(async move {
+        while let Some(x) = transformer_rx.recv().await {
+            let input = match x.input {
+                TransformerInput::String(input) => input,
+                _ => unreachable!(),
+            };
+            // Build a create-message-compatible object, using the string input as a field in the payload.
+            let out = json!({
+                "app_id": "app_1234",
+                "message": {
+                    "eventType": "testing.things",
+                    "payload": {
+                        "hello": input,
+                    }
+                }
+            });
+            x.callback_tx
+                .send(Ok(TransformerOutput::Object(
+                    out.as_object().unwrap().clone(),
+                )))
+                .ok();
+        }
+    });
+    plugin.set_transformer(Some(transformer_tx));
+
+    let handle = tokio::spawn(async move {
+        let fut = plugin.run();
+        fut.await
+    });
+    // Wait for the consumer to connect
+    tokio::time::sleep(Duration::from_millis(WAIT_MS)).await;
+
+    publish(&client, &key, "world").await;
+
+    // Wait for the consumer to consume.
+    tokio::time::sleep(Duration::from_millis(WAIT_MS)).await;
+
+    handle.abort();
+
+    delete_test_stream(&client, &key).await;
+}
+
 #[tokio::test]
 async fn test_missing_app_id_nack() {
     let client = redis_connection().await;
@@ -212,7 +291,7 @@ async fn test_missing_app_id_nack() {
         .expect(0);
     mock_server.register(mock).await;
 
-    let plugin = get_test_plugin(mock_server.uri(), key.clone(), false);
+    let plugin = get_test_plugin(mock_server.uri(), key.clone(), None);
 
     let handle = tokio::spawn(async move {
         let fut = plugin.run();
@@ -260,7 +339,7 @@ async fn test_missing_event_type_nack() {
         .expect(0);
     mock_server.register(mock).await;
 
-    let plugin = get_test_plugin(mock_server.uri(), key.clone(), false);
+    let plugin = get_test_plugin(mock_server.uri(), key.clone(), None);
 
     let handle = tokio::spawn(async move {
         let fut = plugin.run();
@@ -309,7 +388,7 @@ async fn test_consume_svix_503() {
         .expect(1);
     mock_server.register(mock).await;
 
-    let plugin = get_test_plugin(mock_server.uri(), key.clone(), false);
+    let plugin = get_test_plugin(mock_server.uri(), key.clone(), None);
 
     let handle = tokio::spawn(async move {
         let fut = plugin.run();
@@ -347,7 +426,7 @@ async fn test_consume_svix_offline() {
 
     let mock_server = MockServer::start().await;
 
-    let plugin = get_test_plugin(mock_server.uri(), key.clone(), false);
+    let plugin = get_test_plugin(mock_server.uri(), key.clone(), None);
 
     // bye-bye svix...
     drop(mock_server);

--- a/bridge/svix-bridge.example.receivers.yaml
+++ b/bridge/svix-bridge.example.receivers.yaml
@@ -55,6 +55,7 @@ receivers:
         type: "svix"
         endpoint_secret: "whsec_XXXXX="
     # Optional - when unset, webhooks received will be forwarded to the output as-is.
+    # N.b. only `json` formatted transformations (the default) are allowed for receivers.
     transformation: |
       function handler(input) {
         let event_type = input.eventType;

--- a/bridge/svix-bridge.example.senders.yaml
+++ b/bridge/svix-bridge.example.senders.yaml
@@ -31,16 +31,18 @@ senders:
       # Optional - will fallback to looking at env vars when left unset.
       credentials_file: "/path/to/credentials.json"
     # Optional - when unset, messages from the queue will be sent to Svix as-is.
-    transformation: |
-      function handler(input) {
-        return {
-          app_id: input.key,
-          message: {
-            eventType: input.event_type,
-            payload: input.data
-          }
-        };
-      }
+    transformation:
+      format: "json"
+      src: |
+        function handler(input) {
+          return {
+            app_id: input.key,
+            message: {
+              eventType: input.event_type,
+              payload: input.data
+            }
+          };
+        }
     output:
       type: "svix"
       # Required (the Svix token to use when creating messages with this consumer)

--- a/bridge/svix-bridge/src/config/tests.rs
+++ b/bridge/svix-bridge/src/config/tests.rs
@@ -263,6 +263,7 @@ fn test_senders_parses_ok() {
     type: "rabbitmq"
     queue_name: "local"
     uri: "amqp://example.com/%2f"
+  # Implicit json transformation
   transformation: |
     handler = (x) => ({ app_id: "app_1234", message: { eventType: "foo.bar", payload: x }})
   output:
@@ -272,8 +273,13 @@ fn test_senders_parses_ok() {
   input:
     type: "sqs"
     queue_dsn: "http://sqs.example.com/foo/bar"
-  transformation: |
-    handler = (x) => ({ app_id: "app_1234", message: { eventType: "foo.bar", payload: x }})
+  # Explicit string transformation
+  transformation:
+    format: string
+    src: |
+        function handler(x) {
+            return { app_id: "app_1234", message: { eventType: "foo.bar", payload: x }}
+        }
   output:
     type: "svix"
     token: "YYYY"

--- a/bridge/svix-bridge/src/runtime/mod.rs
+++ b/bridge/svix-bridge/src/runtime/mod.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use std::sync::Arc;
 
 use deno_core::{anyhow, serde_v8, v8, JsRuntime};
-use svix_bridge_types::{JsObject, JsReturn};
+use svix_bridge_types::{JsObject, TransformerInput, TransformerOutput};
 use threadpool::ThreadPool;
 use tokio::sync::{oneshot, Mutex};
 
@@ -14,7 +14,11 @@ impl TpHandle {
         Self(Arc::new(Mutex::new(ThreadPool::default())))
     }
 
-    pub async fn run_script(&self, input: serde_json::Value, script: String) -> Result<JsReturn> {
+    pub async fn run_script(
+        &self,
+        input: TransformerInput,
+        script: String,
+    ) -> Result<TransformerOutput> {
         let (tx, rx) = oneshot::channel();
 
         self.0.lock().await.execute(move || {
@@ -25,19 +29,17 @@ impl TpHandle {
     }
 }
 
-fn run_script_inner(input: &serde_json::Value, script: String) -> Result<JsReturn> {
+fn run_script_inner(input: &TransformerInput, script: String) -> Result<TransformerOutput> {
     let mut runtime = JsRuntime::new(Default::default());
-    let res = runtime.execute_script(
-        "<anon>",
-        &format!("{script}\nhandler({})", serde_json::to_string(input)?),
-    );
+    let input = serde_json::to_string(input)?;
+    let res = runtime.execute_script("<anon>", &format!("{script}\nhandler({})", input));
     match res {
         Ok(global) => {
             let scope = &mut runtime.handle_scope();
             let local = v8::Local::new(scope, global);
             match serde_v8::from_v8::<JsObject>(scope, local) {
-                Ok(v) => Ok(JsReturn::Object(v)),
-                Err(serde_v8::Error::ExpectedObject) => Ok(JsReturn::Invalid),
+                Ok(v) => Ok(TransformerOutput::Object(v)),
+                Err(serde_v8::Error::ExpectedObject) => Ok(TransformerOutput::Invalid),
                 Err(e) => Err(e)?,
             }
         }

--- a/bridge/svix-bridge/src/runtime/tests.rs
+++ b/bridge/svix-bridge/src/runtime/tests.rs
@@ -1,6 +1,6 @@
 use super::run_script_inner;
 use serde_json::json;
-use svix_bridge_types::JsReturn;
+use svix_bridge_types::{TransformerInput, TransformerOutput};
 
 // Really just trying to figure out if the deno runtime is working the way I hope.
 #[test]
@@ -11,13 +11,13 @@ fn test_happy_fn() {
     }
     "#
     .to_string();
-    let res = run_script_inner(&json!({ "y": 456 }), src).unwrap();
+    let res = run_script_inner(&json!({ "y": 456 }).into(), src).unwrap();
     match res {
-        JsReturn::Object(v) => {
+        TransformerOutput::Object(v) => {
             assert_eq!(v["x"].as_i64(), Some(123));
             assert_eq!(v["y"].as_i64(), Some(456));
         }
-        JsReturn::Invalid => panic!("got unexpected return value"),
+        TransformerOutput::Invalid => panic!("got unexpected return value"),
     }
 }
 
@@ -29,10 +29,10 @@ fn test_invalid_output_bool() {
     }
     "#
     .to_string();
-    let res = run_script_inner(&json!({}), src).unwrap();
+    let res = run_script_inner(&json!({}).into(), src).unwrap();
     match res {
-        JsReturn::Invalid => (),
-        JsReturn::Object(_) => panic!("got unexpected return value"),
+        TransformerOutput::Invalid => (),
+        TransformerOutput::Object(_) => panic!("got unexpected return value"),
     }
 }
 
@@ -46,11 +46,53 @@ fn test_invalid_output_array() {
     }
     "#
     .to_string();
-    let res = run_script_inner(&json!({}), src).unwrap();
+    let res = run_script_inner(&json!({}).into(), src).unwrap();
     match res {
-        JsReturn::Invalid => (),
-        JsReturn::Object(_) => {
+        TransformerOutput::Invalid => (),
+        TransformerOutput::Object(_) => {
             panic!("got unexpected return value");
         }
+    }
+}
+
+/// Receives a string input, parses as JSON in js, then returns the result back to rust.
+#[test]
+fn test_string_input() {
+    let src = r#"
+    function handler(input) {
+        return JSON.parse(input);
+    }
+    "#
+    .to_string();
+    let res = run_script_inner(
+        &TransformerInput::String(String::from(r#"{"x": 123}"#)),
+        src,
+    )
+    .unwrap();
+    match res {
+        TransformerOutput::Object(v) => {
+            assert_eq!(v["x"].as_i64(), Some(123));
+        }
+        TransformerOutput::Invalid => (),
+    }
+}
+
+/// Take the string input and just add it to a field in the returned object.
+/// The string should make it through, back to rust, as-is.
+#[test]
+fn test_string_input2() {
+    let src = r#"
+    function handler(input) {
+        return { "payload": input };
+    }
+    "#
+    .to_string();
+    let res =
+        run_script_inner(&TransformerInput::String(String::from("Hello World")), src).unwrap();
+    match res {
+        TransformerOutput::Object(v) => {
+            assert_eq!(v["payload"].as_str(), Some("Hello World"));
+        }
+        TransformerOutput::Invalid => (),
     }
 }

--- a/bridge/svix-bridge/src/webhook_receiver/config.rs
+++ b/bridge/svix-bridge/src/webhook_receiver/config.rs
@@ -1,6 +1,6 @@
 use crate::config::ReceiverConfig;
 use serde::Deserialize;
-use svix_bridge_types::WebhookVerifier;
+use svix_bridge_types::{TransformationConfig, WebhookVerifier};
 
 /// The [`IntegrationConfig`] is the struct associated with a given [`IntegrationId`]. When the route
 /// associated with an [`IntegrationId`] receives a webhook, or any other HTTP request, then it will
@@ -12,5 +12,5 @@ pub struct IntegrationConfig {
     pub receiver_cfg: ReceiverConfig,
     pub verification: WebhookVerifier,
     #[serde(default)]
-    pub transformation: Option<String>,
+    pub transformation: Option<TransformationConfig>,
 }


### PR DESCRIPTION
Adds a bunch of plumbing to allow the message payloads from consumers to
be passed to transformations as strings rather than pre-parsing as JSON
in rust.

One concrete use case for this is if the system publishing those
messages to the queue is sending XML or perhaps base64 encoded data.

When configured to specify the `format` of a transformation, you can set
it to `string` rather than the default `json`. Then, when the
transformation receives that string as an argument, it can do whatever
parsing is required in order to return a valid `Object`.

Tests have been added up and down the stack to show that strings are
handled correctly, and that the new config data is propagated.

Notable omissions:

- redis relies on JSON values internally and can't easily support "raw"
  inputs. We can revisit this when we switch to `omniqueue` since I
  believe it handles this better.

- [x] webhook receivers _can support_ raw inputs, I think, but _don't currently_.
  I'll try to get this going before the PR merges.

Update: got receivers going now. For both senders and receivers, we now check the configuration to catch cases where redis is paired with a string transformation and call that an Error. There's some tests in place to make sure those errors show up early in the process, rather than waiting for some message to come through.