### PR TITLE
server: Print more info on failed assertions in redis module

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -215,6 +215,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-channel"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4252,6 +4258,7 @@ version = "1.20.0"
 dependencies = [
  "aide",
  "anyhow",
+ "assert_matches",
  "axum",
  "axum-server",
  "base64 0.13.1",

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -79,6 +79,7 @@ tikv-jemallocator = { version = "0.5", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0.56"
+assert_matches = "1.5.0"
 # NOTE: Purposely not the latest version such as not to mess up the `hyper` fork patch
 axum-server = { version = "0.5", features = ["tls-openssl"] }
 


### PR DESCRIPTION
## Motivation

In #1228, I needed some extra context on failing assertions.

## Solution

Prefer `assert_eq!`, `assert_matches!` to check expected emptiness of a value, such that if the assertion fails, the non-empty value is printed.