### PR TITLE
Remove Bundler as a dependency

### DIFF
--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -32,7 +32,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (>= 2.2.10)
   rake (~> 13.0)
   rspec (~> 3.2)
   svix!

--- a/ruby/svix.gemspec
+++ b/ruby/svix.gemspec
@@ -47,7 +47,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
 
-  spec.add_development_dependency "bundler", ">= 2.2.10"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.2"
 end


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
We are going to use Svix for our webhooks and we have a Gemfile with `bundler 2.4.21` and a `ruby version 2.7.8`.
But due to `bundler (>= 2.2.10)` in svix/ruby/gemfile.lock our build is failing on Heroku because `>=` tries to get the latest version of bundler which is currently `2.5.6` that requires ruby version 3.0 (which we don't have in our repo). So basically we need to restrict the bundler from updating to the latest version.

## Solution

There are two options:

- We can include the bundler dependency but with the `~>` sign, not the `>=` (so that it will not jump to the latest version).
- As we do not have any need to add bundler as a dependency we can remove it too.

I have implemented the 2nd one in my PR.
