### PR TITLE
Server: remove rustix via clap bump

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -157,16 +157,15 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
  "utf8parse",
 ]
 
@@ -196,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.1"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -691,20 +690,19 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.19"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd304a20bff958a57f04c4e96a2e7594cc4490a0e809cbd48bb6437edaa452d"
+checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
 dependencies = [
  "clap_builder",
  "clap_derive",
- "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.19"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c6a3f08f1fe5662a35cfe393aec09c4df95f60ee93b7556505260f75eee9e1"
+checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
 dependencies = [
  "anstream",
  "anstyle",
@@ -714,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.12"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -1864,17 +1862,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi",
- "rustix 0.38.4",
- "windows-sys",
 ]
 
 [[package]]


### PR DESCRIPTION
Same boat for `svix-server` as with `svix-bridge` in #1109

Bumping clap removes the sole runtime dependency on `rustix`, but it still exists in the dep tree impacting only compile-time code paths.

```
$ cargo tree -p rustix@0.38.4 -i
rustix v0.38.4
└── tempfile v3.7.0
    ├── figment v0.10.10
    │   └── svix-server v1.13.0 (/home/onelson/Projects/svix-webhooks/server/svix-server)
    ├── prost-build v0.9.0
    │   └── tonic-build v0.6.2
    │       [build-dependencies]
    │       └── opentelemetry-otlp v0.10.0
    │           └── svix-server v1.13.0 (/home/onelson/Projects/svix-webhooks/server/svix-server)
    └── sqlx-macros-core v0.7.1
        └── sqlx-macros v0.7.1 (proc-macro)
            └── sqlx v0.7.1
                ├── sea-orm v0.12.2
                │   └── svix-server v1.13.0 (/home/onelson/Projects/svix-webhooks/server/svix-server)
                ├── sea-query-binder v0.5.0
                │   └── sea-orm v0.12.2 (*)
                └── svix-server v1.13.0 (/home/onelson/Projects/svix-webhooks/server/svix-server)
```

Updating sea-orm, and otel-related deps will help get the affected `rustix` version out of our tree entirely, but it's a larger lift.

Refs: https://github.com/svix/svix-webhooks/security/dependabot/74