### PR TITLE
Fix Docker Images

### DIFF
--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -49,7 +49,7 @@ RUN touch */src/lib.rs && touch */src/main.rs
 RUN cargo build --release --frozen
 
 # Production
-FROM debian:12.1-slim AS prod
+FROM debian:bullseye-slim AS prod
 
 RUN set -ex ; \
         mkdir -p /app ;\

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -27,7 +27,7 @@ COPY . .
 RUN cargo build --release --frozen
 
 # Production
-FROM debian:12.1-slim AS prod
+FROM debian:bullseye-slim AS prod
 
 RUN set -ex ; \
         mkdir -p /app ;\


### PR DESCRIPTION
Images built on Debian 12 were failing due to openssl lib issue. Upgrading to Debian 12 will require more significant changes to our dependencies, so for now use `bullseye`-based images, which will keep our images on latest 11.x release.

Fixes #1061 