### PR TITLE
Bump version and update changelog.

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -27,9 +27,9 @@ jobs:
         override: true
         profile: minimal
         components: clippy, rustfmt
-    - uses: Swatinem/rust-cache@v1
+    - uses: Swatinem/rust-cache@v2
       with:
-        working-directory: server
+        workspaces: "server -> target"
 
     - name: rustfmt
       uses: actions-rs/cargo@v1


### PR DESCRIPTION
## Motivation

Server CI was failing because of "no space left on device" while building test binaries via `run-tests.sh`.

## Solution

Bump to the latest version of the rust cache action.

Updating to the latest rust-cache seems to reset the starting disk to `70Gb` which leaves around `14Gb` for the rest of the job to run.

This may just be a bandaid, perhaps requiring us to "bump the cache prefix" in the future to shed accumulated artifacts. Unsure.

Still, bumping the action seems to solve the immediate need.
