### PR TITLE
Add commit SHA to prerelease version to avoid overlaps

### DIFF
--- a/.github/workflows/javascript-release.yml
+++ b/.github/workflows/javascript-release.yml
@@ -38,7 +38,7 @@ jobs:
           git config user.name "${{ github.event.pusher.name }}"
           git config user.email "${{ github.event.pusher.email }}"
           cd javascript
-          yarn version --prerelease --preid next
+          yarn version --prerelease --preid next-${{ github.sha }}
           yarn publish --tag next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Last run of the JS release action failed since the prerelease version already existed in npm https://github.com/svix/svix-webhooks/actions/runs/6472292636/job/17572620116

## Solution

Add commit SHA to prerelease version to avoid overlaps
