### PR TITLE
ci: Limit when CI cache is written

### DIFF
--- a/.github/workflows/bridge-ci.yml
+++ b/.github/workflows/bridge-ci.yml
@@ -39,6 +39,9 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: "bridge -> target"
+        # only save the cache on the main branch
+        # cf https://github.com/Swatinem/rust-cache/issues/95
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: rustfmt
       run: cargo fmt -- --check

--- a/.github/workflows/other-lint.yml
+++ b/.github/workflows/other-lint.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter@v4
+        uses: super-linter/super-linter@v6.0.0
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main

--- a/.github/workflows/other-lint.yml
+++ b/.github/workflows/other-lint.yml
@@ -25,6 +25,7 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_CHECKOV: false
           VALIDATE_PYTHON: false
           VALIDATE_JAVASCRIPT_ES: false
           VALIDATE_JAVASCRIPT_STANDARD: false

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -46,6 +46,9 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: "rust -> target"
+        # only save the cache on the main branch
+        # cf https://github.com/Swatinem/rust-cache/issues/95
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Clippy
       run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -43,9 +43,9 @@ jobs:
         toolchain: ${{ matrix.rust }}
         components: clippy, rustfmt
 
-    - uses: Swatinem/rust-cache@v1
+    - uses: Swatinem/rust-cache@v2
       with:
-        working-directory: rust
+        workspaces: "rust -> target"
 
     - name: Clippy
       run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -31,7 +31,9 @@ jobs:
         with:
           components: clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "rust -> target"
 
       - name: Publish
         env:

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -34,6 +34,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "rust -> target"
+          # only restore cache for faster publishing, don't save back results
+          save-if: false
 
       - name: Publish
         env:

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -39,6 +39,9 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: "server -> target"
+        # only save the cache on the main branch
+        # cf https://github.com/Swatinem/rust-cache/issues/95
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: rustfmt
       run: cargo fmt -- --check


### PR DESCRIPTION
Caches saved from PRs count against the 10GB cache limit after which old cache entries are evicted, but they rarely get re-used as they're only available for further commits on the same PR.

We hit this limit all the time: https://github.com/svix/svix-webhooks/actions/caches

![Screenshot 2024-02-12 at 15-56-49 Workflow runs · svix_svix-webhooks](https://github.com/svix/svix-webhooks/assets/158304798/00e7e6fe-f833-4ec3-82e5-2de122d37b1f)

https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache