### PR TITLE
server: Reformat remaining imports using nightly

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -24,6 +24,20 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  check-fmt:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+
+      - name: rustfmt
+        run: cargo fmt -- --check
+        working-directory: server
+
   test-versions:
     name: Server CI
     runs-on: ubuntu-latest
@@ -32,10 +46,12 @@ jobs:
         rust: [stable, beta]
     steps:
     - uses: actions/checkout@v4
+
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
-        components: clippy, rustfmt
+        components: clippy
+
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: "server -> target"
@@ -46,10 +62,6 @@ jobs:
         prefix-key: "server-${{ matrix.rust }}"
 
     - uses: taiki-e/install-action@nextest
-
-    - name: rustfmt
-      run: cargo fmt -- --check
-      working-directory: server
 
     - name: Build
       run: cargo test --all-features --no-run --locked

--- a/server/.rustfmt.toml
+++ b/server/.rustfmt.toml
@@ -1,0 +1,2 @@
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"

--- a/server/svix-server/src/core/cache/memory.rs
+++ b/server/svix-server/src/core/cache/memory.rs
@@ -1,15 +1,14 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
+use std::{collections::HashMap, sync::Arc};
+
+use axum::async_trait;
 use tokio::{
     sync::RwLock,
     task,
     time::{sleep, Duration, Instant},
 };
-
-use axum::async_trait;
-use std::collections::HashMap;
-use std::sync::Arc;
 
 use super::{Cache, CacheBehavior, CacheKey, Result};
 
@@ -105,12 +104,13 @@ fn check_is_expired(vw: &ValueWrapper) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use serde::{Deserialize, Serialize};
+
     use super::{
         super::{kv_def, CacheValue},
         *,
     };
     use crate::core::cache::string_kv_def;
-    use serde::{Deserialize, Serialize};
 
     // Test structures
 

--- a/server/svix-server/src/core/cache/redis.rs
+++ b/server/svix-server/src/core/cache/redis.rs
@@ -6,9 +6,8 @@ use std::time::Duration;
 use axum::async_trait;
 use redis::AsyncCommands as _;
 
-use crate::redis::RedisPool;
-
 use super::{Cache, CacheBehavior, CacheKey, Error, Result};
+use crate::redis::RedisPool;
 
 pub fn new(redis: RedisPool) -> Cache {
     RedisCache { redis }.into()
@@ -76,12 +75,12 @@ impl CacheBehavior for RedisCache {
 
 #[cfg(test)]
 mod tests {
+    use serde::{Deserialize, Serialize};
+
     use super::{
         super::{kv_def, string_kv_def, CacheValue},
         *,
     };
-    use serde::{Deserialize, Serialize};
-
     use crate::cfg::CacheType;
 
     // Test structures

--- a/server/svix-server/src/core/cryptography.rs
+++ b/server/svix-server/src/core/cryptography.rs
@@ -3,8 +3,10 @@
 
 use std::fmt::Debug;
 
-use chacha20poly1305::aead::{Aead, KeyInit};
-use chacha20poly1305::{Key, XChaCha20Poly1305, XNonce};
+use chacha20poly1305::{
+    aead::{Aead, KeyInit},
+    Key, XChaCha20Poly1305, XNonce,
+};
 use ed25519_compact::*;
 use rand::Rng;
 

--- a/server/svix-server/src/core/idempotency.rs
+++ b/server/svix-server/src/core/idempotency.rs
@@ -14,10 +14,8 @@ use axum::{
     http::{Request, Response, StatusCode},
     response::IntoResponse,
 };
-
 use blake2::{Blake2b512, Digest};
 use http::request::Parts;
-
 use serde::{Deserialize, Serialize};
 use tower::Service;
 

--- a/server/svix-server/src/core/message_app.rs
+++ b/server/svix-server/src/core/message_app.rs
@@ -4,6 +4,7 @@ use chrono::{DateTime, FixedOffset, Utc};
 use sea_orm::{DatabaseConnection, DatabaseTransaction, TransactionTrait};
 use serde::{Deserialize, Serialize};
 
+use super::types::EventTypeName;
 use crate::{
     core::{
         cache::{kv_def, Cache, CacheBehavior, CacheKey, CacheValue},
@@ -16,8 +17,6 @@ use crate::{
     db::models::{application, endpoint},
     error::{Error, Result},
 };
-
-use super::types::EventTypeName;
 
 /// The information cached during the creation of a message. Includes a [`Vec`] of all endpoints
 /// associated with the given application and organization ID.

--- a/server/svix-server/src/core/operational_webhooks.rs
+++ b/server/svix-server/src/core/operational_webhooks.rs
@@ -18,8 +18,8 @@ use super::{
         MessageUid, OrganizationId,
     },
 };
-use crate::core::security::JwtSigningConfig;
 use crate::{
+    core::security::JwtSigningConfig,
     db::models::{endpoint, messageattempt},
     error::{Error, HttpError, Result},
 };

--- a/server/svix-server/src/core/permissions.rs
+++ b/server/svix-server/src/core/permissions.rs
@@ -5,16 +5,14 @@ use axum::{
     http::request::Parts,
 };
 
-use crate::error::Traceable;
-use crate::{
-    db::models::{application, applicationmetadata},
-    error::{Error, HttpError, Result},
-    AppState,
-};
-
 use super::{
     security::{permissions_from_bearer, AccessLevel, Permissions},
     types::{ApplicationId, ApplicationIdOrUid, FeatureFlagSet, OrganizationId},
+};
+use crate::{
+    db::models::{application, applicationmetadata},
+    error::{Error, HttpError, Result, Traceable},
+    AppState,
 };
 
 pub struct ReadAll {

--- a/server/svix-server/src/core/security.rs
+++ b/server/svix-server/src/core/security.rs
@@ -7,20 +7,16 @@ use axum::{
     extract::{FromRequestParts, TypedHeader},
     headers::{authorization::Bearer, Authorization},
 };
-
 use http::request::Parts;
 use jwt_simple::prelude::*;
 use serde::Deserializer;
-
 use validator::Validate;
 
-use crate::error::Error;
+use super::types::{ApplicationId, FeatureFlagSet, OrganizationId};
 use crate::{
-    error::{HttpError, Result},
+    error::{Error, HttpError, Result},
     AppState,
 };
-
-use super::types::{ApplicationId, FeatureFlagSet, OrganizationId};
 
 /// The default org_id we use (useful for generating JWTs when testing).
 pub fn default_org_id() -> OrganizationId {

--- a/server/svix-server/src/core/types/metadata.rs
+++ b/server/svix-server/src/core/types/metadata.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 
-use crate::json_wrapper;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+
+use crate::json_wrapper;
 
 pub const MAX_METADATA_SIZE: usize = 4096;
 

--- a/server/svix-server/src/core/types/mod.rs
+++ b/server/svix-server/src/core/types/mod.rs
@@ -1,18 +1,18 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    ops::Deref,
+};
 
 use chrono::{DateTime, Utc};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
-use rand::Rng;
-
-use regex::Regex;
-
 use once_cell::sync::Lazy;
+use rand::Rng;
+use regex::Regex;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::ops::Deref;
 use svix_ksuid::*;
 use validator::{Validate, ValidationErrors};
 

--- a/server/svix-server/src/core/webhook_http_client.rs
+++ b/server/svix-server/src/core/webhook_http_client.rs
@@ -15,8 +15,7 @@ use futures::{future::BoxFuture, FutureExt};
 use hickory_resolver::{
     error::ResolveError, lookup_ip::LookupIpIntoIter, AsyncResolver, TokioAsyncResolver,
 };
-use http::header::HeaderName;
-use http::{HeaderMap, HeaderValue, Method, Response, StatusCode, Version};
+use http::{header::HeaderName, HeaderMap, HeaderValue, Method, Response, StatusCode, Version};
 use hyper::{
     client::connect::{dns::Name, HttpConnector},
     ext::HeaderCaseMap,

--- a/server/svix-server/src/db/models/eventtype.rs
+++ b/server/svix-server/src/db/models/eventtype.rs
@@ -3,18 +3,18 @@
 
 use std::collections::HashMap;
 
+use chrono::Utc;
+use jsonschema::{Draft, JSONSchema};
+use schemars::JsonSchema;
+use sea_orm::{entity::prelude::*, ActiveValue::Set};
+use serde::{Deserialize, Serialize};
+
 use crate::{
     core::types::{
         BaseId, EventTypeId, EventTypeName, FeatureFlag, FeatureFlagSet, OrganizationId,
     },
     json_wrapper,
 };
-use chrono::Utc;
-use jsonschema::{Draft, JSONSchema};
-use schemars::JsonSchema;
-use sea_orm::entity::prelude::*;
-use sea_orm::ActiveValue::Set;
-use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "eventtype")]

--- a/server/svix-server/src/db/models/message.rs
+++ b/server/svix-server/src/db/models/message.rs
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
+use chrono::Utc;
+use sea_orm::{entity::prelude::*, ActiveValue::Set, Condition};
+
 use crate::core::types::{
     ApplicationId, BaseId, EventChannelSet, EventTypeName, MessageId, MessageIdOrUid, MessageUid,
     OrganizationId,
 };
-use chrono::Utc;
-use sea_orm::ActiveValue::Set;
-use sea_orm::{entity::prelude::*, Condition};
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "message")]

--- a/server/svix-server/src/db/models/messageattempt.rs
+++ b/server/svix-server/src/db/models/messageattempt.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 use chrono::Utc;
-use sea_orm::entity::prelude::*;
-use sea_orm::ActiveValue::Set;
+use sea_orm::{entity::prelude::*, ActiveValue::Set};
 
 use crate::core::types::{
     BaseId, EndpointId, MessageAttemptId, MessageAttemptTriggerType, MessageEndpointId, MessageId,

--- a/server/svix-server/src/db/models/messagecontent.rs
+++ b/server/svix-server/src/db/models/messagecontent.rs
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
-use crate::core::types::MessageId;
 use chrono::Utc;
-use sea_orm::entity::prelude::*;
-use sea_orm::ActiveValue::Set;
+use sea_orm::{entity::prelude::*, ActiveValue::Set};
+
+use crate::core::types::MessageId;
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "messagecontent")]

--- a/server/svix-server/src/db/models/messagedestination.rs
+++ b/server/svix-server/src/db/models/messagedestination.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 use chrono::Utc;
-use sea_orm::entity::prelude::*;
-use sea_orm::ActiveValue::Set;
+use sea_orm::{entity::prelude::*, ActiveValue::Set};
 
 use crate::core::types::{BaseId, EndpointId, MessageEndpointId, MessageId, MessageStatus};
 

--- a/server/svix-server/src/error.rs
+++ b/server/svix-server/src/error.rs
@@ -1,21 +1,17 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
-use std::error;
-use std::fmt;
-use std::panic::Location;
+use std::{error, fmt, panic::Location};
 
 use aide::OperationOutput;
-use axum::extract::rejection::ExtensionRejection;
-use axum::extract::rejection::PathRejection;
-use axum::response::IntoResponse;
-use axum::response::Response;
-use axum::Json;
+use axum::{
+    extract::rejection::{ExtensionRejection, PathRejection},
+    response::{IntoResponse, Response},
+    Json,
+};
 use hyper::StatusCode;
 use schemars::JsonSchema;
-use sea_orm::DbErr;
-use sea_orm::RuntimeErr;
-use sea_orm::TransactionError;
+use sea_orm::{DbErr, RuntimeErr, TransactionError};
 use serde::Serialize;
 use serde_json::json;
 

--- a/server/svix-server/src/expired_message_cleaner.rs
+++ b/server/svix-server/src/expired_message_cleaner.rs
@@ -1,14 +1,17 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
-use std::sync::atomic::Ordering;
+use std::{
+    sync::atomic::Ordering,
+    time::{Duration, Instant},
+};
 
-use crate::error::{Error, Result};
 use sea_orm::{
     ConnectionTrait, DatabaseConnection, DbErr, ExecResult, QueryResult, Statement,
     TransactionTrait, UpdateResult,
 };
-use std::time::{Duration, Instant};
+
+use crate::error::{Error, Result};
 
 type DbResult<T> = std::result::Result<T, DbErr>;
 

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -4,21 +4,20 @@
 #![warn(clippy::all)]
 #![forbid(unsafe_code)]
 
-use aide::axum::ApiRouter;
-use sentry::integrations::tracing::EventFilter;
-
-use crate::core::cache::Cache;
-use cfg::ConfigurationInner;
-use opentelemetry_otlp::WithExportConfig;
-use opentelemetry_sdk::runtime::Tokio;
-use queue::TaskQueueProducer;
-use sea_orm::DatabaseConnection;
 use std::{
     borrow::Cow,
     net::TcpListener,
     sync::atomic::{AtomicBool, Ordering},
     time::Duration,
 };
+
+use aide::axum::ApiRouter;
+use cfg::ConfigurationInner;
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::runtime::Tokio;
+use queue::TaskQueueProducer;
+use sea_orm::DatabaseConnection;
+use sentry::integrations::tracing::EventFilter;
 use tower::layer::layer_fn;
 use tower_http::{
     cors::{AllowHeaders, Any, CorsLayer},
@@ -30,6 +29,7 @@ use crate::{
     cfg::{CacheBackend, Configuration},
     core::{
         cache,
+        cache::Cache,
         idempotency::IdempotencyService,
         operational_webhooks::{OperationalWebhookSender, OperationalWebhookSenderInner},
     },

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -4,17 +4,20 @@
 #![warn(clippy::all)]
 #![forbid(unsafe_code)]
 
+use clap::{Parser, Subcommand};
 use dotenv::dotenv;
-use svix_server::core::types::{EndpointSecretInternal, OrganizationId};
-use svix_server::db::wipe_org;
+use svix_server::{
+    cfg,
+    core::{
+        security::{default_org_id, generate_org_token},
+        types::{EndpointSecretInternal, OrganizationId},
+    },
+    db,
+    db::wipe_org,
+    run, setup_tracing,
+};
 use tracing_subscriber::util::SubscriberInitExt;
 use validator::Validate;
-
-use svix_server::core::security::{default_org_id, generate_org_token};
-
-use svix_server::{cfg, db, run, setup_tracing};
-
-use clap::{Parser, Subcommand};
 
 #[cfg(all(target_env = "msvc", feature = "jemalloc"))]
 compile_error!("jemalloc cannot be enabled on msvc");

--- a/server/svix-server/src/redis/cluster.rs
+++ b/server/svix-server/src/redis/cluster.rs
@@ -1,5 +1,4 @@
 use axum::async_trait;
-
 use redis::{
     cluster::{ClusterClient, ClusterClientBuilder},
     ErrorKind, IntoConnectionInfo, RedisError,

--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -1,14 +1,29 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
-use crate::error::Traceable;
+use aide::axum::{
+    routing::{get_with, post_with},
+    ApiRouter,
+};
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use chrono::{DateTime, Utc};
+use futures::FutureExt;
+use schemars::JsonSchema;
+use sea_orm::{ActiveModelTrait, ActiveValue::Set, TransactionTrait};
+use serde::{Deserialize, Serialize};
+use svix_server_derive::{aide_annotate, ModelOut};
+use validator::{Validate, ValidationError};
+
 use crate::{
     core::{
         permissions,
         types::{metadata::Metadata, ApplicationId, ApplicationUid},
     },
     db::models::{application, applicationmetadata},
-    error::{http_error_on_conflict, HttpError, Result},
+    error::{http_error_on_conflict, HttpError, Result, Traceable},
     v1::utils::{
         apply_pagination, openapi_tag,
         patch::{
@@ -22,22 +37,6 @@ use crate::{
     },
     AppState,
 };
-use aide::axum::{
-    routing::{get_with, post_with},
-    ApiRouter,
-};
-use axum::{
-    extract::{Path, State},
-    Json,
-};
-use chrono::{DateTime, Utc};
-use futures::FutureExt;
-use schemars::JsonSchema;
-use sea_orm::ActiveValue::Set;
-use sea_orm::{ActiveModelTrait, TransactionTrait};
-use serde::{Deserialize, Serialize};
-use svix_server_derive::{aide_annotate, ModelOut};
-use validator::{Validate, ValidationError};
 
 fn application_name_example() -> &'static str {
     "My first application"
@@ -406,9 +405,10 @@ pub fn router() -> ApiRouter<AppState> {
 
 #[cfg(test)]
 mod tests {
-    use super::{ApplicationIn, ApplicationPatch};
     use serde_json::json;
     use validator::Validate;
+
+    use super::{ApplicationIn, ApplicationPatch};
 
     const APP_NAME_INVALID: &str = "";
     const APP_NAME_VALID: &str = "test-app";

--- a/server/svix-server/src/v1/endpoints/endpoint/secrets.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/secrets.rs
@@ -1,11 +1,11 @@
+use std::iter;
+
 use axum::{
     extract::{Path, State},
     Json,
 };
 use chrono::{Duration, Utc};
-use sea_orm::ActiveModelTrait;
-use sea_orm::ActiveValue::Set;
-use std::iter;
+use sea_orm::{ActiveModelTrait, ActiveValue::Set};
 use svix_server_derive::aide_annotate;
 
 use super::{EndpointSecretOut, EndpointSecretRotateIn};

--- a/server/svix-server/src/v1/mod.rs
+++ b/server/svix-server/src/v1/mod.rs
@@ -41,9 +41,11 @@ mod development {
     use axum::{async_trait, extract::FromRequestParts, routing::get, Json, Router};
     use http::request::Parts;
 
-    use crate::error::{Error, Result};
-    use crate::v1::utils::EmptyResponse;
-    use crate::AppState;
+    use crate::{
+        error::{Error, Result},
+        v1::utils::EmptyResponse,
+        AppState,
+    };
 
     struct EchoData {
         pub headers: String,

--- a/server/svix-server/src/v1/utils/mod.rs
+++ b/server/svix-server/src/v1/utils/mod.rs
@@ -27,7 +27,6 @@ use regex::Regex;
 use schemars::JsonSchema;
 use sea_orm::{ColumnTrait, QueryFilter, QueryOrder, QuerySelect};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-
 use validator::{Validate, ValidationError};
 
 use crate::{
@@ -769,12 +768,11 @@ impl<T: JsonSchema + Serialize> OperationOutput for JsonStatusUpsert<T> {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
     use validator::Validate;
 
     use super::{default_limit, validate_no_control_characters, validation_errors, Pagination};
-    use crate::core::types::ApplicationUid;
-    use crate::error::ValidationErrorItem;
-    use serde_json::json;
+    use crate::{core::types::ApplicationUid, error::ValidationErrorItem};
 
     #[derive(Debug, Validate)]
     struct ValidationErrorTestStruct {


### PR DESCRIPTION
After #1268 for the client library and #1280 for the bridge workspace, this is the last PR in this series for more (import) formatting consistency.

PRs for comment wrapping / doctest formatting will likely follow, in the coming weeks.