### PR TITLE
Rust verification library: fix comparison of different length signatures

### DIFF
--- a/go/webhook_test.go
+++ b/go/webhook_test.go
@@ -102,6 +102,14 @@ func TestWebhook(t *testing.T) {
 			expectedErr: true,
 		},
 		{
+			name:        "partial signature is invalid",
+			testPayload: newTestPayload(time.Now()),
+			modifyPayload: func(tp *testPayload) {
+				tp.header.Set("svix-signature", "v1,")
+			},
+			expectedErr: true,
+		},
+		{
 			name:        "old timestamp fails",
 			testPayload: newTestPayload(time.Now().Add(tolerance * -1)),
 			expectedErr: true,

--- a/javascript/src/webhook.test.ts
+++ b/javascript/src/webhook.test.ts
@@ -103,6 +103,23 @@ test("invalid signature throws error", () => {
   }).toThrowError(WebhookVerificationError);
 });
 
+test("partial signature throws error", () => {
+  const wh = new Webhook("MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw");
+
+  const testPayload = new TestPayload();
+  testPayload.header["svix-signature"] = testPayload.header["svix-signature"].slice(0, 8);
+
+  expect(() => {
+    wh.verify(testPayload.payload, testPayload.header);
+  }).toThrowError(WebhookVerificationError);
+
+  testPayload.header["svix-signature"] = "v1,";
+
+  expect(() => {
+    wh.verify(testPayload.payload, testPayload.header);
+  }).toThrowError(WebhookVerificationError);
+});
+
 test("valid signature is valid and returns valid json", () => {
   const wh = new Webhook("MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw");
 


### PR DESCRIPTION
There was a bug in the code which meant that the signatures are only compared up to the length of the shorter signature, which means that an attacker can just pass `v1,` as the signature and that will always pass verification.

This change fixes it so that the length of the signature is also taken into account when comparing, to make sure that it's always the same length before comparing.

Manually verified all of the other libraries are correct, and added tests to JavaScript and Go (even though they were also not affected).

Many thanks to Fredrik Meringdal (@fmeringdal) for the report.