### PR TITLE
server: Fix redis tests relying on dev configuration

### DIFF
--- a/server/svix-server/src/core/cache/redis.rs
+++ b/server/svix-server/src/core/cache/redis.rs
@@ -115,8 +115,10 @@ mod tests {
 
     async fn get_pool(redis_dsn: &str, cfg: &crate::cfg::Configuration) -> RedisPool {
         match cfg.cache_type {
-            CacheType::RedisCluster => crate::redis::new_redis_pool_clustered(redis_dsn, cfg).await,
-            _ => crate::redis::new_redis_pool(redis_dsn, cfg).await,
+            CacheType::RedisCluster => {
+                crate::redis::new_redis_pool_clustered(redis_dsn, cfg.redis_pool_max_size).await
+            }
+            _ => crate::redis::new_redis_pool(redis_dsn, cfg.redis_pool_max_size).await,
         }
     }
 

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -107,11 +107,11 @@ pub async fn run_with_prefix(
         CacheBackend::None => cache::none::new(),
         CacheBackend::Memory => cache::memory::new(),
         CacheBackend::Redis(dsn) => {
-            let mgr = crate::redis::new_redis_pool(dsn, &cfg).await;
+            let mgr = crate::redis::new_redis_pool(dsn, cfg.redis_pool_max_size).await;
             cache::redis::new(mgr)
         }
         CacheBackend::RedisCluster(dsn) => {
-            let mgr = crate::redis::new_redis_pool_clustered(dsn, &cfg).await;
+            let mgr = crate::redis::new_redis_pool_clustered(dsn, cfg.redis_pool_max_size).await;
             cache::redis::new(mgr)
         }
     };

--- a/server/svix-server/src/queue/mod.rs
+++ b/server/svix-server/src/queue/mod.rs
@@ -45,11 +45,11 @@ pub async fn new_pair(
 ) -> (TaskQueueProducer, TaskQueueConsumer) {
     match cfg.queue_backend() {
         QueueBackend::Redis(dsn) => {
-            let pool = crate::redis::new_redis_pool(dsn, cfg).await;
+            let pool = crate::redis::new_redis_pool(dsn, cfg.redis_pool_max_size).await;
             redis::new_pair(pool, prefix).await
         }
         QueueBackend::RedisCluster(dsn) => {
-            let pool = crate::redis::new_redis_pool_clustered(dsn, cfg).await;
+            let pool = crate::redis::new_redis_pool_clustered(dsn, cfg.redis_pool_max_size).await;
             redis::new_pair(pool, prefix).await
         }
         QueueBackend::Memory => {

--- a/server/svix-server/src/queue/redis.rs
+++ b/server/svix-server/src/queue/redis.rs
@@ -704,38 +704,17 @@ pub mod tests {
     };
 
     use crate::{
-        cfg::{CacheType, Configuration},
         core::types::{ApplicationId, EndpointId, MessageAttemptTriggerType, MessageId},
         queue::{
             redis::RedisQueueInner, Acker, MessageTask, QueueTask, TaskQueueConsumer,
             TaskQueueDelivery, TaskQueueProducer,
         },
-        redis::RedisPool,
+        redis::tests::get_pool,
     };
-
-    pub async fn get_pool(cfg: Configuration) -> RedisPool {
-        match cfg.cache_type {
-            CacheType::RedisCluster => {
-                crate::redis::new_redis_pool_clustered(
-                    cfg.redis_dsn.as_ref().unwrap().as_str(),
-                    cfg.redis_pool_max_size,
-                )
-                .await
-            }
-            _ => {
-                crate::redis::new_redis_pool(
-                    cfg.redis_dsn.as_ref().unwrap().as_str(),
-                    cfg.redis_pool_max_size,
-                )
-                .await
-            }
-        }
-    }
 
     #[tokio::test]
     async fn test_migrate_list() {
-        let cfg = crate::cfg::load().unwrap();
-        let pool = get_pool(cfg).await;
+        let pool = get_pool().await;
         let mut pool = pool.get().await.unwrap();
 
         const TEST_QUEUE: &str = "{queue}_svix_test_queue_list";
@@ -766,8 +745,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_migrate_sset() {
-        let cfg = crate::cfg::load().unwrap();
-        let pool = get_pool(cfg).await;
+        let pool = get_pool().await;
         let mut pool = pool.get().await.unwrap();
 
         const TEST_QUEUE: &str = "{queue}_svix_test_queue_sset";
@@ -815,8 +793,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_idle_period() {
-        let cfg = crate::cfg::load().unwrap();
-        let pool = get_pool(cfg).await;
+        let pool = get_pool().await;
 
         let (p, mut c) = new_pair_inner(
             pool.clone(),
@@ -880,8 +857,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_ack() {
-        let cfg = crate::cfg::load().unwrap();
-        let pool = get_pool(cfg).await;
+        let pool = get_pool().await;
 
         // Delete the keys used in this test to ensure nothing pollutes the output
         let mut conn = pool
@@ -939,8 +915,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_nack() {
-        let cfg = crate::cfg::load().unwrap();
-        let pool = get_pool(cfg).await;
+        let pool = get_pool().await;
 
         let (p, mut c) = new_pair_inner(
             pool,
@@ -982,8 +957,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_delay() {
-        let cfg = crate::cfg::load().unwrap();
-        let pool = get_pool(cfg).await;
+        let pool = get_pool().await;
 
         let (p, mut c) = new_pair_inner(
             pool,
@@ -1030,8 +1004,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_migrations() {
-        let cfg = crate::cfg::load().unwrap();
-        let pool = get_pool(cfg).await;
+        let pool = get_pool().await;
 
         // Test queue name constants
         let v1_main = "{test}_migrations_main_v1";

--- a/server/svix-server/src/queue/redis.rs
+++ b/server/svix-server/src/queue/redis.rs
@@ -718,11 +718,17 @@ pub mod tests {
             CacheType::RedisCluster => {
                 crate::redis::new_redis_pool_clustered(
                     cfg.redis_dsn.as_ref().unwrap().as_str(),
-                    &cfg,
+                    cfg.redis_pool_max_size,
                 )
                 .await
             }
-            _ => crate::redis::new_redis_pool(cfg.redis_dsn.as_ref().unwrap().as_str(), &cfg).await,
+            _ => {
+                crate::redis::new_redis_pool(
+                    cfg.redis_dsn.as_ref().unwrap().as_str(),
+                    cfg.redis_pool_max_size,
+                )
+                .await
+            }
         }
     }
 

--- a/server/svix-server/tests/it/message_app.rs
+++ b/server/svix-server/tests/it/message_app.rs
@@ -66,11 +66,11 @@ async fn test_app_deletion() {
     let cache = match cfg.cache_backend() {
         CacheBackend::None => cache::none::new(),
         CacheBackend::Redis(dsn) => {
-            let mgr = new_redis_pool(dsn, &cfg).await;
+            let mgr = new_redis_pool(dsn, cfg.redis_pool_max_size).await;
             cache::redis::new(mgr)
         }
         CacheBackend::RedisCluster(dsn) => {
-            let mgr = new_redis_pool_clustered(dsn, &cfg).await;
+            let mgr = new_redis_pool_clustered(dsn, cfg.redis_pool_max_size).await;
             cache::redis::new(mgr)
         }
 
@@ -150,11 +150,11 @@ async fn test_endp_deletion() {
     let cache = match cfg.cache_backend() {
         CacheBackend::None => cache::none::new(),
         CacheBackend::Redis(dsn) => {
-            let mgr = new_redis_pool(dsn, &cfg).await;
+            let mgr = new_redis_pool(dsn, cfg.redis_pool_max_size).await;
             cache::redis::new(mgr)
         }
         CacheBackend::RedisCluster(dsn) => {
-            let mgr = new_redis_pool_clustered(dsn, &cfg).await;
+            let mgr = new_redis_pool_clustered(dsn, cfg.redis_pool_max_size).await;
             cache::redis::new(mgr)
         }
 

--- a/server/svix-server/tests/it/queue.rs
+++ b/server/svix-server/tests/it/queue.rs
@@ -20,9 +20,19 @@ use svix_server::{
 pub async fn get_pool(cfg: Configuration) -> RedisPool {
     match cfg.cache_type {
         CacheType::RedisCluster => {
-            new_redis_pool_clustered(cfg.redis_dsn.as_ref().unwrap().as_str(), &cfg).await
+            new_redis_pool_clustered(
+                cfg.redis_dsn.as_ref().unwrap().as_str(),
+                cfg.redis_pool_max_size,
+            )
+            .await
         }
-        _ => new_redis_pool(cfg.redis_dsn.as_ref().unwrap().as_str(), &cfg).await,
+        _ => {
+            new_redis_pool(
+                cfg.redis_dsn.as_ref().unwrap().as_str(),
+                cfg.redis_pool_max_size,
+            )
+            .await
+        }
     }
 }
 


### PR DESCRIPTION
## Motivation

Previously, running tests would only work if there was a `config.toml` with a useable configuration, or the `SVIX_JWT_SECRET` environment variable was set (one test would also pick this up from `.env`, others not).

## Solution

Make tests work independently of dev configuration by hardcoding config values that work for testing.