### PR TITLE
Update redis health check

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -557,7 +557,18 @@ checksum = "4094bc17b933090cfded54315a86db01d67ec999583d4bab894c520f8c097d1f"
 dependencies = [
  "async-trait",
  "bb8",
- "redis",
+ "redis 0.24.0",
+]
+
+[[package]]
+name = "bb8-redis"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb4f141b33a750b5f667c445bd8588de10b8f2b045cd2aabc040ca746fb53ae"
+dependencies = [
+ "async-trait",
+ "bb8",
+ "redis 0.25.3",
 ]
 
 [[package]]
@@ -668,6 +679,12 @@ name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+
+[[package]]
+name = "bytesize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
 
 [[package]]
 name = "cbc"
@@ -2531,16 +2548,16 @@ dependencies = [
 
 [[package]]
 name = "omniqueue"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cba3b7f69e420be6e32a580307e38aef7f53ac01cc09c3bb6851aec37d710894"
+version = "0.2.1"
+source = "git+https://github.com/svix/omniqueue-rs?rev=5ae22000e2ea214ba707cac81657f098e5785a76#5ae22000e2ea214ba707cac81657f098e5785a76"
 dependencies = [
  "async-trait",
  "bb8",
- "bb8-redis",
+ "bb8-redis 0.15.0",
+ "bytesize",
  "futures-util",
  "lapin",
- "redis",
+ "redis 0.25.3",
  "serde",
  "serde_json",
  "svix-ksuid 0.8.0",
@@ -3204,6 +3221,33 @@ dependencies = [
  "ryu",
  "sha1_smol",
  "socket2 0.4.10",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "redis"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6472825949c09872e8f2c50bde59fcefc17748b6be5c90fd67cd8b4daca73bfd"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "combine",
+ "crc16",
+ "futures",
+ "futures-util",
+ "itoa",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rand",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.5.6",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -4318,7 +4362,7 @@ dependencies = [
  "axum-server",
  "base64 0.13.1",
  "bb8",
- "bb8-redis",
+ "bb8-redis 0.14.0",
  "blake2",
  "bytes",
  "chacha20poly1305",
@@ -4350,7 +4394,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "rand",
- "redis",
+ "redis 0.24.0",
  "regex",
  "reqwest",
  "schemars",

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -72,7 +72,7 @@ urlencoding = "2.1.2"
 form_urlencoded = "1.1.0"
 lapin = "2.1.1"
 sentry = { version = "0.32.2", features = ["tracing"] }
-omniqueue = { version = "0.2.0", default-features = false, features = ["in_memory", "rabbitmq-with-message-ids", "redis_cluster"] }
+omniqueue = { git = "https://github.com/svix/omniqueue-rs", rev = "5ae22000e2ea214ba707cac81657f098e5785a76", default-features = false, features = ["in_memory", "rabbitmq-with-message-ids", "redis_cluster"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.5", optional = true }

--- a/server/svix-server/src/queue/redis.rs
+++ b/server/svix-server/src/queue/redis.rs
@@ -29,8 +29,7 @@
 
 use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
-use bb8_redis::RedisMultiplexedConnectionManager;
-use omniqueue::backends::{redis::RedisClusterConnectionManager, RedisBackend, RedisConfig};
+use omniqueue::backends::{RedisBackend, RedisConfig};
 use redis::{AsyncCommands as _, RedisResult};
 
 use super::{QueueTask, TaskQueueConsumer, TaskQueueProducer};
@@ -213,22 +212,20 @@ async fn new_pair_inner(
 
     match &cfg.queue_type {
         QueueType::RedisCluster => {
-            let (producer, consumer) =
-                RedisBackend::<RedisClusterConnectionManager>::builder(config)
-                    .build_pair()
-                    .await
-                    .expect("Error initializing redis-cluster queue");
+            let (producer, consumer) = RedisBackend::cluster_builder(config)
+                .build_pair()
+                .await
+                .expect("Error initializing redis-cluster queue");
 
             let producer = TaskQueueProducer::new(producer);
             let consumer = TaskQueueConsumer::new(consumer);
             (producer, consumer)
         }
         _ => {
-            let (producer, consumer) =
-                RedisBackend::<RedisMultiplexedConnectionManager>::builder(config)
-                    .build_pair()
-                    .await
-                    .expect("Error initializing redis queue");
+            let (producer, consumer) = RedisBackend::builder(config)
+                .build_pair()
+                .await
+                .expect("Error initializing redis queue");
 
             let producer = TaskQueueProducer::new(producer);
             let consumer = TaskQueueConsumer::new(consumer);


### PR DESCRIPTION
Due to recent changes in the redis library, a PING command is now routed to all main nodes by default, rather than a single random node, and all must succeed. This makes connections particularly fragile if a single node is having transient issues. So, in an effort to maximize uptime, let's require a successful response from only one node.

This also updates omniqueue to the same version we use downstream. It includes the same version of the redis lib/bb8.