### PR TITLE
More redis updates

### DIFF
--- a/server/svix-server/src/core/cache/redis.rs
+++ b/server/svix-server/src/core/cache/redis.rs
@@ -7,15 +7,15 @@ use axum::async_trait;
 use redis::AsyncCommands as _;
 
 use super::{Cache, CacheBehavior, CacheKey, Error, Result};
-use crate::redis::RedisPool;
+use crate::redis::RedisManager;
 
-pub fn new(redis: RedisPool) -> Cache {
+pub fn new(redis: RedisManager) -> Cache {
     RedisCache { redis }.into()
 }
 
 #[derive(Clone)]
 pub struct RedisCache {
-    redis: RedisPool,
+    redis: RedisManager,
 }
 
 #[async_trait]
@@ -112,7 +112,7 @@ mod tests {
         }
     }
 
-    async fn get_pool(redis_dsn: &str, cfg: &crate::cfg::Configuration) -> RedisPool {
+    async fn get_pool(redis_dsn: &str, cfg: &crate::cfg::Configuration) -> RedisManager {
         match cfg.cache_type {
             CacheType::RedisCluster => crate::redis::new_redis_clustered_unpooled(redis_dsn).await,
             CacheType::Redis => crate::redis::new_redis_unpooled(redis_dsn).await,

--- a/server/svix-server/src/core/cache/redis.rs
+++ b/server/svix-server/src/core/cache/redis.rs
@@ -81,7 +81,7 @@ mod tests {
         super::{kv_def, string_kv_def, CacheValue},
         *,
     };
-    use crate::cfg::CacheType;
+    use crate::cfg::Configuration;
 
     // Test structures
 
@@ -112,14 +112,8 @@ mod tests {
         }
     }
 
-    async fn get_pool(redis_dsn: &str, cfg: &crate::cfg::Configuration) -> RedisManager {
-        match cfg.cache_type {
-            CacheType::RedisCluster => crate::redis::new_redis_clustered_unpooled(redis_dsn).await,
-            CacheType::Redis => crate::redis::new_redis_unpooled(redis_dsn).await,
-            _ => panic!(
-                "This test should only be run when redis is configured as the cache provider"
-            ),
-        }
+    async fn get_pool(cfg: &Configuration) -> RedisManager {
+        RedisManager::from_cache_backend(&cfg.cache_backend()).await
     }
 
     #[tokio::test]
@@ -129,7 +123,7 @@ mod tests {
         dotenvy::dotenv().ok();
         let cfg = crate::cfg::load().unwrap();
 
-        let redis_pool = get_pool(cfg.redis_dsn.as_ref().unwrap().as_str(), &cfg).await;
+        let redis_pool = get_pool(&cfg).await;
         let cache = super::new(redis_pool);
 
         let (first_key, first_val_a, first_val_b) =
@@ -206,7 +200,7 @@ mod tests {
         dotenvy::dotenv().ok();
         let cfg = crate::cfg::load().unwrap();
 
-        let redis_pool = get_pool(cfg.redis_dsn.as_ref().unwrap().as_str(), &cfg).await;
+        let redis_pool = get_pool(&cfg).await;
         let cache = super::new(redis_pool);
 
         let key = TestKeyA::new("key".to_owned());
@@ -225,7 +219,7 @@ mod tests {
         dotenvy::dotenv().ok();
         let cfg = crate::cfg::load().unwrap();
 
-        let redis_pool = get_pool(cfg.redis_dsn.as_ref().unwrap().as_str(), &cfg).await;
+        let redis_pool = get_pool(&cfg).await;
         let cache = super::new(redis_pool);
 
         let key = TestKeyA::new("nx_status_test_key".to_owned());

--- a/server/svix-server/src/queue/redis.rs
+++ b/server/svix-server/src/queue/redis.rs
@@ -36,7 +36,7 @@ use super::{QueueTask, TaskQueueConsumer, TaskQueueProducer};
 use crate::{
     cfg::{Configuration, QueueType},
     error::Result,
-    redis::{PooledConnection, RedisPool},
+    redis::{PooledConnection, RedisManager},
 };
 
 /// This is the key of the main queue. As a KV store, redis places the entire stream under this key.
@@ -93,7 +93,7 @@ pub async fn new_pair(
 /// Runs Redis queue migrations with the given delay schedule. Migrations are run on this schedule
 /// such that if an old instance of the server is online after the migrations are made, that no data
 /// will be lost assuming the old server is taken offline before the last scheduled delay.
-async fn run_migration_schedule(delays: &[Duration], pool: RedisPool) {
+async fn run_migration_schedule(delays: &[Duration], pool: RedisManager) {
     let mut conn = pool
         .get()
         .await
@@ -358,10 +358,10 @@ pub mod tests {
         cfg::{Configuration, QueueType},
         core::types::{ApplicationId, EndpointId, MessageAttemptTriggerType, MessageId},
         queue::{MessageTask, QueueTask, TaskQueueConsumer, TaskQueueProducer},
-        redis::RedisPool,
+        redis::RedisManager,
     };
 
-    async fn get_pool(cfg: &Configuration) -> RedisPool {
+    async fn get_pool(cfg: &Configuration) -> RedisManager {
         match cfg.queue_type {
             QueueType::RedisCluster => {
                 crate::redis::new_redis_clustered_pooled(cfg.redis_dsn.as_deref().unwrap(), cfg)

--- a/server/svix-server/tests/it/message_app.rs
+++ b/server/svix-server/tests/it/message_app.rs
@@ -12,7 +12,7 @@ use svix_server::{
         message_app::AppEndpointKey,
         types::{BaseId, OrganizationId},
     },
-    redis::{new_redis_clustered_unpooled, new_redis_unpooled},
+    redis::RedisManager,
 };
 
 use crate::utils::{
@@ -65,12 +65,8 @@ async fn test_app_deletion() {
     // Delete the cached [`CreateMessageApp`] here instead of waiting 30s for it to expire
     let cache = match cfg.cache_backend() {
         CacheBackend::None => cache::none::new(),
-        CacheBackend::Redis(dsn) => {
-            let mgr = new_redis_unpooled(dsn).await;
-            cache::redis::new(mgr)
-        }
-        CacheBackend::RedisCluster(dsn) => {
-            let mgr = new_redis_clustered_unpooled(dsn).await;
+        CacheBackend::Redis(_) | CacheBackend::RedisCluster(_) => {
+            let mgr = RedisManager::from_cache_backend(&cfg.cache_backend()).await;
             cache::redis::new(mgr)
         }
 
@@ -149,12 +145,8 @@ async fn test_endp_deletion() {
     // Delete the cached [`CreateMessageApp`] here instead of waiting 30s for it to expire
     let cache = match cfg.cache_backend() {
         CacheBackend::None => cache::none::new(),
-        CacheBackend::Redis(dsn) => {
-            let mgr = new_redis_unpooled(dsn).await;
-            cache::redis::new(mgr)
-        }
-        CacheBackend::RedisCluster(dsn) => {
-            let mgr = new_redis_clustered_unpooled(dsn).await;
+        CacheBackend::Redis(_) | CacheBackend::RedisCluster(_) => {
+            let mgr = RedisManager::from_cache_backend(&cfg.cache_backend()).await;
             cache::redis::new(mgr)
         }
 

--- a/server/svix-server/tests/it/redis_queue.rs
+++ b/server/svix-server/tests/it/redis_queue.rs
@@ -13,11 +13,11 @@ use svix_server::{
     queue::{
         new_pair, MessageTask, QueueTask, TaskQueueConsumer, TaskQueueDelivery, TaskQueueProducer,
     },
-    redis::{new_redis_clustered_pooled, new_redis_pooled, RedisPool},
+    redis::{new_redis_clustered_pooled, new_redis_pooled, RedisManager},
 };
 
 // TODO: Don't copy this from the Redis queue test directly, place the fn somewhere both can access
-async fn get_pool(cfg: &Configuration) -> RedisPool {
+async fn get_pool(cfg: &Configuration) -> RedisManager {
     match cfg.queue_type {
         QueueType::RedisCluster => {
             new_redis_clustered_pooled(cfg.redis_dsn.as_deref().unwrap(), cfg).await


### PR DESCRIPTION
* Rename `RedisPool` to `RedisManager`
  Now that our redis backends are not always pooled,
  having `Pool` in the name is sort of confusing, so
  rename the type to something a bit more generic.

* Refactor redis helper functions into methods
  This is slightly less error-prone, since the caller no longer has
  to specify whether to create a pooled or unpooled manager, and it's
  also less repetitive.
