### PR TITLE
Libs(Go): add `EventType.DeleteWithOptions`

### DIFF
--- a/go/eventtype.go
+++ b/go/eventtype.go
@@ -105,7 +105,18 @@ func (e *EventType) Patch(ctx context.Context, eventTypeName string, eventTypePa
 }
 
 func (e *EventType) Delete(ctx context.Context, eventTypeName string) error {
+	return e.DeleteWithOptions(ctx, eventTypeName, nil)
+}
+
+type EventTypeDeleteOptions struct {
+	Expunge *bool
+}
+
+func (e *EventType) DeleteWithOptions(ctx context.Context, eventTypeName string, options *EventTypeDeleteOptions) error {
 	req := e.api.EventTypeApi.V1EventTypeDelete(ctx, eventTypeName)
+	if options.Expunge != nil {
+		req = req.Expunge(*options.Expunge)
+	}
 	res, err := req.Execute()
 	return wrapError(err, res)
 }


### PR DESCRIPTION
This is to help add support for sending `expunge` through the `svix-cli`.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
