### PR TITLE
Fix route of development/echo

### DIFF
--- a/server/svix-server/src/v1/mod.rs
+++ b/server/svix-server/src/v1/mod.rs
@@ -71,6 +71,6 @@ mod development {
     }
 
     pub fn router() -> Router<AppState> {
-        Router::new().route("/development/echo/", get(echo).post(echo))
+        Router::new().route("/development/echo", get(echo).post(echo))
     }
 }


### PR DESCRIPTION
Now that we normalize paths, any routes registered with a slash at the end can't actually be hit at all as the trailing slash will be stripped before the request goes to the router.

Follow-up to #1270 