### PR TITLE
Bridge: debulk consumer code

### DIFF
--- a/bridge/svix-bridge-plugin-queue/src/error.rs
+++ b/bridge/svix-bridge-plugin-queue/src/error.rs
@@ -8,6 +8,7 @@ pub enum Error {
     Svix(svix::error::Error),
     Generic(String),
 }
+pub type Result<T> = std::result::Result<T, Error>;
 
 impl From<svix::error::Error> for Error {
     fn from(value: svix::error::Error) -> Self {

--- a/bridge/svix-bridge-plugin-queue/src/gcp_pubsub/mod.rs
+++ b/bridge/svix-bridge-plugin-queue/src/gcp_pubsub/mod.rs
@@ -1,15 +1,11 @@
-use crate::error::Error;
-use crate::{run_inner, Consumer};
+use crate::error::{Error, Result};
+use omniqueue::queue::producer::DynProducer;
 use omniqueue::{
     backends,
     queue::{consumer::DynConsumer, QueueBackend},
 };
 use serde::Deserialize;
 use std::path::PathBuf;
-use svix_bridge_types::{
-    async_trait, svix::api::Svix, SenderInput, SenderOutputOpts, TransformationConfig,
-    TransformerTx,
-};
 
 #[derive(Debug, Default, Deserialize)]
 pub struct GCPPubSubInputOpts {
@@ -17,89 +13,34 @@ pub struct GCPPubSubInputOpts {
     pub credentials_file: Option<PathBuf>,
 }
 
-pub struct GCPPubSubConsumerPlugin {
-    name: String,
-    input_options: GCPPubSubInputOpts,
-    svix_client: Svix,
-    transformer_tx: Option<TransformerTx>,
-    transformation: Option<TransformationConfig>,
-}
-
-impl GCPPubSubConsumerPlugin {
-    pub fn new(
-        name: String,
-        input: GCPPubSubInputOpts,
-        transformation: Option<TransformationConfig>,
-        output: SenderOutputOpts,
-    ) -> Self {
-        Self {
-            name,
-            input_options: input,
-            svix_client: match output {
-                SenderOutputOpts::Svix(output) => {
-                    Svix::new(output.token, output.options.map(Into::into))
-                }
-            },
-            transformer_tx: None,
-            transformation,
-        }
-    }
-}
-
-#[async_trait]
-impl Consumer for GCPPubSubConsumerPlugin {
-    fn source(&self) -> &str {
-        &self.input_options.subscription_id
-    }
-
-    fn system(&self) -> &str {
-        "gcp-pubsub"
-    }
-
-    fn transformer_tx(&self) -> &Option<TransformerTx> {
-        &self.transformer_tx
-    }
-
-    fn transformation(&self) -> &Option<TransformationConfig> {
-        &self.transformation
-    }
-
-    fn svix_client(&self) -> &Svix {
-        &self.svix_client
-    }
-
-    async fn consumer(&self) -> std::io::Result<DynConsumer> {
-        let consumer = backends::gcp_pubsub::GcpPubSubBackend::builder(
-            backends::gcp_pubsub::GcpPubSubConfig {
-                subscription_id: self.input_options.subscription_id.clone(),
-                credentials_file: self.input_options.credentials_file.clone(),
-                // Topics are for producers so we don't care
-                topic_id: String::new(),
-            },
-        )
-        .make_dynamic()
-        .build_consumer()
-        .await
-        .map_err(Error::from)?;
-        Ok(consumer)
-    }
-}
-
-#[async_trait]
-impl SenderInput for GCPPubSubConsumerPlugin {
-    fn name(&self) -> &str {
-        &self.name
-    }
-    fn set_transformer(&mut self, tx: Option<TransformerTx>) {
-        self.transformer_tx = tx;
-    }
-    async fn run(&self) -> std::io::Result<()> {
-        run_inner(self).await
-    }
-}
-
 #[derive(Clone, Debug, Deserialize)]
 pub struct GCPPubSubOutputOpts {
     pub topic: String,
     pub credentials_file: Option<PathBuf>,
+}
+
+pub async fn consumer(cfg: &GCPPubSubInputOpts) -> Result<DynConsumer> {
+    backends::gcp_pubsub::GcpPubSubBackend::builder(backends::gcp_pubsub::GcpPubSubConfig {
+        subscription_id: cfg.subscription_id.clone(),
+        credentials_file: cfg.credentials_file.clone(),
+        // Don't need this. Topics are for producers only.
+        topic_id: String::new(),
+    })
+    .make_dynamic()
+    .build_consumer()
+    .await
+    .map_err(Error::from)
+}
+
+pub async fn producer(cfg: &GCPPubSubOutputOpts) -> Result<DynProducer> {
+    backends::gcp_pubsub::GcpPubSubBackend::builder(backends::gcp_pubsub::GcpPubSubConfig {
+        topic_id: cfg.topic.clone(),
+        credentials_file: cfg.credentials_file.clone(),
+        // Don't need this. Subscriptions are for consumers only.
+        subscription_id: String::new(),
+    })
+    .make_dynamic()
+    .build_producer()
+    .await
+    .map_err(Error::from)
 }

--- a/bridge/svix-bridge-plugin-queue/src/rabbitmq/mod.rs
+++ b/bridge/svix-bridge-plugin-queue/src/rabbitmq/mod.rs
@@ -1,15 +1,10 @@
-use crate::error::Error;
-use crate::run_inner;
-use crate::Consumer;
+use crate::error::{Error, Result};
+use omniqueue::queue::producer::DynProducer;
 use omniqueue::{
     backends,
     queue::{consumer::DynConsumer, QueueBackend},
 };
 use serde::Deserialize;
-use svix_bridge_types::{
-    async_trait, svix::api::Svix, SenderInput, SenderOutputOpts, TransformationConfig,
-    TransformerTx,
-};
 
 #[derive(Debug, Deserialize)]
 pub struct RabbitMqInputOpts {
@@ -33,93 +28,6 @@ fn default_requeue() -> bool {
     true
 }
 
-pub struct RabbitMqConsumerPlugin {
-    name: String,
-    input_options: RabbitMqInputOpts,
-    svix_client: Svix,
-    transformer_tx: Option<TransformerTx>,
-    transformation: Option<TransformationConfig>,
-}
-
-impl RabbitMqConsumerPlugin {
-    pub fn new(
-        name: String,
-        input: RabbitMqInputOpts,
-        transformation: Option<TransformationConfig>,
-        output: SenderOutputOpts,
-    ) -> Self {
-        Self {
-            name,
-            input_options: input,
-            svix_client: match output {
-                SenderOutputOpts::Svix(output) => {
-                    Svix::new(output.token, output.options.map(Into::into))
-                }
-            },
-            transformer_tx: None,
-            transformation,
-        }
-    }
-}
-
-#[async_trait]
-impl Consumer for RabbitMqConsumerPlugin {
-    fn source(&self) -> &str {
-        &self.input_options.queue_name
-    }
-
-    fn system(&self) -> &str {
-        "rabbitmq"
-    }
-
-    fn transformer_tx(&self) -> &Option<TransformerTx> {
-        &self.transformer_tx
-    }
-
-    fn transformation(&self) -> &Option<TransformationConfig> {
-        &self.transformation
-    }
-
-    fn svix_client(&self) -> &Svix {
-        &self.svix_client
-    }
-
-    async fn consumer(&self) -> std::io::Result<DynConsumer> {
-        let consumer =
-            backends::rabbitmq::RabbitMqBackend::builder(backends::rabbitmq::RabbitMqConfig {
-                uri: self.input_options.uri.clone(),
-                connection_properties: backends::rabbitmq::ConnectionProperties::default(),
-                publish_exchange: String::new(),
-                publish_routing_key: String::new(),
-                publish_options: backends::rabbitmq::BasicPublishOptions::default(),
-                publish_properites: backends::rabbitmq::BasicProperties::default(),
-                consume_queue: self.input_options.queue_name.clone(),
-                consumer_tag: self.input_options.consumer_tag.clone().unwrap_or_default(),
-                consume_options: self.input_options.consume_opts.unwrap_or_default(),
-                consume_arguments: self.input_options.consume_args.clone().unwrap_or_default(),
-                requeue_on_nack: self.input_options.requeue_on_nack,
-            })
-            .make_dynamic()
-            .build_consumer()
-            .await
-            .map_err(Error::from)?;
-        Ok(consumer)
-    }
-}
-
-#[async_trait]
-impl SenderInput for RabbitMqConsumerPlugin {
-    fn name(&self) -> &str {
-        &self.name
-    }
-    fn set_transformer(&mut self, tx: Option<TransformerTx>) {
-        self.transformer_tx = tx;
-    }
-    async fn run(&self) -> std::io::Result<()> {
-        run_inner(self).await
-    }
-}
-
 #[derive(Clone, Debug, Deserialize)]
 pub struct RabbitMqOutputOpts {
     /// Connection string for RabbitMQ.
@@ -132,4 +40,47 @@ pub struct RabbitMqOutputOpts {
     pub publish_options: backends::rabbitmq::BasicPublishOptions,
     #[serde(default)]
     pub publish_properties: backends::rabbitmq::BasicProperties,
+}
+
+pub async fn consumer(cfg: &RabbitMqInputOpts) -> Result<DynConsumer> {
+    backends::rabbitmq::RabbitMqBackend::builder(backends::rabbitmq::RabbitMqConfig {
+        uri: cfg.uri.clone(),
+        connection_properties: backends::rabbitmq::ConnectionProperties::default(),
+        publish_exchange: String::new(),
+        publish_routing_key: String::new(),
+        publish_options: backends::rabbitmq::BasicPublishOptions::default(),
+        publish_properites: backends::rabbitmq::BasicProperties::default(),
+        consume_queue: cfg.queue_name.clone(),
+        consumer_tag: cfg.consumer_tag.clone().unwrap_or_default(),
+        consume_options: cfg.consume_opts.unwrap_or_default(),
+        consume_arguments: cfg.consume_args.clone().unwrap_or_default(),
+        requeue_on_nack: cfg.requeue_on_nack,
+    })
+    .make_dynamic()
+    .build_consumer()
+    .await
+    .map_err(Error::from)
+}
+pub async fn producer(cfg: &RabbitMqOutputOpts) -> Result<DynProducer> {
+    backends::rabbitmq::RabbitMqBackend::builder(backends::rabbitmq::RabbitMqConfig {
+        uri: cfg.uri.clone(),
+        // N.b the connection properties type is not serde-friendly. If we want to expose some
+        // of these settings we'll probably need to provide our own type and build the real one
+        // here from cfg.
+        connection_properties: Default::default(),
+        publish_exchange: cfg.exchange.clone(),
+        publish_routing_key: cfg.routing_key.clone(),
+        publish_options: cfg.publish_options,
+        publish_properites: cfg.publish_properties.clone(),
+        // consumer stuff we don't care about
+        consume_queue: "".to_string(),
+        consumer_tag: "".to_string(),
+        consume_options: Default::default(),
+        consume_arguments: Default::default(),
+        requeue_on_nack: false,
+    })
+    .make_dynamic()
+    .build_producer()
+    .await
+    .map_err(Error::from)
 }

--- a/bridge/svix-bridge-plugin-queue/src/redis/mod.rs
+++ b/bridge/svix-bridge-plugin-queue/src/redis/mod.rs
@@ -1,16 +1,11 @@
-use crate::error::Error;
-use crate::run_inner;
-use crate::Consumer;
+use crate::error::{Error, Result};
+use omniqueue::queue::producer::DynProducer;
 use omniqueue::{
     backends,
     queue::{consumer::DynConsumer, QueueBackend},
 };
 
 use serde::Deserialize;
-use svix_bridge_types::{
-    async_trait, svix::api::Svix, SenderInput, SenderOutputOpts, TransformationConfig,
-    TransformerTx,
-};
 
 #[derive(Debug, Default, Deserialize)]
 pub struct RedisInputOpts {
@@ -27,94 +22,46 @@ fn default_reinsert_on_nack() -> bool {
     true
 }
 
-pub struct RedisConsumerPlugin {
-    name: String,
-    input_options: RedisInputOpts,
-    svix_client: Svix,
-    transformer_tx: Option<TransformerTx>,
-    transformation: Option<TransformationConfig>,
-}
-
-impl RedisConsumerPlugin {
-    pub fn new(
-        name: String,
-        input: RedisInputOpts,
-        transformation: Option<TransformationConfig>,
-        output: SenderOutputOpts,
-    ) -> Self {
-        Self {
-            name,
-            input_options: input,
-            svix_client: match output {
-                SenderOutputOpts::Svix(output) => {
-                    Svix::new(output.token, output.options.map(Into::into))
-                }
-            },
-            transformer_tx: None,
-            transformation,
-        }
-    }
-}
-
-#[async_trait]
-impl Consumer for RedisConsumerPlugin {
-    fn source(&self) -> &str {
-        &self.input_options.queue_key
-    }
-
-    fn system(&self) -> &str {
-        "redis"
-    }
-
-    fn transformer_tx(&self) -> &Option<TransformerTx> {
-        &self.transformer_tx
-    }
-
-    fn transformation(&self) -> &Option<TransformationConfig> {
-        &self.transformation
-    }
-
-    fn svix_client(&self) -> &Svix {
-        &self.svix_client
-    }
-
-    async fn consumer(&self) -> std::io::Result<DynConsumer> {
-        let consumer = backends::redis::RedisQueueBackend::<
-            backends::redis::RedisMultiplexedConnectionManager,
-        >::builder(backends::redis::RedisConfig {
-            dsn: self.input_options.dsn.clone(),
-            max_connections: self.input_options.max_connections,
-            reinsert_on_nack: self.input_options.reinsert_on_nack,
-            queue_key: self.input_options.queue_key.clone(),
-            consumer_group: self.input_options.consumer_group.clone(),
-            consumer_name: self.input_options.consumer_name.clone(),
-            // FIXME: expose in config?
-            payload_key: "payload".to_string(),
-        })
-        .make_dynamic()
-        .build_consumer()
-        .await
-        .map_err(Error::from)?;
-        Ok(consumer)
-    }
-}
-
-#[async_trait]
-impl SenderInput for RedisConsumerPlugin {
-    fn name(&self) -> &str {
-        &self.name
-    }
-    fn set_transformer(&mut self, tx: Option<TransformerTx>) {
-        self.transformer_tx = tx;
-    }
-    async fn run(&self) -> std::io::Result<()> {
-        run_inner(self).await
-    }
-}
-
 #[derive(Clone, Debug, Deserialize)]
 pub struct RedisOutputOpts {
     pub dsn: String,
     pub max_connections: u16,
     pub queue_key: String,
+}
+
+pub async fn consumer(cfg: &RedisInputOpts) -> Result<DynConsumer> {
+    backends::redis::RedisQueueBackend::<
+        backends::redis::RedisMultiplexedConnectionManager,
+    >::builder(backends::redis::RedisConfig {
+        dsn: cfg.dsn.clone(),
+        max_connections: cfg.max_connections,
+        reinsert_on_nack: cfg.reinsert_on_nack,
+        queue_key: cfg.queue_key.clone(),
+        consumer_group: cfg.consumer_group.clone(),
+        consumer_name: cfg.consumer_name.clone(),
+        // FIXME: expose in config?
+        payload_key: "payload".to_string(),
+    })
+        .make_dynamic()
+        .build_consumer()
+        .await
+        .map_err(Error::from)
+}
+pub async fn producer(cfg: &RedisOutputOpts) -> Result<DynProducer> {
+    backends::redis::RedisQueueBackend::<
+        backends::redis::RedisMultiplexedConnectionManager,
+    >::builder(backends::redis::RedisConfig {
+        dsn: cfg.dsn.clone(),
+        max_connections: cfg.max_connections,
+        queue_key: cfg.queue_key.clone(),
+        // FIXME: expose in config?
+        payload_key: "payload".to_string(),
+        // consumer stuff we don't care about.
+        reinsert_on_nack: false,
+        consumer_group: String::new(),
+        consumer_name: String::new(),
+    })
+        .make_dynamic()
+        .build_producer()
+        .await.map_err(Error::from)
 }

--- a/bridge/svix-bridge-plugin-queue/src/sender_input/mod.rs
+++ b/bridge/svix-bridge-plugin-queue/src/sender_input/mod.rs
@@ -1,0 +1,111 @@
+use crate::config::SenderInputOpts;
+use crate::{error::Error, gcp_pubsub, rabbitmq, run_inner, sqs, Consumer};
+use omniqueue::queue::consumer::DynConsumer;
+
+use svix_bridge_types::svix::api::Svix;
+use svix_bridge_types::{
+    async_trait, SenderInput, SenderOutputOpts, TransformationConfig, TransformerTx,
+};
+
+pub struct QueueSender {
+    name: String,
+    source: String,
+    system: String,
+    input_opts: SenderInputOpts,
+    transformation: Option<TransformationConfig>,
+    transformer_tx: Option<TransformerTx>,
+    svix_client: Svix,
+}
+
+impl std::fmt::Debug for QueueSender {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SenderInput").finish()
+    }
+}
+
+fn system_name(opts: &SenderInputOpts) -> &'static str {
+    match opts {
+        SenderInputOpts::GCPPubSub(_) => "gcp-pubsub",
+        SenderInputOpts::RabbitMQ(_) => "rabbitmq",
+        SenderInputOpts::Redis(_) => "redis",
+        SenderInputOpts::SQS(_) => "sqs",
+    }
+}
+
+fn source_name(opts: &SenderInputOpts) -> &str {
+    match opts {
+        SenderInputOpts::GCPPubSub(opts) => &opts.subscription_id,
+        SenderInputOpts::RabbitMQ(opts) => &opts.queue_name,
+        SenderInputOpts::Redis(opts) => &opts.queue_key,
+        SenderInputOpts::SQS(opts) => &opts.queue_dsn,
+    }
+}
+
+impl QueueSender {
+    pub fn new(
+        name: String,
+        input: SenderInputOpts,
+        transformation: Option<TransformationConfig>,
+        output: SenderOutputOpts,
+    ) -> Self {
+        Self {
+            name,
+            source: source_name(&input).into(),
+            system: system_name(&input).into(),
+            input_opts: input,
+            transformation,
+            transformer_tx: None,
+            svix_client: match output {
+                SenderOutputOpts::Svix(output) => {
+                    Svix::new(output.token, output.options.map(Into::into))
+                }
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl Consumer for QueueSender {
+    fn source(&self) -> &str {
+        &self.source
+    }
+
+    fn system(&self) -> &str {
+        &self.system
+    }
+
+    fn transformer_tx(&self) -> Option<&TransformerTx> {
+        self.transformer_tx.as_ref()
+    }
+
+    fn transformation(&self) -> Option<&TransformationConfig> {
+        self.transformation.as_ref()
+    }
+
+    fn svix_client(&self) -> &Svix {
+        &self.svix_client
+    }
+
+    async fn consumer(&self) -> std::io::Result<DynConsumer> {
+        Ok(match &self.input_opts {
+            SenderInputOpts::GCPPubSub(cfg) => gcp_pubsub::consumer(cfg).await,
+            SenderInputOpts::RabbitMQ(cfg) => rabbitmq::consumer(cfg).await,
+            SenderInputOpts::Redis(cfg) => crate::redis::consumer(cfg).await,
+            SenderInputOpts::SQS(cfg) => sqs::consumer(cfg).await,
+        }
+        .map_err(Error::from)?)
+    }
+}
+
+#[async_trait]
+impl SenderInput for QueueSender {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn set_transformer(&mut self, tx: Option<TransformerTx>) {
+        self.transformer_tx = tx;
+    }
+    async fn run(&self) -> std::io::Result<()> {
+        run_inner(self).await
+    }
+}

--- a/bridge/svix-bridge-plugin-queue/src/sqs/mod.rs
+++ b/bridge/svix-bridge-plugin-queue/src/sqs/mod.rs
@@ -1,14 +1,10 @@
-use crate::error::Error;
-use crate::{run_inner, Consumer};
+use crate::error::{Error, Result};
+use omniqueue::queue::producer::DynProducer;
 use omniqueue::{
     backends,
     queue::{consumer::DynConsumer, QueueBackend},
 };
 use serde::Deserialize;
-use svix_bridge_types::{
-    async_trait, svix::api::Svix, SenderInput, SenderOutputOpts, TransformationConfig,
-    TransformerTx,
-};
 
 #[derive(Debug, Default, Deserialize)]
 pub struct SqsInputOpts {
@@ -17,86 +13,31 @@ pub struct SqsInputOpts {
     pub override_endpoint: bool,
 }
 
-pub struct SqsConsumerPlugin {
-    name: String,
-    input_options: SqsInputOpts,
-    svix_client: Svix,
-    transformer_tx: Option<TransformerTx>,
-    transformation: Option<TransformationConfig>,
-}
-
-impl SqsConsumerPlugin {
-    pub fn new(
-        name: String,
-        input: SqsInputOpts,
-        transformation: Option<TransformationConfig>,
-        output: SenderOutputOpts,
-    ) -> Self {
-        Self {
-            name,
-            input_options: input,
-            svix_client: match output {
-                SenderOutputOpts::Svix(output) => {
-                    Svix::new(output.token, output.options.map(Into::into))
-                }
-            },
-            transformer_tx: None,
-            transformation,
-        }
-    }
-}
-
-#[async_trait]
-impl Consumer for SqsConsumerPlugin {
-    fn source(&self) -> &str {
-        &self.input_options.queue_dsn
-    }
-
-    fn system(&self) -> &str {
-        "sqs"
-    }
-
-    fn transformer_tx(&self) -> &Option<TransformerTx> {
-        &self.transformer_tx
-    }
-
-    fn transformation(&self) -> &Option<TransformationConfig> {
-        &self.transformation
-    }
-
-    fn svix_client(&self) -> &Svix {
-        &self.svix_client
-    }
-
-    async fn consumer(&self) -> std::io::Result<DynConsumer> {
-        let consumer = backends::sqs::SqsQueueBackend::builder(backends::sqs::SqsConfig {
-            queue_dsn: self.input_options.queue_dsn.clone(),
-            override_endpoint: self.input_options.override_endpoint,
-        })
-        .make_dynamic()
-        .build_consumer()
-        .await
-        .map_err(Error::from)?;
-        Ok(consumer)
-    }
-}
-
-#[async_trait]
-impl SenderInput for SqsConsumerPlugin {
-    fn name(&self) -> &str {
-        &self.name
-    }
-    fn set_transformer(&mut self, tx: Option<TransformerTx>) {
-        self.transformer_tx = tx;
-    }
-    async fn run(&self) -> std::io::Result<()> {
-        run_inner(self).await
-    }
-}
-
 #[derive(Clone, Debug, Deserialize)]
 pub struct SqsOutputOpts {
     pub queue_dsn: String,
     #[serde(default)]
     pub override_endpoint: bool,
+}
+
+pub async fn consumer(cfg: &SqsInputOpts) -> Result<DynConsumer> {
+    backends::sqs::SqsQueueBackend::builder(backends::sqs::SqsConfig {
+        queue_dsn: cfg.queue_dsn.clone(),
+        override_endpoint: cfg.override_endpoint,
+    })
+    .make_dynamic()
+    .build_consumer()
+    .await
+    .map_err(Error::from)
+}
+
+pub async fn producer(cfg: &SqsOutputOpts) -> Result<DynProducer> {
+    backends::sqs::SqsQueueBackend::builder(backends::sqs::SqsConfig {
+        queue_dsn: cfg.queue_dsn.clone(),
+        override_endpoint: cfg.override_endpoint,
+    })
+    .make_dynamic()
+    .build_producer()
+    .await
+    .map_err(Error::from)
 }

--- a/bridge/svix-bridge-plugin-queue/tests/gcp_pubsub_consumer.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/gcp_pubsub_consumer.rs
@@ -10,7 +10,9 @@ use google_cloud_pubsub::topic::Topic;
 use std::time::Duration;
 
 use serde_json::json;
-use svix_bridge_plugin_queue::{config::GCPPubSubInputOpts, GCPPubSubConsumerPlugin};
+use svix_bridge_plugin_queue::config::GCPPubSubInputOpts;
+use svix_bridge_plugin_queue::config::SenderInputOpts;
+use svix_bridge_plugin_queue::sender_input::QueueSender;
 use svix_bridge_types::{
     svix::api::MessageIn, CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions,
     SvixSenderOutputOpts, TransformationConfig, TransformerInput, TransformerInputFormat,
@@ -25,13 +27,13 @@ fn get_test_plugin(
     svix_url: String,
     subscription_id: String,
     use_transformation: Option<TransformerInputFormat>,
-) -> GCPPubSubConsumerPlugin {
-    GCPPubSubConsumerPlugin::new(
+) -> QueueSender {
+    QueueSender::new(
         "test".into(),
-        GCPPubSubInputOpts {
+        SenderInputOpts::GCPPubSub(GCPPubSubInputOpts {
             subscription_id,
             credentials_file: None,
-        },
+        }),
         use_transformation.map(|format| TransformationConfig::Explicit {
             format,
             src: String::from("function handle(x) { return x; }"),

--- a/bridge/svix-bridge-plugin-queue/tests/rabbitmq_consumer.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/rabbitmq_consumer.rs
@@ -8,7 +8,9 @@ use lapin::{
 };
 use serde_json::json;
 use std::time::Duration;
-use svix_bridge_plugin_queue::{config::RabbitMqInputOpts, RabbitMqConsumerPlugin};
+use svix_bridge_plugin_queue::config::RabbitMqInputOpts;
+use svix_bridge_plugin_queue::config::SenderInputOpts;
+use svix_bridge_plugin_queue::sender_input::QueueSender;
 use svix_bridge_types::{
     svix::api::MessageIn, CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions,
     SvixSenderOutputOpts, TransformationConfig, TransformerInput, TransformerInputFormat,
@@ -22,17 +24,17 @@ fn get_test_plugin(
     mq_uri: &str,
     queue_name: &str,
     use_transformation: Option<TransformerInputFormat>,
-) -> RabbitMqConsumerPlugin {
-    RabbitMqConsumerPlugin::new(
+) -> QueueSender {
+    QueueSender::new(
         "test".into(),
-        RabbitMqInputOpts {
+        SenderInputOpts::RabbitMQ(RabbitMqInputOpts {
             uri: mq_uri.to_string(),
             queue_name: queue_name.to_string(),
             consumer_tag: None,
             consume_opts: None,
             consume_args: None,
             requeue_on_nack: false,
-        },
+        }),
         use_transformation.map(|format| TransformationConfig::Explicit {
             format,
             src: String::from("function handle(x) { return x; }"),

--- a/bridge/svix-bridge-plugin-queue/tests/redis_stream_consumer.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/redis_stream_consumer.rs
@@ -5,7 +5,9 @@ use std::time::Duration;
 
 use redis::{AsyncCommands, Client};
 use serde_json::json;
-use svix_bridge_plugin_queue::{config::RedisInputOpts, RedisConsumerPlugin};
+use svix_bridge_plugin_queue::config::RedisInputOpts;
+use svix_bridge_plugin_queue::config::SenderInputOpts;
+use svix_bridge_plugin_queue::sender_input::QueueSender;
 use svix_bridge_types::{
     svix::api::MessageIn, CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions,
     SvixSenderOutputOpts, TransformationConfig, TransformerInput, TransformerInputFormat,
@@ -18,17 +20,17 @@ fn get_test_plugin(
     svix_url: String,
     queue_key: String,
     use_transformation: Option<TransformerInputFormat>,
-) -> RedisConsumerPlugin {
-    RedisConsumerPlugin::new(
+) -> QueueSender {
+    QueueSender::new(
         "test".into(),
-        RedisInputOpts {
+        SenderInputOpts::Redis(RedisInputOpts {
             dsn: "redis://localhost/".to_owned(),
             max_connections: 8,
             reinsert_on_nack: false,
             queue_key,
             consumer_group: "test_cg".to_owned(),
             consumer_name: "test_cn".to_owned(),
-        },
+        }),
         use_transformation.map(|format| TransformationConfig::Explicit {
             format,
             src: String::from("function handle(x) { return x; }"),

--- a/bridge/svix-bridge-plugin-queue/tests/sqs_consumer.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/sqs_consumer.rs
@@ -7,7 +7,9 @@ use std::time::Duration;
 
 use aws_sdk_sqs::Client;
 use serde_json::json;
-use svix_bridge_plugin_queue::{config::SqsInputOpts, SqsConsumerPlugin};
+use svix_bridge_plugin_queue::config::SenderInputOpts;
+use svix_bridge_plugin_queue::config::SqsInputOpts;
+use svix_bridge_plugin_queue::sender_input::QueueSender;
 use svix_bridge_types::svix::api::MessageIn;
 use svix_bridge_types::{
     CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions, SvixSenderOutputOpts,
@@ -28,13 +30,13 @@ fn get_test_plugin(
     svix_url: String,
     queue_dsn: String,
     use_transformation: Option<TransformerInputFormat>,
-) -> SqsConsumerPlugin {
-    SqsConsumerPlugin::new(
+) -> QueueSender {
+    QueueSender::new(
         "test".into(),
-        SqsInputOpts {
+        SenderInputOpts::SQS(SqsInputOpts {
             queue_dsn,
             override_endpoint: true,
-        },
+        }),
         use_transformation.map(|format| TransformationConfig::Explicit {
             format,
             src: String::from("function handle(x) { return x; }"),

--- a/bridge/svix-bridge/src/config/mod.rs
+++ b/bridge/svix-bridge/src/config/mod.rs
@@ -197,7 +197,7 @@ impl ReceiverConfig {
     pub async fn into_receiver_output(self) -> std::io::Result<Box<dyn ReceiverOutput>> {
         match self.output {
             ReceiverOut::QueueProducer(x) => {
-                into_receiver_output(self.name.clone(), x, &self.transformation)
+                into_receiver_output(self.name.clone(), x, self.transformation.as_ref())
                     .await
                     .map_err(Into::into)
             }


### PR DESCRIPTION
Essentially, once we've got omniqueue in bridge, we can "debulk" a lot
of the consumer code by un-traiting it.

A single concrete type can hold an input config which can be used to
produce a `DynConsumer` which can then be used to run the consumer loop.

This diff takes us _most of the way there_, keeping the trait, but now
building a single type which implements it from a range of config
values.