### PR TITLE
Add `messagecontent` model

### DIFF
--- a/server/svix-server/migrations/20231010170520_messagecontent_table.down.sql
+++ b/server/svix-server/migrations/20231010170520_messagecontent_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE messagecontent;

--- a/server/svix-server/migrations/20231010170520_messagecontent_table.up.sql
+++ b/server/svix-server/migrations/20231010170520_messagecontent_table.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE messagecontent (
+    id character varying NOT NULL COLLATE pg_catalog."C",
+    created_at timestamp with time zone NOT NULL,
+    payload bytea NOT NULL,
+    expiration timestamp with time zone NOT NULL DEFAULT now() + INTERVAL '90 day' 
+);
+
+ALTER TABLE ONLY messagecontent
+    ADD CONSTRAINT pk_messagecontent PRIMARY KEY (id);
+
+CREATE INDEX messagecontent_expiry ON messagecontent (expiration);

--- a/server/svix-server/src/db/models/message.rs
+++ b/server/svix-server/src/db/models/message.rs
@@ -19,8 +19,8 @@ pub struct Model {
     pub app_id: ApplicationId,
     pub event_type: EventTypeName,
     pub uid: Option<MessageUid>,
-    #[sea_orm(column_type = "JsonBinary", nullable)]
-    pub payload: Option<Json>,
+    #[sea_orm(column_type = "JsonBinary", column_name = "payload", nullable)]
+    pub legacy_payload: Option<Json>,
     pub channels: Option<EventChannelSet>,
     pub expiration: DateTimeWithTimeZone,
 }
@@ -37,6 +37,8 @@ pub enum Relation {
     Application,
     #[sea_orm(has_many = "super::messagedestination::Entity")]
     Messagedestination,
+    #[sea_orm(has_one = "super::messagecontent::Entity")]
+    Messagecontent,
 }
 
 impl Related<super::application::Entity> for Entity {
@@ -48,6 +50,12 @@ impl Related<super::application::Entity> for Entity {
 impl Related<super::messagedestination::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::Messagedestination.def()
+    }
+}
+
+impl Related<super::messagecontent::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Messagecontent.def()
     }
 }
 

--- a/server/svix-server/src/db/models/messagecontent.rs
+++ b/server/svix-server/src/db/models/messagecontent.rs
@@ -21,9 +21,7 @@ pub enum Relation {
     #[sea_orm(
         belongs_to = "super::message::Entity",
         from = "Column::Id",
-        to = "super::message::Column::Id",
-        on_update = "NoAction",
-        on_delete = "Cascade"
+        to = "super::message::Column::Id"
     )]
     Message,
 }

--- a/server/svix-server/src/db/models/messagecontent.rs
+++ b/server/svix-server/src/db/models/messagecontent.rs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2022 Svix Authors
+// SPDX-License-Identifier: MIT
+
+use crate::core::types::MessageId;
+use chrono::Utc;
+use sea_orm::entity::prelude::*;
+use sea_orm::ActiveValue::Set;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "messagecontent")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: MessageId,
+    pub created_at: DateTimeWithTimeZone,
+    pub payload: Vec<u8>,
+    pub expiration: DateTimeWithTimeZone,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::message::Entity",
+        from = "Column::Id",
+        to = "super::message::Column::Id",
+        on_update = "NoAction",
+        on_delete = "Cascade"
+    )]
+    Message,
+}
+
+impl Related<super::message::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Message.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}
+
+impl ActiveModel {
+    pub fn new(msg_id: MessageId, payload: Vec<u8>) -> Self {
+        let timestamp = Utc::now();
+        Self {
+            id: Set(msg_id),
+            created_at: Set(timestamp.into()),
+            payload: Set(payload),
+            ..ActiveModelTrait::default()
+        }
+    }
+}
+
+impl Entity {
+    pub fn secure_find_by_id_in(ids: Vec<MessageId>) -> Select<Entity> {
+        Self::find().filter(Column::Id.is_in(ids))
+    }
+}

--- a/server/svix-server/src/db/models/mod.rs
+++ b/server/svix-server/src/db/models/mod.rs
@@ -8,4 +8,5 @@ pub mod endpointmetadata;
 pub mod eventtype;
 pub mod message;
 pub mod messageattempt;
+pub mod messagecontent;
 pub mod messagedestination;

--- a/server/svix-server/tests/e2e_message.rs
+++ b/server/svix-server/tests/e2e_message.rs
@@ -413,7 +413,7 @@ async fn test_payload_retention_period() {
         .await
         .unwrap();
 
-    assert_eq!(message.unwrap().payload, None);
+    assert_eq!(message.unwrap().legacy_payload, None);
 }
 
 #[tokio::test]

--- a/server/svix-server/tests/e2e_message.rs
+++ b/server/svix-server/tests/e2e_message.rs
@@ -6,7 +6,7 @@ use reqwest::StatusCode;
 use sea_orm::{sea_query::Expr, ColumnTrait, EntityTrait, QueryFilter};
 
 use svix_server::{
-    db::models::message,
+    db::models::{message, messagecontent},
     expired_message_cleaner,
     v1::{
         endpoints::attempt::MessageAttemptOut,
@@ -384,7 +384,7 @@ async fn test_payload_retention_period() {
         .unwrap()
         .id;
 
-    let msg_row: MessageOut = client
+    let msg: MessageOut = client
         .post(
             &format!("api/v1/app/{}/msg/", &app_id),
             message_in(&app_id, serde_json::json!({"test": "value"})).unwrap(),
@@ -392,28 +392,34 @@ async fn test_payload_retention_period() {
         )
         .await
         .unwrap();
-    let msg_row_2 = msg_row.clone();
+    let msg_id = msg.id.clone();
 
-    message::Entity::update_many()
+    let res = messagecontent::Entity::update_many()
         .col_expr(
             message::Column::Expiration,
             Expr::value(Utc::now() - Duration::days(1)),
         )
-        .filter(message::Column::Id.eq(msg_row.id))
+        .filter(messagecontent::Column::Id.eq(msg_id.clone()))
         .exec(&pool)
         .await
         .unwrap();
+    assert_eq!(1, res.rows_affected);
+
+    let content: Option<messagecontent::Model> = messagecontent::Entity::find_by_id(msg_id.clone())
+        .one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(content.unwrap().id, msg_id.clone());
 
     expired_message_cleaner::clean_expired_messages(&pool, 5000)
         .await
         .unwrap();
 
-    let message: Option<message::Model> = message::Entity::find_by_id(msg_row_2.id)
+    let content: Option<messagecontent::Model> = messagecontent::Entity::find_by_id(msg_id)
         .one(&pool)
         .await
         .unwrap();
-
-    assert_eq!(message.unwrap().legacy_payload, None);
+    assert!(content.is_none());
 }
 
 #[tokio::test]


### PR DESCRIPTION
Move message content from `message.payload` to its own table. Data is stored as `bytea` for future flexibility. Payloads will be queried from the new table but will fall back to the existing column, which has been renamed in code for clarity. The `expired_message_cleaner` process has been updated to expire records from both tables.