### PR TITLE
Set prerelease version before publishing to npm in Github action

### DIFF
--- a/.github/workflows/javascript-release.yml
+++ b/.github/workflows/javascript-release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'javascript/**'
     tags:
       - 'v*'
 
@@ -32,6 +34,7 @@ jobs:
         if: github.ref_type == 'branch'
         run: |
           cd javascript
+          yarn version --prerelease --preid next
           yarn publish --tag next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
See https://github.com/svix/svix-webhooks/actions/runs/6173804183/job/16756967707

Publishing the prerelease package failed because we didn't set the correct version before `yarn publish`

## Solution
This uses `yarn version --prerelease --preid next`. For example, `1.12.0` becomes `1.12.0-next.1` before publishing, so it doesn't conflict with the current released version. 

Also added a filter to only run the workflow if the javascript directory was changed. 