### PR TITLE
Tracing initialization improvements

### DIFF
--- a/bridge/svix-bridge/src/main.rs
+++ b/bridge/svix-bridge/src/main.rs
@@ -14,7 +14,7 @@ use svix_ksuid::{KsuidLike as _, KsuidMs};
 #[cfg(all(not(target_env = "msvc"), feature = "jemalloc"))]
 use tikv_jemallocator::Jemalloc;
 use tracing::Instrument;
-use tracing_subscriber::prelude::*;
+use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _};
 
 mod allocator;
 mod config;

--- a/bridge/svix-bridge/src/main.rs
+++ b/bridge/svix-bridge/src/main.rs
@@ -96,16 +96,16 @@ fn setup_tracing(cfg: &Config) {
         tracing_opentelemetry::layer().with_tracer(tracer)
     });
 
-    // Then initialize logging with an additional layer printing to stdout. This additional layer is
-    // either formatted normally or in JSON format
-    let _ = match cfg.log_format {
+    // Then create a subscriber with an additional layer printing to stdout.
+    // This additional layer is either formatted normally or in JSON format.
+    match cfg.log_format {
         config::LogFormat::Default => {
             let stdout_layer = tracing_subscriber::fmt::layer();
             tracing_subscriber::Registry::default()
                 .with(otel_layer)
                 .with(stdout_layer)
                 .with(tracing_subscriber::EnvFilter::new(filter_directives))
-                .try_init()
+                .init()
         }
         config::LogFormat::Json => {
             let fmt = tracing_subscriber::fmt::format().json().flatten_event(true);
@@ -119,7 +119,7 @@ fn setup_tracing(cfg: &Config) {
                 .with(otel_layer)
                 .with(stdout_layer)
                 .with(tracing_subscriber::EnvFilter::new(filter_directives))
-                .try_init()
+                .init()
         }
     };
 }

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -21,7 +21,7 @@ use std::{
 };
 use tower::ServiceBuilder;
 use tower_http::cors::{AllowHeaders, Any, CorsLayer};
-use tracing_subscriber::{prelude::*, util::SubscriberInitExt};
+use tracing_subscriber::prelude::*;
 
 use crate::{
     cfg::{CacheBackend, Configuration},
@@ -226,7 +226,7 @@ pub async fn run_with_prefix(
     expired_message_cleaner_loop.expect("Error initializing expired message cleaner")
 }
 
-pub fn setup_tracing(cfg: &ConfigurationInner) -> impl Drop {
+pub fn setup_tracing(cfg: &ConfigurationInner) -> (tracing::Dispatch, sentry::ClientInitGuard) {
     let filter_directives = std::env::var("RUST_LOG").unwrap_or_else(|e| {
         if let std::env::VarError::NotUnicode(_) = e {
             eprintln!("RUST_LOG environment variable has non-utf8 contents, ignoring!");
@@ -287,10 +287,9 @@ pub fn setup_tracing(cfg: &ConfigurationInner) -> impl Drop {
             _ => EventFilter::Ignore,
         });
 
-    // Then initialize logging with an additional layer printing to stdout. This additional layer is
-    // either formatted normally or in JSON format
-    // Fails if the subscriber was already initialized, which we can safely and silently ignore
-    let _ = match cfg.log_format {
+    // Then create a subscriber with an additional layer printing to stdout.
+    // This additional layer is either formatted normally or in JSON format.
+    let dispatch = match cfg.log_format {
         cfg::LogFormat::Default => {
             let stdout_layer = tracing_subscriber::fmt::layer();
             tracing_subscriber::Registry::default()
@@ -298,7 +297,7 @@ pub fn setup_tracing(cfg: &ConfigurationInner) -> impl Drop {
                 .with(sentry_layer)
                 .with(stdout_layer)
                 .with(tracing_subscriber::EnvFilter::new(filter_directives))
-                .try_init()
+                .into()
         }
         cfg::LogFormat::Json => {
             let fmt = tracing_subscriber::fmt::format().json().flatten_event(true);
@@ -313,10 +312,11 @@ pub fn setup_tracing(cfg: &ConfigurationInner) -> impl Drop {
                 .with(sentry_layer)
                 .with(stdout_layer)
                 .with(tracing_subscriber::EnvFilter::new(filter_directives))
-                .try_init()
+                .into()
         }
     };
-    sentry_guard
+
+    (dispatch, sentry_guard)
 }
 
 mod docs {

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -21,7 +21,7 @@ use std::{
 };
 use tower::ServiceBuilder;
 use tower_http::cors::{AllowHeaders, Any, CorsLayer};
-use tracing_subscriber::prelude::*;
+use tracing_subscriber::layer::SubscriberExt as _;
 
 use crate::{
     cfg::{CacheBackend, Configuration},

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -7,6 +7,7 @@
 use dotenv::dotenv;
 use svix_server::core::types::{EndpointSecretInternal, OrganizationId};
 use svix_server::db::wipe_org;
+use tracing_subscriber::util::SubscriberInitExt;
 use validator::Validate;
 
 use svix_server::core::security::{default_org_id, generate_org_token};
@@ -110,7 +111,8 @@ async fn main() {
     let args = Args::parse();
     let cfg = cfg::load().expect("Error loading configuration");
 
-    let _guard = setup_tracing(&cfg);
+    let (tracing_subscriber, _guard) = setup_tracing(&cfg);
+    tracing_subscriber.init();
 
     if let Some(wait_for_seconds) = args.wait_for {
         let mut wait_for = Vec::with_capacity(2);


### PR DESCRIPTION
Previously, it was possible that tests would overwrite each other's intended logging configuration.