### PR TITLE
ci: Simplify cargo-deny-action usage

### DIFF
--- a/.github/workflows/bridge-ci.yml
+++ b/.github/workflows/bridge-ci.yml
@@ -87,7 +87,7 @@ jobs:
 #          - advisories
 #          - bans licenses sources
 #    steps:
-#      - uses: actions/checkout@v2
+#      - uses: actions/checkout@v4
 #      - uses: EmbarkStudios/cargo-deny-action@v1
 #        with:
 #          command: check ${{ matrix.checks }}

--- a/.github/workflows/bridge-security.yml
+++ b/.github/workflows/bridge-security.yml
@@ -21,4 +21,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
-            arguments: --manifest-path=bridge/Cargo.toml
+          manifest-path: bridge/Cargo.toml

--- a/.github/workflows/bridge-security.yml
+++ b/.github/workflows/bridge-security.yml
@@ -18,7 +18,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
             arguments: --manifest-path=bridge/Cargo.toml

--- a/.github/workflows/csharp-lint.yml
+++ b/.github/workflows/csharp-lint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v1.7.2

--- a/.github/workflows/csharp-release.yml
+++ b/.github/workflows/csharp-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v1.7.2

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:

--- a/.github/workflows/java-lint.yml
+++ b/.github/workflows/java-lint.yml
@@ -10,19 +10,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-  
+      - uses: actions/checkout@v4
+
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
           java-version: '11'
-  
+
       - name: Regen openapi libs
         run: |
           yarn
           ./regen_openapi.sh
-  
+
       - name: Build
         run: |
           cd java

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Java
         uses: actions/setup-java@v2
@@ -46,7 +46,7 @@ jobs:
           echo -e "$OSSRH_GPG_SECRET_KEY" | gpg --batch --import
         env:
           OSSRH_GPG_SECRET_KEY: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
-  
+
       - name: Publish
         run: |
           cd java

--- a/.github/workflows/javascript-lint.yml
+++ b/.github/workflows/javascript-lint.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Regen openapi libs
         run: |

--- a/.github/workflows/javascript-release.yml
+++ b/.github/workflows/javascript-release.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/kotlin-lint.yml
+++ b/.github/workflows/kotlin-lint.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Java
         uses: actions/setup-java@v2

--- a/.github/workflows/kotlin-release.yml
+++ b/.github/workflows/kotlin-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Java
         uses: actions/setup-java@v2
@@ -46,7 +46,7 @@ jobs:
           echo -e "$OSSRH_GPG_SECRET_KEY" | gpg --batch --import
         env:
           OSSRH_GPG_SECRET_KEY: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
-  
+
       - name: Publish
         run: |
           cd kotlin

--- a/.github/workflows/other-lint.yml
+++ b/.github/workflows/other-lint.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,5 +1,5 @@
 name: Python Lint
-on: 
+on:
   pull_request:
     paths:
       - "python/**"
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v2
         name: Install Python

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v2
         name: Install Python

--- a/.github/workflows/ruby-lint.yml
+++ b/.github/workflows/ruby-lint.yml
@@ -1,6 +1,6 @@
 name: Ruby Lint
 
-on: 
+on:
   pull_request:
     paths:
       - "ruby/**"
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/ruby-release.yml
+++ b/.github/workflows/ruby-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Regen openapi libs
         run: |

--- a/.github/workflows/rust-security.yml
+++ b/.github/workflows/rust-security.yml
@@ -21,4 +21,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
-            arguments: --manifest-path=rust/Cargo.toml
+          manifest-path: rust/Cargo.toml

--- a/.github/workflows/rust-security.yml
+++ b/.github/workflows/rust-security.yml
@@ -18,7 +18,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
             arguments: --manifest-path=rust/Cargo.toml

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -96,7 +96,7 @@ jobs:
 #          - advisories
 #          - bans licenses sources
 #    steps:
-#      - uses: actions/checkout@v2
+#      - uses: actions/checkout@v4
 #      - uses: EmbarkStudios/cargo-deny-action@v1
 #        with:
 #          command: check ${{ matrix.checks }}

--- a/.github/workflows/server-security.yml
+++ b/.github/workflows/server-security.yml
@@ -21,4 +21,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
-            arguments: --manifest-path=server/Cargo.toml
+          manifest-path: server/Cargo.toml

--- a/.github/workflows/server-security.yml
+++ b/.github/workflows/server-security.yml
@@ -18,7 +18,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
             arguments: --manifest-path=server/Cargo.toml

--- a/.github/workflows/update-postman.yml
+++ b/.github/workflows/update-postman.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install Dependencies
         run: yarn


### PR DESCRIPTION
I saw breakage from `arguments: --manifest-path` in a private PR, but even if the old way was still working, is nice to use the dedicated option.
