### PR TITLE
Allow EventType hard delete from .net client.

### DIFF
--- a/csharp/Svix/Abstractions/IEventType.cs
+++ b/csharp/Svix/Abstractions/IEventType.cs
@@ -8,9 +8,9 @@ namespace Svix.Abstractions
 {
     public interface IEventType
     {
-        bool Archive(string eventType, string idempotencyKey = default);
+        bool Archive(string eventType, bool? expunge = null, string idempotencyKey = default);
 
-        Task<bool> ArchiveAsync(string eventType, string idempotencyKey = default,
+        Task<bool> ArchiveAsync(string eventType, bool? expunge = null, string idempotencyKey = default,
             CancellationToken cancellationToken = default);
 
         EventTypeOut Create(EventTypeIn eventType, string idempotencyKey = default);

--- a/csharp/Svix/EventType.cs
+++ b/csharp/Svix/EventType.cs
@@ -22,13 +22,13 @@ namespace Svix
             _eventTypeApi = eventTypeApi ?? throw new ArgumentNullException(nameof(eventTypeApi));
         }
 
-        public bool Archive(string eventType, string idempotencyKey = default)
+        public bool Archive(string eventType, bool? expunge = null, string idempotencyKey = default)
         {
             try
             {
                 var lResponse = _eventTypeApi.V1EventTypeDeleteWithHttpInfo(
                     eventType,
-                    null);
+                    expunge);
 
                 return lResponse.StatusCode == HttpStatusCode.NoContent;
             }
@@ -43,13 +43,13 @@ namespace Svix
             }
         }
 
-        public async Task<bool> ArchiveAsync(string eventType, string idempotencyKey = default, CancellationToken cancellationToken = default)
+        public async Task<bool> ArchiveAsync(string eventType, bool? expunge = null, string idempotencyKey = default, CancellationToken cancellationToken = default)
         {
             try
             {
                 var lResponse = await _eventTypeApi.V1EventTypeDeleteWithHttpInfoAsync(
                     eventType,
-                    null,
+                    expunge,
                     cancellationToken);
 
                 return lResponse.StatusCode == HttpStatusCode.NoContent;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation


The .net client does not have the option to hard delete an EventType, only to archive it.


## Solution


Allow to send the 'expunge' parameter as a bool optional parameter with the Archive() and ArchiveAsync() methods. 

