### PR TITLE
Server: Add Sentry support

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -4133,7 +4133,6 @@ dependencies = [
  "schemars",
  "sea-orm",
  "sentry",
- "sentry-tracing",
  "serde",
  "serde_json",
  "serde_path_to_error",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -910,6 +910,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1186,6 +1196,18 @@ dependencies = [
  "toml",
  "uncased",
  "version_check",
+]
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1666,6 +1688,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -2417,6 +2452,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_info"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e"
+dependencies = [
+ "log",
+ "serde",
+ "winapi",
+]
+
+[[package]]
 name = "ouroboros"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3017,11 +3063,13 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -3031,6 +3079,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tower-service",
  "trust-dns-resolver",
@@ -3125,6 +3174,15 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -3385,6 +3443,120 @@ checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+
+[[package]]
+name = "sentry"
+version = "0.31.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b0ad16faa5d12372f914ed40d00bda21a6d1bdcc99264c5e5e1c9495cf3654"
+dependencies = [
+ "httpdate",
+ "native-tls",
+ "reqwest",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-debug-images",
+ "sentry-panic",
+ "sentry-tracing",
+ "tokio",
+ "ureq",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.31.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f2ee8f147bb5f22ac59b5c35754a759b9a6f6722402e2a14750b2a63fc59bd"
+dependencies = [
+ "backtrace",
+ "once_cell",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.31.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcd133362c745151eeba0ac61e3ba8350f034e9fe7509877d08059fe1d7720c6"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.31.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7163491708804a74446642ff2c80b3acd668d4b9e9f497f85621f3d250fd012b"
+dependencies = [
+ "once_cell",
+ "rand",
+ "sentry-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "sentry-debug-images"
+version = "0.31.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a5003d7ff08aa3b2b76994080b183e8cfa06c083e280737c9cee02ca1c70f5e"
+dependencies = [
+ "findshlibs",
+ "once_cell",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.31.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4dfe8371c9b2e126a8b64f6fefa54cef716ff2a50e63b5558a48b899265bccd"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.31.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aca8b88978677a27ee1a91beafe4052306c474c06f582321fde72d2e2cc2f7f"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.31.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e7a88e0c1922d19b3efee12a8215f6a8a806e442e665ada71cc222cab72985f"
+dependencies = [
+ "debugid",
+ "getrandom",
+ "hex",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time 0.3.23",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -3960,6 +4132,8 @@ dependencies = [
  "reqwest",
  "schemars",
  "sea-orm",
+ "sentry",
+ "sentry-tracing",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -4094,6 +4268,7 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
+ "itoa",
  "serde",
  "time-core",
  "time-macros",
@@ -4547,6 +4722,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "uncased"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4612,6 +4796,19 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "ureq"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b11c96ac7ee530603dcdf68ed1557050f374ce55a5a07193ebf8cbc9f8927e9"
+dependencies = [
+ "base64 0.21.2",
+ "log",
+ "native-tls",
+ "once_cell",
+ "url",
+]
 
 [[package]]
 name = "url"

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -75,6 +75,8 @@ strum_macros = "0.24"
 strum = { version = "0.24", features = ["derive"] }
 form_urlencoded = "1.1.0"
 lapin = "2.1.1"
+sentry = { version = "0.31.5", features = ["tracing"] }
+sentry-tracing = "0.31.5"
 
 [dev-dependencies]
 anyhow = "1.0.56"

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -76,7 +76,6 @@ strum = { version = "0.24", features = ["derive"] }
 form_urlencoded = "1.1.0"
 lapin = "2.1.1"
 sentry = { version = "0.31.5", features = ["tracing"] }
-sentry-tracing = "0.31.5"
 
 [dev-dependencies]
 anyhow = "1.0.56"

--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -39,6 +39,13 @@ log_format = "default"
 # always sending. If the OpenTelemetry address is not set, this will do nothing.
 # opentelemetry_sample_ratio = 1.0
 
+# The Sentry DSN to use for error reporting. Disabled when omitted/null
+# sentry_dsn = "https://somedsn.ingest.sentry.io/12345"
+
+# The environment that the server is running in.
+# Supported: "dev", "staging", "prod"
+environment = "dev"
+
 # Whether to enable the logging of the databases at the configured log level. This may be useful for
 # analyzing their response times.
 db_tracing = false

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -342,10 +342,9 @@ pub enum DefaultSignatureType {
     Ed25519,
 }
 
-#[derive(Clone, Debug, Deserialize, Default)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Environment {
-    #[default]
     Dev,
     Staging,
     Prod,

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -111,6 +111,11 @@ pub struct ConfigurationInner {
     /// Whether to enable the logging of the databases at the configured log level. This may be
     /// useful for analyzing their response times.
     pub db_tracing: bool,
+    /// The Sentry DSN to use for error reporting. If this is `None`,
+    /// then sentry reporting is disabled
+    pub sentry_dsn: Option<sentry::types::Dsn>,
+    /// The environment (dev, staging, or prod) that the server is running in.
+    pub environment: Environment,
 
     /// The wanted retry schedule in seconds. Each value is the time to wait between retries.
     #[serde(deserialize_with = "deserialize_retry_schedule")]
@@ -335,6 +340,29 @@ pub enum CacheType {
 pub enum DefaultSignatureType {
     Hmac256,
     Ed25519,
+}
+
+#[derive(Clone, Debug, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Environment {
+    #[default]
+    Dev,
+    Staging,
+    Prod,
+}
+
+impl std::fmt::Display for Environment {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Environment::Dev => "dev",
+                Environment::Staging => "staging",
+                Environment::Prod => "prod",
+            }
+        )
+    }
 }
 
 impl ToString for LogLevel {

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -5,7 +5,7 @@
 #![forbid(unsafe_code)]
 
 use aide::axum::ApiRouter;
-use sentry_tracing::EventFilter;
+use sentry::integrations::tracing::EventFilter;
 
 use crate::core::cache::Cache;
 use cfg::ConfigurationInner;
@@ -277,7 +277,7 @@ pub fn setup_tracing(cfg: &ConfigurationInner) -> impl Drop {
         ..Default::default()
     });
 
-    let sentry_layer = sentry_tracing::layer().event_filter(|md| match *md.level() {
+    let sentry_layer = sentry::integrations::tracing::layer().event_filter(|md| match *md.level() {
         tracing::Level::ERROR | tracing::Level::WARN => EventFilter::Event,
         _ => EventFilter::Ignore,
     });

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -277,10 +277,11 @@ pub fn setup_tracing(cfg: &ConfigurationInner) -> impl Drop {
         ..Default::default()
     });
 
-    let sentry_layer = sentry::integrations::tracing::layer().event_filter(|md| match *md.level() {
-        tracing::Level::ERROR | tracing::Level::WARN => EventFilter::Event,
-        _ => EventFilter::Ignore,
-    });
+    let sentry_layer =
+        sentry::integrations::tracing::layer().event_filter(|md| match *md.level() {
+            tracing::Level::ERROR | tracing::Level::WARN => EventFilter::Event,
+            _ => EventFilter::Ignore,
+        });
 
     // Then initialize logging with an additional layer priting to stdout. This additional layer is
     // either formatted normally or in JSON format

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -5,6 +5,7 @@
 #![forbid(unsafe_code)]
 
 use aide::axum::ApiRouter;
+use sentry_tracing::EventFilter;
 
 use crate::core::cache::Cache;
 use cfg::ConfigurationInner;
@@ -13,6 +14,7 @@ use opentelemetry_otlp::WithExportConfig;
 use queue::TaskQueueProducer;
 use sea_orm::DatabaseConnection;
 use std::{
+    borrow::Cow,
     net::TcpListener,
     sync::atomic::{AtomicBool, Ordering},
     time::Duration,
@@ -224,7 +226,7 @@ pub async fn run_with_prefix(
     expired_message_cleaner_loop.expect("Error initializing expired message cleaner")
 }
 
-pub fn setup_tracing(cfg: &ConfigurationInner) {
+pub fn setup_tracing(cfg: &ConfigurationInner) -> impl Drop {
     if std::env::var_os("RUST_LOG").is_none() {
         let level = cfg.log_level.to_string();
         let mut var = vec![
@@ -268,6 +270,18 @@ pub fn setup_tracing(cfg: &ConfigurationInner) {
         tracing_opentelemetry::layer().with_tracer(tracer)
     });
 
+    let sentry_guard = sentry::init(sentry::ClientOptions {
+        dsn: cfg.sentry_dsn.clone(),
+        environment: Some(Cow::Owned(cfg.environment.to_string())),
+        release: sentry::release_name!(),
+        ..Default::default()
+    });
+
+    let sentry_layer = sentry_tracing::layer().event_filter(|md| match *md.level() {
+        tracing::Level::ERROR | tracing::Level::WARN => EventFilter::Event,
+        _ => EventFilter::Ignore,
+    });
+
     // Then initialize logging with an additional layer priting to stdout. This additional layer is
     // either formatted normally or in JSON format
     // Fails if the subscriber was already initialized, which we can safely and silently ignore
@@ -276,6 +290,7 @@ pub fn setup_tracing(cfg: &ConfigurationInner) {
             let stdout_layer = tracing_subscriber::fmt::layer();
             tracing_subscriber::Registry::default()
                 .with(otel_layer)
+                .with(sentry_layer)
                 .with(stdout_layer)
                 .with(tracing_subscriber::EnvFilter::from_default_env())
                 .try_init()
@@ -290,11 +305,13 @@ pub fn setup_tracing(cfg: &ConfigurationInner) {
 
             tracing_subscriber::Registry::default()
                 .with(otel_layer)
+                .with(sentry_layer)
                 .with(stdout_layer)
                 .with(tracing_subscriber::EnvFilter::from_default_env())
                 .try_init()
         }
     };
+    sentry_guard
 }
 
 mod docs {

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -103,7 +103,7 @@ async fn main() {
     let args = Args::parse();
     let cfg = cfg::load().expect("Error loading configuration");
 
-    setup_tracing(&cfg);
+    let _guard = setup_tracing(&cfg);
 
     if let Some(wait_for_seconds) = args.wait_for {
         let mut wait_for = Vec::with_capacity(2);

--- a/server/svix-server/tests/utils/mod.rs
+++ b/server/svix-server/tests/utils/mod.rs
@@ -271,7 +271,7 @@ pub async fn start_svix_server_with_cfg_and_org_id(
     cfg: &ConfigurationInner,
     org_id: OrganizationId,
 ) -> (TestClient, tokio::task::JoinHandle<()>) {
-    setup_tracing(cfg);
+    let _guard = setup_tracing(cfg);
 
     let cfg = Arc::new(cfg.clone());
 


### PR DESCRIPTION
## Motivation

Sentry is a useful error-reporting service

## Solution

This adds two new config values - `sentry_dsn` and `sentry_environment`. When `sentry_dsn` is provided, we enable Sentry reporting at the provided DSN with the supplied environment name.

Currently, we report both panics (handled by default by Sentry), and all warnings/errors logged through `tracing`
