### PR TITLE
CI: raise max connections, pool size for redis/pg in server tests

### DIFF
--- a/server/run-tests.sh
+++ b/server/run-tests.sh
@@ -9,6 +9,8 @@ export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres"
 export SVIX_JWT_SECRET="test value"
 export SVIX_LOG_LEVEL="info"
 export SVIX_WHITELIST_SUBNETS="[127.0.0.1/32]"
+export SVIX_DB_POOL_MAX_SIZE="500"
+export SVIX_REDIS_POOL_MAX_SIZE="10000"
 
 echo "*********** RUN 1 ***********"
 SVIX_QUEUE_TYPE="redis" \

--- a/server/testing-docker-compose.yml
+++ b/server/testing-docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.7"
 services:
   postgres:
     image: postgres:13.4
+    command: postgres -c 'max_connections=500'
     volumes:
       - "postgres-data:/var/lib/postgresql/data/"
     environment:


### PR DESCRIPTION
## Motivation

It's not uncommon for tests to fail due to a pool timeout.

## Solution

Raise the connection limits to help avoid this.
