### PR TITLE
Implement send-example route

### DIFF
--- a/server/openapi.json
+++ b/server/openapi.json
@@ -950,6 +950,20 @@
                 ],
                 "type": "object"
             },
+            "EventExampleIn": {
+                "properties": {
+                    "eventType": {
+                        "example": "user.signup",
+                        "maxLength": 256,
+                        "pattern": "^[a-zA-Z0-9\\-_.]+$",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "eventType"
+                ],
+                "type": "object"
+            },
             "EventTypeIn": {
                 "properties": {
                     "archived": {
@@ -4574,8 +4588,35 @@
         },
         "/api/v1/app/{app_id}/endpoint/{endpoint_id}/send-example/": {
             "post": {
-                "description": "Send an example message for event",
+                "description": "Send an example message for an event",
+                "operationId": "v1.endpoint.send-example",
                 "parameters": [
+                    {
+                        "in": "path",
+                        "name": "app_id",
+                        "required": true,
+                        "schema": {
+                            "example": "unique-app-identifier",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+                            "type": "string"
+                        },
+                        "style": "simple"
+                    },
+                    {
+                        "in": "path",
+                        "name": "endpoint_id",
+                        "required": true,
+                        "schema": {
+                            "example": "unique-ep-identifier",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+                            "type": "string"
+                        },
+                        "style": "simple"
+                    },
                     {
                         "description": "The request's idempotency key",
                         "in": "header",
@@ -4586,11 +4627,89 @@
                         "style": "simple"
                     }
                 ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EventExampleIn"
+                            }
+                        }
+                    },
+                    "required": true
+                },
                 "responses": {
-                    "204": {
-                        "description": "no content"
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MessageOut"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Forbidden"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "409": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Conflict"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                        "description": "Validation Error"
+                    },
+                    "429": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Too Many Requests"
                     }
                 },
+                "summary": "Send Event Type Example Message",
                 "tags": [
                     "Endpoint"
                 ]

--- a/server/svix-server/src/db/models/eventtype.rs
+++ b/server/svix-server/src/db/models/eventtype.rs
@@ -102,6 +102,21 @@ pub fn schema_example() -> serde_json::Value {
 pub struct Schema(HashMap<String, Json>);
 json_wrapper!(Schema);
 
+impl Schema {
+    pub fn example(&self) -> Option<&serde_json::Value> {
+        self.0
+            .get("1")
+            .and_then(|version| match version {
+                serde_json::Value::Object(obj) => obj.get("examples"),
+                _ => None,
+            })
+            .and_then(|examples| match examples {
+                serde_json::Value::Array(arr) => arr.iter().next(),
+                _ => None,
+            })
+    }
+}
+
 impl JsonSchema for Schema {
     fn schema_name() -> String {
         stringify!(Schema).to_string()

--- a/server/svix-server/src/queue/mod.rs
+++ b/server/svix-server/src/queue/mod.rs
@@ -94,6 +94,7 @@ impl MessageTask {
 pub struct MessageTaskBatch {
     pub msg_id: MessageId,
     pub app_id: ApplicationId,
+    pub force_endpoint: Option<EndpointId>,
     pub trigger_type: MessageAttemptTriggerType,
 }
 
@@ -101,11 +102,13 @@ impl MessageTaskBatch {
     pub fn new_task(
         msg_id: MessageId,
         app_id: ApplicationId,
+        force_endpoint: Option<EndpointId>,
         trigger_type: MessageAttemptTriggerType,
     ) -> QueueTask {
         QueueTask::MessageBatch(Self {
             msg_id,
             app_id,
+            force_endpoint,
             trigger_type,
         })
     }

--- a/server/svix-server/src/worker.rs
+++ b/server/svix-server/src/worker.rs
@@ -748,7 +748,7 @@ async fn process_queue_task_inner(
         QueueTask::MessageBatch(task) => {
             let msg = ctx!(message::Entity::find_by_id(task.msg_id).one(db).await)?
                 .ok_or_else(|| err_generic!("Unexpected: message doesn't exist"))?;
-            (msg, None, None, task.trigger_type, 0)
+            (msg, task.force_endpoint, None, task.trigger_type, 0)
         }
     };
 


### PR DESCRIPTION
This change implements the `send-example` route which allows dispatching example events to a given endpoint.