### PR TITLE
Bridge: load config from string (env var or cli flag)

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -123,15 +123,22 @@ If you don't want to use docker, see [Building from Source](../README.md#buildin
 
 # Usage and Configuration
 
-```
-$ svix-bridge -c path/to/svix-bridge.yaml
-```
+The CLI itself will look for a config file named `svix-bridge.yaml` or `svix-bridge.json` in the current working
+directory.
+Additionally, Bridge can load its configuration from a different location via `--cfg-file` (or `SVIX_BRIDGE_CFG_FILE`),
+or otherwise the config can be given as a string via `--cfg` (or `SVIX_BRIDGE_CFG`).
 
-The CLI itself exposes only a single flag (`-c`, `--cfg`) used to set the path for the config file.
-The location of the config file can also be set with the `SVIX_BRIDGE_CFG` env var.
-The config file itself does the heavy lifting.
+Examples:
+```
+# Using the default config file location
+$ svix-bridge
 
-When unset, the current working directory is checked for a file named `svix-bridge.yaml`.
+# Specifying an alternate location
+$ svix-bridge --cfg-file path/to/svix-bridge.json
+
+# Config data supplied directly
+$ svix-bridge --cfg '{"log_format": "json", "senders": []}'
+```
 
 ## Variable Expansion
 


### PR DESCRIPTION
## Motivation

Writing out config data to disk can sometimes be awkward. Users of the Bridge docker image would either need to customize, using the bridge image as a base then add their config file to the fs, or otherwise use a volume mount (or similar).

k8s users have the benefit of config maps, which can be represented as files on disk, but this is not always a good option.

## Solution

Allows Bridge to load its config data from a string, which can be supplied as an env var or directly on the cli with `--cfg`.

The original flag for specifying an alternative file path to read config data from (formerly `--cfg` or `-c`) has been renamed to `--cfg-file`.

Sorry that's so confusing!

- Use `--cfg` to pass config as string
- Use `--cfg-file` to read from file, non-default loction

Additionally, a naive "search path" has been provided to look for the default config file using a series of names:

- `svix-bridge.yaml`
- `svix-bridge.yml`
- `svix-bridge.json`

This was done specifically to formalize the fact we're advertising "we accept json config data" in the readme.
