### PR TITLE
Server: add 'event_types' query param to 'list-attempted-messages'

### DIFF
--- a/server/openapi.json
+++ b/server/openapi.json
@@ -4152,6 +4152,22 @@
                             "type": "string"
                         },
                         "style": "simple"
+                    },
+                    {
+                        "in": "query",
+                        "name": "event_types",
+                        "schema": {
+                            "items": {
+                                "example": "user.signup",
+                                "maxLength": 256,
+                                "pattern": "^[a-zA-Z0-9\\-_.]+$",
+                                "type": "string"
+                            },
+                            "nullable": true,
+                            "type": "array",
+                            "uniqueItems": true
+                        },
+                        "style": "form"
                     }
                 ],
                 "responses": {

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -177,6 +177,7 @@ async fn list_attempted_messages(
     }): ValidatedQuery<ListAttemptedMessagesQueryParams>,
     Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,
     permissions::Application { app }: permissions::Application,
+    EventTypesQueryParams(event_types): EventTypesQueryParams,
 ) -> Result<Json<ListResponse<EndpointMessageOut>>> {
     let PaginationLimit(limit) = pagination.limit;
     let endp = ctx!(
@@ -196,6 +197,10 @@ async fn list_attempted_messages(
 
     if let Some(status) = status {
         dests_and_msgs = dests_and_msgs.filter(messagedestination::Column::Status.eq(status));
+    }
+
+    if let Some(EventTypeNameSet(event_types)) = event_types {
+        dests_and_msgs = dests_and_msgs.filter(message::Column::EventType.is_in(event_types));
     }
 
     async fn _get_msg_dest_id(

--- a/server/svix-server/tests/e2e_attempt.rs
+++ b/server/svix-server/tests/e2e_attempt.rs
@@ -178,6 +178,43 @@ async fn test_list_attempted_messages() {
         .unwrap();
     assert_eq!(list_filtered.data.len(), 1);
     assert!(list_filtered.data[0].msg == msg_3);
+
+    // Test 'event_types' query parameter
+
+    let list_balloon_popped: ListResponse<EndpointMessageOut> = client
+        .get(
+            &format!("api/v1/app/{app_id}/endpoint/{endp_id_1}/msg/?event_types=balloon.popped",),
+            StatusCode::OK,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(list_balloon_popped.data.len(), 1);
+    assert!(list_balloon_popped.data[0].msg == msg_3);
+
+    let list_event_type: ListResponse<EndpointMessageOut> = client
+        .get(
+            &format!("api/v1/app/{app_id}/endpoint/{endp_id_1}/msg/?event_types=event.type",),
+            StatusCode::OK,
+        )
+        .await
+        .unwrap();
+    assert_eq!(list_event_type.data.len(), 2);
+    assert!(list_event_type.data.iter().any(|x| x.msg == msg_1));
+    assert!(list_event_type.data.iter().any(|x| x.msg == msg_2));
+
+    let list_both_event_types: ListResponse<EndpointMessageOut> = client
+        .get(
+            &format!("api/v1/app/{app_id}/endpoint/{endp_id_1}/msg/?event_types=event.type,balloon.popped",),
+            StatusCode::OK,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(list_both_event_types.data.len(), 3);
+    assert!(list_both_event_types.data.iter().any(|x| x.msg == msg_1));
+    assert!(list_both_event_types.data.iter().any(|x| x.msg == msg_2));
+    assert!(list_both_event_types.data.iter().any(|x| x.msg == msg_3));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Motivation

The 'v1.message-attempt.list-by-endpoint' API takes in a 'event_types' parameter that filters the returned 'MessageAttemptOut's by event type. The similar  'v1.message-attempt.list-by-endpoint' API should have an equivalent parameter.


## Solution

Add `EventTypesQueryParams` to the `'v1.message-attempt.list-by-endpoint' API