### PR TITLE
Cleanup error macros

### DIFF
--- a/server/svix-server/src/core/idempotency.rs
+++ b/server/svix-server/src/core/idempotency.rs
@@ -287,7 +287,7 @@ async fn lock_loop(
             // Start value has expired
             Ok(None) => return Ok(None),
 
-            Err(e) => return Err(err_database!(e)),
+            Err(e) => return Err(err_database!("{e:?}")),
         }
     }
 }

--- a/server/svix-server/src/error.rs
+++ b/server/svix-server/src/error.rs
@@ -128,9 +128,6 @@ macro_rules! location {
 
 #[macro_export]
 macro_rules! err_generic {
-   ($s:expr) => {
-        $crate::error::Error::generic($s, $crate::location!())
-   };
    ($($arg:tt)*) => {
         $crate::error::Error::generic(format!($($arg)*), $crate::location!())
    }
@@ -138,30 +135,30 @@ macro_rules! err_generic {
 
 #[macro_export]
 macro_rules! err_database {
-    ($s:expr) => {
-        $crate::error::Error::database($s, $crate::location!())
-    };
+    ($($arg:tt)*) => {
+        $crate::error::Error::database(format!($($arg)*), $crate::location!())
+   }
 }
 
 #[macro_export]
 macro_rules! err_queue {
-    ($s:expr) => {
-        $crate::error::Error::queue($s, $crate::location!())
-    };
+    ($($arg:tt)*) => {
+        $crate::error::Error::queue(format!($($arg)*), $crate::location!())
+   }
 }
 
 #[macro_export]
 macro_rules! err_cache {
-    ($s:expr) => {
-        $crate::error::Error::cache($s, $crate::location!())
-    };
+    ($($arg:tt)*) => {
+        $crate::error::Error::cache(format!($($arg)*), $crate::location!())
+   }
 }
 
 #[macro_export]
 macro_rules! err_validation {
-    ($s:expr) => {
-        $crate::error::Error::validation($s, $crate::location!())
-    };
+    ($($arg:tt)*) => {
+        $crate::error::Error::validation(format!($($arg)*), $crate::location!())
+   }
 }
 
 pub trait Traceable<T> {
@@ -439,11 +436,12 @@ impl From<ErrorType> for Error {
     }
 }
 
+// FIXME - delete
 impl From<crate::core::webhook_http_client::Error> for Error {
     fn from(err: webhook_http_client::Error) -> Error {
         match err {
             webhook_http_client::Error::TimedOut => ErrorType::Timeout(err.to_string()).into(),
-            _ => err_generic!(err.to_string()),
+            _ => err_generic!("{err:?}"),
         }
     }
 }

--- a/server/svix-server/src/queue/rabbitmq.rs
+++ b/server/svix-server/src/queue/rabbitmq.rs
@@ -256,7 +256,7 @@ impl TaskQueueReceive for Consumer {
             .ok_or(err_generic!("task is missing message_id!"))?
             .to_string();
 
-        let task: QueueTask = serde_json::from_slice(&delivery.data).map_err(|_e| {
+        let task: QueueTask = serde_json::from_slice(&delivery.data).map_err(|e| {
             err_generic!("rabbitmq task deserialization unexpectedly failed?!: {e:?}")
         })?;
 


### PR DESCRIPTION
## Motivation

This cleans up some of our error macros to make them a bit more ergonomic (no need to manually call `format!`), and add more detail by using the `Debug` representation of errors at certain callsites.
