### PR TITLE
Server: add jemalloc

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -4164,6 +4164,7 @@ dependencies = [
  "svix-ksuid",
  "svix-server_derive",
  "thiserror",
+ "tikv-jemallocator",
  "time 0.3.23",
  "tokio",
  "tower",
@@ -4267,6 +4268,26 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -77,7 +77,14 @@ form_urlencoded = "1.1.0"
 lapin = "2.1.1"
 sentry = { version = "0.31.5", features = ["tracing"] }
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { version = "0.5", optional = true }
+
 [dev-dependencies]
 anyhow = "1.0.56"
 # NOTE: Purposely not the latest version such as not to mess up the `hyper` fork patch
 axum-server = { version = "0.5", features = ["tls-openssl"] }
+
+[features]
+default = ["jemalloc"]
+jemalloc = ["dep:tikv-jemallocator"]

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -15,6 +15,13 @@ use svix_server::{cfg, db, run, setup_tracing};
 
 use clap::{Parser, Subcommand};
 
+#[cfg(all(target_env = "msvc", feature = "jemalloc"))]
+compile_error!("jemalloc cannot be enabled on msvc");
+
+#[cfg(all(not(target_env = "msvc"), feature = "jemalloc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 mod wait_for;
 use wait_for::wait_for_dsn;
 


### PR DESCRIPTION
This adds jemalloc as the global allocator.

This is gated by an optional feature (on by default), which should be turned off in the case of building on windows as jemalloc is not supported on that platform.
