### PR TITLE
Explicitly allow "CC0-1.0" license in deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -27,6 +27,7 @@ allow = [
     "Apache-2.0",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "CC0-1.0",
     "ISC",
     "MIT",
     "MPL-2.0",


### PR DESCRIPTION
This is an explicit public domain license:
https://creativecommons.org/publicdomain/zero/1.0/

This is needed by a transitive dependency I'm adding.