### PR TITLE
Enable `endpoint-https-only` by default

### DIFF
--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -91,7 +91,7 @@ cache_type = "memory"
 whitelabel_headers = false
 
 # If true, only allow https endpoints, otherwise also allow http.
-endpoint_https_only = false
+endpoint_https_only = true
 
 # How long of a period an endpoint must be consistently failing to be disabled. If a message is
 # successfully sent during this time, then the endpoint will not disable. Measured in hours.

--- a/server/svix-server/tests/it/utils/mod.rs
+++ b/server/svix-server/tests/it/utils/mod.rs
@@ -251,9 +251,11 @@ impl TestClient {
 
 pub fn get_default_test_config() -> ConfigurationInner {
     let _ = dotenvy::dotenv();
-    let cfg = svix_server::cfg::load().unwrap();
+    let mut cfg = svix_server::cfg::load().unwrap().as_ref().clone();
 
-    cfg.as_ref().clone()
+    cfg.endpoint_https_only = false;
+
+    cfg
 }
 
 pub async fn start_svix_server() -> (TestClient, tokio::task::JoinHandle<()>) {


### PR DESCRIPTION
Changes the default to `true` here. That's it.

Note that this requires setting it to false in our default test config, else all the tests break. We do have a test that actually tests changing `endpoint_https_only` explicitly, though, so we should be fine.