### PR TITLE
Remove totally unnecessary DatabaseConnection clone

### DIFF
--- a/server/svix-server/src/expired_message_cleaner.rs
+++ b/server/svix-server/src/expired_message_cleaner.rs
@@ -67,8 +67,7 @@ pub async fn expired_message_cleaner_loop(pool: &DatabaseConnection) -> Result<(
         if let Some(duration) = sleep_time {
             sleep(duration).await;
         }
-        let pool = pool.clone();
-        match clean_expired_messages(&pool, BATCH_SIZE).await {
+        match clean_expired_messages(pool, BATCH_SIZE).await {
             Err(err) => {
                 tracing::error!("{}", err);
             }


### PR DESCRIPTION
## Motivation

This clone is totally unnecessary. It's not a huge deal since the underlying PgPool is ARCed, but still.