### PR TITLE
Bridge: switch `envsubst` for `shellexpand`

### DIFF
--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -2302,15 +2302,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "envsubst"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2f29f6ee674d1229e5715dfc7e24f14395a20d66949e36032de68b31542643"
-dependencies = [
- "thiserror",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5392,6 +5383,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellexpand"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5669,7 +5666,6 @@ dependencies = [
  "deno_ast",
  "deno_runtime",
  "enum_dispatch",
- "envsubst",
  "http",
  "hyper 0.14.27",
  "once_cell",
@@ -5679,6 +5675,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "shellexpand",
  "svix-bridge-plugin-queue",
  "svix-bridge-types",
  "svix-ksuid",

--- a/bridge/svix-bridge/Cargo.toml
+++ b/bridge/svix-bridge/Cargo.toml
@@ -10,7 +10,6 @@ anyhow = "1"
 clap = { version = "4.2.4", features = ["env", "derive"] }
 axum = { version = "0.6", features = ["macros"] }
 enum_dispatch = "0.3"
-envsubst = "0.2.1"
 http = "0.2"
 hyper = { version = "0.14", features = ["full"] }
 once_cell = "1.18.0"
@@ -33,6 +32,7 @@ tracing-subscriber = { version="0.3", features=["env-filter", "fmt", "json"] }
 deno_runtime = "0.125.0"
 deno_ast = "0.28.0"
 deadpool = { version = "0.9.5", features = ["unmanaged", "rt_tokio_1"] }
+shellexpand = { version = "3.1.0", default-features = false, features = ["base-0"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.5", optional = true }


### PR DESCRIPTION
The implementation used for variable substitution in `envsubst` makes it illegal for env vars to point to values with characters that could make the replacement text look like a new variable to be substituted. This restriction is needed to make replacements deterministic.

The crux of the issue for us is this validation prevents us from defining env vars that point to JSON strings, which is necessary for GCP's credential handling scheme and can otherwise show up in the wild as in the case of https://github.com/svix/svix-webhooks/issues/1084 where vars injected by vscode contained braces which triggered a validation error.

`shellexpand` has no such requirement, allowing JSON to appear in values without failing.

Key difference:

1. `shellexpand` reads directly from the env instead of from a supplied `HashMap`.
2. `shellexpand` supports more token styles than `envsubst`.

For 1, this was initially thought to be a benefit of `envsubst` since it separates isolates us from the full env by default, allowing us to filter vars if we so choose. In `shellexpand` they have a concept of a `context` which is a function that can be used for this purpose. I've leveraged this, allowing us to continue to read from a `HashMap` (which we build from the env). No additional filtering is performed, but it did help to retain the original signature for `Config::from_src`.

For 2, I mean, it's fine. The initial aim was just to keep things simple. Having support for more token styles, e.g. `$FOO` in addition to `${FOO}` as well as `${FOO:fallback}`. I think these styles are fine, but won't advertise them in the readme for now.

Existing tests for variable substitution continued to pass _except for one_: `test_variable_substitution_requires_braces`. Naturally this test should fail now that we actually support `$FOO` style vars. The test has been updated to match the new reality, effectively putting us on the hook to support this style moving forward, but that's probably fine.
