### PR TITLE
server: Update docker image to bookworm and add CI workflow to test it

### DIFF
--- a/.github/workflows/server-docker-image.yml
+++ b/.github/workflows/server-docker-image.yml
@@ -1,0 +1,42 @@
+name: Server docker image CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'server/Dockerfile'
+      - '.github/workflows/server-docker-image.yml'
+  pull_request:
+    paths:
+      - 'server/Dockerfile'
+      - '.github/workflows/server-docker-image.yml'
+
+jobs:
+  test-image:
+    name: Server docker image CI
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+
+    - name: Build server image
+      run: docker-compose build
+      working-directory: ./server
+
+    - name: Run server with docker-compose
+      run: docker-compose up -d
+      working-directory: ./server
+
+    - name: Check server container is up and running
+      run: curl --retry 5 --retry-all-errors http://localhost:8071/api/v1/health/
+
+    - name: Display server container logs
+      if: failure()
+      run: docker-compose logs backend
+      working-directory: ./server
+
+    - name: Terminate docker-compose created containers
+      if: always()
+      run: docker-compose down -v
+      working-directory: ./server

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,7 +1,13 @@
 # Base build
-FROM rust:1.72-slim-bullseye AS build
+FROM rust:1.72-slim-bookworm AS build
 
-RUN apt-get update && apt-get install -y build-essential=12.* checkinstall=1.* zlib1g-dev=1:* pkg-config=0.29.* libssl-dev=* --no-install-recommends
+RUN apt-get update && apt-get install -y \
+        build-essential=12.* \
+        checkinstall=1.* \
+        zlib1g-dev=1:* \
+        pkg-config=1.8.* \
+        libssl-dev=* \
+        --no-install-recommends
 
 RUN set -ex ; \
         mkdir -p /app ;\
@@ -27,7 +33,7 @@ COPY . .
 RUN cargo build --release --frozen
 
 # Production
-FROM debian:bullseye-slim AS prod
+FROM debian:bookworm-slim AS prod
 
 RUN set -ex ; \
         mkdir -p /app ;\
@@ -36,10 +42,12 @@ RUN set -ex ; \
         mkdir -p /home/appuser ;\
         chown -R appuser: /home/appuser
 
-RUN apt-get update ;\
-    apt-get install --no-install-recommends -y ca-certificates=20210119; \
-    update-ca-certificates; \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y \
+        ca-certificates=20230311 \
+        libssl3=3.* \
+        --no-install-recommends && \
+        update-ca-certificates && \
+        rm -rf /var/lib/apt/lists/*
 
 USER appuser
 EXPOSE 8080


### PR DESCRIPTION
Following #1061, update the svix-server docker image to debian bookworm.

Add a CI workflow to test image build and container execution.
