### PR TITLE
Some testing improvements

### DIFF
--- a/rust/src/webhooks.rs
+++ b/rust/src/webhooks.rs
@@ -188,8 +188,12 @@ mod private {
 #[cfg(test)]
 mod tests {
     use http02::HeaderMap;
+    use time::OffsetDateTime;
 
-    use super::*;
+    use super::{
+        Webhook, SVIX_MSG_ID_KEY, SVIX_MSG_SIGNATURE_KEY, SVIX_MSG_TIMESTAMP_KEY,
+        UNBRANDED_MSG_ID_KEY, UNBRANDED_MSG_SIGNATURE_KEY, UNBRANDED_MSG_TIMESTAMP_KEY,
+    };
 
     fn get_svix_headers(msg_id: &str, signature: &str) -> HeaderMap {
         let mut headers = HeaderMap::new();

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -944,6 +944,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df"
 
 [[package]]
+name = "ctor"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad291aa74992b9b7a7e88c38acbbf6ad7e107f1d90ee8775b7bc1fc3394f485c"
+dependencies = [
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4347,6 +4357,7 @@ dependencies = [
  "chacha20poly1305",
  "chrono",
  "clap",
+ "ctor",
  "dotenv",
  "ed25519-compact 1.0.16",
  "enum_dispatch",

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -82,6 +82,7 @@ anyhow = "1.0.56"
 assert_matches = "1.5.0"
 # NOTE: Purposely not the latest version such as not to mess up the `hyper` fork patch
 axum-server = { version = "0.5", features = ["tls-openssl"] }
+ctor = "0.2.7"
 
 [features]
 default = ["jemalloc"]

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -397,8 +397,15 @@ pub fn load() -> Result<Arc<ConfigurationInner>> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::core::security::JWTAlgorithm;
+    use std::{sync::Arc, time::Duration};
+
+    use figment::{
+        providers::{Format as _, Toml},
+        Figment,
+    };
+
+    use super::{load, CacheBackend, CacheType, QueueBackend, QueueType};
+    use crate::core::security::{JWTAlgorithm, JwtSigningConfig};
 
     #[test]
     fn test_retry_schedule_parsing() {

--- a/server/svix-server/src/core/cryptography.rs
+++ b/server/svix-server/src/core/cryptography.rs
@@ -109,7 +109,7 @@ impl Default for Encryption {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::Encryption;
 
     #[test]
     fn test_encryption() {

--- a/server/svix-server/src/core/message_app.rs
+++ b/server/svix-server/src/core/message_app.rs
@@ -219,9 +219,16 @@ impl AppEndpointKey {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::core::cryptography::Encryption;
-    use crate::core::types::{EndpointSecret, ExpiringSigningKey};
+    use chrono::Utc;
+
+    use super::CreateMessageEndpoint;
+    use crate::core::{
+        cryptography::Encryption,
+        types::{
+            EndpointId, EndpointSecret, EndpointSecretInternal, ExpiringSigningKey,
+            ExpiringSigningKeys,
+        },
+    };
 
     #[test]
     fn test_valid_signing_keys() {

--- a/server/svix-server/src/core/message_app.rs
+++ b/server/svix-server/src/core/message_app.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::HashSet,
-    convert::{TryFrom, TryInto},
-    time::Duration,
-};
+use std::{collections::HashSet, time::Duration};
 
 use chrono::{DateTime, FixedOffset, Utc};
 use sea_orm::{DatabaseConnection, DatabaseTransaction, TransactionTrait};

--- a/server/svix-server/src/core/types/mod.rs
+++ b/server/svix-server/src/core/types/mod.rs
@@ -1371,11 +1371,15 @@ pub type FeatureFlagSet = HashSet<FeatureFlag>;
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::core::types::{EventChannel, EventTypeName};
-
     use std::collections::HashMap;
+
     use validator::Validate;
+
+    use super::{
+        validate_header_map, ApplicationId, ApplicationUid, EndpointHeaders, EndpointHeadersPatch,
+        EndpointSecret, EventChannel, EventTypeName,
+    };
+    use crate::core::cryptography::AsymmetricKey;
 
     #[test]
     fn test_id_validation() {

--- a/server/svix-server/src/core/webhook_http_client.rs
+++ b/server/svix-server/src/core/webhook_http_client.rs
@@ -619,12 +619,15 @@ mod tests {
         net::{IpAddr, TcpListener},
         path::PathBuf,
         str::FromStr,
+        sync::Arc,
     };
 
     use axum::{routing, Router};
     use axum_server::tls_openssl::{OpenSSLAcceptor, OpenSSLConfig};
+    use http::{HeaderValue, Method, Version};
+    use ipnet::IpNet;
 
-    use super::*;
+    use super::{is_allowed, CaseSensitiveHeaderMap, RequestBuilder, WebhookClient};
 
     #[test]
     fn is_allowed_test() {

--- a/server/svix-server/src/redis/mod.rs
+++ b/server/svix-server/src/redis/mod.rs
@@ -162,13 +162,13 @@ pub async fn new_redis_pool(redis_dsn: &str, cfg: &Configuration) -> RedisPool {
 mod tests {
     use redis::AsyncCommands;
 
-    use super::*;
-    use crate::cfg::CacheType;
+    use super::RedisPool;
+    use crate::cfg::{CacheType, Configuration};
 
     async fn get_pool(redis_dsn: &str, cfg: &Configuration) -> RedisPool {
         match cfg.cache_type {
-            CacheType::RedisCluster => crate::redis::new_redis_pool_clustered(redis_dsn, cfg).await,
-            CacheType::Redis => crate::redis::new_redis_pool(redis_dsn, cfg).await,
+            CacheType::RedisCluster => super::new_redis_pool_clustered(redis_dsn, cfg).await,
+            CacheType::Redis => super::new_redis_pool(redis_dsn, cfg).await,
             _ => panic!(
                 "This test should only be run when redis is configured as the cache provider"
             ),

--- a/server/svix-server/src/worker.rs
+++ b/server/svix-server/src/worker.rs
@@ -1004,13 +1004,16 @@ pub async fn queue_handler(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::core::cryptography::AsymmetricKey;
-    use crate::core::types::{BaseId, EndpointSecret};
+    use std::collections::HashMap;
 
     use bytes::Bytes;
     use ed25519_compact::Signature;
-    use std::collections::HashMap;
+
+    use super::{bytes_to_string, generate_msg_headers, sign_msg, CaseSensitiveHeaderMap};
+    use crate::core::{
+        cryptography::{AsymmetricKey, Encryption},
+        types::{BaseId, EndpointHeaders, EndpointSecret, EndpointSecretInternal, MessageId},
+    };
 
     // [`generate_msg_headers`] tests
     const TIMESTAMP: i64 = 1;

--- a/server/svix-server/tests/it/main.rs
+++ b/server/svix-server/tests/it/main.rs
@@ -12,3 +12,8 @@ mod message_app;
 mod redis_queue;
 mod utils;
 mod worker;
+
+#[ctor::ctor]
+fn test_setup() {
+    svix_server::setup_tracing_for_tests();
+}


### PR DESCRIPTION
Since #1244, we were no longer installing a global tracing subscriber that would print logs from (failing) tests. With this, we do again.

First two commits are drive-by improvements in response to local warnings from my nightly toolchain about redundant imports.