### PR TITLE
Python: add a comment about potentially dangerous update.

### DIFF
--- a/python/requirements.in/development.txt
+++ b/python/requirements.in/development.txt
@@ -8,4 +8,4 @@ mypy>=1.4.0
 pip-tools>=6.13.0
 pytest
 httpx>=0.23.0
-openapi-python-client>=0.14.1
+openapi-python-client>=0.14.1,<0.15 # I think version 0.15 is now dangerous for us? https://github.com/openapi-generators/openapi-python-client/pull/775#issuecomment-1646977834


### PR DESCRIPTION
I'm not entirely sure, but it looks like we can't upgrade to 0.15.0?
