### PR TITLE
Server: Add `with_content` to attempt listing endpoints

### DIFF
--- a/server/openapi.json
+++ b/server/openapi.json
@@ -2712,6 +2712,15 @@
                     },
                     {
                         "in": "query",
+                        "name": "with_content",
+                        "schema": {
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
                         "name": "event_types",
                         "schema": {
                             "items": {
@@ -2916,6 +2925,15 @@
                             "format": "date-time",
                             "nullable": true,
                             "type": "string"
+                        },
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "with_content",
+                        "schema": {
+                            "default": true,
+                            "type": "boolean"
                         },
                         "style": "form"
                     },
@@ -4132,6 +4150,15 @@
                             "format": "date-time",
                             "nullable": true,
                             "type": "string"
+                        },
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "with_content",
+                        "schema": {
+                            "default": true,
+                            "type": "boolean"
                         },
                         "style": "form"
                     },

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -124,9 +124,14 @@ impl EndpointMessageOut {
     pub fn from_dest_and_msg(
         dest: messagedestination::Model,
         msg: message::Model,
+        with_content: bool,
     ) -> EndpointMessageOut {
         EndpointMessageOut {
-            msg: msg.into(),
+            msg: if with_content {
+                msg.into()
+            } else {
+                MessageOut::without_payload(msg)
+            },
             status: dest.status,
             next_attempt: dest.next_attempt,
         }
@@ -245,15 +250,11 @@ async fn list_attempted_messages(
     let into = |(dest, msg): (messagedestination::Model, Option<message::Model>)| {
         let msg =
             msg.ok_or_else(|| err_database!("No associated message with messagedestination"))?;
-        Ok(EndpointMessageOut {
-            msg: if with_content {
-                msg.into()
-            } else {
-                MessageOut::without_payload(msg)
-            },
-            status: dest.status,
-            next_attempt: dest.next_attempt,
-        })
+        Ok(EndpointMessageOut::from_dest_and_msg(
+            dest,
+            msg,
+            with_content,
+        ))
     };
 
     let out = ctx!(dests_and_msgs.all(db).await)?

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -183,7 +183,7 @@ pub struct MessageOut {
 }
 
 impl MessageOut {
-    fn without_payload(model: message::Model) -> Self {
+    pub fn without_payload(model: message::Model) -> Self {
         Self {
             payload: RawPayload::from_string("{}".to_string()).expect("Can never fail"),
             ..model.into()


### PR DESCRIPTION
Add support for the `with_content` parameter to three endpoints, defaulting them to `true` for backwards compatibility.

For `GET /api/v1/app/{app_id}/endpoint/{endpoint_id}/msg/`, the "list attempted messages by endpoint" route:
`with_content` set to false replaces the message payload with an empty object `{}`, in the same way that `with_content` functions on other message-related endpoints.

For `GET /api/v1/app/{app_id}/attempt/endpoint/{endpoint_id}/`, the "list attempts by endpoint" route:
`with_content` set to false replaces the response payload of the attempt with the string `{}`.

For `GET /api/v1/app/{app_id}/attempt/msg/{msg_id}/`, the "list attempts by message id" route:
`with_content` set to false replaces the response payload of the attempt with the string `{}`.