### PR TITLE
Make config type, variant names less confusing

### DIFF
--- a/bridge/svix-bridge-plugin-queue/src/config.rs
+++ b/bridge/svix-bridge-plugin-queue/src/config.rs
@@ -13,7 +13,7 @@ pub use crate::{
 };
 
 #[derive(Deserialize)]
-pub struct QueueConsumerConfig {
+pub struct QueueSenderConfig {
     pub name: String,
     pub input: SenderInputOpts,
     #[serde(default)]
@@ -21,7 +21,7 @@ pub struct QueueConsumerConfig {
     pub output: SenderOutputOpts,
 }
 
-impl QueueConsumerConfig {
+impl QueueSenderConfig {
     pub fn into_sender_input(self) -> Result<Box<dyn SenderInput>, &'static str> {
         // FIXME: see if this check is still needed. String transforms worked for the omniqueue redis receiver, I think?
         if matches!(self.input, SenderInputOpts::Redis(_))
@@ -92,7 +92,7 @@ mod tests {
         SenderOutputOpts, SvixSenderOutputOpts, TransformationConfig, TransformerInputFormat,
     };
 
-    use super::{into_receiver_output, QueueConsumerConfig};
+    use super::{into_receiver_output, QueueSenderConfig};
     use crate::{
         config::{ReceiverOutputOpts, SenderInputOpts},
         redis::{RedisInputOpts, RedisOutputOpts},
@@ -102,7 +102,7 @@ mod tests {
     //   Revisit after `omniqueue` adoption.
     #[test]
     fn redis_sender_with_string_transformation_is_err() {
-        let cfg = QueueConsumerConfig {
+        let cfg = QueueSenderConfig {
             name: "redis-with-string-transformation".to_string(),
             input: SenderInputOpts::Redis(RedisInputOpts {
                 dsn: "".to_string(),

--- a/bridge/svix-bridge-types/src/lib.rs
+++ b/bridge/svix-bridge-types/src/lib.rs
@@ -161,14 +161,13 @@ pub enum WebhookVerifier {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "type", rename_all = "lowercase")]
+#[serde(tag = "type", rename_all = "kebab-case")]
 pub enum ReceiverInputOpts {
     Webhook {
         path_id: String,
         #[serde(default)]
         verification: WebhookVerifier,
     },
-    #[serde(rename = "svix-webhook")]
     SvixWebhook {
         path_id: String,
         endpoint_secret: String,

--- a/bridge/svix-bridge/src/config/mod.rs
+++ b/bridge/svix-bridge/src/config/mod.rs
@@ -11,7 +11,7 @@ use std::{
 use serde::Deserialize;
 use shellexpand::LookupError;
 use svix_bridge_plugin_queue::config::{
-    into_receiver_output, QueueConsumerConfig, ReceiverOutputOpts as QueueOutOpts,
+    into_receiver_output, QueueSenderConfig, ReceiverOutputOpts as QueueOutOpts,
 };
 use svix_bridge_types::{ReceiverInputOpts, ReceiverOutput, SenderInput, TransformationConfig};
 use tracing::Level;
@@ -150,18 +150,18 @@ pub enum SenderConfig {
         feature = "redis",
         feature = "sqs"
     ))]
-    QueueConsumer(QueueConsumerConfig),
+    Queue(QueueSenderConfig),
 }
 
 impl SenderConfig {
     pub fn name(&self) -> &str {
         match self {
-            SenderConfig::QueueConsumer(cfg) => &cfg.name,
+            SenderConfig::Queue(cfg) => &cfg.name,
         }
     }
     pub fn transformation(&self) -> Option<&TransformationConfig> {
         match self {
-            SenderConfig::QueueConsumer(cfg) => cfg.transformation.as_ref(),
+            SenderConfig::Queue(cfg) => cfg.transformation.as_ref(),
         }
     }
 }
@@ -176,7 +176,7 @@ impl TryFrom<SenderConfig> for Box<dyn SenderInput> {
                 feature = "redis",
                 feature = "sqs"
             ))]
-            SenderConfig::QueueConsumer(backend) => backend.into_sender_input(),
+            SenderConfig::Queue(backend) => backend.into_sender_input(),
         }
     }
 }
@@ -199,13 +199,13 @@ pub enum ReceiverOut {
         feature = "redis",
         feature = "sqs"
     ))]
-    QueueProducer(QueueOutOpts),
+    Queue(QueueOutOpts),
 }
 
 impl ReceiverConfig {
     pub async fn into_receiver_output(self) -> std::io::Result<Box<dyn ReceiverOutput>> {
         match self.output {
-            ReceiverOut::QueueProducer(x) => {
+            ReceiverOut::Queue(x) => {
                 into_receiver_output(self.name.clone(), x, self.transformation.as_ref())
                     .await
                     .map_err(Into::into)

--- a/bridge/svix-bridge/src/config/tests.rs
+++ b/bridge/svix-bridge/src/config/tests.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use svix_bridge_plugin_queue::config::{QueueConsumerConfig, RabbitMqInputOpts, SenderInputOpts};
+use svix_bridge_plugin_queue::config::{QueueSenderConfig, RabbitMqInputOpts, SenderInputOpts};
 use svix_bridge_types::{SenderOutputOpts, SvixSenderOutputOpts};
 
 use super::Config;
@@ -340,7 +340,7 @@ fn test_senders_example() {
 #[test]
 fn test_variable_substitution_missing_vars() {
     let src = r#"
-    opentelemetry: 
+    opentelemetry:
         address: "${OTEL_ADDR}"
     "#;
     let vars = HashMap::new();
@@ -455,7 +455,7 @@ fn test_variable_substitution_repeated_lookups() {
     vars.insert(String::from("SVIX_TOKEN"), String::from("x"));
     let cfg = Config::from_src(src, Some(&vars)).unwrap();
 
-    if let SenderConfig::QueueConsumer(QueueConsumerConfig {
+    if let SenderConfig::Queue(QueueSenderConfig {
         input:
             SenderInputOpts::RabbitMQ(RabbitMqInputOpts {
                 uri, queue_name, ..
@@ -471,7 +471,7 @@ fn test_variable_substitution_repeated_lookups() {
         panic!("sender did not match expected pattern");
     }
 
-    if let SenderConfig::QueueConsumer(QueueConsumerConfig {
+    if let SenderConfig::Queue(QueueSenderConfig {
         input:
             SenderInputOpts::RabbitMQ(RabbitMqInputOpts {
                 uri, queue_name, ..


### PR DESCRIPTION
## Motivation

I want to add a kafka variant to `SenderConfig` and `ReceiverOut`, but with current variant names, that will either cause a common suffix (which clippy will likely complain about) or odd-looking naming inconsistencies.

## Solution

Remove the unnecessary `Consumer`, `Producer` variant name suffixes. Since both enums are `#[serde(untagged)]`, this does not affect deserialization. Also rename `QueueConsumerConfig` to `QueueSenderConfig`, which seems to be correct naming given it contains fields of type `Sender*Opts` and it's contained in the only variant of `SenderConfig`, whereas the previous name was rather confusing.

Part of https://github.com/svix/monorepo-private/issues/8508.