### PR TITLE
ci: Build server tests earlier

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -48,7 +48,7 @@ jobs:
       working-directory: server
 
     - name: Build
-      run: cargo build --locked
+      run: cargo test --all-features --no-run --locked
       working-directory: server
 
     - name: Install dependencies


### PR DESCRIPTION
- Counts test build time against the build step
- Aborts earlier in case tests fail to build
