### PR TITLE
Bridge: remove refs to generic-queue in Dockerfile

### DIFF
--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -23,22 +23,18 @@ WORKDIR /app
 # Hack to enable docker caching
 COPY Cargo.toml .
 COPY Cargo.lock .
-COPY generic-queue/Cargo.toml generic-queue/
 COPY svix-bridge-types/Cargo.toml svix-bridge-types/
 COPY svix-bridge-plugin-queue/Cargo.toml svix-bridge-plugin-queue/
 COPY svix-bridge/Cargo.toml svix-bridge/
 RUN set -ex ;\
-        mkdir generic-queue/src ;\
         mkdir svix-bridge-plugin-queue/src ;\
         mkdir svix-bridge-types/src ;\
         mkdir svix-bridge/src ;\
-        echo '' > generic-queue/src/lib.rs ;\
         echo '' > svix-bridge-plugin-queue/src/lib.rs ;\
         echo '' > svix-bridge-types/src/lib.rs ;\
         echo 'fn main() { println!("Dummy!"); }' > svix-bridge/src/main.rs ;\
         cargo build --release ;\
         rm -rf \
-          generic-queue/src \
           svix-bridge-plugin-queue/src \
           svix-bridge-types/src \
           svix-bridge/src


### PR DESCRIPTION
We normally try to compile all transitive deps in their own layer when building a Docker image.

When we removed `generic-queue`, we neglected to also cleanup references to it in the Dockerfile to support this transitive dep layer.

This diff removes those now-orphaned references.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
