### PR TITLE
Bridge: Replace lazy_static macro with once_cell

### DIFF
--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -5754,7 +5754,7 @@ dependencies = [
  "envsubst",
  "http",
  "hyper 0.14.27",
- "lazy_static",
+ "once_cell",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-otlp",

--- a/bridge/svix-bridge/Cargo.toml
+++ b/bridge/svix-bridge/Cargo.toml
@@ -13,7 +13,7 @@ enum_dispatch = "0.3"
 envsubst = "0.2.1"
 http = "0.2"
 hyper = { version = "0.14", features = ["full"] }
-lazy_static = "1.4"
+once_cell = "1.18.0"
 opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
 opentelemetry-http = "0.7.0"
 opentelemetry-otlp = { version = "0.11.0", features = ["metrics", "grpc-tonic", "http-proto", "reqwest-client"] }

--- a/bridge/svix-bridge/src/main.rs
+++ b/bridge/svix-bridge/src/main.rs
@@ -1,6 +1,6 @@
 use self::config::Config;
 use clap::Parser;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use opentelemetry::runtime::Tokio;
 use opentelemetry::sdk::export::metrics::aggregation::delta_temporality_selector;
 use opentelemetry::sdk::metrics::controllers::BasicController;
@@ -32,12 +32,10 @@ static GLOBAL: Jemalloc = Jemalloc;
 #[cfg(all(target_env = "msvc", feature = "jemalloc"))]
 compile_error!("jemalloc cannot be enabled on msvc");
 
-lazy_static! {
-    // Seems like it would be useful to be able to configure this.
-    // In some docker setups, hostname is sometimes the container id, and advertising this can be
-    // helpful.
-    pub static ref INSTANCE_ID: String = KsuidMs::new(None, None).to_string();
-}
+// Seems like it would be useful to be able to configure this.
+// In some docker setups, hostname is sometimes the container id, and advertising this can be
+// helpful.
+static INSTANCE_ID: Lazy<String> = Lazy::new(|| KsuidMs::new(None, None).to_string());
 
 fn get_svc_identifiers(cfg: &Config) -> opentelemetry::sdk::Resource {
     opentelemetry::sdk::Resource::new(vec![


### PR DESCRIPTION
See also #1024 

lazy_static is unmaintained, once_cell is the new hotness. This PR swaps out the one lazy_static invocation for the equivalent lazy construct from once_cell.