### PR TITLE
Bridge: variable expansion for config files

### DIFF
--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -1122,6 +1122,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "envsubst"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2f29f6ee674d1229e5715dfc7e24f14395a20d66949e36032de68b31542643"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3137,6 +3146,7 @@ dependencies = [
  "clap",
  "deno_core",
  "enum_dispatch",
+ "envsubst",
  "http",
  "hyper",
  "lazy_static",

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -133,6 +133,27 @@ The config file itself does the heavy lifting.
 
 When unset, the current working directory is checked for a file named `svix-bridge.yaml`.
 
+## Variable Expansion
+
+`svix-bridge` supports environment variable expansion inside the config file.
+
+Using "dollar brace" notation, e.g. `${MY_VARIABLE}`, a substitution will be made from the environment.
+If the variable lookup fails, the raw variable text is left in the config as-is.
+
+As an example, here's a RabbitMQ sender configured with environment variables:
+
+```yaml
+senders:
+  - name: "send-webhooks-from-${QUEUE_NAME}"
+    input:
+      type: "rabbitmq"
+      uri: "${MQ_URI}"
+      queue_name: "${QUEUE_NAME}"
+    output:
+      type: "svix"
+      token: "${SVIX_TOKEN}"
+```
+
 Each sender and receiver can optionally specify a `transformation`.
 Transformations should define a function called `handler` that accepts an object and returns an object.
 

--- a/bridge/svix-bridge/Cargo.toml
+++ b/bridge/svix-bridge/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "1"
 clap = { version = "4.2.4", features = ["env", "derive"] }
 axum = { version = "0.6", features = ["macros"] }
 enum_dispatch = "0.3"
+envsubst = "0.2.1"
 http = "0.2"
 hyper = { version = "0.14", features = ["full"] }
 lazy_static = "1.4"


### PR DESCRIPTION
Config files can now use "dollar brace" notation to do variable
substitutions. See the readme for an example.

~~Since variable expansion might not be assumed, this behavior is gated by
a CLI flag/env var and is **off by default**.~~

Furthermore, the variables available for substitution are exposed via a
simple HashMap meaning we can filter the vars exposed in the future, if
requested. This also has the benefit of being nicer for testing ;)

Tests are added to capture the initial behavior of the new dep, but also
to lock in the contract if we decided to "roll our own" in the future.

---

Open source review required.

Adds a dependency on [envsubst-rs](https://github.com/coreos/envsubst-rs)
to provide the base substitution capability.

This was selected based on the following criteria:

- support for the absolute minimum features (no expression evaluation
  for fallbacks, etc).
- Tiny. 170LOC (60+ of which are tests), easy to understand and fork if
  needed.
- Vaguely looks maintained, owned by coreos (part of redhat).

The big idea with adding this dep is, _"it already exists, but rolling
our own based on this if we want to customize behavior is easy."_