### PR TITLE
Use fully-qualified image names in docker-compose files

### DIFF
--- a/bridge/testing-docker-compose.yml
+++ b/bridge/testing-docker-compose.yml
@@ -1,13 +1,13 @@
 version: "3.7"
 services:
   rabbitmq:
-    image: rabbitmq:3.11.11-management-alpine
+    image: "docker.io/rabbitmq:3.11.11-management-alpine"
     ports:
       - "5672:5672"
       - "15672:15672"
 
   elasticmq: # Drop-in SQS replacement
-    image: softwaremill/elasticmq:1.3.14
+    image: "docker.io/softwaremill/elasticmq:1.3.14"
     ports:
       - "9324:9324"
       - "9325:9325"
@@ -18,7 +18,7 @@ services:
       - "6379:6379"
 
   gcp-pubsub:
-    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators
+    image: "gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators"
     ports:
       - "8085:8085"
     command: [

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -16,14 +16,14 @@ services:
     - redis
 
   postgres:
-    image: postgres:13.4
+    image: "docker.io/postgres:13.4"
     volumes:
       - "postgres-data:/var/lib/postgresql/data/"
     environment:
       POSTGRES_PASSWORD: postgres
 
   pgbouncer:
-    image: edoburu/pgbouncer:1.15.0
+    image: "docker.io/edoburu/pgbouncer:1.15.0"
     healthcheck:
       test: "pg_isready -h localhost"
       interval: 30s
@@ -38,7 +38,7 @@ services:
     - postgres
 
   redis:
-    image: "redis:7-alpine"
+    image: "docker.io/redis:7-alpine"
     # Enable persistence
     command: "--save 60 500 --appendonly yes --appendfsync everysec"
     volumes:

--- a/server/testing-docker-compose.yml
+++ b/server/testing-docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   postgres:
-    image: postgres:13.4
+    image: "docker.io/postgres:13.4"
     command: postgres -c 'max_connections=500'
     volumes:
       - "postgres-data:/var/lib/postgresql/data/"
@@ -17,7 +17,7 @@ services:
 
   # Redis cluster
   redis-cluster:
-    image: "bitnami/redis-cluster:7.0.10"
+    image: "docker.io/bitnami/redis-cluster:7.0.10"
     environment:
       ALLOW_EMPTY_PASSWORD: "yes"
       REDIS_NODES: "redis-cluster redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4"
@@ -33,7 +33,7 @@ services:
       - redis-cluster-node-4
 
   redis-cluster-node-0:
-    image: "bitnami/redis-cluster:7.0.10"
+    image: "docker.io/bitnami/redis-cluster:7.0.10"
     ports:
       - "6381:6379"
     environment:
@@ -41,7 +41,7 @@ services:
       REDIS_NODES: "redis-cluster redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4"
 
   redis-cluster-node-1:
-    image: "bitnami/redis-cluster:7.0.10"
+    image: "docker.io/bitnami/redis-cluster:7.0.10"
     ports:
       - "6382:6379"
     environment:
@@ -49,7 +49,7 @@ services:
       REDIS_NODES: "redis-cluster redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4"
 
   redis-cluster-node-2:
-    image: "bitnami/redis-cluster:7.0.10"
+    image: "docker.io/bitnami/redis-cluster:7.0.10"
     ports:
       - "6383:6379"
     environment:
@@ -57,7 +57,7 @@ services:
       REDIS_NODES: "redis-cluster redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4"
 
   redis-cluster-node-3:
-    image: "bitnami/redis-cluster:7.0.10"
+    image: "docker.io/bitnami/redis-cluster:7.0.10"
     ports:
       - "6384:6379"
     environment:
@@ -65,7 +65,7 @@ services:
       REDIS_NODES: "redis-cluster redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4"
 
   redis-cluster-node-4:
-    image: "bitnami/redis-cluster:7.0.10"
+    image: "docker.io/bitnami/redis-cluster:7.0.10"
     ports:
       - "6385:6379"
     environment:
@@ -73,7 +73,7 @@ services:
       REDIS_NODES: "redis-cluster redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4"
 
   rabbitmq:
-    image: rabbitmq:3.11.13-management-alpine
+    image: "docker.io/rabbitmq:3.11.13-management-alpine"
     ports:
       - "5672:5672"
       - "15672:15672"


### PR DESCRIPTION
## Motivation

Compatibility with podman-compose w/ default configuration.

## Solution

Use `docker.io/` prefix for image names from DockerHub.
