### PR TITLE
Update Rust to latest stable version

### DIFF
--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -1,5 +1,5 @@
 # Base build
-FROM rust:1.69-slim-bullseye AS build
+FROM rust:1.70-slim-bullseye AS build
 
 RUN apt-get update && apt-get install -y \
     build-essential=12.* \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,5 @@
 # Base build
-FROM rust:1.65-slim-bullseye AS build
+FROM rust:1.70-slim-bullseye AS build
 
 RUN apt-get update && apt-get install -y build-essential=12.* checkinstall=1.* zlib1g-dev=1:* pkg-config=0.29.* libssl-dev=* --no-install-recommends
 


### PR DESCRIPTION
This updates Rust to the latest stable version for both server and bridge.

That's it.

Folks are recommended to update Rust locally as well.
```
rustup update
```