### PR TITLE
server: Some redis queue refactorings

### DIFF
--- a/server/svix-server/src/queue/mod.rs
+++ b/server/svix-server/src/queue/mod.rs
@@ -196,7 +196,7 @@ impl TaskQueueDelivery {
             || async {
                 match &self.acker {
                     Acker::Memory(_) => Ok(()), // nothing to do
-                    Acker::Redis(q) => q.ack(&self).await.trace(),
+                    Acker::Redis(q) => q.ack(&self.id, &self.task).await.trace(),
                     Acker::RabbitMQ(delivery) => {
                         delivery
                             .ack(BasicAckOptions {
@@ -222,7 +222,7 @@ impl TaskQueueDelivery {
                         tracing::debug!("nack {}", self.id);
                         q.send(self.task.clone(), None).await.trace()
                     }
-                    Acker::Redis(q) => q.nack(&self).await.trace(),
+                    Acker::Redis(q) => q.nack(&self.id, &self.task).await.trace(),
                     Acker::RabbitMQ(delivery) => {
                         // See https://www.rabbitmq.com/confirms.html#consumer-nacks-requeue
 

--- a/server/svix-server/src/queue/redis.rs
+++ b/server/svix-server/src/queue/redis.rs
@@ -499,15 +499,13 @@ impl RedisQueueInner {
         ))
         .add_command(Cmd::xdel(&self.main_queue_name, &[delivery.id.as_str()]));
 
-        let (processed, deleted): (u8, u8) = pool.query_async_pipeline(pipe).await?;
-        if processed != 1 || deleted != 1 {
+        let (acked, deleted): (u8, u8) = pool.query_async_pipeline(pipe).await?;
+        if acked != 1 || deleted != 1 {
             tracing::warn!(
-                "Expected to remove 1 from the list, acked {}, deleted {}, for {}|{}",
-                processed,
-                deleted,
+                "Expected to remove 1 from the list, acked {acked}, deleted {deleted}, for {}|{}",
                 delivery.id,
                 serde_json::to_string(&delivery.task)
-                    .map_err(|e| Error::generic(format!("serialization error: {}", e)))?
+                    .map_err(|e| Error::generic(format!("serialization error: {e}")))?
             );
         }
 


### PR DESCRIPTION
## Motivation

Preparation for omniqueue integration, in particular solves the problem discussed [here](https://github.com/svix/svix-webhooks/pull/1129/files#r1463610989).

## Solution

Refactor redis queue implementation to not take `TaskQueueDelivery` parameter in `ack`, `nack` methods, instead only taking references to the fields it is interested in, specifically *ex*cluding the `acker` field (such that it can be borrowed mutably when calling one of these methods).

Additionally, I improved one of the methods to use implicit named format arguments.
