### PR TITLE
ci: Set custom prefix names for Rust caches

### DIFF
--- a/.github/workflows/bridge-ci.yml
+++ b/.github/workflows/bridge-ci.yml
@@ -42,6 +42,8 @@ jobs:
         # only save the cache on the main branch
         # cf https://github.com/Swatinem/rust-cache/issues/95
         save-if: ${{ github.ref == 'refs/heads/main' }}
+        # include relevant information in the cache name
+        prefix-key: "bridge-${{ matrix.rust }}"
 
     - name: rustfmt
       run: cargo fmt -- --check

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -49,6 +49,8 @@ jobs:
         # only save the cache on the main branch
         # cf https://github.com/Swatinem/rust-cache/issues/95
         save-if: ${{ github.ref == 'refs/heads/main' }}
+        # include relevant information in the cache name
+        prefix-key: "rust-client-${{ matrix.rust }}"
 
     - name: Clippy
       run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -36,6 +36,8 @@ jobs:
           workspaces: "rust -> target"
           # only restore cache for faster publishing, don't save back results
           save-if: false
+          # use the cache from rust-lint/stable
+          prefix-key: "rust-client-stable"
 
       - name: Publish
         env:

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -42,6 +42,8 @@ jobs:
         # only save the cache on the main branch
         # cf https://github.com/Swatinem/rust-cache/issues/95
         save-if: ${{ github.ref == 'refs/heads/main' }}
+        # include relevant information in the cache name
+        prefix-key: "server-${{ matrix.rust }}"
 
     - name: rustfmt
       run: cargo fmt -- --check


### PR DESCRIPTION
… to be able to tell caches apart easily in the web UI.

I just ran into an out-of-disk-space error in #1242. I think we're likely littering the disk with Rust build artifacts, considering we have one Actions cache entry that's a whopping 3.1GB in size _after_ the automatic pruning the rust-cache action does. I could confirm that that entry corresponds to the bridge workflow¹, but it was kind of annoying and it would have been much nicer to be able to tell that at a glance.

Currently, the [cache page](https://github.com/svix/svix-webhooks/actions/caches) looks like this:

![Screenshot 2024-02-29 at 12-04-01 Workflow runs · svix_svix-webhooks](https://github.com/svix/svix-webhooks/assets/158304798/ec2b56ac-91fc-4ee8-85aa-a621a68cf556)

After this PR is merged and the relevant CI jobs ran on `main`, we should get new entries that start with `bridge-`, `server-` and `rust-client-` plus the Rust toolchain name instead of the current `v0-rust-`, so that we can match up the cache entries with which workflow is using them.

¹ by deleting it and seeing the next run not restore anything; could also have compared hashes