### PR TITLE
Add NullableBool function

### DIFF
--- a/go/svix.go
+++ b/go/svix.go
@@ -47,6 +47,9 @@ func NullableInt32(num *int32) *openapi.NullableInt32 {
 func Int32(i int32) *int32 {
 	return &i
 }
+func NullableBool(b *bool) *openapi.NullableBool {
+	return openapi.NewNullableBool(b)
+}
 
 func New(token string, options *SvixOptions) *Svix {
 	conf := openapi.NewConfiguration()


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

The `AppPortalAccess` function in the golang SDK takes a `ReadOnly` parameter, of type `NullableBool`. However, the `NullableBool` struct and associated functions aren't accessible outside the SDK, so it's not possible to construct a `NullableBool` to pass into this function. 

For other types (`NullableString`, `NullableInt32`), there's a set of wrapper functions defined in the `svix` package. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Add a `NullableBool` function to the svix package, next to the existing wrapper functions.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
