### PR TITLE
Bridge: receivers now publish to queues with `payload` field

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -35,7 +35,7 @@ Transformations are configured as either a single string of JS source code:
 transformation: |
     function handler(input) {
       return {
-        app_id: input.key,
+        appId: input.key,
         message: {
           eventType: input.event_type,
           payload: input.data
@@ -52,7 +52,7 @@ transformation:
   src: |
     function handler(input) {
       return {
-        app_id: input.key,
+        appId: input.key,
         message: {
           eventType: input.event_type,
           payload: input.data
@@ -78,7 +78,7 @@ transformation:
       let payload = JSON.parse(msg.getElementsByTagName("payload")[0].textContent)
 
       return {
-        app_id: msg.attributes.appId,
+        appId: msg.attributes.appId,
         message: {
           eventType: msg.attributes.eventType,
           payload,
@@ -91,7 +91,7 @@ by the configured `format` field.
 
 Note that regardless of the `format`, the return type of `handler` must be an `Object`.
 
-> N.b. at time of writing, `format: string` is currently unsupported for `senders` and `receivers` configured with
+> N.b. at time of writing, `format: string` is unsupported for `senders` and `receivers` configured with
 > a `redis` input or output.
 
 ---
@@ -137,24 +137,29 @@ Each sender and receiver can optionally specify a `transformation`.
 Transformations should define a function called `handler` that accepts an object and returns an object.
 
 Senders should produce JSON following an expected shape:
-```
+```json
 {
-    // This indicates which Svix application to send the message to
-    "app_id": "app_XYZ",
-    
-    // The `message` field has the same requirements as the standard `MessageIn`
-    // used for Create Message API requests
+    "appId": "app_XYZ",
     "message": {
         "eventType": "my.event",
-        "payload": {"abc": 123}
+        "payload": {"code": 123, "message": "something happened..."}
     }
 }
 ```
 
-> The comments in the above JSON are for illustrative purposes only ;)
-> That's not valid JSON! Sorry!
-
 For detail on the `message` field, see: <https://api.svix.com/docs#tag/Message/operation/v1.message.create>
+
+Receivers can accept arbitrary body data but their outputs require a JSON object with a `payload` field representing the
+message to publish.
+
+```json
+{
+    "payload": {"msg": "my cool message, published by svix-bridge!"}
+}
+```
+
+By configuring a transformation, you should be able to consume a variety of `POST` bodies and
+produce a valid output.
 
 See the example configs for how to configure each input and output in more detail:
 - [senders](./svix-bridge.example.senders.yaml)

--- a/bridge/svix-bridge-plugin-queue/src/receiver_output/mod.rs
+++ b/bridge/svix-bridge-plugin-queue/src/receiver_output/mod.rs
@@ -9,7 +9,7 @@ use generic_queue::redis::{RedisConfig, RedisQueueBackend};
 use generic_queue::sqs::{SqsConfig, SqsQueueBackend};
 use generic_queue::{TaskQueueBackend, TaskQueueSend};
 use std::sync::Arc;
-use svix_bridge_types::{async_trait, JsObject, ReceiverOutput};
+use svix_bridge_types::{async_trait, ForwardRequest, ReceiverOutput};
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -120,11 +120,9 @@ impl ReceiverOutput for QueueForwarder {
     fn name(&self) -> &str {
         &self.name
     }
-    async fn handle(&self, payload: JsObject) -> std::io::Result<()> {
+    async fn handle(&self, request: ForwardRequest) -> std::io::Result<()> {
         self.sender
-            // FIXME(#5762): the payload to publish should be coming from a specific field in the
-            //   Object, not the whole thing.
-            .send(serde_json::Value::Object(payload))
+            .send(request.payload)
             .await
             .map_err(crate::Error::from)?;
         Ok(())

--- a/bridge/svix-bridge-plugin-queue/tests/gcp_pubsub_consumer.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/gcp_pubsub_consumer.rs
@@ -10,13 +10,11 @@ use google_cloud_pubsub::topic::Topic;
 use std::time::Duration;
 
 use serde_json::json;
-use svix_bridge_plugin_queue::{
-    config::GCPPubSubInputOpts, CreateMessageRequest, GCPPubSubConsumerPlugin,
-};
+use svix_bridge_plugin_queue::{config::GCPPubSubInputOpts, GCPPubSubConsumerPlugin};
 use svix_bridge_types::{
-    svix::api::MessageIn, SenderInput, SenderOutputOpts, SvixOptions, SvixSenderOutputOpts,
-    TransformationConfig, TransformerInput, TransformerInputFormat, TransformerJob,
-    TransformerOutput,
+    svix::api::MessageIn, CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions,
+    SvixSenderOutputOpts, TransformationConfig, TransformerInput, TransformerInputFormat,
+    TransformerJob, TransformerOutput,
 };
 use wiremock::matchers::{body_partial_json, method};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -286,7 +284,7 @@ async fn test_consume_transformed_string_ok() {
             };
             // Build a create-message-compatible object, using the string input as a field in the payload.
             let out = json!({
-                "app_id": "app_1234",
+                "appId": "app_1234",
                 "message": {
                     "eventType": "testing.things",
                     "payload": {
@@ -396,7 +394,7 @@ async fn test_missing_event_type_nack() {
     publish(
         &topic,
         &serde_json::to_string(&json!({
-            "app_id": "app_1234",
+            "appId": "app_1234",
             "message": {
                 // No event type
                 "payload": {

--- a/bridge/svix-bridge-plugin-queue/tests/rabbitmq_consumer.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/rabbitmq_consumer.rs
@@ -6,13 +6,11 @@ use generic_queue::rabbitmq::FieldTable;
 use lapin::{options::QueueDeclareOptions, Channel, Connection, ConnectionProperties, Queue};
 use serde_json::json;
 use std::time::Duration;
-use svix_bridge_plugin_queue::{
-    config::RabbitMqInputOpts, CreateMessageRequest, RabbitMqConsumerPlugin,
-};
+use svix_bridge_plugin_queue::{config::RabbitMqInputOpts, RabbitMqConsumerPlugin};
 use svix_bridge_types::{
-    svix::api::MessageIn, SenderInput, SenderOutputOpts, SvixOptions, SvixSenderOutputOpts,
-    TransformationConfig, TransformerInput, TransformerInputFormat, TransformerJob,
-    TransformerOutput,
+    svix::api::MessageIn, CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions,
+    SvixSenderOutputOpts, TransformationConfig, TransformerInput, TransformerInputFormat,
+    TransformerJob, TransformerOutput,
 };
 use wiremock::matchers::{body_partial_json, method};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -270,7 +268,7 @@ async fn test_consume_transformed_string_ok() {
             };
             // Build a create-message-compatible object, using the string input as a field in the payload.
             let out = json!({
-                "app_id": "app_1234",
+                "appId": "app_1234",
                 "message": {
                     "eventType": "testing.things",
                     "payload": {
@@ -390,7 +388,7 @@ async fn test_missing_event_type_nack() {
         &channel,
         queue_name,
         &serde_json::to_vec(&json!({
-            "app_id": "app_1234",
+            "appId": "app_1234",
             "message": {
                 // No event type
                 "payload": {

--- a/bridge/svix-bridge-plugin-queue/tests/redis_stream_consumer.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/redis_stream_consumer.rs
@@ -5,11 +5,11 @@ use std::time::Duration;
 
 use redis::{AsyncCommands, Client};
 use serde_json::json;
-use svix_bridge_plugin_queue::{config::RedisInputOpts, CreateMessageRequest, RedisConsumerPlugin};
+use svix_bridge_plugin_queue::{config::RedisInputOpts, RedisConsumerPlugin};
 use svix_bridge_types::{
-    svix::api::MessageIn, SenderInput, SenderOutputOpts, SvixOptions, SvixSenderOutputOpts,
-    TransformationConfig, TransformerInput, TransformerInputFormat, TransformerJob,
-    TransformerOutput,
+    svix::api::MessageIn, CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions,
+    SvixSenderOutputOpts, TransformationConfig, TransformerInput, TransformerInputFormat,
+    TransformerJob, TransformerOutput,
 };
 use wiremock::matchers::{body_partial_json, method};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -243,7 +243,7 @@ async fn test_consume_transformed_string_ok() {
             };
             // Build a create-message-compatible object, using the string input as a field in the payload.
             let out = json!({
-                "app_id": "app_1234",
+                "appId": "app_1234",
                 "message": {
                     "eventType": "testing.things",
                     "payload": {
@@ -353,7 +353,7 @@ async fn test_missing_event_type_nack() {
         &client,
         &key,
         &serde_json::to_string(&json!({
-            "app_id": "app_1234",
+            "appId": "app_1234",
             "message": {
                 // No event type
                 "payload": {

--- a/bridge/svix-bridge-plugin-queue/tests/sqs_consumer.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/sqs_consumer.rs
@@ -7,11 +7,12 @@ use std::time::Duration;
 
 use aws_sdk_sqs::Client;
 use serde_json::json;
-use svix_bridge_plugin_queue::{config::SqsInputOpts, CreateMessageRequest, SqsConsumerPlugin};
+use svix_bridge_plugin_queue::{config::SqsInputOpts, SqsConsumerPlugin};
 use svix_bridge_types::svix::api::MessageIn;
 use svix_bridge_types::{
-    SenderInput, SenderOutputOpts, SvixOptions, SvixSenderOutputOpts, TransformationConfig,
-    TransformerInput, TransformerInputFormat, TransformerJob, TransformerOutput,
+    CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions, SvixSenderOutputOpts,
+    TransformationConfig, TransformerInput, TransformerInputFormat, TransformerJob,
+    TransformerOutput,
 };
 use wiremock::matchers::{body_partial_json, method};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -261,7 +262,7 @@ async fn test_consume_transformed_string_ok() {
             };
             // Build a create-message-compatible object, using the string input as a field in the payload.
             let out = json!({
-                "app_id": "app_1234",
+                "appId": "app_1234",
                 "message": {
                     "eventType": "testing.things",
                     "payload": {
@@ -385,7 +386,7 @@ async fn test_missing_event_type_nack() {
         &client,
         &queue_url,
         &serde_json::to_string(&json!({
-            "app_id": "app_1234",
+            "appId": "app_1234",
             "message": {
                 // No event type
                 "payload": {

--- a/bridge/svix-bridge.example.receivers.yaml
+++ b/bridge/svix-bridge.example.receivers.yaml
@@ -55,12 +55,12 @@ receivers:
         type: "svix"
         endpoint_secret: "whsec_XXXXX="
     # Optional - when unset, webhooks received will be forwarded to the output as-is.
-    # N.b. only `json` formatted transformations (the default) are allowed for receivers.
     transformation: |
       function handler(input) {
         let event_type = input.eventType;
         delete input.eventType;
-        return { event_type, ...input };
+        // N.b. receiver outputs expect to find the message body to publish in the `payload` field.
+        return { payload: { event_type, ...input }};
       }
     output:
       type: "gcp-pubsub"

--- a/bridge/svix-bridge.example.senders.yaml
+++ b/bridge/svix-bridge.example.senders.yaml
@@ -36,7 +36,7 @@ senders:
       src: |
         function handler(input) {
           return {
-            app_id: input.key,
+            appId: input.key,
             message: {
               eventType: input.event_type,
               payload: input.data
@@ -64,7 +64,7 @@ senders:
     transformation: |
       function handler(input) {
         return {
-          app_id: input.key,
+          appId: input.key,
           message: {
             eventType: input.event_type,
             payload: input.data
@@ -96,7 +96,7 @@ senders:
     transformation: |
       function handler(input) {
         return {
-          app_id: input.key,
+          appId: input.key,
           message: {
             eventType: input.event_type,
             payload: input.data
@@ -124,7 +124,7 @@ senders:
     transformation: |
       function handler(input) {
         return {
-          app_id: input.key,
+          appId: input.key,
           message: {
             eventType: input.event_type,
             payload: input.data

--- a/bridge/svix-bridge/src/config/tests.rs
+++ b/bridge/svix-bridge/src/config/tests.rs
@@ -41,7 +41,7 @@ senders:
     transformation: |
       function handler(input) {
         return {
-          app_id: input.key,
+          appId: input.key,
           message: {
             eventType: input.event_type,
             payload: input.data
@@ -69,7 +69,7 @@ senders:
     transformation: |
       function handler(input) {
         return {
-          app_id: input.key,
+          appId: input.key,
           message: {
             eventType: input.event_type,
             payload: input.data
@@ -101,7 +101,7 @@ senders:
     transformation: |
       function handler(input) {
         return {
-          app_id: input.key,
+          appId: input.key,
           message: {
             eventType: input.event_type,
             payload: input.data
@@ -129,7 +129,7 @@ senders:
     transformation: |
       function handler(input) {
         return {
-          app_id: input.key,
+          appId: input.key,
           message: {
             eventType: input.event_type,
             payload: input.data
@@ -244,7 +244,7 @@ input:
     queue_name: "local"
     uri: "amqp://example.com/%2f"
 transformation: |
-    handler = (x) => ({ app_id: "app_1234", message: { eventType: "foo.bar", payload: x }})
+    handler = (x) => ({ appId: "app_1234", message: { eventType: "foo.bar", payload: x }})
 output:
     type: "svix"
     token: "XXXX"
@@ -265,7 +265,7 @@ fn test_senders_parses_ok() {
     uri: "amqp://example.com/%2f"
   # Implicit json transformation
   transformation: |
-    handler = (x) => ({ app_id: "app_1234", message: { eventType: "foo.bar", payload: x }})
+    handler = (x) => ({ appId: "app_1234", message: { eventType: "foo.bar", payload: x }})
   output:
     type: "svix"
     token: "XXXX"
@@ -278,7 +278,7 @@ fn test_senders_parses_ok() {
     format: string
     src: |
         function handler(x) {
-            return { app_id: "app_1234", message: { eventType: "foo.bar", payload: x }}
+            return { appId: "app_1234", message: { eventType: "foo.bar", payload: x }}
         }
   output:
     type: "svix"


### PR DESCRIPTION
This diff is a little more broad than just "put the payload in a field."
It also tries to formalize the requirements of each output case, both
Senders and Receivers.

For Senders, we need a certain shape useful for building a call to
Create Message.
For Receivers, outputs expect to get a JSON object with a `payload`
field on it, representing the data to publish to the queue or what have
you.

These boundary types are now both in the `-types` crate, and used to
ensure both as-is and transformed data conforms where needed.

Existing tests caught the changes on the receiver side (which is
the main thing for this diff).

Additionally, for Senders, I camelCased the `appId` field to make the
create message JSON cased more consistently. This was a remark that came
up during review of an up-coming blog post.