### PR TITLE
Server/Bridge: enable arm64 docker builds.

### DIFF
--- a/.github/workflows/bridge-release.yml
+++ b/.github/workflows/bridge-release.yml
@@ -80,10 +80,10 @@ jobs:
           echo DOCKER_TAGS="$(echo "${{ github.event.release.tag_name }}" | sed -E "s#v([0-9]+)\.([0-9]+)\.([0-9]+)#${REPO}:latest,${REPO}:v\1.\2.\3,${REPO}:v\1.\2,${REPO}:v\1#")" >> "$GITHUB_ENV"
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: ./bridge
           file: ./bridge/Dockerfile
           push: true
           tags: ${{ env.DOCKER_TAGS }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -80,10 +80,10 @@ jobs:
           echo DOCKER_TAGS="$(echo "${{ github.event.release.tag_name }}" | sed -E "s#v([0-9]+)\.([0-9]+)\.([0-9]+)#${REPO}:latest,${REPO}:v\1.\2.\3,${REPO}:v\1.\2,${REPO}:v\1#")" >> "$GITHUB_ENV"
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: ./server
           file: ./server/Dockerfile
           push: true
           tags: ${{ env.DOCKER_TAGS }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
We want to also release arm64 images for both server and bridge. These are popular targets and we should be building for them.

The builds take forever, but at least it's arm64 + amd64, and it only runs on release anyway.