### PR TITLE
JavaScript: Add an explicit check that payload is a string

### DIFF
--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -768,6 +768,10 @@ export class Webhook {
       | WebhookUnbrandedRequiredHeaders
       | Record<string, string>
   ): unknown {
+    if (typeof payload !== "string") {
+      throw new Error("Expected payload to be of type string. Please refer to https://docs.svix.com/receiving/verifying-payloads/how for more information.");
+    }
+
     const headers: Record<string, string> = {};
     for (const key of Object.keys(headers_)) {
       headers[key.toLowerCase()] = (headers_ as Record<string, string>)[key];


### PR DESCRIPTION
We had a check in typescript, but this obviously doesn't matter in JavaScript environments. Passing an object instead of a payload is an extremely common error case, so it's better to be explicit about it rather than implicit (just failing verification).

Fixes #977