### PR TITLE
More ktlint formatting

### DIFF
--- a/kotlin/lib/src/main/kotlin/Application.kt
+++ b/kotlin/lib/src/main/kotlin/Application.kt
@@ -25,7 +25,10 @@ class Application internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun create(applicationIn: ApplicationIn, options: PostOptions = PostOptions()): ApplicationOut {
+    suspend fun create(
+        applicationIn: ApplicationIn,
+        options: PostOptions = PostOptions(),
+    ): ApplicationOut {
         try {
             return api.v1ApplicationCreate(applicationIn, null, options.idempotencyKey)
         } catch (e: Exception) {
@@ -33,7 +36,10 @@ class Application internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun getOrCreate(applicationIn: ApplicationIn, options: PostOptions = PostOptions()): ApplicationOut {
+    suspend fun getOrCreate(
+        applicationIn: ApplicationIn,
+        options: PostOptions = PostOptions(),
+    ): ApplicationOut {
         try {
             return api.v1ApplicationCreate(applicationIn, true, options.idempotencyKey)
         } catch (e: Exception) {
@@ -49,7 +55,10 @@ class Application internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun update(appId: String, applicationIn: ApplicationIn): ApplicationOut {
+    suspend fun update(
+        appId: String,
+        applicationIn: ApplicationIn,
+    ): ApplicationOut {
         try {
             return api.v1ApplicationUpdate(appId, applicationIn)
         } catch (e: Exception) {
@@ -57,7 +66,10 @@ class Application internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun patch(appId: String, applicationPatch: ApplicationPatch): ApplicationOut {
+    suspend fun patch(
+        appId: String,
+        applicationPatch: ApplicationPatch,
+    ): ApplicationOut {
         try {
             return api.v1ApplicationPatch(appId, applicationPatch)
         } catch (e: Exception) {

--- a/kotlin/lib/src/main/kotlin/Authentication.kt
+++ b/kotlin/lib/src/main/kotlin/Authentication.kt
@@ -19,7 +19,7 @@ class Authentication internal constructor(token: String, options: SvixOptions) {
     suspend fun appPortalAccess(
         appId: String,
         appPortalAccessIn: AppPortalAccessIn,
-        options: PostOptions = PostOptions()
+        options: PostOptions = PostOptions(),
     ): AppPortalAccessOut {
         try {
             return api.v1AuthenticationAppPortalAccess(appId, appPortalAccessIn, options.idempotencyKey)
@@ -28,7 +28,10 @@ class Authentication internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun dashboardAccess(appId: String, options: PostOptions = PostOptions()): DashboardAccessOut {
+    suspend fun dashboardAccess(
+        appId: String,
+        options: PostOptions = PostOptions(),
+    ): DashboardAccessOut {
         try {
             return api.v1AuthenticationDashboardAccess(appId, options.idempotencyKey)
         } catch (e: Exception) {

--- a/kotlin/lib/src/main/kotlin/Endpoint.kt
+++ b/kotlin/lib/src/main/kotlin/Endpoint.kt
@@ -31,14 +31,14 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
 
     suspend fun list(
         appId: String,
-        options: EndpointListOptions = EndpointListOptions()
+        options: EndpointListOptions = EndpointListOptions(),
     ): ListResponseEndpointOut {
         try {
             return api.v1EndpointList(
                 appId,
                 options.limit,
                 options.iterator,
-                options.order
+                options.order,
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
@@ -48,20 +48,23 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
     suspend fun create(
         appId: String,
         endpointIn: EndpointIn,
-        options: PostOptions = PostOptions()
+        options: PostOptions = PostOptions(),
     ): EndpointOut {
         try {
             return api.v1EndpointCreate(
                 appId,
                 endpointIn,
-                options.idempotencyKey
+                options.idempotencyKey,
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
-    suspend fun get(appId: String, endpointId: String): EndpointOut {
+    suspend fun get(
+        appId: String,
+        endpointId: String,
+    ): EndpointOut {
         try {
             return api.v1EndpointGet(endpointId, appId)
         } catch (e: Exception) {
@@ -72,13 +75,13 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
     suspend fun update(
         appId: String,
         endpointId: String,
-        endpointUpdate: EndpointUpdate
+        endpointUpdate: EndpointUpdate,
     ): EndpointOut {
         try {
             return api.v1EndpointUpdate(
                 appId,
                 endpointId,
-                endpointUpdate
+                endpointUpdate,
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
@@ -88,20 +91,23 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
     suspend fun patch(
         appId: String,
         endpointId: String,
-        endpointPatch: EndpointPatch
+        endpointPatch: EndpointPatch,
     ): EndpointOut {
         try {
             return api.v1EndpointPatch(
                 appId,
                 endpointId,
-                endpointPatch
+                endpointPatch,
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
-    suspend fun delete(appId: String, endpointId: String) {
+    suspend fun delete(
+        appId: String,
+        endpointId: String,
+    ) {
         try {
             api.v1EndpointDelete(appId, endpointId)
         } catch (e: Exception) {
@@ -109,11 +115,14 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun getSecret(appId: String, endpointId: String): EndpointSecretOut {
+    suspend fun getSecret(
+        appId: String,
+        endpointId: String,
+    ): EndpointSecretOut {
         try {
             return api.v1EndpointGetSecret(
                 appId,
-                endpointId
+                endpointId,
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
@@ -124,14 +133,14 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         appId: String,
         endpointId: String,
         endpointSecretRotateIn: EndpointSecretRotateIn,
-        options: PostOptions = PostOptions()
+        options: PostOptions = PostOptions(),
     ) {
         try {
             api.v1EndpointRotateSecret(
                 appId,
                 endpointId,
                 endpointSecretRotateIn,
-                options.idempotencyKey
+                options.idempotencyKey,
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
@@ -142,25 +151,28 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         appId: String,
         endpointId: String,
         recoverIn: RecoverIn,
-        options: PostOptions = PostOptions()
+        options: PostOptions = PostOptions(),
     ) {
         try {
             api.v1EndpointRecover(
                 appId,
                 endpointId,
                 recoverIn,
-                options.idempotencyKey
+                options.idempotencyKey,
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
-    suspend fun getHeaders(appId: String, endpointId: String): EndpointHeadersOut {
+    suspend fun getHeaders(
+        appId: String,
+        endpointId: String,
+    ): EndpointHeadersOut {
         try {
             return api.v1EndpointGetHeaders(
                 appId,
-                endpointId
+                endpointId,
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
@@ -170,13 +182,13 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
     suspend fun updateHeaders(
         appId: String,
         endpointId: String,
-        endpointHeadersIn: EndpointHeadersIn
+        endpointHeadersIn: EndpointHeadersIn,
     ) {
         try {
             api.v1EndpointUpdateHeaders(
                 appId,
                 endpointId,
-                endpointHeadersIn
+                endpointHeadersIn,
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
@@ -186,13 +198,13 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
     suspend fun patchHeaders(
         appId: String,
         endpointId: String,
-        endpointHeadersIn: EndpointHeadersPatchIn
+        endpointHeadersIn: EndpointHeadersPatchIn,
     ) {
         try {
             api.v1EndpointPatchHeaders(
                 appId,
                 endpointId,
-                endpointHeadersIn
+                endpointHeadersIn,
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
@@ -202,14 +214,14 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
     suspend fun getStats(
         appId: String,
         endpointId: String,
-        options: EndpointStatsOptions = EndpointStatsOptions()
+        options: EndpointStatsOptions = EndpointStatsOptions(),
     ): EndpointStats {
         try {
             return api.v1EndpointGetStats(
                 appId,
                 endpointId,
                 options.since,
-                options.until
+                options.until,
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
@@ -220,50 +232,62 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         appId: String,
         endpointId: String,
         replayIn: ReplayIn,
-        options: PostOptions = PostOptions()
+        options: PostOptions = PostOptions(),
     ) {
         try {
             api.v1EndpointReplay(
                 appId,
                 endpointId,
                 replayIn,
-                options.idempotencyKey
+                options.idempotencyKey,
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
-    suspend fun transformationGet(appId: String, endpointId: String): EndpointTransformationOut {
+    suspend fun transformationGet(
+        appId: String,
+        endpointId: String,
+    ): EndpointTransformationOut {
         try {
             return api.v1EndpointTransformationGet(
                 appId,
-                endpointId
+                endpointId,
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
-    suspend fun transformationPartialUpdate(appId: String, endpointId: String, endpointTransformationIn: EndpointTransformationIn) {
+    suspend fun transformationPartialUpdate(
+        appId: String,
+        endpointId: String,
+        endpointTransformationIn: EndpointTransformationIn,
+    ) {
         try {
             api.v1EndpointTransformationPartialUpdate(
                 appId,
                 endpointId,
-                endpointTransformationIn
+                endpointTransformationIn,
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
-    suspend fun sendExample(appId: String, endpointId: String, eventExampleIn: EventExampleIn, options: PostOptions = PostOptions()) {
+    suspend fun sendExample(
+        appId: String,
+        endpointId: String,
+        eventExampleIn: EventExampleIn,
+        options: PostOptions = PostOptions(),
+    ) {
         try {
             api.v1EndpointSendExample(
                 appId,
                 endpointId,
                 eventExampleIn,
-                options.idempotencyKey
+                options.idempotencyKey,
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)

--- a/kotlin/lib/src/main/kotlin/EventType.kt
+++ b/kotlin/lib/src/main/kotlin/EventType.kt
@@ -28,7 +28,10 @@ class EventType internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun create(eventTypeIn: EventTypeIn, options: PostOptions = PostOptions()): EventTypeOut {
+    suspend fun create(
+        eventTypeIn: EventTypeIn,
+        options: PostOptions = PostOptions(),
+    ): EventTypeOut {
         try {
             return api.v1EventTypeCreate(eventTypeIn, options.idempotencyKey)
         } catch (e: Exception) {
@@ -44,7 +47,10 @@ class EventType internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun update(eventTypeName: String, eventTypeUpdate: EventTypeUpdate): EventTypeOut {
+    suspend fun update(
+        eventTypeName: String,
+        eventTypeUpdate: EventTypeUpdate,
+    ): EventTypeOut {
         try {
             return api.v1EventTypeUpdate(eventTypeName, eventTypeUpdate)
         } catch (e: Exception) {
@@ -52,7 +58,10 @@ class EventType internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun patch(eventTypeName: String, eventTypePatch: EventTypePatch): EventTypeOut {
+    suspend fun patch(
+        eventTypeName: String,
+        eventTypePatch: EventTypePatch,
+    ): EventTypeOut {
         try {
             return api.v1EventTypePatch(eventTypeName, eventTypePatch)
         } catch (e: Exception) {
@@ -68,7 +77,10 @@ class EventType internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun importOpenApi(eventTypeImportOpenApiIn: EventTypeImportOpenApiIn, options: PostOptions = PostOptions()): EventTypeImportOpenApiOut {
+    suspend fun importOpenApi(
+        eventTypeImportOpenApiIn: EventTypeImportOpenApiIn,
+        options: PostOptions = PostOptions(),
+    ): EventTypeImportOpenApiOut {
         try {
             return api.v1EventTypeImportOpenapi(eventTypeImportOpenApiIn, options.idempotencyKey)
         } catch (e: Exception) {

--- a/kotlin/lib/src/main/kotlin/Integration.kt
+++ b/kotlin/lib/src/main/kotlin/Integration.kt
@@ -18,7 +18,10 @@ class Integration internal constructor(token: String, options: SvixOptions) {
         options.numRetries?.let { api.numRetries = it }
     }
 
-    suspend fun list(appId: String, options: IntegrationListOptions = IntegrationListOptions()): ListResponseIntegrationOut {
+    suspend fun list(
+        appId: String,
+        options: IntegrationListOptions = IntegrationListOptions(),
+    ): ListResponseIntegrationOut {
         try {
             return api.v1IntegrationList(appId, options.limit, options.iterator)
         } catch (e: Exception) {
@@ -26,7 +29,11 @@ class Integration internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun create(appId: String, integIn: IntegrationIn, options: PostOptions = PostOptions()): IntegrationOut {
+    suspend fun create(
+        appId: String,
+        integIn: IntegrationIn,
+        options: PostOptions = PostOptions(),
+    ): IntegrationOut {
         try {
             return api.v1IntegrationCreate(appId, integIn, options.idempotencyKey)
         } catch (e: Exception) {
@@ -34,7 +41,10 @@ class Integration internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun get(appId: String, integId: String): IntegrationOut {
+    suspend fun get(
+        appId: String,
+        integId: String,
+    ): IntegrationOut {
         try {
             return api.v1IntegrationGet(appId, integId)
         } catch (e: Exception) {
@@ -42,7 +52,11 @@ class Integration internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun update(appId: String, integId: String, integUpdate: IntegrationUpdate): IntegrationOut {
+    suspend fun update(
+        appId: String,
+        integId: String,
+        integUpdate: IntegrationUpdate,
+    ): IntegrationOut {
         try {
             return api.v1IntegrationUpdate(appId, integId, integUpdate)
         } catch (e: Exception) {
@@ -50,7 +64,10 @@ class Integration internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun delete(appId: String, integId: String) {
+    suspend fun delete(
+        appId: String,
+        integId: String,
+    ) {
         try {
             api.v1IntegrationDelete(appId, integId)
         } catch (e: Exception) {
@@ -58,7 +75,10 @@ class Integration internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun getKey(appId: String, integId: String): IntegrationKeyOut {
+    suspend fun getKey(
+        appId: String,
+        integId: String,
+    ): IntegrationKeyOut {
         try {
             return api.v1IntegrationGetKey(appId, integId)
         } catch (e: Exception) {
@@ -66,12 +86,16 @@ class Integration internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun rotateKey(appId: String, integId: String, options: PostOptions = PostOptions()): IntegrationKeyOut {
+    suspend fun rotateKey(
+        appId: String,
+        integId: String,
+        options: PostOptions = PostOptions(),
+    ): IntegrationKeyOut {
         try {
             return api.v1IntegrationRotateKey(
                 appId,
                 integId,
-                options.idempotencyKey
+                options.idempotencyKey,
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)

--- a/kotlin/lib/src/main/kotlin/Message.kt
+++ b/kotlin/lib/src/main/kotlin/Message.kt
@@ -16,7 +16,10 @@ class Message internal constructor(token: String, options: SvixOptions) {
         options.numRetries?.let { api.numRetries = it }
     }
 
-    suspend fun list(appId: String, options: MessageListOptions = MessageListOptions()): ListResponseMessageOut {
+    suspend fun list(
+        appId: String,
+        options: MessageListOptions = MessageListOptions(),
+    ): ListResponseMessageOut {
         try {
             return api.v1MessageList(
                 appId,
@@ -27,14 +30,18 @@ class Message internal constructor(token: String, options: SvixOptions) {
                 options.after,
                 options.withContent,
                 options.tag,
-                HashSet(options.eventTypes)
+                HashSet(options.eventTypes),
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
-    suspend fun create(appId: String, messageIn: MessageIn, options: PostOptions = PostOptions()): MessageOut {
+    suspend fun create(
+        appId: String,
+        messageIn: MessageIn,
+        options: PostOptions = PostOptions(),
+    ): MessageOut {
         try {
             return api.v1MessageCreate(appId, messageIn, null, options.idempotencyKey)
         } catch (e: Exception) {
@@ -42,7 +49,10 @@ class Message internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun get(msgId: String, appId: String): MessageOut {
+    suspend fun get(
+        msgId: String,
+        appId: String,
+    ): MessageOut {
         try {
             return api.v1MessageGet(appId, msgId, null)
         } catch (e: Exception) {
@@ -50,7 +60,10 @@ class Message internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun expungeContent(msgId: String, appId: String) {
+    suspend fun expungeContent(
+        msgId: String,
+        appId: String,
+    ) {
         try {
             return api.v1MessageExpungeContent(appId, msgId)
         } catch (e: Exception) {

--- a/kotlin/lib/src/main/kotlin/MessageAttempt.kt
+++ b/kotlin/lib/src/main/kotlin/MessageAttempt.kt
@@ -22,11 +22,19 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
      * @deprecated use listByMsg or listByEndpoint instead.
      */
     @Deprecated(message = "use listByMsg or listByEndpoint instead.")
-    suspend fun list(appId: String, msgId: String, options: MessageAttemptListOptions = MessageAttemptListOptions()): ListResponseMessageAttemptOut {
+    suspend fun list(
+        appId: String,
+        msgId: String,
+        options: MessageAttemptListOptions = MessageAttemptListOptions(),
+    ): ListResponseMessageAttemptOut {
         return this.listByMsg(appId, msgId, options)
     }
 
-    suspend fun listByMsg(appId: String, msgId: String, options: MessageAttemptListOptions = MessageAttemptListOptions()): ListResponseMessageAttemptOut {
+    suspend fun listByMsg(
+        appId: String,
+        msgId: String,
+        options: MessageAttemptListOptions = MessageAttemptListOptions(),
+    ): ListResponseMessageAttemptOut {
         try {
             return api.v1MessageAttemptListByMsg(
                 appId,
@@ -41,14 +49,18 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
                 options.before,
                 options.after,
                 options.withContent,
-                HashSet(options.eventTypes)
+                HashSet(options.eventTypes),
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
-    suspend fun listByEndpoint(appId: String, endpointId: String, options: MessageAttemptListOptions = MessageAttemptListOptions()): ListResponseMessageAttemptOut {
+    suspend fun listByEndpoint(
+        appId: String,
+        endpointId: String,
+        options: MessageAttemptListOptions = MessageAttemptListOptions(),
+    ): ListResponseMessageAttemptOut {
         try {
             return api.v1MessageAttemptListByEndpoint(
                 appId,
@@ -63,14 +75,18 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
                 options.after,
                 options.withContent,
                 options.withMsg,
-                HashSet(options.eventTypes)
+                HashSet(options.eventTypes),
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
-    suspend fun get(appId: String, msgId: String, attemptId: String): MessageAttemptOut {
+    suspend fun get(
+        appId: String,
+        msgId: String,
+        attemptId: String,
+    ): MessageAttemptOut {
         try {
             return api.v1MessageAttemptGet(appId, msgId, attemptId)
         } catch (e: Exception) {
@@ -78,13 +94,18 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun resend(appId: String, msgId: String, endpointId: String, options: PostOptions = PostOptions()) {
+    suspend fun resend(
+        appId: String,
+        msgId: String,
+        endpointId: String,
+        options: PostOptions = PostOptions(),
+    ) {
         try {
             api.v1MessageAttemptResend(
                 appId,
                 msgId,
                 endpointId,
-                options.idempotencyKey
+                options.idempotencyKey,
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
@@ -94,7 +115,7 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
     suspend fun listAttemptedMessages(
         appId: String,
         endpointId: String,
-        options: MessageAttemptListOptions = MessageAttemptListOptions()
+        options: MessageAttemptListOptions = MessageAttemptListOptions(),
     ): ListResponseEndpointMessageOut {
         try {
             return api.v1MessageAttemptListAttemptedMessages(
@@ -108,7 +129,7 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
                 options.before,
                 options.after,
                 options.withContent,
-                HashSet(options.eventTypes)
+                HashSet(options.eventTypes),
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
@@ -118,14 +139,14 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
     suspend fun listAttemptedDestinations(
         appId: String,
         msgId: String,
-        options: MessageAttemptListOptions = MessageAttemptListOptions()
+        options: MessageAttemptListOptions = MessageAttemptListOptions(),
     ): ListResponseMessageEndpointOut {
         try {
             return api.v1MessageAttemptListAttemptedDestinations(
                 appId,
                 msgId,
                 options.limit,
-                options.iterator
+                options.iterator,
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
@@ -136,7 +157,7 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
         appId: String,
         endpointId: String,
         msgId: String,
-        options: MessageAttemptListOptions = MessageAttemptListOptions()
+        options: MessageAttemptListOptions = MessageAttemptListOptions(),
     ): ListResponseMessageAttemptEndpointOut {
         return try {
             api.v1MessageAttemptListByEndpointDeprecated(
@@ -150,14 +171,18 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
                 options.messageStatus,
                 options.before,
                 options.after,
-                HashSet(options.eventTypes)
+                HashSet(options.eventTypes),
             )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
-    suspend fun expungeContent(appId: String, msgId: String, attemptId: String) {
+    suspend fun expungeContent(
+        appId: String,
+        msgId: String,
+        attemptId: String,
+    ) {
         try {
             return api.v1MessageAttemptExpungeContent(appId, msgId, attemptId)
         } catch (e: Exception) {

--- a/kotlin/lib/src/main/kotlin/MessageAttemptListOptions.kt
+++ b/kotlin/lib/src/main/kotlin/MessageAttemptListOptions.kt
@@ -4,11 +4,24 @@ import com.svix.kotlin.models.MessageStatus
 import com.svix.kotlin.models.StatusCodeClass
 import java.time.OffsetDateTime
 
-class MessageAttemptListOptions(var messageStatus: MessageStatus? = null, var before: OffsetDateTime? = null, var after: OffsetDateTime? = null, var eventTypes: List<String>? = null, var statusCodeClass: StatusCodeClass? = null, var channel: String? = null, var tag: String? = null, var endpointId: String? = null, var withContent: Boolean? = null, var withMsg: Boolean? = null) : ListOptions() {
+class MessageAttemptListOptions(
+    var messageStatus: MessageStatus? = null,
+    var before: OffsetDateTime? = null,
+    var after: OffsetDateTime? = null,
+    var eventTypes: List<String>? = null,
+    var statusCodeClass: StatusCodeClass? = null,
+    var channel: String? = null,
+    var tag: String? = null,
+    var endpointId: String? = null,
+    var withContent: Boolean? = null,
+    var withMsg: Boolean? = null,
+) : ListOptions() {
     fun messageStatus(messageStatus: MessageStatus) = apply { this.messageStatus = messageStatus }
 
     fun before(before: OffsetDateTime) = apply { this.before = before }
+
     fun after(after: OffsetDateTime) = apply { this.after = after }
+
     fun statusCodeClass(statusCodeClass: StatusCodeClass) = apply { this.statusCodeClass = statusCodeClass }
 
     fun eventTypes(eventTypes: List<String>) = apply { this.eventTypes = eventTypes }

--- a/kotlin/lib/src/main/kotlin/MessageListOptions.kt
+++ b/kotlin/lib/src/main/kotlin/MessageListOptions.kt
@@ -13,6 +13,7 @@ class MessageListOptions : ListOptions() {
     fun eventTypes(eventTypes: List<String>) = apply { this.eventTypes = eventTypes }
 
     fun before(before: OffsetDateTime) = apply { this.before = before }
+
     fun after(after: OffsetDateTime) = apply { this.after = after }
 
     fun channel(channel: String) = apply { this.channel = channel }
@@ -22,5 +23,6 @@ class MessageListOptions : ListOptions() {
     override fun limit(limit: Int) = apply { super.limit(limit) }
 
     fun withContent(withContent: Boolean) = apply { this.withContent = withContent }
+
     fun tag(tag: String) = apply { this.tag = tag }
 }

--- a/kotlin/lib/src/main/kotlin/Statistics.kt
+++ b/kotlin/lib/src/main/kotlin/Statistics.kt
@@ -16,7 +16,10 @@ class Statistics internal constructor(token: String, options: SvixOptions) {
         options.numRetries?.let { api.numRetries = it }
     }
 
-    suspend fun aggregateAppStats(appUsageStatsIn: AppUsageStatsIn, options: PostOptions = PostOptions()): AppUsageStatsOut {
+    suspend fun aggregateAppStats(
+        appUsageStatsIn: AppUsageStatsIn,
+        options: PostOptions = PostOptions(),
+    ): AppUsageStatsOut {
         try {
             return api.v1StatisticsAggregateAppStats(appUsageStatsIn, options.idempotencyKey)
         } catch (e: Exception) {

--- a/kotlin/lib/src/main/kotlin/Svix.kt
+++ b/kotlin/lib/src/main/kotlin/Svix.kt
@@ -1,7 +1,6 @@
 package com.svix.kotlin
 
 class Svix(token: String, options: SvixOptions = SvixOptions()) {
-
     init {
         val tokenParts = token.split(".")
         if (options.wantedServerUrl == null) {

--- a/kotlin/lib/src/main/kotlin/Webhook.kt
+++ b/kotlin/lib/src/main/kotlin/Webhook.kt
@@ -15,7 +15,10 @@ class Webhook {
     private val key: ByteArray
 
     @Throws(WebhookVerificationException::class)
-    fun verify(payload: String?, headers: HttpHeaders) {
+    fun verify(
+        payload: String?,
+        headers: HttpHeaders,
+    ) {
         var msgId = headers.firstValue(SVIX_MSG_ID_KEY)
         var msgSignature = headers.firstValue(SVIX_MSG_SIGNATURE_KEY)
         var msgTimestamp = headers.firstValue(SVIX_MSG_TIMESTAMP_KEY)
@@ -29,11 +32,12 @@ class Webhook {
             }
         }
         val timestamp: Long = verifyTimestamp(msgTimestamp.get())
-        val expectedSignature: String = try {
-            sign(msgId.get(), timestamp, payload).split(",".toRegex()).toTypedArray()[1]
-        } catch (e: WebhookSigningException) {
-            throw WebhookVerificationException("Failed to generate expected signature")
-        }
+        val expectedSignature: String =
+            try {
+                sign(msgId.get(), timestamp, payload).split(",".toRegex()).toTypedArray()[1]
+            } catch (e: WebhookSigningException) {
+                throw WebhookVerificationException("Failed to generate expected signature")
+            }
         val msgSignatures = msgSignature.get().split(" ".toRegex()).toTypedArray()
         for (versionedSignature in msgSignatures) {
             val sigParts = versionedSignature.split(",".toRegex()).toTypedArray()
@@ -53,7 +57,11 @@ class Webhook {
     }
 
     @Throws(WebhookSigningException::class)
-    fun sign(msgId: String?, timestamp: Long, payload: String?): String {
+    fun sign(
+        msgId: String?,
+        timestamp: Long,
+        payload: String?,
+    ): String {
         return try {
             val toSign = String.format("%s.%s.%s", msgId, timestamp, payload)
             val sha512Hmac: Mac = Mac.getInstance(HMAC_SHA256)
@@ -84,11 +92,12 @@ class Webhook {
         @Throws(WebhookVerificationException::class)
         private fun verifyTimestamp(timestampHeader: String): Long {
             val now: Long = System.currentTimeMillis() / SECOND_IN_MS
-            val timestamp: Long = try {
-                timestampHeader.toLong()
-            } catch (e: NumberFormatException) {
-                throw WebhookVerificationException("Invalid Signature Headers")
-            }
+            val timestamp: Long =
+                try {
+                    timestampHeader.toLong()
+                } catch (e: NumberFormatException) {
+                    throw WebhookVerificationException("Invalid Signature Headers")
+                }
 
             if (timestamp < now - TOLERANCE_IN_SECONDS) {
                 throw WebhookVerificationException("Message timestamp too old")

--- a/kotlin/lib/src/main/kotlin/exceptions/ApiException.kt
+++ b/kotlin/lib/src/main/kotlin/exceptions/ApiException.kt
@@ -6,7 +6,9 @@ import com.svix.kotlin.internal.infrastructure.Response
 import com.svix.kotlin.internal.infrastructure.ServerError
 import com.svix.kotlin.internal.infrastructure.ServerException
 
-class ApiException internal constructor(message: String? = null, val statusCode: Int = -1, val body: String? = null) : RuntimeException(message) {
+class ApiException internal constructor(message: String? = null, val statusCode: Int = -1, val body: String? = null) : RuntimeException(
+    message,
+) {
     companion object {
         private fun extractBody(response: Response?): String? {
             return when (response) {

--- a/kotlin/lib/src/test/com/svix/kotlin/BasicTest.kt
+++ b/kotlin/lib/src/test/com/svix/kotlin/BasicTest.kt
@@ -17,12 +17,13 @@ class BasicTest {
                 applicationOut.id,
                 MessageIn(
                     eventType = "invoice.paid",
-                    payload = mapOf<String, Any>(
-                        "id" to "invoice_WF7WtCLFFtd8ubcTgboSFNql",
-                        "status" to "paid",
-                        "attempt" to 2
-                    )
-                )
+                    payload =
+                        mapOf<String, Any>(
+                            "id" to "invoice_WF7WtCLFFtd8ubcTgboSFNql",
+                            "status" to "paid",
+                            "attempt" to 2,
+                        ),
+                ),
             )
             svix.application.delete(applicationOut.id)
         }
@@ -30,7 +31,11 @@ class BasicTest {
 
     companion object {
         // Token for org org_00000000000LibTest000000000
-        private const val AUTH_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2NTc2MzQwNjcsImV4cCI6MTk3Mjk5NDA2NywibmJmIjoxNjU3NjM0MDY3LCJpc3MiOiJzdml4LXNlcnZlciIsInN1YiI6Im9yZ18wMDAwMDAwMDAwMExpYlRlc3QwMDAwMDAwMDAifQ.IAy2wrnWhbGTeGHSYygKOID2LKFITaxNW8mHO7F5jWM"
+        private const val AUTH_TOKEN =
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." +
+                "eyJpYXQiOjE2NTc2MzQwNjcsImV4cCI6MTk3Mjk5NDA2NywibmJmIjoxNjU3NjM0MDY3LCJpc3M" +
+                "iOiJzdml4LXNlcnZlciIsInN1YiI6Im9yZ18wMDAwMDAwMDAwMExpYlRlc3QwMDAwMDAwMDAifQ." +
+                "IAy2wrnWhbGTeGHSYygKOID2LKFITaxNW8mHO7F5jWM"
         private const val SERVER_URL = "http://localhost:8071"
     }
 }

--- a/kotlin/lib/src/test/com/svix/kotlin/WebhookTest.kt
+++ b/kotlin/lib/src/test/com/svix/kotlin/WebhookTest.kt
@@ -11,7 +11,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class WebhookTest {
-
     @Test
     fun verifyValidPayloadAndheader() {
         val testPayload = TestPayload(System.currentTimeMillis())
@@ -34,12 +33,14 @@ class WebhookTest {
     @Test
     fun verifyValidPayloadWithMultipleSignaturesIsValid() {
         val testPayload = TestPayload(System.currentTimeMillis())
-        val sigs = arrayOf(
-            "v1,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
-            "v2,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
-            testPayload.headerMap["svix-signature"]!![0], // valid signature
-            "v1,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc="
-        )
+        val sigs =
+            arrayOf(
+                "v1,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
+                "v2,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
+                // valid signature
+                testPayload.headerMap["svix-signature"]!![0],
+                "v1,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
+            )
         testPayload.headerMap["svix-signature"] = ArrayList(listOf(sigs.joinToString(" ")))
         val webhook = Webhook(testPayload.secret)
         webhook.verify(testPayload.payload, testPayload.headers())
@@ -52,7 +53,7 @@ class WebhookTest {
         assertFailsWith<WebhookVerificationException>(
             block = {
                 verify(testPayload)
-            }
+            },
         )
     }
 
@@ -63,7 +64,7 @@ class WebhookTest {
         assertFailsWith<WebhookVerificationException>(
             block = {
                 verify(testPayload)
-            }
+            },
         )
     }
 
@@ -74,7 +75,7 @@ class WebhookTest {
         assertFailsWith<WebhookVerificationException>(
             block = {
                 verify(testPayload)
-            }
+            },
         )
     }
 
@@ -85,7 +86,7 @@ class WebhookTest {
         assertFailsWith<WebhookVerificationException>(
             block = {
                 verify(testPayload)
-            }
+            },
         )
     }
 
@@ -96,7 +97,7 @@ class WebhookTest {
         assertFailsWith<WebhookVerificationException>(
             block = {
                 verify(testPayload)
-            }
+            },
         )
     }
 
@@ -107,7 +108,7 @@ class WebhookTest {
         assertFailsWith<WebhookVerificationException>(
             block = {
                 verify(testPayload)
-            }
+            },
         )
     }
 
@@ -117,7 +118,7 @@ class WebhookTest {
         assertFailsWith<WebhookVerificationException>(
             block = {
                 verify(testPayload)
-            }
+            },
         )
     }
 
@@ -127,7 +128,7 @@ class WebhookTest {
         assertFailsWith<WebhookVerificationException>(
             block = {
                 verify(testPayload)
-            }
+            },
         )
     }
 
@@ -164,6 +165,7 @@ class WebhookTest {
         val secret: String
         private var signature: String? = null
         var headerMap: HashMap<String, ArrayList<String>>
+
         fun headers(): HttpHeaders {
             val map = HashMap<String, List<String>>()
             for ((key, value) in headerMap) {


### PR DESCRIPTION
Mostly automated with `ktlint --format`. Not needed right now, probably because CI is running an older version of ktlint, but doesn't hurt either.