### PR TITLE
Add constructor for `openapi.NullableInt32`

### DIFF
--- a/go/svix.go
+++ b/go/svix.go
@@ -40,6 +40,9 @@ func String(s string) *string {
 func NullableString(s string) *openapi.NullableString {
 	return openapi.NewNullableString(&s)
 }
+func NullableInt32(num *int32) *openapi.NullableInt32 {
+	return openapi.NewNullableInt32(num)
+}
 func Int32(i int32) *int32 {
 	return &i
 }


### PR DESCRIPTION
what:
- add a simple constructor for NullableInt32 type

why:
- Having this constructor will allow setting `RateLimit` value in `svix.Endpoint...` and `svix.Application...` types.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

solves #1017 