### PR TITLE
Simplify string caching

### DIFF
--- a/server/svix-server/src/core/cache/memory.rs
+++ b/server/svix-server/src/core/cache/memory.rs
@@ -106,7 +106,7 @@ fn check_is_expired(vw: &ValueWrapper) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        super::{kv_def, CacheValue, StringCacheValue},
+        super::{kv_def, CacheValue},
         *,
     };
     use crate::core::cache::string_kv_def;
@@ -134,23 +134,10 @@ mod tests {
 
     #[derive(Deserialize, Serialize, Debug, PartialEq)]
     struct StringTestVal(String);
-    string_kv_def!(StringTestKey, StringTestVal);
+    string_kv_def!(StringTestKey);
     impl StringTestKey {
         fn new(id: String) -> StringTestKey {
             StringTestKey(format!("SVIX_TEST_KEY_STRING_{id}"))
-        }
-    }
-
-    impl std::fmt::Display for StringTestVal {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{}", self.0)
-        }
-    }
-
-    impl TryFrom<String> for StringTestVal {
-        type Error = crate::error::Error;
-        fn try_from(s: String) -> crate::error::Result<Self> {
-            Ok(StringTestVal(s))
         }
     }
 
@@ -167,8 +154,8 @@ mod tests {
         );
         let (third_key, third_val_a, third_val_b) = (
             StringTestKey::new("1".to_owned()),
-            StringTestVal("1".to_owned()),
-            StringTestVal("2".to_owned()),
+            "1".to_owned(),
+            "2".to_owned(),
         );
 
         // Create
@@ -223,10 +210,7 @@ mod tests {
         // Confirm deletion
         assert_eq!(cache.get::<TestValA>(&first_key).await.unwrap(), None);
         assert_eq!(cache.get::<TestValB>(&second_key).await.unwrap(), None);
-        assert_eq!(
-            cache.get_string::<StringTestVal>(&third_key).await.unwrap(),
-            None
-        );
+        assert_eq!(cache.get_string(&third_key).await.unwrap(), None);
     }
 
     #[tokio::test]

--- a/server/svix-server/src/core/cache/none.rs
+++ b/server/svix-server/src/core/cache/none.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use axum::async_trait;
 
-use super::{Cache, CacheBehavior, CacheKey, CacheValue, Result, StringCacheValue};
+use super::{Cache, CacheBehavior, CacheKey, CacheValue, Result, StringCacheKey};
 
 pub fn new() -> Cache {
     tracing::warn!("Running with caching disabled will negatively affect performance. Idempotency is not supported without a cache.");
@@ -29,7 +29,7 @@ impl CacheBehavior for NoCache {
         Ok(None)
     }
 
-    async fn get_string<T: StringCacheValue>(&self, _key: &T::Key) -> Result<Option<T>> {
+    async fn get_string<T: StringCacheKey>(&self, _key: &T) -> Result<Option<String>> {
         Ok(None)
     }
 
@@ -41,10 +41,10 @@ impl CacheBehavior for NoCache {
         Ok(())
     }
 
-    async fn set_string<T: StringCacheValue>(
+    async fn set_string<T: StringCacheKey>(
         &self,
-        _key: &T::Key,
-        _value: &T,
+        _key: &T,
+        _value: &str,
         _ttl: Duration,
     ) -> Result<()> {
         Ok(())
@@ -72,10 +72,10 @@ impl CacheBehavior for NoCache {
         Ok(false)
     }
 
-    async fn set_string_if_not_exists<T: StringCacheValue>(
+    async fn set_string_if_not_exists<T: StringCacheKey>(
         &self,
-        _key: &T::Key,
-        _value: &T,
+        _key: &T,
+        _value: &str,
         _ttl: Duration,
     ) -> Result<bool> {
         Ok(false)

--- a/server/svix-server/src/core/cache/redis.rs
+++ b/server/svix-server/src/core/cache/redis.rs
@@ -76,7 +76,7 @@ impl CacheBehavior for RedisCache {
 #[cfg(test)]
 mod tests {
     use super::{
-        super::{kv_def, string_kv_def, CacheValue, StringCacheValue},
+        super::{kv_def, string_kv_def, CacheValue},
         *,
     };
     use serde::{Deserialize, Serialize};
@@ -105,23 +105,10 @@ mod tests {
 
     #[derive(Deserialize, Serialize, Debug, PartialEq)]
     struct StringTestVal(String);
-    string_kv_def!(StringTestKey, StringTestVal);
+    string_kv_def!(StringTestKey);
     impl StringTestKey {
         fn new(id: String) -> StringTestKey {
             StringTestKey(format!("SVIX_TEST_KEY_STRING_{id}"))
-        }
-    }
-
-    impl std::fmt::Display for StringTestVal {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{}", self.0)
-        }
-    }
-
-    impl TryFrom<String> for StringTestVal {
-        type Error = crate::error::Error;
-        fn try_from(s: String) -> crate::error::Result<Self> {
-            Ok(StringTestVal(s))
         }
     }
 
@@ -149,8 +136,8 @@ mod tests {
         );
         let (third_key, third_val_a, third_val_b) = (
             StringTestKey::new("1".to_owned()),
-            StringTestVal("1".to_owned()),
-            StringTestVal("2".to_owned()),
+            "1".to_owned(),
+            "2".to_owned(),
         );
 
         // Create
@@ -205,10 +192,7 @@ mod tests {
         // Confirm deletion
         assert_eq!(cache.get::<TestValA>(&first_key).await.unwrap(), None);
         assert_eq!(cache.get::<TestValB>(&second_key).await.unwrap(), None);
-        assert_eq!(
-            cache.get_string::<StringTestVal>(&third_key).await.unwrap(),
-            None
-        );
+        assert_eq!(cache.get_string(&third_key).await.unwrap(), None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Since `StringCacheValue` is always a String, there's not much point in having a separate type for it. This adds a marker trait that gets implemented in the macro so that we can have still have type safety around cache keys that store strings, but otherwise change the relevant cache methods to just take/return `&str`/`String` as appropriate.
