### PR TITLE
server: Remove PooledConnectionLike in favor of upstream traits

### DIFF
--- a/server/svix-server/src/core/cache/redis.rs
+++ b/server/svix-server/src/core/cache/redis.rs
@@ -4,8 +4,9 @@
 use std::time::Duration;
 
 use axum::async_trait;
+use redis::AsyncCommands as _;
 
-use crate::redis::{PoolLike, PooledConnectionLike, RedisPool};
+use crate::redis::{PoolLike, RedisPool};
 
 use super::{Cache, CacheBehavior, CacheKey, Error, Result};
 

--- a/server/svix-server/src/core/cache/redis.rs
+++ b/server/svix-server/src/core/cache/redis.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use axum::async_trait;
 use redis::AsyncCommands as _;
 
-use crate::redis::{PoolLike, RedisPool};
+use crate::redis::RedisPool;
 
 use super::{Cache, CacheBehavior, CacheKey, Error, Result};
 

--- a/server/svix-server/src/queue/redis.rs
+++ b/server/svix-server/src/queue/redis.rs
@@ -41,7 +41,7 @@ use tokio::time::sleep;
 use crate::{
     error::{Error, Result},
     queue::Acker,
-    redis::{PoolLike, PooledConnection, RedisPool},
+    redis::{PooledConnection, RedisPool},
 };
 
 use super::{
@@ -716,7 +716,7 @@ pub mod tests {
             redis::RedisQueueInner, Acker, MessageTask, QueueTask, TaskQueueConsumer,
             TaskQueueDelivery, TaskQueueProducer,
         },
-        redis::{PoolLike, RedisPool},
+        redis::RedisPool,
     };
 
     pub async fn get_pool(cfg: Configuration) -> RedisPool {

--- a/server/svix-server/src/queue/redis.rs
+++ b/server/svix-server/src/queue/redis.rs
@@ -34,14 +34,14 @@ use axum::async_trait;
 use chrono::Utc;
 use redis::{
     streams::{StreamClaimReply, StreamId, StreamReadOptions, StreamReadReply},
-    Cmd, FromRedisValue, RedisResult, RedisWrite, ToRedisArgs,
+    AsyncCommands as _, Cmd, FromRedisValue, RedisResult, RedisWrite, ToRedisArgs,
 };
 use tokio::time::sleep;
 
 use crate::{
     error::{Error, Result},
     queue::Acker,
-    redis::{PoolLike, PooledConnection, PooledConnectionLike, RedisPool},
+    redis::{PoolLike, PooledConnection, RedisPool},
 };
 
 use super::{
@@ -703,7 +703,7 @@ pub mod tests {
     use std::{sync::Arc, time::Duration};
 
     use chrono::Utc;
-    use redis::{streams::StreamReadReply, Cmd};
+    use redis::{streams::StreamReadReply, AsyncCommands as _, Cmd};
 
     use super::{
         migrate_list, migrate_list_to_stream, migrate_sset, new_pair_inner, to_redis_key, Direction,
@@ -716,7 +716,7 @@ pub mod tests {
             redis::RedisQueueInner, Acker, MessageTask, QueueTask, TaskQueueConsumer,
             TaskQueueDelivery, TaskQueueProducer,
         },
-        redis::{PoolLike, PooledConnectionLike, RedisPool},
+        redis::{PoolLike, RedisPool},
     };
 
     pub async fn get_pool(cfg: Configuration) -> RedisPool {

--- a/server/svix-server/src/queue/redis.rs
+++ b/server/svix-server/src/queue/redis.rs
@@ -234,9 +234,7 @@ async fn background_task_delayed(
             let _: () = pool.query_async_pipeline(pipe).await?;
 
             // Then remove the tasks from the delayed queue so they aren't resent
-            let _: () = pool
-                .query_async(Cmd::zrem(&delayed_queue_name, keys))
-                .await?;
+            let _: () = pool.zrem(&delayed_queue_name, keys).await?;
 
             // Make sure to release the lock after done processing
             let _: () = pool.del(delayed_lock).await?;
@@ -309,11 +307,7 @@ async fn new_pair_inner(
             .expect("Error retreiving connection from Redis pool");
 
         let consumer_group_resp: RedisResult<()> = conn
-            .query_async(Cmd::xgroup_create_mkstream(
-                &main_queue_name,
-                WORKERS_GROUP,
-                0i8,
-            ))
+            .xgroup_create_mkstream(&main_queue_name, WORKERS_GROUP, 0i8)
             .await;
 
         // If the error is a BUSYGROUP error, then the stream or consumer group already exists. This does
@@ -472,7 +466,7 @@ impl RedisQueueInner {
         let mut pool = self.pool.get().await?;
 
         let _: () = pool
-            .query_async(Cmd::xadd(
+            .xadd(
                 &self.main_queue_name,
                 GENERATE_STREAM_ID,
                 &[(
@@ -480,7 +474,7 @@ impl RedisQueueInner {
                     serde_json::to_string(&task)
                         .map_err(|e| Error::generic(format!("serialization error: {}", e)))?,
                 )],
-            ))
+            )
             .await?;
 
         Ok(())
@@ -564,14 +558,14 @@ impl TaskQueueReceive for RedisQueueConsumer {
             // There is no way to make it await a message for unbounded times, so simply block for a short
             // amount of time (to avoid locking) and loop if no messages were retreived
             let resp: StreamReadReply = pool
-                .query_async(Cmd::xread_options(
+                .xread_options(
                     &[&consumer.0.main_queue_name],
                     &[LISTEN_STREAM_ID],
                     &StreamReadOptions::default()
                         .group(WORKERS_GROUP, WORKER_CONSUMER)
                         .count(1)
                         .block(10_000),
-                ))
+                )
                 .await?;
 
             if !resp.keys.is_empty() && !resp.keys[0].ids.is_empty() {
@@ -703,7 +697,7 @@ pub mod tests {
     use std::{sync::Arc, time::Duration};
 
     use chrono::Utc;
-    use redis::{streams::StreamReadReply, AsyncCommands as _, Cmd};
+    use redis::{streams::StreamReadReply, AsyncCommands as _};
 
     use super::{
         migrate_list, migrate_list_to_stream, migrate_sset, new_pair_inner, to_redis_key, Direction,
@@ -871,7 +865,7 @@ pub mod tests {
             .await
             .expect("Error retreiving connection from Redis pool");
         assert!(conn
-            .query_async::<StreamReadReply>(Cmd::xread(&["{test}_ack"], &[0]))
+            .xread::<_, _, StreamReadReply>(&["{test}_ack"], &[0])
             .await
             .unwrap()
             .keys
@@ -888,13 +882,14 @@ pub mod tests {
             .get()
             .await
             .expect("Error retreiving connection from Redis pool");
-        conn.query_async::<()>(Cmd::del(&[
-            "{test}_ack",
-            "{test}_ack_delayed",
-            "{test}_ack_delayed_lock",
-        ]))
-        .await
-        .unwrap();
+        let _: () = conn
+            .del(&[
+                "{test}_ack",
+                "{test}_ack_delayed",
+                "{test}_ack_delayed_lock",
+            ])
+            .await
+            .unwrap();
 
         let (p, mut c) = new_pair_inner(
             pool.clone(),
@@ -929,7 +924,7 @@ pub mod tests {
 
         // And assert that the task has been deleted
         assert!(conn
-            .query_async::<StreamReadReply>(Cmd::xread(&["{test}_ack"], &[0]))
+            .xread::<_, _, StreamReadReply>(&["{test}_ack"], &[0])
             .await
             .unwrap()
             .keys
@@ -1051,7 +1046,7 @@ pub mod tests {
 
             // Clear test keys
             let _: () = conn
-                .query_async(redis::Cmd::del(&[
+                .del(&[
                     v1_main,
                     v2_main,
                     v3_main,
@@ -1059,24 +1054,20 @@ pub mod tests {
                     v2_processing,
                     v1_delayed,
                     v2_delayed,
-                ]))
+                ])
                 .await
                 .unwrap();
 
             // Add v3 consumer group
             let _: () = conn
-                .query_async(redis::Cmd::xgroup_create_mkstream(
-                    v3_main,
-                    super::WORKERS_GROUP,
-                    0i8,
-                ))
+                .xgroup_create_mkstream(v3_main, super::WORKERS_GROUP, 0i8)
                 .await
                 .unwrap();
 
             // Add v1 data
             for num in 1..=10 {
                 let _: () = conn
-                    .query_async(redis::Cmd::rpush(
+                    .rpush(
                         v1_main,
                         to_redis_key(&TaskQueueDelivery {
                             id: num.to_string(),
@@ -1092,14 +1083,14 @@ pub mod tests {
                                 main_queue_name: v1_main.to_owned(),
                             })),
                         }),
-                    ))
+                    )
                     .await
                     .unwrap();
             }
 
             for num in 11..=15 {
                 let _: () = conn
-                    .query_async(redis::Cmd::zadd(
+                    .zadd(
                         v1_delayed,
                         to_redis_key(&TaskQueueDelivery {
                             id: num.to_string(),
@@ -1116,7 +1107,7 @@ pub mod tests {
                             })),
                         }),
                         Utc::now().timestamp() + 2,
-                    ))
+                    )
                     .await
                     .unwrap();
             }

--- a/server/svix-server/src/redis/mod.rs
+++ b/server/svix-server/src/redis/mod.rs
@@ -5,7 +5,7 @@ use bb8_redis::RedisMultiplexedConnectionManager;
 pub use cluster::RedisClusterConnectionManager;
 
 use axum::async_trait;
-use redis::{FromRedisValue, RedisError, RedisResult, ToRedisArgs};
+use redis::{FromRedisValue, RedisError, RedisResult};
 
 use crate::cfg::Configuration;
 
@@ -30,158 +30,48 @@ pub enum PooledConnection<'a> {
     NonClustered(NonClusteredPooledConnection<'a>),
 }
 
-#[async_trait]
-pub trait PooledConnectionLike {
-    async fn query_async<T: FromRedisValue>(&mut self, cmd: redis::Cmd) -> RedisResult<T>;
-    async fn query_async_pipeline<T: FromRedisValue>(
+impl PooledConnection<'_> {
+    pub async fn query_async<T: FromRedisValue>(&mut self, cmd: redis::Cmd) -> RedisResult<T> {
+        cmd.query_async(self).await
+    }
+
+    pub async fn query_async_pipeline<T: FromRedisValue>(
         &mut self,
         pipe: redis::Pipeline,
-    ) -> RedisResult<T>;
-
-    async fn del<K: ToRedisArgs + Send, T: FromRedisValue>(&mut self, key: K) -> RedisResult<T> {
-        self.query_async(redis::Cmd::del(key)).await
-    }
-
-    async fn get<K: ToRedisArgs + Send, T: FromRedisValue>(&mut self, key: K) -> RedisResult<T> {
-        let mut cmd = redis::cmd(if key.is_single_arg() { "GET" } else { "MGET" });
-        cmd.arg(key);
-        self.query_async(cmd).await
-    }
-
-    async fn lpop<K: ToRedisArgs + Send, T: FromRedisValue>(
-        &mut self,
-        key: K,
-        count: Option<core::num::NonZeroUsize>,
     ) -> RedisResult<T> {
-        self.query_async(redis::Cmd::lpop(key, count)).await
-    }
-
-    async fn lrange<K: ToRedisArgs + Send, T: FromRedisValue>(
-        &mut self,
-        key: K,
-        start: isize,
-        stop: isize,
-    ) -> RedisResult<T> {
-        self.query_async(redis::Cmd::lrange(key, start, stop)).await
-    }
-
-    async fn lrem<K: ToRedisArgs + Send, V: ToRedisArgs + Send, T: FromRedisValue>(
-        &mut self,
-        key: K,
-        count: isize,
-        value: V,
-    ) -> RedisResult<T> {
-        self.query_async(redis::Cmd::lrem(key, count, value)).await
-    }
-
-    async fn pset_ex<K: ToRedisArgs + Send, V: ToRedisArgs + Send, T: FromRedisValue>(
-        &mut self,
-        key: K,
-        value: V,
-        milliseconds: u64,
-    ) -> RedisResult<T> {
-        self.query_async(redis::Cmd::pset_ex(key, value, milliseconds))
-            .await
-    }
-
-    async fn rpush<K: ToRedisArgs + Send, V: ToRedisArgs + Send, T: FromRedisValue>(
-        &mut self,
-        key: K,
-        value: V,
-    ) -> RedisResult<T> {
-        self.query_async(redis::Cmd::rpush(key, value)).await
-    }
-
-    async fn set<K: ToRedisArgs + Send, V: ToRedisArgs + Send, T: FromRedisValue>(
-        &mut self,
-        key: K,
-        value: V,
-    ) -> RedisResult<T> {
-        self.query_async(redis::Cmd::set(key, value)).await
-    }
-
-    async fn zadd<
-        K: ToRedisArgs + Send,
-        S: ToRedisArgs + Send,
-        M: ToRedisArgs + Send,
-        T: FromRedisValue,
-    >(
-        &mut self,
-        key: K,
-        member: M,
-        score: S,
-    ) -> RedisResult<T> {
-        self.query_async(redis::Cmd::zadd(key, member, score)).await
-    }
-
-    async fn zadd_multiple<
-        K: ToRedisArgs + Send,
-        S: ToRedisArgs + Send + Sync,
-        M: ToRedisArgs + Send + Sync,
-        T: FromRedisValue,
-    >(
-        &mut self,
-        key: K,
-        items: &'_ [(S, M)],
-    ) -> RedisResult<T> {
-        self.query_async(redis::Cmd::zadd_multiple(key, items))
-            .await
-    }
-
-    async fn zpopmin<K: ToRedisArgs + Send, T: FromRedisValue>(
-        &mut self,
-        key: K,
-        count: isize,
-    ) -> RedisResult<T> {
-        self.query_async(redis::Cmd::zpopmin(key, count)).await
-    }
-
-    async fn zrange_withscores<K: ToRedisArgs + Send, T: FromRedisValue>(
-        &mut self,
-        key: K,
-        start: isize,
-        stop: isize,
-    ) -> RedisResult<T> {
-        self.query_async(redis::Cmd::zrange_withscores(key, start, stop))
-            .await
-    }
-
-    async fn zrangebyscore_limit<
-        K: ToRedisArgs + Send,
-        M: ToRedisArgs + Send,
-        MM: ToRedisArgs + Send,
-        T: FromRedisValue,
-    >(
-        &mut self,
-        key: K,
-        min: M,
-        max: MM,
-        offset: isize,
-        count: isize,
-    ) -> RedisResult<T> {
-        self.query_async(redis::Cmd::zrangebyscore_limit(
-            key, min, max, offset, count,
-        ))
-        .await
+        pipe.query_async(self).await
     }
 }
 
-#[async_trait]
-impl<'a> PooledConnectionLike for PooledConnection<'a> {
-    async fn query_async<T: FromRedisValue>(&mut self, cmd: redis::Cmd) -> RedisResult<T> {
+impl redis::aio::ConnectionLike for PooledConnection<'_> {
+    fn req_packed_command<'a>(
+        &'a mut self,
+        cmd: &'a redis::Cmd,
+    ) -> redis::RedisFuture<'a, redis::Value> {
         match self {
-            Self::Clustered(pooled_con) => pooled_con.query_async(cmd).await,
-            Self::NonClustered(pooled_con) => pooled_con.query_async(cmd).await,
+            PooledConnection::Clustered(conn) => conn.con.req_packed_command(cmd),
+            PooledConnection::NonClustered(conn) => conn.con.req_packed_command(cmd),
         }
     }
 
-    async fn query_async_pipeline<T: FromRedisValue>(
-        &mut self,
-        pipe: redis::Pipeline,
-    ) -> RedisResult<T> {
+    fn req_packed_commands<'a>(
+        &'a mut self,
+        cmd: &'a redis::Pipeline,
+        offset: usize,
+        count: usize,
+    ) -> redis::RedisFuture<'a, Vec<redis::Value>> {
         match self {
-            Self::Clustered(pooled_con) => pooled_con.query_async_pipeline(pipe).await,
-            Self::NonClustered(pooled_con) => pooled_con.query_async_pipeline(pipe).await,
+            PooledConnection::Clustered(conn) => conn.con.req_packed_commands(cmd, offset, count),
+            PooledConnection::NonClustered(conn) => {
+                conn.con.req_packed_commands(cmd, offset, count)
+            }
+        }
+    }
+
+    fn get_db(&self) -> i64 {
+        match self {
+            PooledConnection::Clustered(conn) => conn.con.get_db(),
+            PooledConnection::NonClustered(conn) => conn.con.get_db(),
         }
     }
 }
@@ -292,6 +182,7 @@ pub async fn new_redis_pool(redis_dsn: &str, cfg: &Configuration) -> RedisPool {
 
 #[cfg(test)]
 mod tests {
+    use redis::AsyncCommands;
 
     use super::*;
     use crate::cfg::CacheType;
@@ -310,19 +201,12 @@ mod tests {
         let cfg = crate::cfg::load().unwrap();
 
         let pool = get_pool(cfg.redis_dsn.as_ref().unwrap().as_str(), &cfg).await;
-        let mut pool = pool.get().await.unwrap();
+        let mut conn = pool.get().await.unwrap();
 
         for (val, key) in "abcdefghijklmnopqrstuvwxyz".chars().enumerate() {
             let key = key.to_string();
-            pool.query_async::<()>(redis::Cmd::set::<String, usize>(key.clone(), val))
-                .await
-                .unwrap();
-            assert_eq!(
-                pool.query_async::<usize>(redis::Cmd::get(&key))
-                    .await
-                    .unwrap(),
-                val
-            );
+            let _: () = conn.set(key.clone(), val).await.unwrap();
+            assert_eq!(conn.get::<_, usize>(&key).await.unwrap(), val);
         }
     }
 }

--- a/server/svix-server/tests/it/queue.rs
+++ b/server/svix-server/tests/it/queue.rs
@@ -12,7 +12,7 @@ use svix_server::{
     queue::{
         new_pair, MessageTask, QueueTask, TaskQueueConsumer, TaskQueueDelivery, TaskQueueProducer,
     },
-    redis::{new_redis_pool, new_redis_pool_clustered, PoolLike, RedisPool},
+    redis::{new_redis_pool, new_redis_pool_clustered, RedisPool},
 };
 
 // TODO: Don't copy this from the Redis queue test directly, place the fn somewhere both can access

--- a/server/svix-server/tests/it/queue.rs
+++ b/server/svix-server/tests/it/queue.rs
@@ -12,7 +12,7 @@ use svix_server::{
     queue::{
         new_pair, MessageTask, QueueTask, TaskQueueConsumer, TaskQueueDelivery, TaskQueueProducer,
     },
-    redis::{new_redis_pool, new_redis_pool_clustered, PoolLike, PooledConnectionLike, RedisPool},
+    redis::{new_redis_pool, new_redis_pool_clustered, PoolLike, RedisPool},
 };
 
 // TODO: Don't copy this from the Redis queue test directly, place the fn somewhere both can access

--- a/server/svix-server/tests/it/queue.rs
+++ b/server/svix-server/tests/it/queue.rs
@@ -6,6 +6,7 @@
 
 use std::{str::FromStr, time::Duration};
 
+use redis::AsyncCommands as _;
 use svix_server::{
     cfg::{CacheType, Configuration},
     core::types::{ApplicationId, EndpointId, MessageAttemptTriggerType, MessageId},
@@ -42,7 +43,8 @@ async fn test_many_queue_consumers_inner(prefix: &str, delay: Option<Duration>) 
         let pool = get_pool(cfg.clone()).await;
         let mut conn = pool.get().await.unwrap();
 
-        conn.query_async::<()>(redis::Cmd::del(&format!("{prefix}{{queue}}_svix_v3_main")))
+        let _: () = conn
+            .del(&format!("{prefix}{{queue}}_svix_v3_main"))
             .await
             .unwrap();
     }


### PR DESCRIPTION
## Motivation

Our own redis traits are a maintenance burden and not necessary.

## Solution

Implement `redis::aio::ConnectionLike`, get `redis::AsyncCommands` impl for free :sparkles: 