### PR TITLE
Debug-print error when constructing 'Error::Generic'

### DIFF
--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -23,7 +23,7 @@ pub enum Error {
 
 impl Error {
     pub(crate) fn generic(err: impl std::error::Error) -> Self {
-        Self::Generic(err.to_string())
+        Self::Generic(format!("{err:?}"))
     }
 
     pub(crate) async fn from_response(status_code: http1::StatusCode, body: Incoming) -> Self {


### PR DESCRIPTION
Since we throw away the original error, let's debug-print it to capture more information