### PR TITLE
Server: Avoid using `map_err` in order to preserve `#[track_caller]`

### DIFF
--- a/server/svix-server/src/error.rs
+++ b/server/svix-server/src/error.rs
@@ -136,7 +136,11 @@ pub trait Traceable<T> {
 
 impl<T> Traceable<T> for Result<T> {
     fn trace(self) -> Result<T> {
-        self.map_err(|e| e.trace())
+        // Using `map_err` would lose `#[track_caller]` information
+        match self {
+            Err(e) => Err(e.trace()),
+            ok => ok,
+        }
     }
 }
 


### PR DESCRIPTION
## Motivation

We currently lose `#[track_caller]` information when our `impl<T> Traceable<T> for Result<T>` impl is used, due to the use of `Result::map_err`

## Solution

Write a manual `match` expression, so that we correctly propagate caller information.