### PR TITLE
[lib/c#] Return iterator information in list endpoints

### DIFF
--- a/csharp/Svix/Abstractions/IApplication.cs
+++ b/csharp/Svix/Abstractions/IApplication.cs
@@ -24,9 +24,9 @@ namespace Svix.Abstractions
         Task<ApplicationOut> GetAsync(string appId, string idempotencyKey = default,
             CancellationToken cancellationToken = default);
 
-        List<ApplicationOut> List(ListOptions options = null, string idempotencyKey = default);
+        ListResponseApplicationOut List(ListOptions options = null, string idempotencyKey = default);
 
-        Task<List<ApplicationOut>> ListAsync(ListOptions options = null, string idempotencyKey = default, CancellationToken cancellationToken = default);
+        Task<ListResponseApplicationOut> ListAsync(ListOptions options = null, string idempotencyKey = default, CancellationToken cancellationToken = default);
 
         ApplicationOut Update(string appId, ApplicationIn application, string idempotencyKey = default);
 

--- a/csharp/Svix/Abstractions/IBackgroundTask.cs
+++ b/csharp/Svix/Abstractions/IBackgroundTask.cs
@@ -13,8 +13,8 @@ namespace Svix.Abstractions
         Task<BackgroundTaskOut> GetAsync(string taskId, string idempotencyKey = default,
             CancellationToken cancellationToken = default);
 
-        List<BackgroundTaskOut> List(BackgroundTaskListOptions options = null, string idempotencyKey = default);
+        ListResponseBackgroundTaskOut List(BackgroundTaskListOptions options = null, string idempotencyKey = default);
 
-        Task<List<BackgroundTaskOut>> ListAsync(BackgroundTaskListOptions options = null, string idempotencyKey = default, CancellationToken cancellationToken = default);
+        Task<ListResponseBackgroundTaskOut> ListAsync(BackgroundTaskListOptions options = null, string idempotencyKey = default, CancellationToken cancellationToken = default);
     }
 }

--- a/csharp/Svix/Abstractions/IEndpoint.cs
+++ b/csharp/Svix/Abstractions/IEndpoint.cs
@@ -33,9 +33,9 @@ namespace Svix.Abstractions
         Task<string> GetSecretAsync(string appId, string endpointId, string idempotencyKey = default,
             CancellationToken cancellationToken = default);
 
-        List<EndpointOut> List(string appId, ListOptions options = null, string idempotencyKey = default);
+        ListResponseEndpointOut List(string appId, ListOptions options = null, string idempotencyKey = default);
 
-        Task<List<EndpointOut>> ListAsync(string appId, ListOptions options = null, string idempotencyKey = default,
+        Task<ListResponseEndpointOut> ListAsync(string appId, ListOptions options = null, string idempotencyKey = default,
             CancellationToken cancellationToken = default);
 
         bool PatchHeaders(string appId, string endpointId, EndpointHeadersPatchIn headers, string idempotencyKey = default);

--- a/csharp/Svix/Abstractions/IEventType.cs
+++ b/csharp/Svix/Abstractions/IEventType.cs
@@ -23,9 +23,9 @@ namespace Svix.Abstractions
         Task<EventTypeOut> GetAsync(string eventType, string idempotencyKey = default,
             CancellationToken cancellationToken = default);
 
-        List<EventTypeOut> List(EventTypeListOptions options = null, string idempotencyKey = default);
+        ListResponseEventTypeOut List(EventTypeListOptions options = null, string idempotencyKey = default);
 
-        Task<List<EventTypeOut>> ListAsync(EventTypeListOptions options = null, string idempotencyKey = default,
+        Task<ListResponseEventTypeOut> ListAsync(EventTypeListOptions options = null, string idempotencyKey = default,
             CancellationToken cancellationToken = default);
 
         EventTypeOut Update(string eventType, EventTypeUpdate update, string idempotencyKey = default);

--- a/csharp/Svix/Abstractions/IIntegration.cs
+++ b/csharp/Svix/Abstractions/IIntegration.cs
@@ -27,9 +27,9 @@ namespace Svix.Abstractions
         Task<string> GetKeyAsync(string appId, string integrationId, string idempotencyKey = default,
             CancellationToken cancellationToken = default);
 
-        List<IntegrationOut> List(string appId, ListOptions options = null, string idempotencyKey = default);
+        ListResponseIntegrationOut List(string appId, ListOptions options = null, string idempotencyKey = default);
 
-        Task<List<IntegrationOut>> ListAsync(string appId, ListOptions options = null, string idempotencyKey = default,
+        Task<ListResponseIntegrationOut> ListAsync(string appId, ListOptions options = null, string idempotencyKey = default,
             CancellationToken cancellationToken = default);
 
         string RotateKey(string appId, string integrationId, string idempotencyKey = default);

--- a/csharp/Svix/Abstractions/IMessage.cs
+++ b/csharp/Svix/Abstractions/IMessage.cs
@@ -19,9 +19,9 @@ namespace Svix.Abstractions
         Task<MessageOut> GetAsync(string appId, string messageId, string idempotencyKey = default,
             CancellationToken cancellationToken = default);
 
-        List<MessageOut> List(string appId, MessageListOptions options = null, string idempotencyKey = default);
+        ListResponseMessageOut List(string appId, MessageListOptions options = null, string idempotencyKey = default);
 
-        Task<List<MessageOut>> ListAsync(string appId, MessageListOptions options = null, string idempotencyKey = default,
+        Task<ListResponseMessageOut> ListAsync(string appId, MessageListOptions options = null, string idempotencyKey = default,
             CancellationToken cancellationToken = default);
     }
 }

--- a/csharp/Svix/Abstractions/IMessageAttempt.cs
+++ b/csharp/Svix/Abstractions/IMessageAttempt.cs
@@ -12,38 +12,38 @@ namespace Svix.Abstractions
 
         Task<MessageAttemptOut> GetAttemptAsync(string appId, string attemptId, string messageId, string idempotencyKey = default, CancellationToken cancellationToken = default);
 
-        List<EndpointMessageOut> ListAttemptedMessages(string appId, string endpointId, MessageAttemptListOptions options = null,
+        ListResponseEndpointMessageOut ListAttemptedMessages(string appId, string endpointId, MessageAttemptListOptions options = null,
             string idempotencyKey = default);
 
-        Task<List<EndpointMessageOut>> ListAttemptedMessagesAsync(string appId, string endpointId, MessageAttemptListOptions options = null,
+        Task<ListResponseEndpointMessageOut> ListAttemptedMessagesAsync(string appId, string endpointId, MessageAttemptListOptions options = null,
             string idempotencyKey = default, CancellationToken cancellationToken = default);
 
-        List<MessageAttemptOut> ListAttemptsByEndpoint(string appId, string endpointId, AttemptsByEndpointListOptions options = null, string idempotencyKey = default);
+        ListResponseMessageAttemptOut ListAttemptsByEndpoint(string appId, string endpointId, AttemptsByEndpointListOptions options = null, string idempotencyKey = default);
 
-        Task<List<MessageAttemptOut>> ListAttemptsByEndpointAsync(string appId, string endpointId, AttemptsByEndpointListOptions options = null, string idempotencyKey = default, CancellationToken cancellationToken = default);
+        Task<ListResponseMessageAttemptOut> ListAttemptsByEndpointAsync(string appId, string endpointId, AttemptsByEndpointListOptions options = null, string idempotencyKey = default, CancellationToken cancellationToken = default);
 
-        List<MessageAttemptOut> ListAttemptsByMessage(string appId, string messageId, AttemptsByMessageListOptions options = null, string idempotencyKey = default);
+        ListResponseMessageAttemptOut ListAttemptsByMessage(string appId, string messageId, AttemptsByMessageListOptions options = null, string idempotencyKey = default);
 
-        Task<List<MessageAttemptOut>> ListAttemptsByMessageAsync(string appId, string messageId, AttemptsByMessageListOptions options = null, string idempotencyKey = default, CancellationToken cancellationToken = default);
+        Task<ListResponseMessageAttemptOut> ListAttemptsByMessageAsync(string appId, string messageId, AttemptsByMessageListOptions options = null, string idempotencyKey = default, CancellationToken cancellationToken = default);
 
-        List<MessageAttemptEndpointOut> ListAttemptsForEndpoint(string appId, string messageId, string endpointId,
+        ListResponseMessageAttemptEndpointOut ListAttemptsForEndpoint(string appId, string messageId, string endpointId,
             AttemptsByEndpointListOptions options = null, string idempotencyKey = default);
 
-        Task<List<MessageAttemptEndpointOut>> ListAttemptsForEndpointAsync(string appId, string messageId, string endpointId,
+        Task<ListResponseMessageAttemptEndpointOut> ListAttemptsForEndpointAsync(string appId, string messageId, string endpointId,
             AttemptsByEndpointListOptions options = null, string idempotencyKey = default,
             CancellationToken cancellationToken = default);
 
-        List<MessageAttemptOut> ListAttempts(string appId, string messageId,
+        ListResponseMessageAttemptOut ListAttempts(string appId, string messageId,
             MessageAttemptListOptions options = null, string idempotencyKey = default);
 
-        Task<List<MessageAttemptOut>> ListAttemptsAsync(string appId, string messageId,
+        Task<ListResponseMessageAttemptOut> ListAttemptsAsync(string appId, string messageId,
             MessageAttemptListOptions options = null, string idempotencyKey = default,
             CancellationToken cancellationToken = default);
 
-        List<MessageEndpointOut> ListAttemptedDestinations(string appId, string messageId,
+        ListResponseMessageEndpointOut ListAttemptedDestinations(string appId, string messageId,
             ListOptions options = null, string idempotencyKey = default);
 
-        Task<List<MessageEndpointOut>> ListAttemptedDestinationsAsync(string appId, string messageId,
+        Task<ListResponseMessageEndpointOut> ListAttemptedDestinationsAsync(string appId, string messageId,
             ListOptions options = null, string idempotencyKey = default,
             CancellationToken cancellationToken = default);
 

--- a/csharp/Svix/Application.cs
+++ b/csharp/Svix/Application.cs
@@ -149,7 +149,7 @@ namespace Svix
             }
         }
 
-        public List<ApplicationOut> List(ListOptions options = null, string idempotencyKey = default)
+        public ListResponseApplicationOut List(ListOptions options = null, string idempotencyKey = default)
         {
             try
             {
@@ -158,7 +158,7 @@ namespace Svix
                     options?.Iterator,
                     options?.Order);
 
-                return lResponse?.Data;
+                return lResponse;
             }
             catch (ApiException e)
             {
@@ -167,11 +167,11 @@ namespace Svix
                 if (Throw)
                     throw;
 
-                return new List<ApplicationOut>();
+                return new ListResponseApplicationOut();
             }
         }
 
-        public async Task<List<ApplicationOut>> ListAsync(ListOptions options = null, string idempotencyKey = default, CancellationToken cancellationToken = default)
+        public async Task<ListResponseApplicationOut> ListAsync(ListOptions options = null, string idempotencyKey = default, CancellationToken cancellationToken = default)
         {
             try
             {
@@ -181,7 +181,7 @@ namespace Svix
                     options?.Order,
                     cancellationToken);
 
-                return lResponse?.Data;
+                return lResponse;
             }
             catch (ApiException e)
             {
@@ -190,7 +190,7 @@ namespace Svix
                 if (Throw)
                     throw;
 
-                return new List<ApplicationOut>();
+                return new ListResponseApplicationOut();
             }
         }
 

--- a/csharp/Svix/BackgroundTask.cs
+++ b/csharp/Svix/BackgroundTask.cs
@@ -60,7 +60,7 @@ namespace Svix
             }
         }
 
-        public List<BackgroundTaskOut> List(BackgroundTaskListOptions options = null, string idempotencyKey = default)
+        public ListResponseBackgroundTaskOut List(BackgroundTaskListOptions options = null, string idempotencyKey = default)
         {
             try
             {
@@ -71,7 +71,7 @@ namespace Svix
                     options?.Iterator,
                     options?.Order);
 
-                return lResponse?.Data;
+                return lResponse;
             }
             catch (ApiException e)
             {
@@ -80,11 +80,11 @@ namespace Svix
                 if (Throw)
                     throw;
 
-                return new List<BackgroundTaskOut>();
+                return new ListResponseBackgroundTaskOut();
             }
         }
 
-        public async Task<List<BackgroundTaskOut>> ListAsync(BackgroundTaskListOptions options = null, string idempotencyKey = default, CancellationToken cancellationToken = default)
+        public async Task<ListResponseBackgroundTaskOut> ListAsync(BackgroundTaskListOptions options = null, string idempotencyKey = default, CancellationToken cancellationToken = default)
         {
             try
             {
@@ -96,7 +96,7 @@ namespace Svix
                     options?.Order,
                     cancellationToken);
 
-                return lResponse?.Data;
+                return lResponse;
             }
             catch (ApiException e)
             {
@@ -105,7 +105,7 @@ namespace Svix
                 if (Throw)
                     throw;
 
-                return new List<BackgroundTaskOut>();
+                return new ListResponseBackgroundTaskOut();
             }
         }
     }

--- a/csharp/Svix/Endpoint.cs
+++ b/csharp/Svix/Endpoint.cs
@@ -244,7 +244,7 @@ namespace Svix
             }
         }
 
-        public List<EndpointOut> List(string appId, ListOptions options = null, string idempotencyKey = default)
+        public ListResponseEndpointOut List(string appId, ListOptions options = null, string idempotencyKey = default)
         {
             try
             {
@@ -254,7 +254,7 @@ namespace Svix
                     options?.Iterator,
                     options?.Order);
 
-                return lEndpoints?.Data;
+                return lEndpoints;
             }
             catch (ApiException e)
             {
@@ -263,11 +263,11 @@ namespace Svix
                 if (Throw)
                     throw;
 
-                return new List<EndpointOut>();
+                return new ListResponseEndpointOut();
             }
         }
 
-        public async Task<List<EndpointOut>> ListAsync(string appId, ListOptions options = null, string idempotencyKey = default,
+        public async Task<ListResponseEndpointOut> ListAsync(string appId, ListOptions options = null, string idempotencyKey = default,
             CancellationToken cancellationToken = default)
         {
             try
@@ -279,7 +279,7 @@ namespace Svix
                     options?.Order,
                     cancellationToken);
 
-                return lEndpoints?.Data;
+                return lEndpoints;
             }
             catch (ApiException e)
             {
@@ -288,7 +288,7 @@ namespace Svix
                 if (Throw)
                     throw;
 
-                return new List<EndpointOut>();
+                return new ListResponseEndpointOut();
             }
         }
 

--- a/csharp/Svix/EventType.cs
+++ b/csharp/Svix/EventType.cs
@@ -148,7 +148,7 @@ namespace Svix
             }
         }
 
-        public List<EventTypeOut> List(EventTypeListOptions options = null, string idempotencyKey = default)
+        public ListResponseEventTypeOut List(EventTypeListOptions options = null, string idempotencyKey = default)
         {
             try
             {
@@ -159,7 +159,7 @@ namespace Svix
                     options?.IncludeArchived,
                     options?.WithContent);
 
-                return lResults?.Data;
+                return lResults;
             }
             catch (ApiException e)
             {
@@ -168,11 +168,11 @@ namespace Svix
                 if (Throw)
                     throw;
 
-                return new List<EventTypeOut>();
+                return new ListResponseEventTypeOut();
             }
         }
 
-        public async Task<List<EventTypeOut>> ListAsync(EventTypeListOptions options = null, string idempotencyKey = default,
+        public async Task<ListResponseEventTypeOut> ListAsync(EventTypeListOptions options = null, string idempotencyKey = default,
             CancellationToken cancellationToken = default)
         {
             try
@@ -185,7 +185,7 @@ namespace Svix
                     options?.WithContent,
                     cancellationToken);
 
-                return lResults?.Data;
+                return lResults;
             }
             catch (ApiException e)
             {
@@ -194,7 +194,7 @@ namespace Svix
                 if (Throw)
                     throw;
 
-                return new List<EventTypeOut>();
+                return new ListResponseEventTypeOut();
             }
         }
 

--- a/csharp/Svix/Integration.cs
+++ b/csharp/Svix/Integration.cs
@@ -198,7 +198,7 @@ namespace Svix
             }
         }
 
-        public List<IntegrationOut> List(string appId, ListOptions options = null, string idempotencyKey = default)
+        public ListResponseIntegrationOut List(string appId, ListOptions options = null, string idempotencyKey = default)
         {
             try
             {
@@ -207,7 +207,7 @@ namespace Svix
                     options?.Limit,
                     options?.Iterator);
 
-                return lResult?.Data;
+                return lResult;
             }
             catch (ApiException e)
             {
@@ -216,11 +216,11 @@ namespace Svix
                 if (Throw)
                     throw;
 
-                return new List<IntegrationOut>();
+                return new ListResponseIntegrationOut();
             }
         }
 
-        public async Task<List<IntegrationOut>> ListAsync(string appId, ListOptions options = null, string idempotencyKey = default,
+        public async Task<ListResponseIntegrationOut> ListAsync(string appId, ListOptions options = null, string idempotencyKey = default,
             CancellationToken cancellationToken = default)
         {
             try
@@ -231,7 +231,7 @@ namespace Svix
                     options?.Iterator,
                     cancellationToken);
 
-                return lResult?.Data;
+                return lResult;
             }
             catch (ApiException e)
             {
@@ -240,7 +240,7 @@ namespace Svix
                 if (Throw)
                     throw;
 
-                return new List<IntegrationOut>();
+                return new ListResponseIntegrationOut();
             }
         }
 

--- a/csharp/Svix/Message.cs
+++ b/csharp/Svix/Message.cs
@@ -116,7 +116,7 @@ namespace Svix
             }
         }
 
-        public List<MessageOut> List(string appId, MessageListOptions options = null, string idempotencyKey = default)
+        public ListResponseMessageOut List(string appId, MessageListOptions options = null, string idempotencyKey = default)
         {
             try
             {
@@ -132,7 +132,7 @@ namespace Svix
                     options?.EventTypes
                     );
 
-                return lResponse?.Data;
+                return lResponse;
             }
             catch (ApiException e)
             {
@@ -141,11 +141,11 @@ namespace Svix
                 if (Throw)
                     throw;
 
-                return new List<MessageOut>();
+                return new ListResponseMessageOut();
             }
         }
 
-        public async Task<List<MessageOut>> ListAsync(string appId, MessageListOptions options = null, string idempotencyKey = default, CancellationToken cancellationToken = default)
+        public async Task<ListResponseMessageOut> ListAsync(string appId, MessageListOptions options = null, string idempotencyKey = default, CancellationToken cancellationToken = default)
         {
             try
             {
@@ -161,7 +161,7 @@ namespace Svix
                     options?.EventTypes,
                     cancellationToken);
 
-                return lResponse?.Data;
+                return lResponse;
             }
             catch (ApiException e)
             {
@@ -170,7 +170,7 @@ namespace Svix
                 if (Throw)
                     throw;
 
-                return new List<MessageOut>();
+                return new ListResponseMessageOut();
             }
         }
 

--- a/csharp/Svix/MessageAttempt.cs
+++ b/csharp/Svix/MessageAttempt.cs
@@ -69,7 +69,7 @@ namespace Svix
             }
         }
 
-        public List<EndpointMessageOut> ListAttemptedMessages(string appId, string endpointId, MessageAttemptListOptions options = null,
+        public ListResponseEndpointMessageOut ListAttemptedMessages(string appId, string endpointId, MessageAttemptListOptions options = null,
             string idempotencyKey = default)
         {
             try
@@ -85,7 +85,7 @@ namespace Svix
                     options?.Before,
                     options?.After);
 
-                return lResults?.Data;
+                return lResults;
             }
             catch (ApiException e)
             {
@@ -94,11 +94,11 @@ namespace Svix
                 if (Throw)
                     throw;
 
-                return new List<EndpointMessageOut>();
+                return new ListResponseEndpointMessageOut();
             }
         }
 
-        public async Task<List<EndpointMessageOut>> ListAttemptedMessagesAsync(string appId, string endpointId, MessageAttemptListOptions options = null,
+        public async Task<ListResponseEndpointMessageOut> ListAttemptedMessagesAsync(string appId, string endpointId, MessageAttemptListOptions options = null,
             string idempotencyKey = default, CancellationToken cancellationToken = default)
         {
             try
@@ -110,14 +110,14 @@ namespace Svix
                     options?.Iterator,
                     options?.Channel,
                     options?.Tag,
-                    (Svix.Model.MessageStatus?)options?.Status,
+                    (MessageStatus?)options?.Status,
                     options?.Before,
                     options?.After,
                     options?.WithContent,
                     options?.EventTypes,
                     cancellationToken);
 
-                return lResults?.Data;
+                return lResults;
             }
             catch (ApiException e)
             {
@@ -126,11 +126,11 @@ namespace Svix
                 if (Throw)
                     throw;
 
-                return new List<EndpointMessageOut>();
+                return new ListResponseEndpointMessageOut();
             }
         }
 
-        public List<MessageAttemptOut> ListAttemptsByEndpoint(string appId, string endpointId, AttemptsByEndpointListOptions options = null,
+        public ListResponseMessageAttemptOut ListAttemptsByEndpoint(string appId, string endpointId, AttemptsByEndpointListOptions options = null,
             string idempotencyKey = default)
         {
             try
@@ -150,7 +150,7 @@ namespace Svix
                     options?.WithMsg,
                     options?.EventTypes);
 
-                return lResults?.Data;
+                return lResults;
             }
             catch (ApiException e)
             {
@@ -159,11 +159,11 @@ namespace Svix
                 if (Throw)
                     throw;
 
-                return new List<MessageAttemptOut>();
+                return new ListResponseMessageAttemptOut();
             }
         }
 
-        public async Task<List<MessageAttemptOut>> ListAttemptsByEndpointAsync(string appId, string endpointId, AttemptsByEndpointListOptions options = null,
+        public async Task<ListResponseMessageAttemptOut> ListAttemptsByEndpointAsync(string appId, string endpointId, AttemptsByEndpointListOptions options = null,
             string idempotencyKey = default, CancellationToken cancellationToken = default)
         {
             try
@@ -184,7 +184,7 @@ namespace Svix
                     options?.EventTypes,
                     cancellationToken);
 
-                return lResults?.Data;
+                return lResults;
             }
             catch (ApiException e)
             {
@@ -193,11 +193,11 @@ namespace Svix
                 if (Throw)
                     throw;
 
-                return new List<MessageAttemptOut>();
+                return new ListResponseMessageAttemptOut();
             }
         }
 
-        public List<MessageAttemptOut> ListAttemptsByMessage(string appId, string messageId, AttemptsByMessageListOptions options = null,
+        public ListResponseMessageAttemptOut ListAttemptsByMessage(string appId, string messageId, AttemptsByMessageListOptions options = null,
             string idempotencyKey = default)
         {
             try
@@ -217,7 +217,7 @@ namespace Svix
                     options?.WithContent,
                     options?.EventTypes);
 
-                return lResults?.Data;
+                return lResults;
             }
             catch (ApiException e)
             {
@@ -226,11 +226,11 @@ namespace Svix
                 if (Throw)
                     throw;
 
-                return new List<MessageAttemptOut>();
+                return new ListResponseMessageAttemptOut();
             }
         }
 
-        public async Task<List<MessageAttemptOut>> ListAttemptsByMessageAsync(string appId, string messageId, AttemptsByMessageListOptions options = null,
+        public async Task<ListResponseMessageAttemptOut> ListAttemptsByMessageAsync(string appId, string messageId, AttemptsByMessageListOptions options = null,
             string idempotencyKey = default, CancellationToken cancellationToken = default)
         {
             try
@@ -251,7 +251,7 @@ namespace Svix
                     options?.EventTypes,
                     cancellationToken);
 
-                return lResults?.Data;
+                return lResults;
             }
             catch (ApiException e)
             {
@@ -260,12 +260,12 @@ namespace Svix
                 if (Throw)
                     throw;
 
-                return new List<MessageAttemptOut>();
+                return new ListResponseMessageAttemptOut();
             }
         }
 
         // Deprecated
-        public List<MessageAttemptEndpointOut> ListAttemptsForEndpoint(string appId, string messageId,
+        public ListResponseMessageAttemptEndpointOut ListAttemptsForEndpoint(string appId, string messageId,
             string endpointId, AttemptsByEndpointListOptions options = null, string idempotencyKey = default)
         {
             try
@@ -283,7 +283,7 @@ namespace Svix
                     options?.After,
                     options?.EventTypes);
 
-                return lResults?.Data;
+                return lResults;
             }
             catch (ApiException e)
             {
@@ -292,12 +292,12 @@ namespace Svix
                 if (Throw)
                     throw;
 
-                return new List<MessageAttemptEndpointOut>();
+                return new ListResponseMessageAttemptEndpointOut();
             }
         }
 
         // Deprecated
-        public async Task<List<MessageAttemptEndpointOut>> ListAttemptsForEndpointAsync(string appId,
+        public async Task<ListResponseMessageAttemptEndpointOut> ListAttemptsForEndpointAsync(string appId,
             string messageId, string endpointId, AttemptsByEndpointListOptions options = null, string idempotencyKey = default,
             CancellationToken cancellationToken = default)
         {
@@ -317,7 +317,7 @@ namespace Svix
                     options?.EventTypes?.ToList(),
                     cancellationToken);
 
-                return lResults?.Data;
+                return lResults;
             }
             catch (ApiException e)
             {
@@ -326,12 +326,12 @@ namespace Svix
                 if (Throw)
                     throw;
 
-                return new List<MessageAttemptEndpointOut>();
+                return new ListResponseMessageAttemptEndpointOut();
             }
         }
 
         // Deprecated
-        public List<MessageAttemptOut> ListAttempts(string appId, string messageId, MessageAttemptListOptions options = null,
+        public ListResponseMessageAttemptOut ListAttempts(string appId, string messageId, MessageAttemptListOptions options = null,
             string idempotencyKey = default)
         {
             try
@@ -350,7 +350,7 @@ namespace Svix
                     null,
                     options?.EventTypes);
 
-                return lResults?.Data;
+                return lResults;
             }
             catch (ApiException e)
             {
@@ -359,12 +359,12 @@ namespace Svix
                 if (Throw)
                     throw;
 
-                return new List<MessageAttemptOut>();
+                return new ListResponseMessageAttemptOut();
             }
         }
 
         // Deprecated
-        public async Task<List<MessageAttemptOut>> ListAttemptsAsync(string appId, string messageId, MessageAttemptListOptions options = null,
+        public async Task<ListResponseMessageAttemptOut> ListAttemptsAsync(string appId, string messageId, MessageAttemptListOptions options = null,
             string idempotencyKey = default, CancellationToken cancellationToken = default)
         {
             try
@@ -384,7 +384,7 @@ namespace Svix
                     options?.EventTypes,
                     cancellationToken);
 
-                return lResults?.Data;
+                return lResults;
             }
             catch (ApiException e)
             {
@@ -393,11 +393,11 @@ namespace Svix
                 if (Throw)
                     throw;
 
-                return new List<MessageAttemptOut>();
+                return new ListResponseMessageAttemptOut();
             }
         }
 
-        public List<MessageEndpointOut> ListAttemptedDestinations(string appId, string messageId, ListOptions options = null,
+        public ListResponseMessageEndpointOut ListAttemptedDestinations(string appId, string messageId, ListOptions options = null,
             string idempotencyKey = default)
         {
             try
@@ -408,7 +408,7 @@ namespace Svix
                     options?.Limit,
                     options?.Iterator);
 
-                return lResults?.Data;
+                return lResults;
             }
             catch (ApiException e)
             {
@@ -417,11 +417,11 @@ namespace Svix
                 if (Throw)
                     throw;
 
-                return new List<MessageEndpointOut>();
+                return new ListResponseMessageEndpointOut();
             }
         }
 
-        public async Task<List<MessageEndpointOut>> ListAttemptedDestinationsAsync(string appId, string messageId,
+        public async Task<ListResponseMessageEndpointOut> ListAttemptedDestinationsAsync(string appId, string messageId,
             ListOptions options = null, string idempotencyKey = default,
             CancellationToken cancellationToken = default)
         {
@@ -434,7 +434,7 @@ namespace Svix
                     options?.Iterator,
                     cancellationToken);
 
-                return lResults?.Data;
+                return lResults;
             }
             catch (ApiException e)
             {
@@ -443,7 +443,7 @@ namespace Svix
                 if (Throw)
                     throw;
 
-                return new List<MessageEndpointOut>();
+                return new ListResponseMessageEndpointOut();
             }
         }
 


### PR DESCRIPTION
## Motivation

Our list endpoints, e.g., Endpoint.List, Endpoint.ListAsync, do not return pagination data, which makes the library unusable if results are paginated. We need to return the full response, and not just the data portion of it.

## Solution

Return the full response (`data`, `iterator` and `done`) from the listing methods.

**This is a breaking change.** Users upgrading to the latest version of the C# lib will need to update their usage of these endpoints. `var res = Application.List(...)` becomes `var res = Application.List(...).Data`.

Fixes #1200