### PR TITLE
[javascript] Fix no content-type error for empty responses

### DIFF
--- a/javascript/templates/api/api.mustache
+++ b/javascript/templates/api/api.mustache
@@ -166,10 +166,6 @@ export class {{classname}}ResponseProcessor {
      public async {{nickname}}(response: ResponseContext): Promise<{{#returnType}}{{{returnType}}}{{/returnType}} {{^returnType}}void{{/returnType}}> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
 
-        if (contentType === undefined) {
-            throw new Error("Cannot parse content. No Content-Type defined. Body: " + await response.body.text());
-        }
-
         {{#responses}}
         if (isCodeInRange("{{code}}", response.httpStatusCode)) {
             {{#dataType}}


### PR DESCRIPTION
In a previous PR https://github.com/svix/svix-webhooks/pull/1160 I added an error message that is thrown before checking the response types, when no content type is defined. That is causing issues in some cases since there are cases in which the API returns no content type in the response (for example, when the response code is `202 Accepted`).

Undoing that change for now. We need a better way to check for invalid content-type responses, but I want to get this fix out first. 