### PR TITLE
Bridge: Use jemalloc as the global allocator, except for windows

### DIFF
--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -4224,6 +4224,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
 name = "path-clean"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5758,6 +5764,8 @@ dependencies = [
  "svix-bridge-plugin-queue",
  "svix-bridge-types",
  "svix-ksuid",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
  "tokio",
  "tower",
  "tower-http",
@@ -6276,6 +6284,37 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619bfed27d807b54f7f776b9430d4f8060e66ee138a28632ca898584d462c31c"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/bridge/svix-bridge/Cargo.toml
+++ b/bridge/svix-bridge/Cargo.toml
@@ -34,15 +34,20 @@ deno_runtime = "0.119.0"
 deno_ast = "0.27.2"
 deadpool = { version = "0.9.5", features = ["unmanaged", "rt_tokio_1"] }
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { version = "0.5", optional = true }
+tikv-jemalloc-ctl = { version = "0.5", optional = true, features = ["use_std"] }
+
 [dev-dependencies]
 chrono = "0.4"
 tower = "0.4"
 
 [features]
-default = ["gcp-pubsub", "rabbitmq", "redis", "sqs"]
+default = ["gcp-pubsub", "rabbitmq", "redis", "sqs", "jemalloc"]
 
 gcp-pubsub = ["generic-queue"]
 generic-queue = ["dep:svix-bridge-plugin-queue"]
 rabbitmq = ["generic-queue"]
 redis = ["generic-queue"]
 sqs = ["generic-queue"]
+jemalloc = ["tikv-jemallocator", "tikv-jemalloc-ctl"]

--- a/bridge/svix-bridge/src/allocator.rs
+++ b/bridge/svix-bridge/src/allocator.rs
@@ -50,6 +50,7 @@ mod supported {
 
 #[cfg(any(target_env = "msvc", not(feature = "jemalloc")))]
 mod unsupported {
+    use anyhow::anyhow;
     use std::sync::Arc;
     pub struct AllocatorStatMibs;
 
@@ -61,6 +62,6 @@ mod unsupported {
     }
 
     pub fn get_allocator_stat_mibs() -> anyhow::Result<Arc<AllocatorStatMibs>> {
-        Arc::new(AllocatorStatMibs)
+        Err(anyhow!("metric collection is not supported"))
     }
 }

--- a/bridge/svix-bridge/src/allocator.rs
+++ b/bridge/svix-bridge/src/allocator.rs
@@ -35,16 +35,16 @@ mod supported {
         Ok(Some((allocated, resident)))
     }
 
-    pub fn get_allocator_stat_mibs() -> anyhow::Result<Option<Arc<AllocatorStatMibs>>> {
+    pub fn get_allocator_stat_mibs() -> anyhow::Result<Arc<AllocatorStatMibs>> {
         let e = epoch::mib()?;
         let allocated = stats::allocated::mib()?;
         let resident = stats::resident::mib()?;
 
-        Ok(Some(Arc::new(AllocatorStatMibs {
+        Ok(Arc::new(AllocatorStatMibs {
             epoch: e,
             allocated,
             resident,
-        })))
+        }))
     }
 }
 
@@ -60,7 +60,7 @@ mod unsupported {
         Ok(None)
     }
 
-    pub fn get_allocator_stat_mibs() -> anyhow::Result<Option<Arc<AllocatorStatMibs>>> {
-        Ok(None)
+    pub fn get_allocator_stat_mibs() -> anyhow::Result<Arc<AllocatorStatMibs>> {
+        Arc::new(AllocatorStatMibs)
     }
 }

--- a/bridge/svix-bridge/src/allocator.rs
+++ b/bridge/svix-bridge/src/allocator.rs
@@ -1,0 +1,66 @@
+//! Allocator stats are only available when we're using jemalloc, and jemalloc doesn't work on windows.
+//!
+//! 2 impls for the helper functions are therefore provided. One set that does nothing (for windows)
+//! and another that works in the non-windows world.
+//!
+//! Care should be taken to keep the signatures aligned between these two so the callsites can be
+//! used consistently regardless of whether jemalloc is in use or not.
+
+#[cfg(all(not(target_env = "msvc"), feature = "jemalloc"))]
+pub use supported::*;
+#[cfg(any(target_env = "msvc", not(feature = "jemalloc")))]
+pub use unsupported::*;
+
+#[cfg(all(not(target_env = "msvc"), feature = "jemalloc"))]
+mod supported {
+    use std::sync::Arc;
+    use tikv_jemalloc_ctl::{epoch, stats};
+
+    pub struct AllocatorStatMibs {
+        epoch: tikv_jemalloc_ctl::epoch_mib,
+        allocated: stats::allocated_mib,
+        resident: stats::resident_mib,
+    }
+
+    pub fn get_allocator_stats(
+        bust_cache: bool,
+        mibs: Arc<AllocatorStatMibs>,
+    ) -> anyhow::Result<Option<(usize, usize)>> {
+        if bust_cache {
+            // Stats are cached internally and advancing the epoch is a way to invalidate those caches.
+            mibs.epoch.advance()?;
+        }
+        let allocated = mibs.allocated.read()?;
+        let resident = mibs.resident.read()?;
+        Ok(Some((allocated, resident)))
+    }
+
+    pub fn get_allocator_stat_mibs() -> anyhow::Result<Option<Arc<AllocatorStatMibs>>> {
+        let e = epoch::mib()?;
+        let allocated = stats::allocated::mib()?;
+        let resident = stats::resident::mib()?;
+
+        Ok(Some(Arc::new(AllocatorStatMibs {
+            epoch: e,
+            allocated,
+            resident,
+        })))
+    }
+}
+
+#[cfg(any(target_env = "msvc", not(feature = "jemalloc")))]
+mod unsupported {
+    use std::sync::Arc;
+    pub struct AllocatorStatMibs;
+
+    pub fn get_allocator_stats(
+        _bust_cache: bool,
+        _mibs: Arc<AllocatorStatMibs>,
+    ) -> anyhow::Result<Option<(usize, usize)>> {
+        Ok(None)
+    }
+
+    pub fn get_allocator_stat_mibs() -> anyhow::Result<Option<Arc<AllocatorStatMibs>>> {
+        Ok(None)
+    }
+}

--- a/bridge/svix-bridge/src/metrics.rs
+++ b/bridge/svix-bridge/src/metrics.rs
@@ -1,0 +1,44 @@
+use opentelemetry::metrics::{Meter, ObservableGauge};
+use opentelemetry::Context;
+
+fn init_metric<T, E: std::fmt::Display>(result: Result<T, E>) -> Option<T> {
+    match result {
+        Ok(t) => Some(t),
+        Err(e) => {
+            tracing::error!("Failed to initialize metric: {}", e);
+            None
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct CommonMetrics {
+    mem_allocated_recorder: Option<ObservableGauge<u64>>,
+    mem_resident_recorder: Option<ObservableGauge<u64>>,
+}
+
+impl CommonMetrics {
+    pub fn new(meter: &Meter) -> Self {
+        let mem_resident_recorder =
+            init_metric(meter.u64_observable_gauge("svix.mem_resident").try_init());
+        let mem_allocated_recorder =
+            init_metric(meter.u64_observable_gauge("svix.mem_allocated").try_init());
+
+        Self {
+            mem_allocated_recorder,
+            mem_resident_recorder,
+        }
+    }
+
+    pub fn record_mem_allocated(&self, value: u64) {
+        if let Some(ref recorder) = self.mem_allocated_recorder {
+            recorder.observe(&Context::current(), value, &[]);
+        }
+    }
+
+    pub fn record_mem_resident(&self, value: u64) {
+        if let Some(ref recorder) = self.mem_resident_recorder {
+            recorder.observe(&Context::current(), value, &[]);
+        }
+    }
+}


### PR DESCRIPTION
This PR changes the global allocator for svix-bridge to jemalloc. Said allocator is only enabled on non-Windows targets.

This also includes some runtime memory metrics exposed via opentelemetry.