### PR TITLE
server: Add defaulted generic error parameter to error::Result

### DIFF
--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -14,7 +14,7 @@ use validator::{Validate, ValidationError};
 
 use crate::{core::cryptography::Encryption, core::security::JwtSigningConfig, error::Result};
 
-fn deserialize_main_secret<'de, D>(deserializer: D) -> std::result::Result<Encryption, D::Error>
+fn deserialize_main_secret<'de, D>(deserializer: D) -> Result<Encryption, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -31,9 +31,7 @@ enum RetryScheduleDeserializer {
     Legacy(String),
 }
 
-fn deserialize_retry_schedule<'de, D>(
-    deserializer: D,
-) -> std::result::Result<Vec<Duration>, D::Error>
+fn deserialize_retry_schedule<'de, D>(deserializer: D) -> Result<Vec<Duration>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -56,7 +54,7 @@ where
     }
 }
 
-fn deserialize_hours<'de, D>(deserializer: D) -> std::result::Result<Duration, D::Error>
+fn deserialize_hours<'de, D>(deserializer: D) -> Result<Duration, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -189,9 +187,7 @@ pub struct ConfigurationInner {
     pub internal: InternalConfig,
 }
 
-fn validate_config_complete(
-    config: &ConfigurationInner,
-) -> std::result::Result<(), ValidationError> {
+fn validate_config_complete(config: &ConfigurationInner) -> Result<(), ValidationError> {
     match config.cache_type {
         CacheType::None | CacheType::Memory => {}
         CacheType::Redis | CacheType::RedisCluster => {

--- a/server/svix-server/src/core/security.rs
+++ b/server/svix-server/src/core/security.rs
@@ -266,10 +266,7 @@ pub enum EdDSA {
 }
 
 impl JwtSigningConfig {
-    pub fn generate(
-        &self,
-        claims: JWTClaims<CustomClaim>,
-    ) -> std::result::Result<String, jwt_simple::Error> {
+    pub fn generate(&self, claims: JWTClaims<CustomClaim>) -> Result<String, jwt_simple::Error> {
         match self {
             JwtSigningConfig::Advanced(a) => match a {
                 JWTAlgorithm::HS256(key) => key.authenticate(claims),
@@ -308,7 +305,7 @@ impl JwtSigningConfig {
         &self,
         token: &str,
         options: Option<VerificationOptions>,
-    ) -> std::result::Result<JWTClaims<CustomClaim>, jwt_simple::Error> {
+    ) -> Result<JWTClaims<CustomClaim>, jwt_simple::Error> {
         match self {
             JwtSigningConfig::Advanced(a) => match a {
                 JWTAlgorithm::HS256(key) => key.verify_token(token, options),
@@ -361,7 +358,7 @@ impl Debug for JwtSigningConfig {
     }
 }
 
-fn deserialize_hs256<'de, D>(deserializer: D) -> std::result::Result<HS256Key, D::Error>
+fn deserialize_hs256<'de, D>(deserializer: D) -> Result<HS256Key, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -370,7 +367,7 @@ where
     ))
 }
 
-fn deserialize_hs384<'de, D>(deserializer: D) -> std::result::Result<HS384Key, D::Error>
+fn deserialize_hs384<'de, D>(deserializer: D) -> Result<HS384Key, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -379,7 +376,7 @@ where
     ))
 }
 
-fn deserialize_hs512<'de, D>(deserializer: D) -> std::result::Result<HS512Key, D::Error>
+fn deserialize_hs512<'de, D>(deserializer: D) -> Result<HS512Key, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -388,7 +385,7 @@ where
     ))
 }
 
-fn deserialize_rs256<'de, D>(deserializer: D) -> std::result::Result<RS256, D::Error>
+fn deserialize_rs256<'de, D>(deserializer: D) -> Result<RS256, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -402,7 +399,7 @@ where
     }
 }
 
-fn deserialize_rs384<'de, D>(deserializer: D) -> std::result::Result<RS384, D::Error>
+fn deserialize_rs384<'de, D>(deserializer: D) -> Result<RS384, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -416,7 +413,7 @@ where
     }
 }
 
-fn deserialize_rs512<'de, D>(deserializer: D) -> std::result::Result<RS512, D::Error>
+fn deserialize_rs512<'de, D>(deserializer: D) -> Result<RS512, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -430,7 +427,7 @@ where
     }
 }
 
-fn deserialize_eddsa<'de, D>(deserializer: D) -> std::result::Result<EdDSA, D::Error>
+fn deserialize_eddsa<'de, D>(deserializer: D) -> Result<EdDSA, D::Error>
 where
     D: Deserializer<'de>,
 {

--- a/server/svix-server/src/core/types/mod.rs
+++ b/server/svix-server/src/core/types/mod.rs
@@ -182,7 +182,7 @@ pub trait BaseId: Deref<Target = String> {
     const PREFIX: &'static str;
     type Output;
 
-    fn validate_(&self) -> std::result::Result<(), ValidationErrors> {
+    fn validate_(&self) -> Result<(), ValidationErrors> {
         let mut errors = ValidationErrors::new();
         if !&self.starts_with(Self::PREFIX) {
             errors.add(
@@ -215,7 +215,7 @@ pub trait BaseId: Deref<Target = String> {
     }
 }
 
-fn validate_limited_str(s: &str) -> std::result::Result<(), ValidationErrors> {
+fn validate_limited_str(s: &str) -> Result<(), ValidationErrors> {
     const MAX_LENGTH: usize = 256;
     static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[a-zA-Z0-9\-_.]+$").unwrap());
     let mut errors = ValidationErrors::new();
@@ -251,7 +251,7 @@ fn validate_limited_str(s: &str) -> std::result::Result<(), ValidationErrors> {
 pub trait BaseUid: Deref<Target = String> {
     const ID_PREFIX: &'static str;
 
-    fn validate_(&self) -> std::result::Result<(), ValidationErrors> {
+    fn validate_(&self) -> Result<(), ValidationErrors> {
         let mut errors = match validate_limited_str(self) {
             Ok(_) => ValidationErrors::new(),
             Err(x) => x,
@@ -1013,7 +1013,7 @@ impl<'de> Deserialize<'de> for EndpointSecret {
 }
 
 impl Validate for EndpointSecret {
-    fn validate(&self) -> std::result::Result<(), ValidationErrors> {
+    fn validate(&self) -> Result<(), ValidationErrors> {
         let mut errors = ValidationErrors::new();
 
         match self {
@@ -1159,9 +1159,7 @@ impl<'de> Deserialize<'de> for EndpointHeaders {
     }
 }
 
-fn validate_header_map(
-    headers: &HashMap<String, String>,
-) -> std::result::Result<(), ValidationErrors> {
+fn validate_header_map(headers: &HashMap<String, String>) -> Result<(), ValidationErrors> {
     let mut errors = ValidationErrors::new();
     for (k, v) in headers {
         validate_header_key(k, &mut errors);
@@ -1204,7 +1202,7 @@ impl<'de> Deserialize<'de> for EndpointHeadersPatch {
 }
 
 impl Validate for EndpointHeadersPatch {
-    fn validate(&self) -> std::result::Result<(), ValidationErrors> {
+    fn validate(&self) -> Result<(), ValidationErrors> {
         let mut errors = ValidationErrors::new();
         self.0
             .iter()

--- a/server/svix-server/src/error.rs
+++ b/server/svix-server/src/error.rs
@@ -21,8 +21,8 @@ use serde_json::json;
 
 use crate::core::webhook_http_client;
 
-/// A short-hand version of a [std::result::Result] that always returns an Svix [Error].
-pub type Result<T> = std::result::Result<T, Error>;
+/// A short-hand version of a [`std::result::Result`] that defaults to Svix'es [Error].
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// The error type returned from the Svix API
 #[derive(Debug)]

--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -128,9 +128,7 @@ impl ModelIn for ApplicationPatch {
     }
 }
 
-fn validate_name_length_patch(
-    name: &UnrequiredField<String>,
-) -> std::result::Result<(), ValidationError> {
+fn validate_name_length_patch(name: &UnrequiredField<String>) -> Result<(), ValidationError> {
     match name {
         UnrequiredField::Absent => Ok(()),
         UnrequiredField::Some(s) => {
@@ -148,7 +146,7 @@ fn validate_name_length_patch(
 
 fn validate_rate_limit_patch(
     rate_limit: &UnrequiredNullableField<u16>,
-) -> std::result::Result<(), ValidationError> {
+) -> Result<(), ValidationError> {
     match rate_limit {
         UnrequiredNullableField::Absent | UnrequiredNullableField::None => Ok(()),
         UnrequiredNullableField::Some(rate_limit) => {
@@ -428,7 +426,7 @@ mod tests {
                     "rateLimit": RATE_LIMIT_INVALID }))
         .unwrap();
         let invalid_3: ApplicationIn = serde_json::from_value(json!({
-                    "name": APP_NAME_VALID, 
+                    "name": APP_NAME_VALID,
                     "uid": UID_INVALID }))
         .unwrap();
 
@@ -455,7 +453,7 @@ mod tests {
                     "rateLimit": RATE_LIMIT_INVALID }))
         .unwrap();
         let invalid_3: ApplicationPatch = serde_json::from_value(json!({
-                    "name": APP_NAME_VALID, 
+                    "name": APP_NAME_VALID,
                     "uid": UID_INVALID }))
         .unwrap();
 

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -139,7 +139,7 @@ impl EndpointMessageOut {
 
 // XXX: only used in tests, so OK if it's a bit hacky
 impl<'de> Deserialize<'de> for EndpointMessageOut {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {

--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -54,9 +54,7 @@ use self::secrets::generate_secret;
 
 use super::message::{create_message_inner, MessageIn, MessageOut, RawPayload};
 
-pub fn validate_event_types_ids(
-    event_types_ids: &EventTypeNameSet,
-) -> std::result::Result<(), ValidationError> {
+pub fn validate_event_types_ids(event_types_ids: &EventTypeNameSet) -> Result<(), ValidationError> {
     if event_types_ids.0.is_empty() {
         Err(validation_error(
             Some("filterTypes"),
@@ -69,16 +67,14 @@ pub fn validate_event_types_ids(
 
 fn validate_event_types_ids_unrequired_nullable(
     event_types_ids: &UnrequiredNullableField<EventTypeNameSet>,
-) -> std::result::Result<(), ValidationError> {
+) -> Result<(), ValidationError> {
     match event_types_ids {
         UnrequiredNullableField::Absent | UnrequiredNullableField::None => Ok(()),
         UnrequiredNullableField::Some(event_type_ids) => validate_event_types_ids(event_type_ids),
     }
 }
 
-pub fn validate_channels_endpoint(
-    channels: &EventChannelSet,
-) -> std::result::Result<(), ValidationError> {
+pub fn validate_channels_endpoint(channels: &EventChannelSet) -> Result<(), ValidationError> {
     let len = channels.0.len();
     if !(1..=10).contains(&len) {
         Err(validation_error(
@@ -92,14 +88,14 @@ pub fn validate_channels_endpoint(
 
 fn validate_channels_endpoint_unrequired_nullable(
     channels: &UnrequiredNullableField<EventChannelSet>,
-) -> std::result::Result<(), ValidationError> {
+) -> Result<(), ValidationError> {
     match channels {
         UnrequiredNullableField::Absent | UnrequiredNullableField::None => Ok(()),
         UnrequiredNullableField::Some(channels) => validate_channels_endpoint(channels),
     }
 }
 
-pub fn validate_url(url: &Url) -> std::result::Result<(), ValidationError> {
+pub fn validate_url(url: &Url) -> Result<(), ValidationError> {
     let scheme = url.scheme();
     if scheme == "https" || scheme == "http" {
         Ok(())
@@ -111,7 +107,7 @@ pub fn validate_url(url: &Url) -> std::result::Result<(), ValidationError> {
     }
 }
 
-fn validate_url_unrequired(val: &UnrequiredField<Url>) -> std::result::Result<(), ValidationError> {
+fn validate_url_unrequired(val: &UnrequiredField<Url>) -> Result<(), ValidationError> {
     match val {
         UnrequiredField::Absent => Ok(()),
         UnrequiredField::Some(val) => validate_url(val),
@@ -434,7 +430,7 @@ impl ModelIn for EndpointPatch {
 
 fn validate_rate_limit_patch(
     rate_limit: &UnrequiredNullableField<u16>,
-) -> std::result::Result<(), ValidationError> {
+) -> Result<(), ValidationError> {
     match rate_limit {
         UnrequiredNullableField::Absent | UnrequiredNullableField::None => Ok(()),
         UnrequiredNullableField::Some(rate_limit) => {
@@ -450,9 +446,7 @@ fn validate_rate_limit_patch(
     }
 }
 
-fn validate_minimum_version_patch(
-    version: &UnrequiredField<u16>,
-) -> std::result::Result<(), ValidationError> {
+fn validate_minimum_version_patch(version: &UnrequiredField<u16>) -> Result<(), ValidationError> {
     match version {
         UnrequiredField::Absent => Ok(()),
         UnrequiredField::Some(version) => {

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -45,9 +45,7 @@ use validator::{Validate, ValidationError};
 use crate::db::models::message;
 use crate::error::Error;
 
-pub fn validate_channels_msg(
-    channels: &EventChannelSet,
-) -> std::result::Result<(), ValidationError> {
+pub fn validate_channels_msg(channels: &EventChannelSet) -> Result<(), ValidationError> {
     let len = channels.0.len();
     if !(1..=5).contains(&len) {
         Err(validation_error(
@@ -96,9 +94,7 @@ impl RawPayload {
     }
 }
 
-pub fn validate_raw_payload_is_object(
-    payload: &RawPayload,
-) -> std::result::Result<(), ValidationError> {
+pub fn validate_raw_payload_is_object(payload: &RawPayload) -> Result<(), ValidationError> {
     // Verify it's an object/map
     if payload.0.get().starts_with('{') {
         Ok(())

--- a/server/svix-server/src/v1/utils/mod.rs
+++ b/server/svix-server/src/v1/utils/mod.rs
@@ -79,7 +79,7 @@ pub struct Pagination<T: Validate + JsonSchema> {
 pub struct PaginationLimit(pub u64);
 
 impl<'de> Deserialize<'de> for PaginationLimit {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -95,7 +95,7 @@ impl<'de> Deserialize<'de> for PaginationLimit {
 }
 
 impl Validate for PaginationLimit {
-    fn validate(&self) -> std::result::Result<(), validator::ValidationErrors> {
+    fn validate(&self) -> Result<(), validator::ValidationErrors> {
         let mut errs = validator::ValidationErrors::new();
 
         if self.0 > PAGINATION_LIMIT_CAP_LIMIT {
@@ -122,7 +122,7 @@ pub enum ReversibleIterator<T: Validate> {
 impl<'de, T: 'static + Deserialize<'de> + Validate + From<String>> Deserialize<'de>
     for ReversibleIterator<T>
 {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -137,7 +137,7 @@ impl<'de, T: 'static + Deserialize<'de> + Validate + From<String>> Deserialize<'
 }
 
 impl<T: Validate> Validate for ReversibleIterator<T> {
-    fn validate(&self) -> std::result::Result<(), validator::ValidationErrors> {
+    fn validate(&self) -> Result<(), validator::ValidationErrors> {
         match self {
             ReversibleIterator::Normal(val) => val.validate(),
             ReversibleIterator::Prev(val) => val.validate(),
@@ -610,7 +610,7 @@ pub async fn api_not_implemented() -> Result<()> {
     Err(HttpError::not_implemented(None, None).into())
 }
 
-pub fn validate_no_control_characters(str: &str) -> std::result::Result<(), ValidationError> {
+pub fn validate_no_control_characters(str: &str) -> Result<(), ValidationError> {
     let re = Regex::new(r"[\x00-\x08]").unwrap();
     if re.is_match(str) {
         return Err(validation_error(
@@ -623,7 +623,7 @@ pub fn validate_no_control_characters(str: &str) -> std::result::Result<(), Vali
 
 pub fn validate_no_control_characters_unrequired(
     str: &UnrequiredField<String>,
-) -> std::result::Result<(), ValidationError> {
+) -> Result<(), ValidationError> {
     match str {
         UnrequiredField::Absent => Ok(()),
         UnrequiredField::Some(str) => validate_no_control_characters(str),

--- a/server/svix-server/src/v1/utils/patch.rs
+++ b/server/svix-server/src/v1/utils/patch.rs
@@ -84,7 +84,7 @@ impl<T> From<Option<T>> for UnrequiredNullableField<T> {
 }
 
 impl<T: Validate> Validate for UnrequiredNullableField<T> {
-    fn validate(&self) -> std::result::Result<(), validator::ValidationErrors> {
+    fn validate(&self) -> Result<(), validator::ValidationErrors> {
         match self {
             UnrequiredNullableField::Absent | UnrequiredNullableField::None => Ok(()),
             UnrequiredNullableField::Some(v) => v.validate(),
@@ -93,7 +93,7 @@ impl<T: Validate> Validate for UnrequiredNullableField<T> {
 }
 
 impl<T: Validate> Validate for UnrequiredField<T> {
-    fn validate(&self) -> std::result::Result<(), validator::ValidationErrors> {
+    fn validate(&self) -> Result<(), validator::ValidationErrors> {
         match self {
             UnrequiredField::Absent => Ok(()),
             UnrequiredField::Some(v) => v.validate(),
@@ -127,7 +127,7 @@ impl<'de, T> Deserialize<'de> for UnrequiredNullableField<T>
 where
     T: Deserialize<'de>,
 {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -139,7 +139,7 @@ impl<'de, T> Deserialize<'de> for UnrequiredField<T>
 where
     T: Deserialize<'de>,
 {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -151,7 +151,7 @@ impl<T> Serialize for UnrequiredNullableField<T>
 where
     T: Serialize,
 {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
@@ -168,7 +168,7 @@ impl<T> Serialize for UnrequiredField<T>
 where
     T: Serialize,
 {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {

--- a/server/svix-server/src/worker.rs
+++ b/server/svix-server/src/worker.rs
@@ -825,7 +825,7 @@ async fn process_queue_task_inner(
                 .exec(db)
                 .await?;
 
-            let dests: std::result::Result<_, _> = destinations
+            let dests: Result<_, _> = destinations
                 .into_iter()
                 .map(|d| d.try_into_model())
                 .collect();


### PR DESCRIPTION
## Motivation

Removes the need to fully qualify `std::result::Result` anywhere except the one place the alias is introduced.

## Solution

Allow our `Result` alias to be a proper drop-in replacement for std's result by having an optional second type parameter.