### PR TITLE
Extend Rust enum generation template to handle integer-based enums

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -24,6 +24,7 @@ http = "0.2"
 serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"
+serde_repr = "^0.1"
 url = "^2.2"
 reqwest = { version = "^0.11", features = ["json", "multipart"], default-features = false }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -6,6 +6,8 @@
 
 #[macro_use]
 extern crate serde_derive;
+#[macro_use]
+extern crate serde_repr;
 
 extern crate reqwest;
 extern crate serde;

--- a/rust/templates/model.mustache
+++ b/rust/templates/model.mustache
@@ -8,6 +8,7 @@
 {{!-- for enum schemas --}}
 {{#isEnum}}
 /// {{{description}}}
+{{#isString}}
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum {{{classname}}} {
 {{#allowableValues}}
@@ -16,6 +17,17 @@ pub enum {{{classname}}} {
     {{{name}}},
 {{/enumVars}}{{/allowableValues}}
 }
+{{/isString}}
+{{#isInteger}}
+#[repr(i16)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize_repr, Deserialize_repr)]
+pub enum {{{classname}}} {
+{{#allowableValues}}
+{{#enumVars}}
+    {{{name}}} = {{{value}}},
+{{/enumVars}}{{/allowableValues}}
+}
+{{/isInteger}}
 
 impl ToString for {{{classname}}} {
     fn to_string(&self) -> String {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

We have a couple of integer-based enums in our API responses. The existing template for enum generation in the Rust client library only supports string-based enums.

Fixes #1009 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

We can switch on the type of enum as defined in the OpenAPI specification. Then it's just a matter of pulling in serde_repr to do the heavy lifting.
