### PR TITLE
Server: Remove unused redis dependency

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -503,7 +503,7 @@ checksum = "cd456361ba8e4e7f5fe58e1697ce078a149c85ebce13bf9c6b483d3f566fc9c3"
 dependencies = [
  "async-trait",
  "bb8",
- "redis 0.23.0",
+ "redis",
 ]
 
 [[package]]
@@ -1497,7 +1497,7 @@ dependencies = [
  "http",
  "httpdate",
  "mime",
- "sha1 0.10.5",
+ "sha1",
 ]
 
 [[package]]
@@ -2523,7 +2523,7 @@ dependencies = [
  "hmac",
  "lazy_static",
  "rc2",
- "sha1 0.10.5",
+ "sha1",
  "yasna",
 ]
 
@@ -2954,26 +2954,6 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152f3863635cbb76b73bc247845781098302c6c9ad2060e1a9a7de56840346b6"
-dependencies = [
- "async-trait",
- "bytes",
- "combine",
- "futures-util",
- "itoa",
- "percent-encoding",
- "pin-project-lite",
- "ryu",
- "sha1 0.6.1",
- "tokio",
- "tokio-util 0.7.8",
- "url",
-]
-
-[[package]]
-name = "redis"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ea8c51b5dc1d8e5fd3350ec8167f464ec0995e79f2e90a075b63371500d557f"
@@ -2996,20 +2976,6 @@ dependencies = [
  "tokio-native-tls",
  "tokio-util 0.7.8",
  "url",
-]
-
-[[package]]
-name = "redis_cluster_async"
-version = "0.7.1-alpha.0"
-source = "git+https://github.com/redis-rs/redis-cluster-async.git?rev=e6fe168#e6fe168276faf0049061eb98ba1aa3ad68f7fd04"
-dependencies = [
- "crc16",
- "futures",
- "log",
- "pin-project-lite",
- "rand",
- "redis 0.21.7",
- "tokio",
 ]
 
 [[package]]
@@ -3665,15 +3631,6 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
-dependencies = [
- "sha1_smol",
-]
-
-[[package]]
-name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
@@ -3948,7 +3905,7 @@ dependencies = [
  "rand",
  "rsa 0.9.2",
  "serde",
- "sha1 0.10.5",
+ "sha1",
  "sha2",
  "smallvec",
  "sqlx-core",
@@ -3988,7 +3945,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "sha1 0.10.5",
+ "sha1",
  "sha2",
  "smallvec",
  "sqlx-core",
@@ -4145,8 +4102,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-otlp",
  "rand",
- "redis 0.23.0",
- "redis_cluster_async",
+ "redis",
  "regex",
  "reqwest",
  "schemars",

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -61,7 +61,6 @@ sqlx = { version = "0.7.1", features = [ "runtime-tokio-rustls", "postgres", "mi
 http = "0.2"
 time = { version = "0.3.9", features = [ "std" ]}
 futures = "0.3"
-redis_cluster_async = { git = "https://github.com/redis-rs/redis-cluster-async.git", rev = "e6fe168" }
 url = { version = "2.2.2", features = ["serde"] }
 rand = "0.8.5"
 jsonschema = "0.16.1"


### PR DESCRIPTION
We don't use this crate anymore, get rid of it.
