### PR TITLE
Libs(Ruby) Accept options on message get

### DIFF
--- a/ruby/lib/svix/message_api.rb
+++ b/ruby/lib/svix/message_api.rb
@@ -14,8 +14,8 @@ module Svix
       return @api.v1_message_create(app_id, message_in, options)
     end
 
-    def get(app_id, msg_id)
-      return @api.v1_message_get(app_id, msg_id)
+    def get(app_id, msg_id, options = {})
+      return @api.v1_message_get(app_id, msg_id, options)
     end
 
     def expunge_content(app_id, msg_id)

--- a/ruby/spec/message_api_spec.rb
+++ b/ruby/spec/message_api_spec.rb
@@ -5,7 +5,7 @@ require_relative "../lib/svix/message_api.rb"
 RSpec.describe Svix::MessageAPI do
   let(:app_id) { "app_123" }
   let(:msg_id) { "msg_123" }
-  let(:options) { {foo: "bar"} }
+  let(:options) { {with_content: true} }
   subject { described_class.new(param_mock) }
 
   let(:param_mock) { double("MessageApiParam") }

--- a/ruby/spec/message_api_spec.rb
+++ b/ruby/spec/message_api_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative "../lib/svix/message_api.rb"
+
+RSpec.describe Svix::MessageAPI do
+  let(:app_id) { "app_123" }
+  let(:msg_id) { "msg_123" }
+  let(:options) { {foo: "bar"} }
+  subject { described_class.new(param_mock) }
+
+  let(:param_mock) { double("MessageApiParam") }
+  let(:api_instance_mock) { double("MessageApi") }
+  let(:api_class_mock) { double("MessageApiClass") }
+
+  # Mock out the API calls
+  before(:each) do
+    stub_const("Svix::MessageApi", api_class_mock)
+    expect(api_class_mock).to receive(:new).with(param_mock).and_return(api_instance_mock)
+  end
+
+  describe "#get" do
+    it "passes it's parameters to the correct method" do
+      # Assert that the correct method is called with the correct parameters
+      expect(api_instance_mock).to receive(:v1_message_get).with(app_id, msg_id, options)
+
+      subject.get(app_id, msg_id, options)
+    end
+
+    context "without options" do
+      it "defaults to an empty hash" do
+        # Assert that the correct method is called with the correct parameters
+        expect(api_instance_mock).to receive(:v1_message_get).with(app_id, msg_id, {})
+
+        subject.get(app_id, msg_id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

This PR adds the ability to pass options in the `message.get` calls. [The Documentation](https://api.svix.com/docs#tag/Message/operation/v1.message.get) shows that the "with_content" option is valid, but the ruby wrapper made no accommodation to pass the option.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
