### PR TITLE
Update sea_orm to latest stable version

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -3186,15 +3186,14 @@ dependencies = [
 
 [[package]]
 name = "sea-orm"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88694d01b528a94f90ad87f8d2f546d060d070eee180315c67d158cb69476034"
+checksum = "fade86e8d41fd1a4721f84cb834f4ca2783f973cc30e6212b7fafc134f169214"
 dependencies = [
  "async-stream",
  "async-trait",
  "chrono",
  "futures",
- "futures-util",
  "log",
  "ouroboros",
  "sea-orm-macros",
@@ -3208,13 +3207,14 @@ dependencies = [
  "time 0.3.20",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]
 name = "sea-orm-macros"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7216195de9c6b2474fd0efab486173dccd0eff21f28cc54aa4c0205d52fb3af0"
+checksum = "28936f26d62234ff0be16f80115dbdeb3237fe9c25cf18fbcd1e3b3592360f20"
 dependencies = [
  "bae",
  "heck 0.3.3",
@@ -3225,9 +3225,9 @@ dependencies = [
 
 [[package]]
 name = "sea-query"
-version = "0.27.2"
+version = "0.28.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4f0fc4d8e44e1d51c739a68d336252a18bc59553778075d5e32649be6ec92ed"
+checksum = "bbab99b8cd878ab7786157b7eb8df96333a6807cc6e45e8888c85b51534b401a"
 dependencies = [
  "chrono",
  "sea-query-derive",
@@ -3236,9 +3236,9 @@ dependencies = [
 
 [[package]]
 name = "sea-query-binder"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2585b89c985cfacfe0ec9fc9e7bb055b776c1a2581c4e3c6185af2b8bf8865"
+checksum = "4cea85029985b40dfbf18318d85fe985c04db7c1b4e5e8e0a0a0cdff5f1e30f9"
 dependencies = [
  "chrono",
  "sea-query",
@@ -3248,11 +3248,11 @@ dependencies = [
 
 [[package]]
 name = "sea-query-derive"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cdc022b4f606353fe5dc85b09713a04e433323b70163e81513b141c6ae6eb5"
+checksum = "63f62030c60f3a691f5fe251713b4e220b306e50a71e1d6f9cce1f24bb781978"
 dependencies = [
- "heck 0.3.3",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -4457,6 +4457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "getrandom",
+ "serde",
 ]
 
 [[package]]

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -56,7 +56,7 @@ bytes = "1.1.0"
 blake2 = "0.10.4"
 chacha20poly1305 = "0.9.0"
 # sea orm
-sea-orm = { version = "0.10.2", features = [ "sqlx-postgres", "runtime-tokio-rustls", "macros", "with-chrono", "with-json" ], default-features = false }
+sea-orm = { version = "0.11.3", features = [ "sqlx-postgres", "runtime-tokio-rustls", "macros", "with-chrono", "with-json" ], default-features = false }
 sqlx = { version = "0.6.2", features = [ "runtime-tokio-rustls", "postgres", "migrate" ] }
 http = "0.2"
 time = { version = "0.3.9", features = [ "std" ]}

--- a/server/svix-server/src/db/models/application.rs
+++ b/server/svix-server/src/db/models/application.rs
@@ -86,8 +86,12 @@ impl Model {
     }
 }
 
+#[axum::async_trait]
 impl ActiveModelBehavior for ActiveModel {
-    fn before_save(mut self, _insert: bool) -> Result<Self, DbErr> {
+    async fn before_save<C>(mut self, _db: &C, _insert: bool) -> Result<Self, DbErr>
+    where
+        C: ConnectionTrait,
+    {
         self.updated_at = Set(Utc::now().into());
         Ok(self)
     }

--- a/server/svix-server/src/db/models/applicationmetadata.rs
+++ b/server/svix-server/src/db/models/applicationmetadata.rs
@@ -50,8 +50,12 @@ impl Related<super::application::Entity> for Entity {
     }
 }
 
+#[axum::async_trait]
 impl ActiveModelBehavior for ActiveModel {
-    fn before_save(mut self, _insert: bool) -> Result<Self, DbErr> {
+    async fn before_save<C>(mut self, _db: &C, _insert: bool) -> Result<Self, DbErr>
+    where
+        C: ConnectionTrait,
+    {
         self.updated_at = Set(Utc::now().into());
         Ok(self)
     }

--- a/server/svix-server/src/db/models/endpoint.rs
+++ b/server/svix-server/src/db/models/endpoint.rs
@@ -70,8 +70,12 @@ impl Related<super::endpointmetadata::Entity> for Entity {
     }
 }
 
+#[axum::async_trait]
 impl ActiveModelBehavior for ActiveModel {
-    fn before_save(mut self, _insert: bool) -> Result<Self, DbErr> {
+    async fn before_save<C>(mut self, _db: &C, _insert: bool) -> Result<Self, DbErr>
+    where
+        C: ConnectionTrait,
+    {
         self.updated_at = Set(Utc::now().into());
         Ok(self)
     }

--- a/server/svix-server/src/db/models/endpointmetadata.rs
+++ b/server/svix-server/src/db/models/endpointmetadata.rs
@@ -39,8 +39,12 @@ impl Related<super::endpoint::Entity> for Entity {
     }
 }
 
+#[axum::async_trait]
 impl ActiveModelBehavior for ActiveModel {
-    fn before_save(mut self, _insert: bool) -> Result<Self, DbErr> {
+    async fn before_save<C>(mut self, _db: &C, _insert: bool) -> Result<Self, DbErr>
+    where
+        C: ConnectionTrait,
+    {
         self.updated_at = Set(Utc::now().into());
         Ok(self)
     }

--- a/server/svix-server/src/db/models/eventtype.rs
+++ b/server/svix-server/src/db/models/eventtype.rs
@@ -40,6 +40,7 @@ impl RelationTrait for Relation {
     }
 }
 
+#[axum::async_trait]
 impl ActiveModelBehavior for ActiveModel {
     fn new() -> Self {
         let timestamp = Utc::now();
@@ -52,7 +53,10 @@ impl ActiveModelBehavior for ActiveModel {
         }
     }
 
-    fn before_save(mut self, _insert: bool) -> Result<Self, DbErr> {
+    async fn before_save<C>(mut self, _db: &C, _insert: bool) -> Result<Self, DbErr>
+    where
+        C: ConnectionTrait,
+    {
         self.updated_at = Set(Utc::now().into());
         Ok(self)
     }

--- a/server/svix-server/src/db/models/messagedestination.rs
+++ b/server/svix-server/src/db/models/messagedestination.rs
@@ -60,6 +60,7 @@ impl Related<super::messageattempt::Entity> for Entity {
     }
 }
 
+#[axum::async_trait]
 impl ActiveModelBehavior for ActiveModel {
     fn new() -> Self {
         let timestamp = Utc::now();
@@ -71,7 +72,10 @@ impl ActiveModelBehavior for ActiveModel {
         }
     }
 
-    fn before_save(mut self, _insert: bool) -> Result<Self, DbErr> {
+    async fn before_save<C>(mut self, _db: &C, _insert: bool) -> Result<Self, DbErr>
+    where
+        C: ConnectionTrait,
+    {
         self.updated_at = Set(Utc::now().into());
         Ok(self)
     }


### PR DESCRIPTION
This updates sea_orm to the latest stable version

## Motivation

The newest version of sea_orm isn't _that_ different from what we're currently running, but it does have more features that can be useful.

## Solution

- Updates the dependency
- Fixes compile time errors, of which there were two
   - 1. The `trait TryGetable:` has a new required method that needs implementing. Doing this was pretty straightforward, as everything that implements `TryGetable` is just a wrapper type
   - 2. `ActiveModelBehavior::before_save` is now an async_trait that accepts that DatabaseConnection as a parameter. The code change here isn't really meaningfully different from what we had before.