### PR TITLE
fix: retry if response code is 0

### DIFF
--- a/ruby/templates/api_client_typhoeus_partial.mustache
+++ b/ruby/templates/api_client_typhoeus_partial.mustache
@@ -9,7 +9,7 @@
       request = build_request(http_method, path, opts)
       response = request.run
 
-      # retry 500s
+      # retry on 5XX and general network errors
       sleep_time = 0.05
       retry_count = 0
       (0..1).each do |n|

--- a/ruby/templates/api_client_typhoeus_partial.mustache
+++ b/ruby/templates/api_client_typhoeus_partial.mustache
@@ -13,7 +13,7 @@
       sleep_time = 0.05
       retry_count = 0
       (0..1).each do |n|
-        break if response.success? || response.code < 500
+        break if response.success? || (response.code < 500 && response.code > 0)
         retry_count += 1
         sleep(sleep_time)
         sleep_time = sleep_time * 2


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Currently if there is a general network error, there is no retry to send the message. This fix is suggested here: https://github.com/svix/svix-webhooks/issues/964#issuecomment-1722595011

## Solution

if there is a general network error the response code is 0. In this case we should still retry.

Note: there is no guarantee the second retry will work. Maybe it would be nice to be able to configure the number of retries, if this fix does indeed improve the original issue.

There seem to be no specs for this part of the code at all, please could you confirm whether a test needs to be added here.
