### PR TITLE
Publish pre-release javascript package when openapi spec changes

### DIFF
--- a/.github/workflows/javascript-release.yml
+++ b/.github/workflows/javascript-release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths:
+      - 'openapi.json'
       - 'javascript/**'
     tags:
       - 'v*'

--- a/.github/workflows/javascript-release.yml
+++ b/.github/workflows/javascript-release.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'openapi.json'
       - 'javascript/**'
+      - '.github/workflows/javascript-release.yml'
     tags:
       - 'v*'
 


### PR DESCRIPTION
The trigger was only on changes to `javascript/**`, but the lib changes when the openapi spec if updated. The `javascript` directory is not always modified in a commit since some updates are made by the codegen step.
