### PR TITLE
Regression test for missing message IDs in rabbiqmq

### DIFF
--- a/.github/workflows/other-lint.yml
+++ b/.github/workflows/other-lint.yml
@@ -49,6 +49,7 @@ jobs:
           VALIDATE_RUST_2018: false
           VALIDATE_RUST_2021: false
           VALIDATE_RUST_CLIPPY: false
+          VALIDATE_SHELL_SHFMT: false
           VALIDATE_SQL: false
           VALIDATE_SQLFLUFF: false
           FILTER_REGEX_EXCLUDE: (gradlew|javascript/tsconfig.json)

--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -2894,9 +2894,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-pubsub"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6e4fdcd8303ad0d0cdb8b5722aa3a57de9534af27d4da71fc4d3179174a896"
+checksum = "1da196da473976944d408a91213bafe078e7223e10694d3f8ed36b6e210fa130"
 dependencies = [
  "async-channel 1.9.0",
  "async-stream",
@@ -3940,8 +3940,9 @@ dependencies = [
 
 [[package]]
 name = "omniqueue"
-version = "0.1.0"
-source = "git+https://github.com/svix/omniqueue-rs?rev=044fc688670759859f193bb646fac043bbfd08ba#044fc688670759859f193bb646fac043bbfd08ba"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cba3b7f69e420be6e32a580307e38aef7f53ac01cc09c3bb6851aec37d710894"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/bridge/svix-bridge-plugin-queue/Cargo.toml
+++ b/bridge/svix-bridge-plugin-queue/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-omniqueue = { git = "https://github.com/svix/omniqueue-rs", rev = "044fc688670759859f193bb646fac043bbfd08ba" }
+omniqueue = "0.2.0"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 svix-bridge-types = { path = "../svix-bridge-types" }
@@ -20,7 +20,7 @@ aws-config = "1.1.5"
 aws-sdk-sqs = "1.13.0"
 fastrand = "2.0.1"
 google-cloud-googleapis = "0.12.0"
-google-cloud-pubsub = "0.22.1"
+google-cloud-pubsub = "0.23.0"
 lapin = "2"
 redis = { version = "0.24.0", features = ["tokio-comp", "streams"] }
 tracing-subscriber = "0.3"

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1802,7 +1802,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.6",
  "tokio",
  "tower-service",
  "tracing",
@@ -2521,8 +2521,9 @@ dependencies = [
 
 [[package]]
 name = "omniqueue"
-version = "0.1.0"
-source = "git+https://github.com/svix/omniqueue-rs.git?rev=044fc688670759859f193bb646fac043bbfd08ba#044fc688670759859f193bb646fac043bbfd08ba"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cba3b7f69e420be6e32a580307e38aef7f53ac01cc09c3bb6851aec37d710894"
 dependencies = [
  "async-trait",
  "bb8",

--- a/server/run-tests.sh
+++ b/server/run-tests.sh
@@ -43,8 +43,11 @@ SVIX_REDIS_DSN="redis://localhost:6379" \
 ${TEST_COMMAND}
 
 echo "*********** RUN 6 ***********"
-SVIX_QUEUE_TYPE="rabbitmq" \
-SVIX_CACHE_TYPE="redis" \
-SVIX_REDIS_DSN="redis://localhost:6379" \
-SVIX_RABBIT_DSN="amqp://xivs:xivs@localhost:5672/%2f" \
-${TEST_COMMAND}
+(
+    export SVIX_QUEUE_TYPE="rabbitmq"
+    export SVIX_CACHE_TYPE="redis"
+    export SVIX_REDIS_DSN="redis://localhost:6379"
+    export SVIX_RABBIT_DSN="amqp://xivs:xivs@localhost:5672/%2f"
+    ${TEST_COMMAND}
+    cargo test -- --ignored rabbitmq
+)

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -72,7 +72,7 @@ urlencoding = "2.1.2"
 form_urlencoded = "1.1.0"
 lapin = "2.1.1"
 sentry = { version = "0.32.2", features = ["tracing"] }
-omniqueue = { git = "https://github.com/svix/omniqueue-rs.git", rev = "044fc688670759859f193bb646fac043bbfd08ba", default-features = false, features = ["in_memory", "rabbitmq", "redis_cluster"] }
+omniqueue = { version = "0.2.0", default-features = false, features = ["in_memory", "rabbitmq", "redis_cluster"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.5", optional = true }

--- a/server/svix-server/src/queue/mod.rs
+++ b/server/svix-server/src/queue/mod.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 use axum::async_trait;
 use omniqueue::{
-    backends::InMemoryBackend, Delivery, DynConsumer, DynScheduledQueueProducer, QueueConsumer,
+    backends::InMemoryBackend, Delivery, DynConsumer, DynScheduledProducer, QueueConsumer,
     ScheduledQueueProducer,
 };
 use serde::{Deserialize, Serialize};
@@ -143,7 +143,7 @@ impl QueueTask {
 
 #[derive(Clone)]
 pub struct TaskQueueProducer {
-    inner: Arc<DynScheduledQueueProducer>,
+    inner: Arc<DynScheduledProducer>,
 }
 
 impl TaskQueueProducer {


### PR DESCRIPTION
I'm having trouble running the test locally, but it passed in #1256 ([ci log](https://github.com/svix/svix-webhooks/actions/runs/8171848038/job/22340963872?pr=1256#step:12:1942)). Make sure it doesn't pass when [the fix](https://github.com/svix/svix-webhooks/pull/1256/commits/28502542c14c00d87781abad6adc7d9f0699cc11) is missing. 