### PR TITLE
Update webpki for server and bridge

### DIFF
--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -7218,9 +7218,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+checksum = "f0e74f82d49d545ad128049b7e88f6576df2da6b02e9ce565c6f533be576957e"
 dependencies = [
  "ring",
  "untrusted",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -5005,9 +5005,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+checksum = "f0e74f82d49d545ad128049b7e88f6576df2da6b02e9ce565c6f533be576957e"
 dependencies = [
  "ring",
  "untrusted",


### PR DESCRIPTION
Updates webpki to avoid a DoS vulnerability.

Ref:
- <https://github.com/advisories/GHSA-8qv2-5vq6-g2g7>
- <https://github.com/briansmith/webpki/issues/69#issuecomment-1699894848>