### PR TITLE
Switch to Docker Compose v2

### DIFF
--- a/.github/workflows/bridge-ci.yml
+++ b/.github/workflows/bridge-ci.yml
@@ -79,7 +79,7 @@ jobs:
       working-directory: bridge
 
     - name: Start dependencies
-      run: docker-compose -f "bridge/testing-docker-compose.yml" up -d
+      run: docker compose -f "bridge/testing-docker-compose.yml" up -d
 
     - name: Clippy
       run: cargo clippy --all-targets --all-features -- -D warnings
@@ -90,7 +90,7 @@ jobs:
       run: ./run-tests.sh
 
     - name: Stop dependencies
-      run: docker-compose -f "bridge/testing-docker-compose.yml" down
+      run: docker compose -f "bridge/testing-docker-compose.yml" down
 
 #  deny-check:
 #    name: cargo-deny check

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -75,7 +75,7 @@ jobs:
       run: ./generate-openapi.sh --check
 
     - name: Start dependencies
-      run: docker-compose -f "server/testing-docker-compose.yml" up -d
+      run: docker compose -f "server/testing-docker-compose.yml" up -d
 
     - name: Clippy
       run: cargo clippy --all-targets --all-features -- -D warnings
@@ -96,7 +96,7 @@ jobs:
       run: ./run-tests.sh
 
     - name: Stop dependencies
-      run: docker-compose -f "server/testing-docker-compose.yml" down
+      run: docker compose -f "server/testing-docker-compose.yml" down
 #  deny-check:
 #    name: cargo-deny check
 #    runs-on: ubuntu-latest

--- a/.github/workflows/server-docker-image.yml
+++ b/.github/workflows/server-docker-image.yml
@@ -21,11 +21,11 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Build server image
-      run: docker-compose build
+      run: docker compose build
       working-directory: ./server
 
     - name: Run server with docker-compose
-      run: docker-compose up -d
+      run: docker compose up -d
       working-directory: ./server
 
     - name: Check server container is up and running
@@ -33,10 +33,10 @@ jobs:
 
     - name: Display server container logs
       if: failure()
-      run: docker-compose logs backend
+      run: docker compose logs backend
       working-directory: ./server
 
-    - name: Terminate docker-compose created containers
+    - name: Terminate docker compose created containers
       if: always()
-      run: docker-compose down -v
+      run: docker compose down -v
       working-directory: ./server

--- a/README.md
+++ b/README.md
@@ -139,17 +139,17 @@ Please refer to the [server configuration](#server-configuration) section below 
 
 You can use the official Svix Docker image from [Docker Hub](https://hub.docker.com/r/svix/svix-server). You can either use the `latest` tag, or one of [the versioned tags](https://hub.docker.com/r/svix/svix-server/tags) instead.
 
-You can either use the example [docker-compose.yml](./server/docker-compose.yml) file with `docker-compose` (easiest), `docker swarm` (advanced), or run the container standalone.
+You can either use the example [docker-compose.yml](./server/docker-compose.yml) file with `docker compose` (easiest), `docker swarm` (advanced), or run the container standalone.
 
 #### With Docker Compose
 
 This alternative is the easiest because it will also boot up and configure `redis` and `postgresql`.
 
-This assumes you have docker-compose installed.
+This assumes you have Docker Compose v2 installed.
 
 ```
 cd server
-docker-compose up
+docker compose up
 ```
 
 #### Standalone container

--- a/server/README.md
+++ b/server/README.md
@@ -70,13 +70,13 @@ cargo watch -x run
 
 This however will fail, as you also need to point the server to the database and setup a few other configurations.
 
-The easiest way to achieve that is to use docker-compose to setup a dockerize development environment, and the related config.
+The easiest way to achieve that is to use docker compose to setup a dockerize development environment, and the related config.
 
 ```
 # From the svix inner directory
 cp development.env .env
 # Set up docker (may need sudo depending on your setup)
-docker-compose up
+docker compose up
 ```
 
 Now run `cargo watch -x run` again to start the development server against your local docker environment.


### PR DESCRIPTION
The docker-compose command is apparently no longer available in GitHub's CI runners by default (CI failed on main).
