### PR TITLE
server: Enable some allow-by-default lints

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -4,9 +4,16 @@ resolver = "2"
 
 [workspace.lints.rust]
 rust_2018_idioms = "warn"
+trivial_casts = "warn"
+trivial_numeric_casts = "warn"
 
 [workspace.lints.clippy]
+cloned_instead_of_copied = "warn"
 dbg_macro = "warn"
+inefficient_to_string = "warn"
+macro_use_imports = "warn"
+mut_mut = "warn"
+nonstandard_macro_braces = "warn"
 todo = "warn"
 
 [patch.crates-io]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -2,5 +2,9 @@
 members = ["svix-server", "svix-server_derive"]
 resolver = "2"
 
+[workspace.lints.clippy]
+dbg_macro = "warn"
+todo = "warn"
+
 [patch.crates-io]
 hyper = { git = "https://github.com/svix/hyper/", rev = "63efac5a6719937359d61a1bb1b93d9ce88f0e3d" }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -2,6 +2,9 @@
 members = ["svix-server", "svix-server_derive"]
 resolver = "2"
 
+[workspace.lints.rust]
+rust_2018_idioms = "warn"
+
 [workspace.lints.clippy]
 dbg_macro = "warn"
 todo = "warn"

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -86,3 +86,6 @@ axum-server = { version = "0.5", features = ["tls-openssl"] }
 [features]
 default = ["jemalloc"]
 jemalloc = ["dep:tikv-jemallocator"]
+
+[lints]
+workspace = true

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -352,7 +352,7 @@ pub enum Environment {
 }
 
 impl std::fmt::Display for Environment {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "{}",

--- a/server/svix-server/src/core/cache/mod.rs
+++ b/server/svix-server/src/core/cache/mod.rs
@@ -103,8 +103,7 @@ macro_rules! string_kv_def_inner {
 #[allow(unused_imports)]
 pub(crate) use string_kv_def_inner;
 
-// Used downstream and for testing:
-#[allow(unused_macros)]
+#[cfg(test)]
 macro_rules! string_kv_def {
     ($key_id:ident) => {
         crate::core::cache::string_kv_def_inner!($key_id);
@@ -114,7 +113,7 @@ macro_rules! string_kv_def {
         impl crate::core::cache::CacheKey for $key_id {}
     };
 }
-#[allow(unused_imports)]
+#[cfg(test)]
 pub(crate) use string_kv_def;
 
 #[derive(Clone)]

--- a/server/svix-server/src/core/webhook_http_client.rs
+++ b/server/svix-server/src/core/webhook_http_client.rs
@@ -103,7 +103,7 @@ impl WebhookClient {
         &self,
         request: Request,
         retry: bool,
-    ) -> BoxFuture<Result<Response<Body>, Error>> {
+    ) -> BoxFuture<'_, Result<Response<Body>, Error>> {
         async move {
             let org_req = request.clone();
             if let Some(auth) = request.uri.authority() {

--- a/server/svix-server/src/error.rs
+++ b/server/svix-server/src/error.rs
@@ -97,7 +97,7 @@ impl Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.typ.fmt(f)
     }
 }
@@ -229,7 +229,7 @@ pub enum ErrorType {
 }
 
 impl fmt::Display for ErrorType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Generic(s) => s.fmt(f),
             Self::Database(s) => s.fmt(f),
@@ -372,7 +372,7 @@ impl From<HttpError> for Error {
 }
 
 impl fmt::Display for HttpError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.body {
             HttpErrorBody::Standard(StandardHttpError { code, detail }) => write!(
                 f,

--- a/server/svix-server/src/redis/mod.rs
+++ b/server/svix-server/src/redis/mod.rs
@@ -14,7 +14,7 @@ pub enum RedisPool {
 }
 
 impl RedisPool {
-    pub async fn get(&self) -> Result<PooledConnection, RunError<RedisError>> {
+    pub async fn get(&self) -> Result<PooledConnection<'_>, RunError<RedisError>> {
         match self {
             Self::Clustered(pool) => pool.get().await,
             Self::NonClustered(pool) => pool.get().await,
@@ -28,7 +28,7 @@ pub struct ClusteredRedisPool {
 }
 
 impl ClusteredRedisPool {
-    pub async fn get(&self) -> Result<PooledConnection, RunError<RedisError>> {
+    pub async fn get(&self) -> Result<PooledConnection<'_>, RunError<RedisError>> {
         let con = ClusteredPooledConnection {
             con: self.pool.get().await?,
         };
@@ -42,7 +42,7 @@ pub struct NonClusteredRedisPool {
 }
 
 impl NonClusteredRedisPool {
-    pub async fn get(&self) -> Result<PooledConnection, RunError<RedisError>> {
+    pub async fn get(&self) -> Result<PooledConnection<'_>, RunError<RedisError>> {
         let con = self.pool.get().await?;
         let con = NonClusteredPooledConnection { con };
         Ok(PooledConnection::NonClustered(con))

--- a/server/svix-server/src/v1/endpoints/auth.rs
+++ b/server/svix-server/src/v1/endpoints/auth.rs
@@ -119,7 +119,7 @@ Logout an app token.
 Trying to log out other tokens will fail.
 "#;
 
-fn logout_operation(op: TransformOperation) -> TransformOperation {
+fn logout_operation(op: TransformOperation<'_>) -> TransformOperation<'_> {
     op.id("logout_api_v1_auth_logout__post")
         .summary("Logout")
         .description(LOGOUT_DESCRIPTION)

--- a/server/svix-server/src/v1/utils/mod.rs
+++ b/server/svix-server/src/v1/utils/mod.rs
@@ -630,11 +630,15 @@ pub fn validate_no_control_characters_unrequired(
     }
 }
 
-pub fn openapi_tag<T: AsRef<str>>(tag: T) -> impl Fn(TransformPathItem) -> TransformPathItem {
+pub fn openapi_tag<T: AsRef<str>>(
+    tag: T,
+) -> impl Fn(TransformPathItem<'_>) -> TransformPathItem<'_> {
     move |op| op.tag(tag.as_ref())
 }
 
-pub fn openapi_desc<T: AsRef<str>>(desc: T) -> impl Fn(TransformOperation) -> TransformOperation {
+pub fn openapi_desc<T: AsRef<str>>(
+    desc: T,
+) -> impl Fn(TransformOperation<'_>) -> TransformOperation<'_> {
     move |op| op.description(desc.as_ref())
 }
 

--- a/server/svix-server_derive/Cargo.toml
+++ b/server/svix-server_derive/Cargo.toml
@@ -12,3 +12,6 @@ proc-macro = true
 proc-macro2 = "1.0.78"
 quote = "1.0.15"
 syn = "2.0.48"
+
+[lints]
+workspace = true


### PR DESCRIPTION
Explanations for the rust lints can be found [here](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html).
Explanations for the clippy lints can be found [here](https://rust-lang.github.io/rust-clippy/master).
