### PR TITLE
More clippy and rustfmt things

### DIFF
--- a/bridge/svix-bridge/src/config/mod.rs
+++ b/bridge/svix-bridge/src/config/mod.rs
@@ -2,6 +2,7 @@ use std::{
     borrow::Cow,
     collections::HashMap,
     convert::Infallible,
+    fmt,
     io::{Error, ErrorKind},
     net::SocketAddr,
     num::NonZeroUsize,
@@ -121,14 +122,14 @@ pub enum LogLevel {
     Trace,
 }
 
-impl ToString for LogLevel {
-    fn to_string(&self) -> String {
+impl fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Info => Level::INFO,
             Self::Debug => Level::DEBUG,
             Self::Trace => Level::TRACE,
         }
-        .to_string()
+        .fmt(f)
     }
 }
 

--- a/server/.clippy.toml
+++ b/server/.clippy.toml
@@ -1,0 +1,1 @@
+allow-mixed-uninlined-format-args = false

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -15,6 +15,7 @@ macro_use_imports = "warn"
 mut_mut = "warn"
 nonstandard_macro_braces = "warn"
 todo = "warn"
+uninlined_format_args = "warn"
 
 [profile.dev.package]
 quote = { opt-level = 2 }

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
-use std::{borrow::Cow, collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
+use std::{borrow::Cow, collections::HashMap, fmt, net::SocketAddr, sync::Arc, time::Duration};
 
 use figment::{
     providers::{Env, Format, Toml},
@@ -12,7 +12,10 @@ use serde::{Deserialize, Deserializer};
 use tracing::Level;
 use validator::{Validate, ValidationError};
 
-use crate::{core::cryptography::Encryption, core::security::JwtSigningConfig, error::Result};
+use crate::{
+    core::{cryptography::Encryption, security::JwtSigningConfig},
+    error::Result,
+};
 
 fn deserialize_main_secret<'de, D>(deserializer: D) -> Result<Encryption, D::Error>
 where
@@ -365,16 +368,17 @@ impl std::fmt::Display for Environment {
     }
 }
 
-impl ToString for LogLevel {
-    fn to_string(&self) -> String {
+impl fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Info => Level::INFO,
             Self::Debug => Level::DEBUG,
             Self::Trace => Level::TRACE,
         }
-        .to_string()
+        .fmt(f)
     }
 }
+
 pub fn load() -> Result<Arc<ConfigurationInner>> {
     if let Ok(db_url) = std::env::var("DATABASE_URL") {
         // If we have DATABASE_URL set, we should potentially use it.

--- a/server/svix-server/src/core/message_app.rs
+++ b/server/svix-server/src/core/message_app.rs
@@ -209,7 +209,7 @@ impl AppEndpointKey {
     // FIXME: Rewrite doc comment when AppEndpointValue members are known
     /// Returns a key for fetching all cached endpoints for a given organization and application.
     pub fn new(org: &OrganizationId, app: &ApplicationId) -> AppEndpointKey {
-        AppEndpointKey(format!("SVIX_CACHE_APP_v3_{}_{}", org, app))
+        AppEndpointKey(format!("SVIX_CACHE_APP_v3_{org}_{app}"))
     }
 }
 

--- a/server/svix-server/src/core/webhook_http_client.rs
+++ b/server/svix-server/src/core/webhook_http_client.rs
@@ -381,7 +381,7 @@ impl RequestBuilder {
         let uri = self.uri.unwrap();
         let authority = uri.authority().expect("Missing authority");
         let host = match authority.port() {
-            Some(port) => format!("{}:{}", authority.host(), port),
+            Some(port) => format!("{}:{port}", authority.host()),
             None => authority.host().to_string(),
         };
 

--- a/server/svix-server/src/db/models/application.rs
+++ b/server/svix-server/src/db/models/application.rs
@@ -1,16 +1,14 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
-use crate::core::types::{
-    ApplicationId, ApplicationIdOrUid, ApplicationUid, BaseId, OrganizationId,
-};
-use crate::error;
 use chrono::Utc;
-use sea_orm::ActiveValue::Set;
-use sea_orm::ConnectionTrait;
-use sea_orm::{entity::prelude::*, Condition};
+use sea_orm::{entity::prelude::*, ActiveValue::Set, Condition};
 
 use super::applicationmetadata;
+use crate::{
+    core::types::{ApplicationId, ApplicationIdOrUid, ApplicationUid, BaseId, OrganizationId},
+    error,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "application")]

--- a/server/svix-server/src/db/models/applicationmetadata.rs
+++ b/server/svix-server/src/db/models/applicationmetadata.rs
@@ -1,14 +1,13 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
-use crate::core::types::ApplicationId;
 
-use crate::core::types::metadata::Metadata;
-use crate::error;
 use chrono::Utc;
-use sea_orm::entity::prelude::*;
-use sea_orm::sea_query::OnConflict;
-use sea_orm::ActiveValue::Set;
-use sea_orm::{ConnectionTrait, TryIntoModel};
+use sea_orm::{entity::prelude::*, sea_query::OnConflict, ActiveValue::Set, TryIntoModel};
+
+use crate::{
+    core::types::{metadata::Metadata, ApplicationId},
+    error,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "applicationmetadata")]

--- a/server/svix-server/src/db/models/endpoint.rs
+++ b/server/svix-server/src/db/models/endpoint.rs
@@ -1,17 +1,18 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
-use crate::core::types::{
-    ApplicationId, BaseId, EndpointHeaders, EndpointId, EndpointIdOrUid, EndpointSecretInternal,
-    EndpointUid, EventChannelSet, EventTypeNameSet, ExpiringSigningKeys,
-};
-use crate::error;
 use chrono::Utc;
-use sea_orm::ActiveValue::Set;
-use sea_orm::{entity::prelude::*, Condition};
-use sea_orm::{ConnectionTrait, IntoActiveModel};
+use sea_orm::{entity::prelude::*, ActiveValue::Set, Condition, IntoActiveModel};
 
 use super::endpointmetadata;
+use crate::{
+    core::types::{
+        ApplicationId, BaseId, EndpointHeaders, EndpointId, EndpointIdOrUid,
+        EndpointSecretInternal, EndpointUid, EventChannelSet, EventTypeNameSet,
+        ExpiringSigningKeys,
+    },
+    error,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "endpoint")]

--- a/server/svix-server/src/db/models/endpointmetadata.rs
+++ b/server/svix-server/src/db/models/endpointmetadata.rs
@@ -1,15 +1,13 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
-use crate::core::types::EndpointId;
-
-use crate::core::types::metadata::Metadata;
-use crate::error;
 
 use chrono::Utc;
-use sea_orm::entity::prelude::*;
-use sea_orm::sea_query::OnConflict;
-use sea_orm::ActiveValue::Set;
-use sea_orm::{ConnectionTrait, TryIntoModel};
+use sea_orm::{entity::prelude::*, sea_query::OnConflict, ActiveValue::Set, TryIntoModel};
+
+use crate::{
+    core::types::{metadata::Metadata, EndpointId},
+    error,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "endpointmetadata")]

--- a/server/svix-server/src/error.rs
+++ b/server/svix-server/src/error.rs
@@ -376,8 +376,8 @@ impl fmt::Display for HttpError {
         match &self.body {
             HttpErrorBody::Standard(StandardHttpError { code, detail }) => write!(
                 f,
-                "status={} code=\"{}\" detail=\"{}\"",
-                self.status, code, detail
+                "status={} code=\"{code}\" detail=\"{detail}\"",
+                self.status
             ),
 
             HttpErrorBody::Validation(ValidationHttpError { detail }) => {

--- a/server/svix-server/src/queue/mod.rs
+++ b/server/svix-server/src/queue/mod.rs
@@ -1,6 +1,5 @@
 use std::{sync::Arc, time::Duration};
 
-use axum::async_trait;
 use omniqueue::{
     backends::InMemoryBackend, Delivery, DynConsumer, DynScheduledProducer, QueueConsumer,
     ScheduledQueueProducer,
@@ -273,14 +272,4 @@ impl TryFrom<Delivery> for TaskQueueDelivery {
             acker: value,
         })
     }
-}
-
-#[async_trait]
-trait TaskQueueSend: Sync + Send {
-    async fn send(&self, task: Arc<QueueTask>, delay: Option<Duration>) -> Result<()>;
-}
-
-#[async_trait]
-trait TaskQueueReceive {
-    async fn receive_all(&mut self) -> Result<Vec<TaskQueueDelivery>>;
 }

--- a/server/svix-server/src/queue/redis.rs
+++ b/server/svix-server/src/queue/redis.rs
@@ -156,12 +156,11 @@ async fn new_pair_inner(
         if let Err(e) = consumer_group_resp {
             if !e.to_string().contains("BUSYGROUP") {
                 panic!(
-                    "error creating consumer group or stream: {:?}, {:?}, {:?}, {:?}, {:?}",
+                    "error creating consumer group or stream: {:?}, {:?}, {:?}, {:?}, {e:?}",
                     e.kind(),
                     e.detail(),
                     e.code(),
-                    e.category(),
-                    e
+                    e.category()
                 )
             };
         }

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -413,7 +413,7 @@ async fn list_attempts_by_endpoint(
         .into_iter()
         .map(|mut attempt| {
             if !with_content {
-                attempt.response = "{}".to_owned()
+                "{}".clone_into(&mut attempt.response)
             }
 
             attempt
@@ -507,7 +507,7 @@ async fn list_attempts_by_msg(
         .into_iter()
         .map(|mut attempt| {
             if !with_content {
-                attempt.response = "{}".to_owned()
+                "{}".clone_into(&mut attempt.response)
             }
 
             attempt

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -3,6 +3,23 @@
 
 use std::collections::HashMap;
 
+use aide::axum::{
+    routing::{delete_with, get_with, post_with},
+    ApiRouter,
+};
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use chrono::{DateTime, Utc};
+use hyper::StatusCode;
+use schemars::JsonSchema;
+use sea_orm::{entity::prelude::*, IntoActiveModel, QueryOrder, QuerySelect};
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::value::RawValue;
+use svix_server_derive::{aide_annotate, ModelOut};
+use validator::Validate;
+
 use crate::{
     core::{
         permissions,
@@ -12,7 +29,7 @@ use crate::{
             StatusCodeClass,
         },
     },
-    db::models::{endpoint, message, messagecontent, messagedestination},
+    db::models::{endpoint, message, messageattempt, messagecontent, messagedestination},
     error::{Error, HttpError, Result},
     queue::MessageTask,
     v1::{
@@ -26,29 +43,6 @@ use crate::{
     },
     AppState,
 };
-use aide::axum::{
-    routing::{delete_with, get_with, post_with},
-    ApiRouter,
-};
-use axum::{
-    extract::{Path, State},
-    Json,
-};
-use chrono::{DateTime, Utc};
-
-use hyper::StatusCode;
-use schemars::JsonSchema;
-use sea_orm::{
-    entity::prelude::*, sea_query::Expr, DatabaseConnection, IntoActiveModel, QueryOrder,
-    QuerySelect,
-};
-use serde::{Deserialize, Deserializer, Serialize};
-
-use serde_json::value::RawValue;
-use svix_server_derive::{aide_annotate, ModelOut};
-use validator::Validate;
-
-use crate::db::models::messageattempt;
 
 fn example_status_code() -> i16 {
     200
@@ -933,13 +927,14 @@ pub fn router() -> ApiRouter<AppState> {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+    use validator::Validate;
+
     use super::{
         AttemptListFetchQueryParams, ListAttemptedMessagesQueryParams,
         ListAttemptsByEndpointQueryParams, ListAttemptsByMsgQueryParams,
         ListAttemptsForEndpointQueryParams,
     };
-    use serde_json::json;
-    use validator::Validate;
 
     const INVALID_CHANNEL: &str = "$$invalid-channel";
     const VALID_CHANNEL: &str = "valid-channel";

--- a/server/svix-server/src/v1/endpoints/auth.rs
+++ b/server/svix-server/src/v1/endpoints/auth.rs
@@ -84,7 +84,7 @@ async fn app_portal_access(
     let login_key = base64::encode(login_key);
 
     // Included for API compatibility, but this URL will not be useful
-    let url = format!("{}/login#key={}", &cfg.internal.app_portal_url, login_key);
+    let url = format!("{}/login#key={login_key}", &cfg.internal.app_portal_url);
 
     Ok(Json(AppPortalAccessOut::from(DashboardAccessOut {
         url,

--- a/server/svix-server/src/v1/endpoints/endpoint/crud.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/crud.rs
@@ -4,13 +4,12 @@ use axum::{
     extract::{Path, State},
     Json,
 };
-use sea_orm::{entity::prelude::*, ActiveValue::Set, TransactionTrait};
-use sea_orm::{ActiveModelTrait, DatabaseConnection, QuerySelect};
+use sea_orm::{entity::prelude::*, ActiveValue::Set, QuerySelect, TransactionTrait};
 use svix_server_derive::aide_annotate;
 use url::Url;
 
+use self::hack::EventTypeNameResult;
 use super::{EndpointIn, EndpointOut, EndpointPatch, EndpointUpdate};
-use crate::error::Traceable;
 use crate::{
     cfg::Configuration,
     core::{
@@ -19,7 +18,7 @@ use crate::{
         types::{EndpointId, EventTypeName, EventTypeNameSet, OrganizationId},
     },
     db::models::{application, endpoint, endpointmetadata, eventtype},
-    error::{http_error_on_conflict, HttpError, Result, ValidationErrorItem},
+    error::{http_error_on_conflict, HttpError, Result, Traceable, ValidationErrorItem},
     v1::utils::{
         apply_pagination,
         patch::{patch_field_non_nullable, UnrequiredField, UnrequiredNullableField},
@@ -29,7 +28,6 @@ use crate::{
     },
     AppState,
 };
-use hack::EventTypeNameResult;
 
 /// List the application's endpoints.
 #[aide_annotate(op_id = "v1.endpoint.list")]

--- a/server/svix-server/src/v1/endpoints/endpoint/recovery.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/recovery.rs
@@ -1,11 +1,9 @@
 use axum::extract::{Path, State};
 use chrono::{DateTime, Utc};
-use sea_orm::{entity::prelude::*, QueryOrder};
-use sea_orm::{DatabaseConnection, QuerySelect};
+use sea_orm::{entity::prelude::*, QueryOrder, QuerySelect};
 use svix_server_derive::aide_annotate;
 
 use super::RecoverIn;
-use crate::v1::utils::NoContentWithCode;
 use crate::{
     core::{
         permissions,
@@ -14,7 +12,7 @@ use crate::{
     db::models::{application, endpoint, messagedestination},
     error::{HttpError, Result, ValidationErrorItem},
     queue::{MessageTask, TaskQueueProducer},
-    v1::utils::{ApplicationEndpointPath, ValidatedJson},
+    v1::utils::{ApplicationEndpointPath, NoContentWithCode, ValidatedJson},
     AppState,
 };
 

--- a/server/svix-server/src/v1/endpoints/event_type.rs
+++ b/server/svix-server/src/v1/endpoints/event_type.rs
@@ -1,6 +1,21 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
+use aide::axum::{
+    routing::{get_with, post_with},
+    ApiRouter,
+};
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use sea_orm::{entity::prelude::*, ActiveValue::Set};
+use serde::{Deserialize, Serialize};
+use svix_server_derive::{aide_annotate, ModelIn, ModelOut};
+use validator::Validate;
+
 use crate::{
     core::{
         permissions,
@@ -21,20 +36,6 @@ use crate::{
     },
     AppState,
 };
-use aide::axum::{
-    routing::{get_with, post_with},
-    ApiRouter,
-};
-use axum::{
-    extract::{Path, State},
-    Json,
-};
-use chrono::{DateTime, Utc};
-use schemars::JsonSchema;
-use sea_orm::{entity::prelude::*, ActiveModelTrait, ActiveValue::Set};
-use serde::{Deserialize, Serialize};
-use svix_server_derive::{aide_annotate, ModelIn, ModelOut};
-use validator::Validate;
 
 fn example_event_archived() -> bool {
     false
@@ -440,8 +441,9 @@ pub fn router() -> ApiRouter<AppState> {
 #[cfg(test)]
 mod tests {
 
-    use super::ListFetchQueryParams;
     use serde_json::json;
+
+    use super::ListFetchQueryParams;
 
     #[test]
     fn test_list_fetch_options_default() {

--- a/server/svix-server/src/worker.rs
+++ b/server/svix-server/src/worker.rs
@@ -80,10 +80,7 @@ impl FailureCacheKey {
         app_id: &ApplicationId,
         endp_id: &EndpointId,
     ) -> FailureCacheKey {
-        FailureCacheKey(format!(
-            "SVIX_FAILURE_CACHE_{}_{}_{}",
-            org_id, app_id, endp_id
-        ))
+        FailureCacheKey(format!("SVIX_FAILURE_CACHE_{org_id}_{app_id}_{endp_id}"))
     }
 }
 
@@ -177,7 +174,7 @@ fn sign_msg(
                 EndpointSecretType::Hmac256 => "v1",
                 EndpointSecretType::Ed25519 => "v1a",
             };
-            format!("{},{}", version, base64::encode(sig))
+            format!("{version},{}", base64::encode(sig))
         })
         .collect::<Vec<String>>()
         .join(" ")
@@ -579,8 +576,8 @@ async fn handle_failed_dispatch(
                 .await?
                 .ok_or_else(|| {
                     Error::generic(format!(
-                        "Endpoint not found {} {}",
-                        app_id, &msg_task.endpoint_id
+                        "Endpoint not found {app_id} {}",
+                        &msg_task.endpoint_id
                     ))
                 })?;
 

--- a/server/svix-server/tests/it/e2e_attempt.rs
+++ b/server/svix-server/tests/it/e2e_attempt.rs
@@ -145,7 +145,7 @@ async fn test_list_attempted_messages() {
 
         let list_2_uid: ListResponse<EndpointMessageOut> = client
             .get(
-                &format!("api/v1/app/{}/endpoint/{}/msg/", app_id, "test"),
+                &format!("api/v1/app/{app_id}/endpoint/{}/msg/", "test"),
                 StatusCode::OK,
             )
             .await
@@ -390,7 +390,7 @@ async fn test_message_attempts() {
 
         for i in list.data.iter() {
             assert_eq!(i.status, msg_status);
-            println!("{} {}", i.response_status_code, status_code);
+            println!("{} {status_code}", i.response_status_code);
             assert_eq!(
                 i.response_status_code,
                 TryInto::<i16>::try_into(status_code.as_u16()).unwrap()
@@ -466,7 +466,7 @@ async fn test_message_attempts_empty_retry_schedule() {
 
     for i in list.data.iter() {
         assert_eq!(i.status, msg_status);
-        println!("{} {}", i.response_status_code, status_code);
+        println!("{} {status_code}", i.response_status_code);
         assert_eq!(
             i.response_status_code,
             TryInto::<i16>::try_into(status_code.as_u16()).unwrap()
@@ -524,7 +524,7 @@ async fn test_pagination_by_endpoint() {
         for endp_id in eps.iter().map(|ep| &ep.id) {
             let list: ListResponse<MessageAttemptOut> = client
                 .get(
-                    &format!("api/v1/app/{}/attempt/endpoint/{}/", app.id, endp_id),
+                    &format!("api/v1/app/{}/attempt/endpoint/{endp_id}/", app.id),
                     StatusCode::OK,
                 )
                 .await
@@ -713,7 +713,7 @@ async fn test_pagination_by_msg() {
         for endp_id in eps.iter().map(|ep| &ep.id) {
             let list: ListResponse<MessageAttemptOut> = client
                 .get(
-                    &format!("api/v1/app/{}/attempt/endpoint/{}/", app.id, endp_id),
+                    &format!("api/v1/app/{}/attempt/endpoint/{endp_id}/", app.id),
                     StatusCode::OK,
                 )
                 .await
@@ -726,8 +726,8 @@ async fn test_pagination_by_msg() {
             let list_filtered: ListResponse<MessageAttemptOut> = client
                 .get(
                     &format!(
-                        "api/v1/app/{}/attempt/endpoint/{}/?channel=news",
-                        app.id, endp_id
+                        "api/v1/app/{}/attempt/endpoint/{endp_id}/?channel=news",
+                        app.id
                     ),
                     StatusCode::OK,
                 )
@@ -966,8 +966,8 @@ async fn test_pagination_forward_and_back() {
         let mut out: ListResponse<MessageAttemptOut> = client
             .get(
                 &format!(
-                    "api/v1/app/{}/attempt/endpoint/{}/?limit=10{}",
-                    app.id, ep.id, iter_suffix
+                    "api/v1/app/{}/attempt/endpoint/{}/?limit=10{iter_suffix}",
+                    app.id, ep.id
                 ),
                 StatusCode::OK,
             )
@@ -996,8 +996,8 @@ async fn test_pagination_forward_and_back() {
         let mut out: ListResponse<MessageAttemptOut> = client
             .get(
                 &format!(
-                    "api/v1/app/{}/attempt/endpoint/{}/?limit=10{}",
-                    app.id, ep.id, iter_suffix
+                    "api/v1/app/{}/attempt/endpoint/{}/?limit=10{iter_suffix}",
+                    app.id, ep.id
                 ),
                 StatusCode::OK,
             )

--- a/server/svix-server/tests/it/e2e_endpoint.rs
+++ b/server/svix-server/tests/it/e2e_endpoint.rs
@@ -843,7 +843,7 @@ async fn test_uid() {
 
     client
         .put::<_, IgnoredResponse>(
-            &format!("api/v1/app/{}/endpoint/{}/", app_id, ep_2.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/", ep_2.id),
             ep_2_with_duplicate_uid,
             StatusCode::CONFLICT,
         )
@@ -857,7 +857,7 @@ async fn test_uid() {
 
     let ep_1_updated = client
         .put::<_, EndpointOut>(
-            &format!("api/v1/app/{}/endpoint/{}/", app_id, ep_1.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/", ep_1.id),
             ep_1_with_duplicate_id,
             StatusCode::OK,
         )
@@ -914,7 +914,7 @@ async fn test_endpoint_secret_get_and_rotation() {
 
     let former_secret: EndpointSecretOut = client
         .get(
-            &format!("api/v1/app/{}/endpoint/{}/secret/", app_id, ep.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/secret/", ep.id),
             StatusCode::OK,
         )
         .await
@@ -922,7 +922,7 @@ async fn test_endpoint_secret_get_and_rotation() {
 
     let _: IgnoredResponse = client
         .post(
-            &format!("api/v1/app/{}/endpoint/{}/secret/rotate/", app_id, ep.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/secret/rotate/", ep.id),
             serde_json::json!({ "key": null }),
             StatusCode::NO_CONTENT,
         )
@@ -933,7 +933,7 @@ async fn test_endpoint_secret_get_and_rotation() {
         former_secret,
         client
             .get(
-                &format!("api/v1/app/{}/endpoint/{}/secret/", app_id, ep.id),
+                &format!("api/v1/app/{app_id}/endpoint/{}/secret/", ep.id),
                 StatusCode::OK
             )
             .await
@@ -942,7 +942,7 @@ async fn test_endpoint_secret_get_and_rotation() {
 
     let _: IgnoredResponse = client
         .post(
-            &format!("api/v1/app/{}/endpoint/{}/secret/rotate/", app_id, ep.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/secret/rotate/", ep.id),
             &former_secret,
             StatusCode::NO_CONTENT,
         )
@@ -953,7 +953,7 @@ async fn test_endpoint_secret_get_and_rotation() {
         former_secret,
         client
             .get(
-                &format!("api/v1/app/{}/endpoint/{}/secret/", app_id, ep.id),
+                &format!("api/v1/app/{app_id}/endpoint/{}/secret/", ep.id),
                 StatusCode::OK
             )
             .await
@@ -1092,7 +1092,7 @@ async fn test_endpoint_rotate_signing_e2e() {
 
     let secret1: EndpointSecretOut = client
         .get(
-            &format!("api/v1/app/{}/endpoint/{}/secret/", app_id, endp.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/secret/", endp.id),
             StatusCode::OK,
         )
         .await
@@ -1100,7 +1100,7 @@ async fn test_endpoint_rotate_signing_e2e() {
 
     let _: IgnoredResponse = client
         .post(
-            &format!("api/v1/app/{}/endpoint/{}/secret/rotate/", app_id, endp.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/secret/rotate/", endp.id),
             serde_json::json!({ "key": null }),
             StatusCode::NO_CONTENT,
         )
@@ -1109,7 +1109,7 @@ async fn test_endpoint_rotate_signing_e2e() {
 
     let secret2: EndpointSecretOut = client
         .get(
-            &format!("api/v1/app/{}/endpoint/{}/secret/", app_id, endp.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/secret/", endp.id),
             StatusCode::OK,
         )
         .await
@@ -1124,7 +1124,7 @@ async fn test_endpoint_rotate_signing_e2e() {
 
     let _: IgnoredResponse = client
         .post(
-            &format!("api/v1/app/{}/endpoint/{}/secret/rotate/", app_id, endp.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/secret/rotate/", endp.id),
             serde_json::json!({ "key": secret3_key }),
             StatusCode::NO_CONTENT,
         )
@@ -1133,7 +1133,7 @@ async fn test_endpoint_rotate_signing_e2e() {
 
     let secret3: EndpointSecretOut = client
         .get(
-            &format!("api/v1/app/{}/endpoint/{}/secret/", app_id, endp.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/secret/", endp.id),
             StatusCode::OK,
         )
         .await
@@ -1191,7 +1191,7 @@ async fn test_endpoint_rotate_signing_symmetric_and_asymmetric() {
     // Rotate to asmmetric
     let _: IgnoredResponse = client
         .post(
-            &format!("api/v1/app/{}/endpoint/{}/secret/rotate/", app_id, endp.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/secret/rotate/", endp.id),
             serde_json::json!({ "key": "whsk_6Xb/dCcHpPea21PS1N9VY/NZW723CEc77N4rJCubMbfVKIDij2HKpMKkioLlX0dRqSKJp4AJ6p9lMicMFs6Kvg==" }),
             StatusCode::NO_CONTENT,
         )
@@ -1201,7 +1201,7 @@ async fn test_endpoint_rotate_signing_symmetric_and_asymmetric() {
     // Rotate back to symmetric
     let _: IgnoredResponse = client
         .post(
-            &format!("api/v1/app/{}/endpoint/{}/secret/rotate/", app_id, endp.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/secret/rotate/", endp.id),
             serde_json::json!({ "key": secret_3.serialize_public_key() }),
             StatusCode::NO_CONTENT,
         )
@@ -1236,7 +1236,7 @@ async fn test_endpoint_rotate_signing_symmetric_and_asymmetric() {
                     .unwrap()
                     .to_str()
                     .unwrap();
-                let to_sign = format!("{}.{}.{}", msg_id, timestamp, &last_body);
+                let to_sign = format!("{msg_id}.{timestamp}.{}", &last_body);
                 let found =
                     signatures
                         .split(' ')
@@ -1277,7 +1277,7 @@ async fn test_endpoint_secret_config() {
 
     let key1 = client
         .get::<EndpointSecretOutTest>(
-            &format!("api/v1/app/{}/endpoint/{}/secret/", app_id, ep.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/secret/", ep.id),
             StatusCode::OK,
         )
         .await
@@ -1289,7 +1289,7 @@ async fn test_endpoint_secret_config() {
     // Rotate to asmmetric
     let _: IgnoredResponse = client
         .post(
-            &format!("api/v1/app/{}/endpoint/{}/secret/rotate/", app_id, ep.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/secret/rotate/", ep.id),
             serde_json::json!({ "key": null }),
             StatusCode::NO_CONTENT,
         )
@@ -1298,7 +1298,7 @@ async fn test_endpoint_secret_config() {
 
     let key2 = client
         .get::<EndpointSecretOutTest>(
-            &format!("api/v1/app/{}/endpoint/{}/secret/", app_id, ep.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/secret/", ep.id),
             StatusCode::OK,
         )
         .await
@@ -1348,7 +1348,7 @@ async fn test_custom_endpoint_secret() {
         .unwrap();
     let _: IgnoredResponse = client
         .post(
-            &format!("api/v1/app/{}/endpoint/{}/secret/rotate/", app_id, endp_3.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/secret/rotate/", endp_3.id),
             serde_json::json!({ "key": "whsk_6Xb/dCcHpPea21PS1N9VY/NZW723CEc77N4rJCubMbfVKIDij2HKpMKkioLlX0dRqSKJp4AJ6p9lMicMFs6Kvg==" }),
             StatusCode::NO_CONTENT,
         )
@@ -1365,7 +1365,7 @@ async fn test_custom_endpoint_secret() {
             secret.serialize_public_key(),
             client
                 .get::<EndpointSecretOutTest>(
-                    &format!("api/v1/app/{}/endpoint/{}/secret/", app_id, ep.id),
+                    &format!("api/v1/app/{app_id}/endpoint/{}/secret/", ep.id),
                     StatusCode::OK
                 )
                 .await
@@ -1396,7 +1396,7 @@ async fn test_endpoint_secret_encryption() {
 
     let secret = client
         .get::<EndpointSecretOutTest>(
-            &format!("api/v1/app/{}/endpoint/{}/secret/", app_id, ep.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/secret/", ep.id),
             StatusCode::OK,
         )
         .await
@@ -1411,7 +1411,7 @@ async fn test_endpoint_secret_encryption() {
 
     let secret2 = client
         .get::<EndpointSecretOutTest>(
-            &format!("api/v1/app/{}/endpoint/{}/secret/", app_id, ep.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/secret/", ep.id),
             StatusCode::OK,
         )
         .await
@@ -1424,7 +1424,7 @@ async fn test_endpoint_secret_encryption() {
     // Generate a new encrypted secret
     let _: IgnoredResponse = client
         .post(
-            &format!("api/v1/app/{}/endpoint/{}/secret/rotate/", app_id, ep.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/secret/rotate/", ep.id),
             serde_json::json!({ "key": secret }),
             StatusCode::NO_CONTENT,
         )
@@ -1433,7 +1433,7 @@ async fn test_endpoint_secret_encryption() {
 
     let secret2 = client
         .get::<EndpointSecretOutTest>(
-            &format!("api/v1/app/{}/endpoint/{}/secret/", app_id, ep.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/secret/", ep.id),
             StatusCode::OK,
         )
         .await
@@ -1449,7 +1449,7 @@ async fn test_endpoint_secret_encryption() {
     let (client, _jh) = start_svix_server_with_cfg_and_org_id(&cfg, org_id.clone()).await;
     client
         .get::<IgnoredResponse>(
-            &format!("api/v1/app/{}/endpoint/{}/secret/", app_id, ep.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/secret/", ep.id),
             StatusCode::INTERNAL_SERVER_ERROR,
         )
         .await
@@ -1675,7 +1675,7 @@ async fn test_legacy_endpoint_secret() {
         secret.serialize_public_key(),
         client
             .get::<EndpointSecretOutTest>(
-                &format!("api/v1/app/{}/endpoint/{}/secret/", app_id, ep.id),
+                &format!("api/v1/app/{app_id}/endpoint/{}/secret/", ep.id),
                 StatusCode::OK
             )
             .await
@@ -1801,7 +1801,7 @@ async fn test_endpoint_filter_events() {
 
     let ep_removed_events: EndpointOut = client
         .put(
-            &format!("api/v1/app/{}/endpoint/{}/", app_id, ep_with_valid_event.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/", ep_with_valid_event.id),
             ep_no_events.to_owned(),
             StatusCode::OK,
         )
@@ -1818,7 +1818,7 @@ async fn test_endpoint_filter_events() {
 
     let ep_updated_events: EndpointOut = client
         .put(
-            &format!("api/v1/app/{}/endpoint/{}/", app_id, ep_with_valid_event.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/", ep_with_valid_event.id),
             ep_with_events.to_owned(),
             StatusCode::OK,
         )
@@ -1882,7 +1882,7 @@ async fn test_endpoint_filter_channels() {
 
     let ep_with_deleted_channel: EndpointOut = client
         .put(
-            &format!("api/v1/app/{}/endpoint/{}/", app_id, ep_with_channel.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/", ep_with_channel.id),
             ep_without_channels,
             StatusCode::OK,
         )
@@ -1902,8 +1902,8 @@ async fn test_endpoint_filter_channels() {
     let updated_ep_with_channel: EndpointOut = client
         .put(
             &format!(
-                "api/v1/app/{}/endpoint/{}/",
-                app_id, ep_with_deleted_channel.id
+                "api/v1/app/{app_id}/endpoint/{}/",
+                ep_with_deleted_channel.id
             ),
             ep_with_channels,
             StatusCode::OK,
@@ -2104,7 +2104,7 @@ async fn test_endpoint_headers_manipulation() {
 
     let _: IgnoredResponse = client
         .patch(
-            &format!("api/v1/app/{}/endpoint/{}/headers/", app_id, endp.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/headers/", endp.id),
             patched_headers_in,
             StatusCode::NO_CONTENT,
         )
@@ -2113,7 +2113,7 @@ async fn test_endpoint_headers_manipulation() {
 
     let recvd_headers: EndpointHeadersOut = client
         .get(
-            &format!("api/v1/app/{}/endpoint/{}/headers/", app_id, endp.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/headers/", endp.id),
             StatusCode::OK,
         )
         .await
@@ -2138,7 +2138,7 @@ async fn test_endpoint_headers_manipulation() {
     ] {
         let _: IgnoredResponse = client
             .put(
-                &format!("api/v1/app/{}/endpoint/{}/headers/", app_id, endp.id),
+                &format!("api/v1/app/{app_id}/endpoint/{}/headers/", endp.id),
                 serde_json::json!({ "headers": { bad_hdr: "123"}}),
                 StatusCode::UNPROCESSABLE_ENTITY,
             )
@@ -2163,7 +2163,7 @@ async fn test_endpoint_headers_manipulation() {
     for hdrs in [&org_headers, &updated_headers] {
         let _: IgnoredResponse = client
             .put(
-                &format!("api/v1/app/{}/endpoint/{}/headers/", app_id, endp.id),
+                &format!("api/v1/app/{app_id}/endpoint/{}/headers/", endp.id),
                 hdrs,
                 StatusCode::NO_CONTENT,
             )
@@ -2172,7 +2172,7 @@ async fn test_endpoint_headers_manipulation() {
 
         let recvd_headers: EndpointHeadersOut = client
             .get(
-                &format!("api/v1/app/{}/endpoint/{}/headers/", app_id, endp.id),
+                &format!("api/v1/app/{app_id}/endpoint/{}/headers/", endp.id),
                 StatusCode::OK,
             )
             .await
@@ -2190,7 +2190,7 @@ async fn test_endpoint_headers_manipulation() {
 
     let _: IgnoredResponse = client
         .patch(
-            &format!("api/v1/app/{}/endpoint/{}/headers/", app_id, endp.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/headers/", endp.id),
             &patched_headers_in,
             StatusCode::NO_CONTENT,
         )
@@ -2199,7 +2199,7 @@ async fn test_endpoint_headers_manipulation() {
 
     let recvd_headers: EndpointHeadersOut = client
         .get(
-            &format!("api/v1/app/{}/endpoint/{}/headers/", app_id, endp.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/headers/", endp.id),
             StatusCode::OK,
         )
         .await
@@ -2222,7 +2222,7 @@ async fn test_endpoint_headers_manipulation() {
 
     let _: IgnoredResponse = client
         .put(
-            &format!("api/v1/app/{}/endpoint/{}/headers/", app_id, endp.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/headers/", endp.id),
             redacted_headers,
             StatusCode::NO_CONTENT,
         )
@@ -2231,7 +2231,7 @@ async fn test_endpoint_headers_manipulation() {
 
     let recvd_headers: EndpointHeadersOut = client
         .get(
-            &format!("api/v1/app/{}/endpoint/{}/headers/", app_id, endp.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/headers/", endp.id),
             StatusCode::OK,
         )
         .await
@@ -2269,7 +2269,7 @@ async fn test_endpoint_headers_sending() {
 
     let _: IgnoredResponse = client
         .put(
-            &format!("api/v1/app/{}/endpoint/{}/headers/", app_id, endp.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/headers/", endp.id),
             &headers,
             StatusCode::NO_CONTENT,
         )
@@ -2308,7 +2308,7 @@ async fn test_endpoint_header_key_capitalization() {
 
     let _: IgnoredResponse = client
         .put(
-            &format!("api/v1/app/{}/endpoint/{}/headers/", app_id, endp.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/headers/", endp.id),
             &headers,
             StatusCode::NO_CONTENT,
         )
@@ -2317,7 +2317,7 @@ async fn test_endpoint_header_key_capitalization() {
 
     let retrieved_headers: EndpointHeadersOut = client
         .get(
-            &format!("api/v1/app/{}/endpoint/{}/headers/", app_id, endp.id),
+            &format!("api/v1/app/{app_id}/endpoint/{}/headers/", endp.id),
             StatusCode::OK,
         )
         .await

--- a/server/svix-server/tests/it/e2e_message.rs
+++ b/server/svix-server/tests/it/e2e_message.rs
@@ -230,7 +230,7 @@ async fn test_failed_message_gets_recorded() {
     run_with_retries(|| async {
         let attempts: ListResponse<MessageAttemptOut> = client
             .get(
-                &format!("api/v1/app/{}/attempt/msg/{}/", app_id, msg_res.id),
+                &format!("api/v1/app/{app_id}/attempt/msg/{}/", msg_res.id),
                 StatusCode::OK,
             )
             .await
@@ -302,7 +302,7 @@ async fn test_multiple_endpoints() {
     run_with_retries(|| async {
         let attempts: ListResponse<MessageAttemptOut> = client
             .get(
-                &format!("api/v1/app/{}/attempt/msg/{}/", app_id, msg_res.id),
+                &format!("api/v1/app/{app_id}/attempt/msg/{}/", msg_res.id),
                 StatusCode::OK,
             )
             .await
@@ -355,7 +355,7 @@ async fn test_failed_message_gets_requeued() {
     run_with_retries(|| async {
         let attempts: ListResponse<MessageAttemptOut> = client
             .get(
-                &format!("api/v1/app/{}/attempt/msg/{}/", app_id, msg_res.id),
+                &format!("api/v1/app/{app_id}/attempt/msg/{}/", msg_res.id),
                 StatusCode::OK,
             )
             .await

--- a/server/svix-server/tests/it/utils/common_calls.rs
+++ b/server/svix-server/tests/it/utils/common_calls.rs
@@ -264,7 +264,7 @@ pub async fn common_test_list<
 
     let list = client
         .get::<ListResponse<ModelOut>>(
-            &format!("{}?limit=6&iterator={}", path, list.iterator.unwrap()),
+            &format!("{path}?limit=6&iterator={}", list.iterator.unwrap()),
             StatusCode::OK,
         )
         .await
@@ -275,7 +275,7 @@ pub async fn common_test_list<
 
     let prev = client
         .get::<ListResponse<ModelOut>>(
-            &format!("{}?limit=3&iterator={}", path, list.prev_iterator.unwrap()),
+            &format!("{path}?limit=3&iterator={}", list.prev_iterator.unwrap()),
             StatusCode::OK,
         )
         .await

--- a/server/svix-server/tests/it/utils/mod.rs
+++ b/server/svix-server/tests/it/utils/mod.rs
@@ -61,7 +61,7 @@ impl TestClient {
     }
 
     fn build_uri(&self, endpoint: &str) -> String {
-        format!("{}/{}", self.base_uri, endpoint)
+        format!("{}/{endpoint}", self.base_uri)
     }
 
     fn add_headers(&self, request: RequestBuilder) -> RequestBuilder {


### PR DESCRIPTION
More linting and uniform code style reduces the things to watch out for in review. I'm running a nightly toolchain locally now, and have noticed some extra lints from that. Also enabled one extra clippy lint via `Cargo.toml`.