### PR TITLE
bridge: Upgrade docker containers used for testing

### DIFF
--- a/bridge/testing-docker-compose.yml
+++ b/bridge/testing-docker-compose.yml
@@ -1,19 +1,19 @@
 version: "3.7"
 services:
   rabbitmq:
-    image: "docker.io/rabbitmq:3.11.11-management-alpine"
+    image: "docker.io/rabbitmq:3.12-management-alpine"
     ports:
       - "5672:5672"
       - "15672:15672"
 
   elasticmq: # Drop-in SQS replacement
-    image: "docker.io/softwaremill/elasticmq:1.3.14"
+    image: "docker.io/softwaremill/elasticmq-native:1.5.7"
     ports:
       - "9324:9324"
       - "9325:9325"
 
   redis:
-    image: redis:7
+    image: "docker.io/redis:7"
     ports:
       - "6379:6379"
 


### PR DESCRIPTION
## Motivation

CI for the bridge component is broken in #1217, #1218.

## Solution

Upgrade testing container images. This is just a shot in the dark as upgrading containers has helped with similar issues before.