### PR TITLE
server: Simplify short-circuiting logic for Option::None

### DIFF
--- a/server/svix-server/src/core/operational_webhooks.rs
+++ b/server/svix-server/src/core/operational_webhooks.rs
@@ -125,10 +125,7 @@ impl OperationalWebhookSenderInner {
         recipient_org_id: &OrganizationId,
         payload: OperationalWebhook,
     ) -> Result<()> {
-        let url = match self.url.as_ref() {
-            Some(url) => url,
-            None => return Ok(()),
-        };
+        let Some(url) = &self.url else { return Ok(()) };
 
         let op_webhook_token =
             generate_management_token(&self.signing_config).map_err(Error::generic)?;

--- a/server/svix-server/src/db/models/endpoint.rs
+++ b/server/svix-server/src/db/models/endpoint.rs
@@ -101,13 +101,12 @@ impl ActiveModel {
         app_id: ApplicationId,
         endp_id: EndpointIdOrUid,
     ) -> error::Result<Option<(Self, endpointmetadata::ActiveModel)>> {
-        let (endp, metadata) = match Entity::secure_find_by_id_or_uid(app_id, endp_id)
+        let Some((endp, metadata)) = Entity::secure_find_by_id_or_uid(app_id, endp_id)
             .find_also_related(endpointmetadata::Entity)
             .one(db)
             .await?
-        {
-            Some(models) => models,
-            None => return Ok(None),
+        else {
+            return Ok(None);
         };
 
         let metadata = metadata

--- a/server/svix-server/src/worker.rs
+++ b/server/svix-server/src/worker.rs
@@ -780,7 +780,7 @@ async fn process_queue_task_inner(
         return Ok(());
     };
 
-    let create_message_app = match CreateMessageApp::layered_fetch(
+    let Some(create_message_app) = CreateMessageApp::layered_fetch(
         cache,
         db,
         None,
@@ -789,12 +789,9 @@ async fn process_queue_task_inner(
         Duration::from_secs(30),
     )
     .await?
-    {
-        Some(create_message_app) => create_message_app,
-        None => {
-            tracing::info!("Application doesn't exist: {}", &msg.app_id);
-            return Ok(());
-        }
+    else {
+        tracing::info!("Application doesn't exist: {}", &msg.app_id);
+        return Ok(());
     };
 
     let endpoints: Vec<CreateMessageEndpoint> = create_message_app


### PR DESCRIPTION
Using let-else in most cases, the questionmark operator elsewhere.