### PR TITLE
server: Use tracing_subscriber's TestWriter in tests

### DIFF
--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -111,7 +111,7 @@ async fn main() {
     let args = Args::parse();
     let cfg = cfg::load().expect("Error loading configuration");
 
-    let (tracing_subscriber, _guard) = setup_tracing(&cfg);
+    let (tracing_subscriber, _guard) = setup_tracing(&cfg, /* for_test = */ false);
     tracing_subscriber.init();
 
     if let Some(wait_for_seconds) = args.wait_for {

--- a/server/svix-server/tests/it/utils/mod.rs
+++ b/server/svix-server/tests/it/utils/mod.rs
@@ -272,7 +272,7 @@ pub async fn start_svix_server_with_cfg_and_org_id(
     cfg: &ConfigurationInner,
     org_id: OrganizationId,
 ) -> (TestClient, tokio::task::JoinHandle<()>) {
-    let (tracing_subscriber, _guard) = setup_tracing(cfg);
+    let (tracing_subscriber, _guard) = setup_tracing(cfg, /* for_test = */ true);
 
     let cfg = Arc::new(cfg.clone());
 


### PR DESCRIPTION
… so that logs are only printed for failing tests.
