### PR TITLE
Make procedural macros faster by optimizing quote

### DIFF
--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -10,3 +10,6 @@ members = [
     "svix-bridge",
     "svix-bridge-plugin-queue",
 ]
+
+[profile.dev.package]
+quote = { opt-level = 2 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -16,5 +16,8 @@ mut_mut = "warn"
 nonstandard_macro_braces = "warn"
 todo = "warn"
 
+[profile.dev.package]
+quote = { opt-level = 2 }
+
 [patch.crates-io]
 hyper = { git = "https://github.com/svix/hyper/", rev = "63efac5a6719937359d61a1bb1b93d9ce88f0e3d" }


### PR DESCRIPTION
This takes extra compile time on first build of quote, but the cost is recouped by faster runtime of proc-macros, even for clean `cargo check`. (tested for server, but bridge has just as many proc-macro dependencies)
