### PR TITLE
Upgrade hyper to 0.14.28

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1779,8 +1779,8 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.23"
-source = "git+https://github.com/svix/hyper/?rev=b901ca7c#b901ca7c7772c427d63d150e1bf1c2ce7ce0d733"
+version = "0.14.28"
+source = "git+https://github.com/svix/hyper/?rev=63efac5a6719937359d61a1bb1b93d9ce88f0e3d#63efac5a6719937359d61a1bb1b93d9ce88f0e3d"
 dependencies = [
  "bytes",
  "futures-channel",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -3,4 +3,4 @@ members = ["svix-server", "svix-server_derive"]
 resolver = "2"
 
 [patch.crates-io]
-hyper = { git = "https://github.com/svix/hyper/", rev = "b901ca7c" }
+hyper = { git = "https://github.com/svix/hyper/", rev = "63efac5a6719937359d61a1bb1b93d9ce88f0e3d" }

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -22,7 +22,7 @@ hmac-sha256 = "1"
 clap = { version = "4.1.8", features = ["derive"] }
 axum = { version = "0.6.1", features = ["headers"] }
 base64 = "0.13.0"
-hyper = { version = "=0.14.23", features = ["full"] }
+hyper = { version = "=0.14.28", features = ["full"] }
 hyper-openssl = "0.9.2"
 openssl = "0.10.60"
 tokio = { version = "1.24.2", features = ["full"] }


### PR DESCRIPTION
… of the svix fork. Pre-requisite for omniqueue integration.

## Motivation

Omniqueue pulls in a dependency that needs a newer version of hyper.

## Solution

Upgrade to the latest rev of the fork.