### PR TITLE
Fix Clippy lint errors

### DIFF
--- a/server/svix-server/src/queue/mod.rs
+++ b/server/svix-server/src/queue/mod.rs
@@ -281,7 +281,7 @@ mod tests {
     /// equal to the mock message with the given message_id.
     async fn assert_recv(rx: &mut TaskQueueConsumer, message_id: &str) {
         assert_eq!(
-            *rx.receive_all().await.unwrap().get(0).unwrap().task,
+            *rx.receive_all().await.unwrap().first().unwrap().task,
             mock_message(message_id.to_owned())
         )
     }

--- a/server/svix-server/src/queue/redis.rs
+++ b/server/svix-server/src/queue/redis.rs
@@ -792,7 +792,7 @@ pub mod tests {
 
         let test_key: Vec<(String, i32)> = pool.zpopmin(TEST_QUEUE, 1).await.unwrap();
 
-        assert_eq!(test_key.get(0).unwrap().0, v);
+        assert_eq!(test_key.first().unwrap().0, v);
 
         let should_be_none: Vec<(String, i32)> = pool.zpopmin(TEST_LEGACY, 1).await.unwrap();
         assert!(should_be_none.is_empty());

--- a/server/svix-server/tests/worker.rs
+++ b/server/svix-server/tests/worker.rs
@@ -110,7 +110,7 @@ async fn test_no_redirects_policy() {
             .await
             .unwrap();
 
-        let attempt = attempts.data.get(0);
+        let attempt = attempts.data.first();
 
         if let Some(attempt) = attempt {
             assert_eq!(attempt.response_status_code, 308);


### PR DESCRIPTION
Replace `get(0)` with `first` to appease beta Clippy.
