### PR TITLE
Server: remove `CacheKey::PREFIX_CACHE`, `kv_def!`, `string_kv_def!`

### DIFF
--- a/server/svix-server/src/core/cache/mod.rs
+++ b/server/svix-server/src/core/cache/mod.rs
@@ -38,10 +38,9 @@ pub enum Error {
 type Result<T> = std::result::Result<T, Error>;
 
 /// A valid key value for the cache -- usually just a wrapper around a [`String`]
-pub trait CacheKey: AsRef<str> + Send + Sync {
-    const PREFIX_CACHE: &'static str = "SVIX_CACHE";
-}
-/// Any (de)serializable structure usuable as a value in the cache -- it is associated with a
+pub trait CacheKey: AsRef<str> + Send + Sync {}
+
+/// Any (de)serializable structure usable as a value in the cache -- it is associated with a
 /// given key type to ensure type checking on creation or reading of values from the cache
 pub trait CacheValue: DeserializeOwned + Serialize + Send + Sync {
     type Key: CacheKey;
@@ -74,14 +73,6 @@ pub(crate) use kv_def_inner;
 /// A macro that creates a [`CacheKey`] and ties it to any value that implements
 /// [`DeserializeOwned`] and [`Serialize`]
 macro_rules! kv_def {
-    ($key_id:ident, $val_struct:ident, $lit_prefix:literal) => {
-        crate::core::cache::kv_def_inner!($key_id, $val_struct);
-
-        impl CacheKey for $key_id {
-            const PREFIX_CACHE: &'static str = $lit_prefix;
-        }
-    };
-
     ($key_id:ident, $val_struct:ident) => {
         crate::core::cache::kv_def_inner!($key_id, $val_struct);
 
@@ -115,14 +106,6 @@ pub(crate) use string_kv_def_inner;
 // Used downstream and for testing:
 #[allow(unused_macros)]
 macro_rules! string_kv_def {
-    ($key_id:ident, $val_struct:ident, $lit_prefix:literal) => {
-        crate::core::cache::string_kv_def_inner!($key_id, $val_struct);
-
-        impl CacheKey for $key_id {
-            const PREFIX_CACHE: &'static str = $lit_prefix;
-        }
-    };
-
     ($key_id:ident, $val_struct:ident) => {
         crate::core::cache::string_kv_def_inner!($key_id, $val_struct);
 

--- a/server/svix-server/src/core/idempotency.rs
+++ b/server/svix-server/src/core/idempotency.rs
@@ -52,7 +52,7 @@ enum SerializedResponse {
     },
 }
 
-kv_def!(IdempotencyKey, SerializedResponse, "SVIX_IDEMPOTENCY_CACHE");
+kv_def!(IdempotencyKey, SerializedResponse);
 
 impl IdempotencyKey {
     fn new(auth_token: &str, key: &str, url: &str) -> IdempotencyKey {
@@ -65,6 +65,7 @@ impl IdempotencyKey {
         hasher.update(url);
 
         let res = hasher.finalize();
+        // FIXME: add (previously omitted) prefix: `SVIX_IDEMPOTENCY_CACHE`
         IdempotencyKey(base64::encode(res))
     }
 }

--- a/server/svix-server/src/core/message_app.rs
+++ b/server/svix-server/src/core/message_app.rs
@@ -214,7 +214,7 @@ impl AppEndpointKey {
     // FIXME: Rewrite doc comment when AppEndpointValue members are known
     /// Returns a key for fetching all cached endpoints for a given organization and application.
     pub fn new(org: &OrganizationId, app: &ApplicationId) -> AppEndpointKey {
-        AppEndpointKey(format!("{}_APP_v3_{}_{}", Self::PREFIX_CACHE, org, app))
+        AppEndpointKey(format!("SVIX_CACHE_APP_v3_{}_{}", org, app))
     }
 }
 

--- a/server/svix-server/src/worker.rs
+++ b/server/svix-server/src/worker.rs
@@ -73,7 +73,7 @@ pub struct FailureCacheValue {
     pub first_failure_at: DateTimeUtc,
 }
 
-kv_def!(FailureCacheKey, FailureCacheValue, "SVIX_FAILURE_CACHE");
+kv_def!(FailureCacheKey, FailureCacheValue);
 
 impl FailureCacheKey {
     pub fn new(
@@ -82,11 +82,8 @@ impl FailureCacheKey {
         endp_id: &EndpointId,
     ) -> FailureCacheKey {
         FailureCacheKey(format!(
-            "{}_{}_{}_{}",
-            Self::PREFIX_CACHE,
-            org_id,
-            app_id,
-            endp_id
+            "SVIX_FAILURE_CACHE_{}_{}_{}",
+            org_id, app_id, endp_id
         ))
     }
 }


### PR DESCRIPTION
Removes the associated const `PREFIX_CACHE` from the `CacheKey` trait, and supporting macro APIs.

This diff should be non-breaking in that the key strings should be the same as before, just without the API confusion.

## Motivation

Formerly it was possible to specify an override for the prefix of cache keys via an optional 3rd arg to `kv_def!`, and `string_kv_def!`.

The issue is, the override (or the default when omitted) are not included in the actual string form of the key unless you explicitly `format!()` it in there.

This is to say, the following are equivalent:

```rust
// specify the override, then manually format it in.
kv_def!(KeyA, ValA, "MY_PREFIX")
impl KeyA {
  pub fn new(x: &str) -> Self {
    Self(format!("{Self::PREFIX_CACHE}_{x}"))
  }
}

// no override, so `Self::PREFIX_CACHE` is whatever the default is, but
// it doesn't matter... it's not included in the key string :(
kv_def!(KeyA, ValA)
impl KeyA {
  pub fn new(x: &str) -> Self {
    // Including the prefix here means this version of KeyA is equiv
    Self(format!("MY_PREFIX_{x}"))
  }
}
```

The problem comes when you omit `Self::PREFIX_CACHE` in the key string itself. The assumption would be either the default prefix, or an override when specified, would be included in the string automatically, but it isn't.


## Solution

Removing the confusing 3rd arg from the macros and eliminating the associated const should mean moving forward: "wysiwyg." If there's a prefix in the key string, that's the prefix. There's no need for defaults or overrides.
