### PR TITLE
rust: Use nightly rustfmt to control comment wrapping and import formatting

### DIFF
--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -24,6 +24,20 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  check-fmt:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+
+      - name: rustfmt
+        run: cargo fmt -- --check
+        working-directory: rust
+
   test-versions:
     name: Rust Lint
     runs-on: ubuntu-latest
@@ -41,7 +55,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
-        components: clippy, rustfmt
+        components: clippy
 
     - uses: Swatinem/rust-cache@v2
       with:
@@ -54,10 +68,6 @@ jobs:
 
     - name: Clippy
       run: cargo clippy --all-targets --all-features -- -D warnings
-      working-directory: rust
-
-    - name: rustfmt
-      run: cargo fmt -- --check
       working-directory: rust
 
     - name: Run tests

--- a/rust/.rustfmt.toml
+++ b/rust/.rustfmt.toml
@@ -1,0 +1,2 @@
+wrap_comments = true
+imports_granularity = "Crate"

--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -1,16 +1,17 @@
-use hyper_util::client::legacy::Client as HyperClient;
-use hyper_util::rt::TokioExecutor;
+use hyper_util::{client::legacy::Client as HyperClient, rt::TokioExecutor};
 
-use crate::apis::{
-    application_api, authentication_api, background_tasks_api, endpoint_api, event_type_api,
-    integration_api, message_api, message_attempt_api, statistics_api,
+use crate::{
+    apis::{
+        application_api, authentication_api, background_tasks_api, endpoint_api, event_type_api,
+        integration_api, message_api, message_attempt_api, statistics_api,
+    },
+    error::Result,
+    Configuration,
 };
-use crate::error::Result;
-pub use crate::models::*;
-use crate::Configuration;
 
 #[cfg(feature = "svix_beta")]
-pub use message_api::{V1MessageStreamError, V1MessageStreamParams};
+pub use crate::apis::message_api::{V1MessageStreamError, V1MessageStreamParams};
+pub use crate::models::*;
 
 const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -75,7 +75,8 @@ fn default_connector() -> Connector {
     }
 }
 
-/// Convert a `StatusCode` from the http crate v1 to one from the http crate v0.2.
+/// Convert a `StatusCode` from the http crate v1 to one from the http crate
+/// v0.2.
 fn http1_to_02_status_code(code: http1::StatusCode) -> http02::StatusCode {
     http02::StatusCode::from_u16(code.as_u16())
         .expect("both versions of the http crate enforce the same numerical limits for StatusCode")

--- a/rust/src/request.rs
+++ b/rust/src/request.rs
@@ -1,4 +1,5 @@
-// Modified version of the file openapi-generator would usually put in apis/request.rs
+// Modified version of the file openapi-generator would usually put in
+// apis/request.rs
 
 use std::collections::HashMap;
 
@@ -14,9 +15,9 @@ pub(crate) enum Auth {
     Bearer,
 }
 
-/// If the authorization type is unspecified then it will be automatically detected based
-/// on the configuration. This functionality is useful when the OpenAPI definition does not
-/// include an authorization scheme.
+/// If the authorization type is unspecified then it will be automatically
+/// detected based on the configuration. This functionality is useful when the
+/// OpenAPI definition does not include an authorization scheme.
 pub(crate) struct Request {
     auth: Option<Auth>,
     method: http1::Method,
@@ -93,9 +94,9 @@ impl Request {
 
         let mut uri = format!("{}{}", conf.base_path, path);
 
-        // Work around rustc issue - we need to make sure that `query_string` is not captured
-        // by the outer `async` generator. Using `drop(query_string)` is insufficient, so we
-        // create a new scope
+        // Work around rustc issue - we need to make sure that `query_string` is
+        // not captured by the outer `async` generator. Using
+        // `drop(query_string)` is insufficient, so we create a new scope
         {
             let mut query_string = ::url::form_urlencoded::Serializer::new("".to_owned());
             for (key, val) in self.query_params {

--- a/rust/src/webhooks.rs
+++ b/rust/src/webhooks.rs
@@ -143,7 +143,8 @@ impl Webhook {
     }
 }
 
-/// Trait to abstract over the `HeaderMap` types from both v0.2 and v1.0 of the `http` crate.
+/// Trait to abstract over the `HeaderMap` types from both v0.2 and v1.0 of the
+/// `http` crate.
 pub trait HeaderMap: private::HeaderMapSealed {}
 
 impl HeaderMap for http02::HeaderMap {}
@@ -186,9 +187,9 @@ mod private {
 
 #[cfg(test)]
 mod tests {
+    use http02::HeaderMap;
 
     use super::*;
-    use http02::HeaderMap;
 
     fn get_svix_headers(msg_id: &str, signature: &str) -> HeaderMap {
         let mut headers = HeaderMap::new();


### PR DESCRIPTION
Start with the smallest crate / workspace in the repo. Same thing that was done for omniqueue before: https://github.com/svix/omniqueue-rs/pull/54