### PR TITLE
Allow configurable User-Agent Header

### DIFF
--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -90,6 +90,9 @@ cache_type = "memory"
 # If true, headers are prefixed with `Webhook-`, otherwise with `Svix-` (default).
 whitelabel_headers = false
 
+# Custom User-Agent header
+# user_agent_header = "User Agent"
+
 # If true, only allow https endpoints, otherwise also allow http.
 endpoint_https_only = false
 

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -150,6 +150,9 @@ pub struct ConfigurationInner {
     /// If true, headers are prefixed with `Webhook-`, otherwise with `Svix-` (default).
     pub whitelabel_headers: bool,
 
+    /// Custom User-Agent header
+    pub user_agent_header: Option<String>,
+
     /// If true, only allow https endpoints, otherwise also allow http.
     pub endpoint_https_only: bool,
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

The User-Agent header in HTTP webhooks serves a pivotal role in identifying
the source of the request. 
For any platform sending out webhooks, it's crucial for the recipients to 
recognize and authenticate the origin of the requests they are processing.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Add optional `user_agent_header` in server configuration

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
