### PR TITLE
Publish pre-release version of JS package on pushes to main

### DIFF
--- a/.github/workflows/javascript-release.yml
+++ b/.github/workflows/javascript-release.yml
@@ -2,6 +2,8 @@ name: Javascript Release
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
 
@@ -26,7 +28,16 @@ jobs:
           cd javascript
           yarn
 
+      - name: Publish (pre-release)
+        if: github.ref_type == 'branch'
+        run: |
+          cd javascript
+          yarn publish --tag next
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Publish
+        if: github.ref_type == 'tag'
         run: |
           cd javascript
           yarn publish


### PR DESCRIPTION
## Motivation

It is useful to have pre-release versions of the JS library for development, before the public release. 

## Solution

Publish JS package using `--tag next` on all new pushes to `main` (not just those tagged with a version). Uses `github.ref_type` variable to avoid duplicating the workflow code.