### PR TITLE
Add oauth support to javascript

### DIFF
--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -458,7 +458,7 @@ class Endpoint {
     );
   }
 
-  public updateOauthConfig(
+  public oauthConfigUpdate(
     appId: string,
     endpointId: string,
     endpointOauthConfigIn: EndpointOauthConfigIn,
@@ -468,7 +468,7 @@ class Endpoint {
     });
   }
 
-  public deleteOauthConfig(
+  public oauthConfigDelete(
     appId: string,
     endpointId: string,
   ): Promise<void> {

--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -458,7 +458,7 @@ class Endpoint {
     );
   }
 
-  public oauthConfigUpdate(
+  public oauthUpdate(
     appId: string,
     endpointId: string,
     endpointOauthConfigIn: EndpointOauthConfigIn,
@@ -468,7 +468,7 @@ class Endpoint {
     });
   }
 
-  public oauthConfigDelete(
+  public oauthDelete(
     appId: string,
     endpointId: string,
   ): Promise<void> {

--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -68,6 +68,7 @@ import {
   AppUsageStatsIn,
   AppUsageStatsOut,
   AggregateEventTypesOut,
+  EndpointOauthConfigIn,
 } from "./openapi/index";
 export * from "./openapi/models/all";
 export * from "./openapi/apis/exception";
@@ -455,6 +456,25 @@ class Endpoint {
     return this.api.v1EndpointSendExample(
       { appId, endpointId, eventExampleIn, ...options }
     );
+  }
+
+  public updateOauthConfig(
+    appId: string,
+    endpointId: string,
+    endpointOauthConfigIn: EndpointOauthConfigIn,
+  ): Promise<void> {
+    return this.api.v1EndpointUpdateOauthConfig({
+      appId, endpointId, endpointOauthConfigIn
+    });
+  }
+
+  public deleteOauthConfig(
+    appId: string,
+    endpointId: string,
+  ): Promise<void> {
+    return this.api.v1EndpointDeleteOauthConfig({
+      appId, endpointId
+    });
   }
 }
 

--- a/openapi.json
+++ b/openapi.json
@@ -8324,6 +8324,382 @@
                 ]
             }
         },
+        "/api/v1/app/{app_id}/endpoint/{endpoint_id}/oauth": {
+            "delete": {
+                "description": "Delete endpoint OAuth configuration",
+                "operationId": "v1.endpoint.delete-oauth-config",
+                "parameters": [
+                    {
+                        "description": "The app's ID or UID",
+                        "in": "path",
+                        "name": "app_id",
+                        "required": true,
+                        "schema": {
+                            "description": "The app's ID or UID",
+                            "example": "unique-app-identifier",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+                            "type": "string"
+                        },
+                        "style": "simple"
+                    },
+                    {
+                        "description": "The ep's ID or UID",
+                        "in": "path",
+                        "name": "endpoint_id",
+                        "required": true,
+                        "schema": {
+                            "description": "The ep's ID or UID",
+                            "example": "unique-ep-identifier",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+                            "type": "string"
+                        },
+                        "style": "simple"
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "no content"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Bad request"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Forbidden"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "409": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Conflict"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                        "description": "Validation Error"
+                    },
+                    "429": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Too Many Requests"
+                    }
+                },
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "summary": "Delete Endpoint Oauth Config",
+                "tags": [
+                    "Endpoint"
+                ],
+                "x-codeSamples": [
+                    {
+                        "label": "JavaScript",
+                        "lang": "JavaScript",
+                        "source": "await svix.endpoint.deleteOauthConfig(\"app_id\", \"endpoint_id\");"
+                    },
+                    {
+                        "label": "TypeScript",
+                        "lang": "JavaScript",
+                        "source": "await svix.endpoint.deleteOauthConfig(\"app_id\", \"endpoint_id\");"
+                    },
+                    {
+                        "label": "Python",
+                        "lang": "Python",
+                        "source": "svix.endpoint.delete_oauth_config(\"app_id\", \"endpoint_id\")"
+                    },
+                    {
+                        "label": "Python (Async)",
+                        "lang": "Python",
+                        "source": "await svix.endpoint.delete_oauth_config(\"app_id\", \"endpoint_id\")"
+                    },
+                    {
+                        "label": "Go",
+                        "lang": "Go",
+                        "source": "err := svixClient.Endpoint.DeleteOauthConfig(ctx, \"app_id\", \"endpoint_id\")"
+                    },
+                    {
+                        "label": "Kotlin",
+                        "lang": "Kotlin",
+                        "source": "svix.endpoint.deleteOauthConfig(\"app_id\", \"endpoint_id\")"
+                    },
+                    {
+                        "label": "Java",
+                        "lang": "Java",
+                        "source": "svix.getEndpoint().deleteOauthConfig(\"app_id\", \"endpoint_id\")"
+                    },
+                    {
+                        "label": "Ruby",
+                        "lang": "Ruby",
+                        "source": "svix.endpoint.delete_oauth_config(\"app_id\", \"endpoint_id\")"
+                    },
+                    {
+                        "label": "Rust",
+                        "lang": "Rust",
+                        "source": "svix.endpoint().delete_oauth_config(\"app_id\", \"endpoint_id\").await?;"
+                    },
+                    {
+                        "label": "C#",
+                        "lang": "C#",
+                        "source": "await svix.Endpoint.DeleteOauthConfigAsync(\"app_id\", \"endpoint_id\")"
+                    },
+                    {
+                        "label": "CLI",
+                        "lang": "Shell",
+                        "source": "svix endpoint delete-oauth-config \"app_id\" \"endpoint_id\""
+                    },
+                    {
+                        "label": "cURL",
+                        "lang": "Shell",
+                        "source": "curl -X 'DELETE' \\\n  'https://api.eu.svix.com/api/v1/app/{app_id}/endpoint/{endpoint_id}/oauth' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json'"
+                    }
+                ]
+            },
+            "put": {
+                "description": "Create/update endpoint OAuth configuration",
+                "operationId": "v1.endpoint.update-oauth-config",
+                "parameters": [
+                    {
+                        "description": "The app's ID or UID",
+                        "in": "path",
+                        "name": "app_id",
+                        "required": true,
+                        "schema": {
+                            "description": "The app's ID or UID",
+                            "example": "unique-app-identifier",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+                            "type": "string"
+                        },
+                        "style": "simple"
+                    },
+                    {
+                        "description": "The ep's ID or UID",
+                        "in": "path",
+                        "name": "endpoint_id",
+                        "required": true,
+                        "schema": {
+                            "description": "The ep's ID or UID",
+                            "example": "unique-ep-identifier",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z0-9\\-_.]+$",
+                            "type": "string"
+                        },
+                        "style": "simple"
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EndpointOauthConfigIn"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "204": {
+                        "description": "no content"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Bad request"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Forbidden"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "409": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Conflict"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                        "description": "Validation Error"
+                    },
+                    "429": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Too Many Requests"
+                    }
+                },
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "summary": "Update Endpoint Oauth Config",
+                "tags": [
+                    "Endpoint"
+                ],
+                "x-codeSamples": [
+                    {
+                        "label": "JavaScript",
+                        "lang": "JavaScript",
+                        "source": "await svix.endpoint.updateOauthConfig(\"app_id\", \"endpoint_id\", {\n    jwtParams: null,\n    clientSecret: null,\n    scopes: null,\n    extraParams: null\n});"
+                    },
+                    {
+                        "label": "TypeScript",
+                        "lang": "JavaScript",
+                        "source": "await svix.endpoint.updateOauthConfig(\"app_id\", \"endpoint_id\", {\n    jwtParams: null,\n    clientSecret: null,\n    scopes: null,\n    extraParams: null\n});"
+                    },
+                    {
+                        "label": "Python",
+                        "lang": "Python",
+                        "source": "svix.endpoint.update_oauth_config(\"app_id\", \"endpoint_id\", EndpointOauthConfigIn(\n    jwt_params=None,\n    client_secret=None,\n    scopes=None,\n    extra_params=None\n))"
+                    },
+                    {
+                        "label": "Python (Async)",
+                        "lang": "Python",
+                        "source": "await svix.endpoint.update_oauth_config(\"app_id\", \"endpoint_id\", EndpointOauthConfigIn(\n    jwt_params=None,\n    client_secret=None,\n    scopes=None,\n    extra_params=None\n))"
+                    },
+                    {
+                        "label": "Go",
+                        "lang": "Go",
+                        "source": "err := svixClient.Endpoint.UpdateOauthConfig(ctx, \"app_id\", \"endpoint_id\", &EndpointOauthConfigIn{\n    JwtParams: nil,\n    ClientSecret: nil,\n    Scopes: nil,\n    ExtraParams: nil,\n})"
+                    },
+                    {
+                        "label": "Kotlin",
+                        "lang": "Kotlin",
+                        "source": "svix.endpoint.updateOauthConfig(\"app_id\", \"endpoint_id\", EndpointOauthConfigIn()\n    .jwtParams(null)\n    .clientSecret(null)\n    .scopes(null)\n    .extraParams(null)\n)"
+                    },
+                    {
+                        "label": "Java",
+                        "lang": "Java",
+                        "source": "svix.getEndpoint().updateOauthConfig(\"app_id\", \"endpoint_id\", new EndpointOauthConfigIn()\n    .jwtParams(null)\n    .clientSecret(null)\n    .scopes(null)\n    .extraParams(null)\n)"
+                    },
+                    {
+                        "label": "Ruby",
+                        "lang": "Ruby",
+                        "source": "svix.endpoint.update_oauth_config(\"app_id\", \"endpoint_id\", Svix::EndpointOauthConfigIn.new({\n    \"jwt_params\": nil,\n    \"client_secret\": nil,\n    \"scopes\": nil,\n    \"extra_params\": nil\n}))"
+                    },
+                    {
+                        "label": "Rust",
+                        "lang": "Rust",
+                        "source": "svix.endpoint().update_oauth_config(\"app_id\", \"endpoint_id\", EndpointOauthConfigIn {\n    jwt_params: None,\n    client_secret: None,\n    scopes: None,\n    extra_params: None,\n}).await?;"
+                    },
+                    {
+                        "label": "C#",
+                        "lang": "C#",
+                        "source": "await svix.Endpoint.UpdateOauthConfigAsync(\"app_id\", \"endpoint_id\", new EndpointOauthConfigIn{\n    jwtParams: null,\n    clientSecret: null,\n    scopes: null,\n    extraParams: null\n})"
+                    },
+                    {
+                        "label": "CLI",
+                        "lang": "Shell",
+                        "source": "svix endpoint update-oauth-config \"app_id\" \"endpoint_id\" '{\n    \"jwtParams\": null,\n    \"clientSecret\": null,\n    \"scopes\": null,\n    \"extraParams\": null\n}'"
+                    },
+                    {
+                        "label": "cURL",
+                        "lang": "Shell",
+                        "source": "curl -X 'PUT' \\\n  'https://api.eu.svix.com/api/v1/app/{app_id}/endpoint/{endpoint_id}/oauth' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n        \"jwtParams\": null,\n        \"clientSecret\": null,\n        \"scopes\": null,\n        \"extraParams\": null\n    }'"
+                    }
+                ]
+            }
+        },
         "/api/v1/app/{app_id}/endpoint/{endpoint_id}/recover": {
             "post": {
                 "description": "Resend all failed messages since a given time.",


### PR DESCRIPTION
This updates the OpenApi spec/Javascript lib with new routes 
for oauth support. We are keeping the changes limited to Js
for now until the API is finalized.