### PR TITLE
server: Don't unify features of host and target dependencies

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["svix-server", "svix-server_derive"]
+resolver = "2"
 
 [patch.crates-io]
 hyper = { git = "https://github.com/svix/hyper/", rev = "b901ca7c" }


### PR DESCRIPTION
## Motivation

Extracted from #1129.
The second version of the resolver is the default for edition 2021+ crates, but for workspaces it has to be set like this because there is no `workspace.edition`.

## Solution

Set `resolver = "2"` to avoid Cargo feature unification between host (proc-macro / build script) dependencies and target (regular) dependencies. Could improve or worsen compile times, but for runtime and code size it can only realistically improve things. It's also good for forwards compatibility.
