### PR TITLE
ci: Unset RUST_TEST_THREADS

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -77,11 +77,6 @@ jobs:
 
     - name: Run tests
       working-directory: ./server
-      env:
-        # Timing sensitive tests can flake if the docker-compose services get overwhelmed.
-        # Restrict test execution to help avoid this.
-        # `test_endpoint_disable_on_repeated_failure` specifically benefits.
-        RUST_TEST_THREADS: 1
       run: ./run-tests.sh
 
     - name: Stop dependencies


### PR DESCRIPTION
I think tests should no longer be as flaky as they once were when run in parallel.