### PR TITLE
bridge: Add Kafka as an input

### DIFF
--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -1474,6 +1474,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
+dependencies = [
+ "quote 1.0.36",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4126,6 +4136,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2 1.0.85",
+ "quote 1.0.36",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "object"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4999,6 +5030,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62c64daa8e9438b84aaae55010a93f396f8e60e3911590fcba770d04643fc1dd"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "rdkafka"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1beea247b9a7600a81d4cc33f659ce1a77e1988323d7d2809c7ed1c21f4c316d"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "libc",
+ "log",
+ "rdkafka-sys",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "slab",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "rdkafka-sys"
+version = "4.7.0+2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55e0d2f9ba6253f6ec72385e453294f8618e9e15c2c6aba2a5c01ccf9622d615"
+dependencies = [
+ "cmake",
+ "libc",
+ "libz-sys",
+ "num_enum",
+ "openssl-sys",
+ "pkg-config",
 ]
 
 [[package]]
@@ -6077,6 +6141,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "shellexpand",
+ "svix-bridge-plugin-kafka",
  "svix-bridge-plugin-queue",
  "svix-bridge-types",
  "svix-ksuid 0.7.0",
@@ -6087,6 +6152,22 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "svix-bridge-plugin-kafka"
+version = "0.1.0"
+dependencies = [
+ "ctor",
+ "rdkafka",
+ "serde",
+ "serde_json",
+ "svix-bridge-types",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "wiremock",
 ]
 
 [[package]]

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "svix-bridge-types",
     "svix-bridge",
     "svix-bridge-plugin-queue",
+    "svix-bridge-plugin-kafka",
 ]
 
 [profile.dev.package]

--- a/bridge/svix-bridge-plugin-kafka/Cargo.toml
+++ b/bridge/svix-bridge-plugin-kafka/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "svix-bridge-plugin-kafka"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rdkafka = { version = "0.36.0", features = ["cmake-build", "ssl", "tracing"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.117"
+svix-bridge-types = { path = "../svix-bridge-types" }
+thiserror = "1.0.61"
+tokio = { version = "1.28.1", features = ["time"] }
+tracing = "0.1.40"
+
+[dev-dependencies]
+ctor = "0.2.8"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+wiremock = "0.5.18"

--- a/bridge/svix-bridge-plugin-kafka/LICENSE
+++ b/bridge/svix-bridge-plugin-kafka/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2024 Svix Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/bridge/svix-bridge-plugin-kafka/src/config.rs
+++ b/bridge/svix-bridge-plugin-kafka/src/config.rs
@@ -1,0 +1,97 @@
+use rdkafka::{consumer::StreamConsumer, error::KafkaResult, ClientConfig};
+use serde::Deserialize;
+use svix_bridge_types::{SenderInput, SenderOutputOpts, TransformationConfig};
+
+use crate::{input::KafkaConsumer, Result};
+
+#[derive(Clone, Deserialize)]
+pub struct KafkaInputOpts {
+    /// Comma-separated list of addresses.
+    ///
+    /// Example: `localhost:9094`
+    #[serde(rename = "kafka_bootstrap_brokers")]
+    pub bootstrap_brokers: String,
+
+    /// The consumer group ID, used to track the stream offset between restarts
+    /// (due to host maintenance, upgrades, crashes, etc.).
+    #[serde(rename = "kafka_group_id")]
+    pub group_id: String,
+
+    /// The topic to listen to.
+    #[serde(rename = "kafka_topic")]
+    pub topic: String,
+
+    /// The value for 'security.protocol' in the kafka config.
+    #[serde(flatten)]
+    pub security_protocol: KafkaSecurityProtocol,
+
+    /// The 'debug' config value for rdkafka - enables more verbose logging
+    /// for the selected 'contexts'
+    #[serde(rename = "kafka_debug_contexts")]
+    pub debug_contexts: Option<String>,
+}
+
+impl KafkaInputOpts {
+    pub(crate) fn create_consumer(self) -> KafkaResult<StreamConsumer> {
+        let mut config = ClientConfig::new();
+        config
+            .set("group.id", self.group_id)
+            .set("bootstrap.servers", self.bootstrap_brokers)
+            // messages are committed manually after webhook delivery was successful.
+            .set("enable.auto.commit", "false");
+
+        match self.security_protocol {
+            KafkaSecurityProtocol::Plaintext => {
+                config.set("security.protocol", "plaintext");
+            }
+            KafkaSecurityProtocol::Ssl => {
+                config.set("security.protocol", "ssl");
+            }
+            KafkaSecurityProtocol::SaslSsl {
+                sasl_username,
+                sasl_password,
+            } => {
+                config
+                    .set("security.protocol", "sasl_ssl")
+                    .set("sasl.mechanisms", "SCRAM-SHA-512")
+                    .set("sasl.username", sasl_username)
+                    .set("sasl.password", sasl_password);
+            }
+        }
+
+        if let Some(debug_contexts) = self.debug_contexts {
+            if !debug_contexts.is_empty() {
+                config.set("debug", debug_contexts);
+            }
+        }
+
+        config.create()
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(tag = "kafka_security_protocol", rename_all = "snake_case")]
+pub enum KafkaSecurityProtocol {
+    Plaintext,
+    Ssl,
+    SaslSsl {
+        #[serde(rename = "kafka_sasl_username")]
+        sasl_username: String,
+        #[serde(rename = "kafka_sasl_password")]
+        sasl_password: String,
+    },
+}
+
+pub fn into_sender_input(
+    name: String,
+    opts: KafkaInputOpts,
+    transformation: Option<TransformationConfig>,
+    output: SenderOutputOpts,
+) -> Result<Box<dyn SenderInput>> {
+    Ok(Box::new(KafkaConsumer::new(
+        name,
+        opts,
+        transformation,
+        output,
+    )?))
+}

--- a/bridge/svix-bridge-plugin-kafka/src/error.rs
+++ b/bridge/svix-bridge-plugin-kafka/src/error.rs
@@ -1,0 +1,35 @@
+use std::str;
+
+use rdkafka::error::KafkaError;
+use svix_bridge_types::svix::error::Error as SvixClientError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("kafka error")]
+    Kafka(#[from] KafkaError),
+
+    #[error("svix client error")]
+    SvixClient(#[from] SvixClientError),
+
+    #[error("JSON deserialization failed")]
+    Deserialization(#[source] serde_json::Error),
+
+    #[error("non-UTF8 payload")]
+    NonUtf8Payload(#[source] str::Utf8Error),
+
+    #[error("kafka message is missing payload")]
+    MissingPayload,
+
+    #[error("transformation error: {error}")]
+    Transformation { error: String },
+}
+
+impl Error {
+    pub(crate) fn transformation(error: impl Into<String>) -> Self {
+        Self::Transformation {
+            error: error.into(),
+        }
+    }
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/bridge/svix-bridge-plugin-kafka/src/input.rs
+++ b/bridge/svix-bridge-plugin-kafka/src/input.rs
@@ -1,0 +1,225 @@
+use std::{
+    str,
+    time::{Duration, Instant},
+};
+
+use rdkafka::{
+    consumer::{CommitMode, Consumer as _},
+    error::KafkaError,
+    Message as _,
+};
+use svix_bridge_types::{
+    async_trait, svix::api::Svix, CreateMessageRequest, JsObject, SenderInput, SenderOutputOpts,
+    TransformationConfig, TransformerInput, TransformerInputFormat, TransformerJob,
+    TransformerOutput, TransformerTx,
+};
+use tokio::task::spawn_blocking;
+
+use crate::{config::KafkaInputOpts, Error, Result};
+
+pub struct KafkaConsumer {
+    name: String,
+    opts: KafkaInputOpts,
+    transformation: Option<TransformationConfig>,
+    transformer_tx: Option<TransformerTx>,
+    svix_client: Svix,
+}
+
+impl KafkaConsumer {
+    pub fn new(
+        name: String,
+        opts: KafkaInputOpts,
+        transformation: Option<TransformationConfig>,
+        output: SenderOutputOpts,
+    ) -> Result<Self> {
+        Ok(Self {
+            name,
+            transformation,
+            transformer_tx: None,
+            opts,
+            svix_client: match output {
+                SenderOutputOpts::Svix(output) => {
+                    Svix::new(output.token, output.options.map(Into::into))
+                }
+            },
+        })
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn process(&self, msg: &rdkafka::message::BorrowedMessage<'_>) -> Result<()> {
+        let payload = msg.payload().ok_or_else(|| Error::MissingPayload)?;
+        let payload = if let Some(transformation) = &self.transformation {
+            let input = match transformation.format() {
+                TransformerInputFormat::Json => {
+                    let json_payload =
+                        serde_json::from_slice(payload).map_err(Error::Deserialization)?;
+                    TransformerInput::JSON(json_payload)
+                }
+                TransformerInputFormat::String => {
+                    let raw_payload = str::from_utf8(payload).map_err(Error::NonUtf8Payload)?;
+                    TransformerInput::String(raw_payload.to_string())
+                }
+            };
+
+            let script = transformation.source().clone();
+            let object = self.transform(script, input).await?;
+            serde_json::from_value(serde_json::Value::Object(object))
+                .map_err(Error::Deserialization)?
+        } else {
+            serde_json::from_slice(payload).map_err(Error::Deserialization)?
+        };
+
+        let CreateMessageRequest {
+            app_id,
+            message,
+            mut post_options,
+        } = payload;
+
+        // If committing the message fails or the process crashes after posting the webhook but
+        // before committing, this makes sure that the next run of this fn with the same kafka
+        // message doesn't end up creating a duplicate webhook in svix.
+        let idempotency_key = format!(
+            "svix_bridge_kafka_{}_{}_{}",
+            self.opts.group_id,
+            self.opts.topic,
+            msg.offset()
+        );
+        post_options
+            .get_or_insert_with(Default::default)
+            .idempotency_key = Some(idempotency_key);
+
+        self.svix_client
+            .message()
+            .create(app_id, message, post_options.map(Into::into))
+            .await?;
+
+        Ok(())
+    }
+
+    async fn transform(&self, script: String, input: TransformerInput) -> Result<JsObject> {
+        let (job, rx) = TransformerJob::new(script, input);
+        self.transformer_tx
+            .as_ref()
+            .ok_or_else(|| Error::transformation("transformations not configured"))?
+            .send(job)
+            .map_err(|e| Error::transformation(e.to_string()))?;
+
+        let ret = rx
+            .await
+            .map_err(|_e| Error::transformation("transformation rx failed"))
+            .and_then(|x| {
+                x.map_err(|_e| Error::transformation("transformation execution failed"))
+            })?;
+
+        match ret {
+            TransformerOutput::Object(v) => Ok(v),
+            TransformerOutput::Invalid => Err(Error::transformation(
+                "transformation produced unexpected value",
+            )),
+        }
+    }
+
+    async fn run_inner(&self) -> Result<()> {
+        let opts = self.opts.clone();
+        // `ClientConfig::create` does blocking I/O.
+        // Same for subscribe, most likely.
+        let consumer = spawn_blocking(move || {
+            let topic = opts.topic.clone();
+
+            let consumer = opts.create_consumer()?;
+            tracing::debug!("Created StreamConsumer");
+
+            consumer.subscribe(&[&topic])?;
+            tracing::debug!(topic, "Subscribed");
+
+            Ok::<_, KafkaError>(consumer)
+        })
+        .await
+        .expect("create_consumer task panicked")?;
+
+        loop {
+            // FIXME(jplatte): I don't know if StreamConsumer::recv has an internal buffer.
+            // Overall, rdkafka seems to be doing a bunch of background magic so maybe it does.
+            // In that case, it's likely already doing batching reads (which don't seem to be
+            // a thing in the public API) internally.
+            // If not, we should likely do some sort of batching ourselves, e.g. have two separate
+            // tokio tasks, one which pulls messages from Kafka and one that processes them, with
+            // a bounded channel in between for backpressure.
+            let msg = consumer.recv().await?;
+            tracing::debug!("Received a message");
+
+            let mut process_error_count = 0;
+            while let Err(e) = self.process(&msg).await {
+                match e {
+                    // If the payload is invalid, log an error and continue.
+                    // It would fail the same way if retried.
+                    Error::MissingPayload
+                    | Error::Deserialization(_)
+                    | Error::NonUtf8Payload(_) => {
+                        tracing::error!(error = &e as &dyn std::error::Error, "invalid payload");
+                        break;
+                    }
+
+                    // If the error is (possibly) transient, retry a few times.
+                    // After that, bubble up the error so it's logged at error level.
+                    Error::Kafka(_) | Error::SvixClient(_) | Error::Transformation { .. } => {
+                        process_error_count += 1;
+                        if process_error_count >= 3 {
+                            return Err(e);
+                        }
+
+                        tracing::warn!(
+                            error = &e as &dyn std::error::Error,
+                            "failed to process payload from kafka"
+                        );
+
+                        // retry
+                    }
+                }
+            }
+
+            // FIXME(jplatte): Unlike recv above, this seems less likely to be auto-coalesced
+            // internally in rdkafka so maybe we should introduce our own logic to only commit
+            // after N messages to reduce unnecessary back and forth on the Kafka connection,
+            // or unnecessary disk writes inside Kafka (messages in Kafka are not committed
+            // individually, rather what this call does is update the stored stream position
+            // for the consumer group).
+            consumer.commit_message(&msg, CommitMode::Async)?;
+        }
+    }
+}
+
+#[async_trait]
+impl SenderInput for KafkaConsumer {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn set_transformer(&mut self, tx: Option<TransformerTx>) {
+        self.transformer_tx = tx;
+    }
+
+    async fn run(&self) -> std::io::Result<()> {
+        let mut fails: u64 = 0;
+        let mut last_fail = Instant::now();
+
+        tracing::info!(topic = self.opts.topic, "Starting to listen for messages");
+
+        loop {
+            if let Err(e) = self.run_inner().await {
+                tracing::error!("{e}");
+            }
+
+            if last_fail.elapsed() > Duration::from_secs(10) {
+                // reset the fail count if we didn't have a hiccup in the past short while.
+                tracing::trace!("been a while since last fail, resetting count");
+                fails = 0;
+            } else {
+                fails += 1;
+            }
+
+            last_fail = Instant::now();
+            tokio::time::sleep(Duration::from_millis((300 * fails).min(3000))).await;
+        }
+    }
+}

--- a/bridge/svix-bridge-plugin-kafka/src/lib.rs
+++ b/bridge/svix-bridge-plugin-kafka/src/lib.rs
@@ -1,0 +1,9 @@
+mod config;
+mod error;
+mod input;
+
+pub use self::{
+    config::{into_sender_input, KafkaInputOpts, KafkaSecurityProtocol},
+    error::{Error, Result},
+    input::KafkaConsumer,
+};

--- a/bridge/svix-bridge-plugin-kafka/tests/it/kafka_consumer.rs
+++ b/bridge/svix-bridge-plugin-kafka/tests/it/kafka_consumer.rs
@@ -1,0 +1,536 @@
+//! Requires a rabbitmq node to be running on localhost:5672 (the default port) and using the
+//! default guest/guest credentials.
+//! Try using the `testing-docker-compose.yml` in the repo root to get this going.
+
+use std::time::Duration;
+
+use rdkafka::{
+    admin::{AdminClient, NewTopic, TopicReplication},
+    client::DefaultClientContext,
+    producer::{FutureProducer, FutureRecord},
+    types::RDKafkaErrorCode,
+    util::Timeout,
+    ClientConfig,
+};
+use serde_json::json;
+use svix_bridge_plugin_kafka::{KafkaConsumer, KafkaInputOpts};
+use svix_bridge_types::{
+    svix::api::MessageIn, CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions,
+    SvixSenderOutputOpts, TransformationConfig, TransformerInput, TransformerInputFormat,
+    TransformerJob, TransformerOutput,
+};
+use tracing::info;
+use wiremock::{
+    matchers::{body_partial_json, method},
+    Mock, MockServer, ResponseTemplate,
+};
+
+#[ctor::ctor]
+fn test_setup() {
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                // Output is only printed for failing tests, but still we shouldn't overload
+                // the output with unnecessary info. When debugging a specific test, it's easy
+                // to override this default by setting the `RUST_LOG` environment variable.
+                "info,svix_bridge=debug".into()
+            }),
+        )
+        .with(tracing_subscriber::fmt::layer().with_test_writer())
+        .init();
+}
+
+/// Time to wait for the plugin to connect.
+const CONNECT_WAIT_TIME: Duration = Duration::from_secs(10);
+/// Teimt to wait for the plugin to receive a message sent by a test.
+const CONSUME_WAIT_TIME: Duration = Duration::from_secs(1);
+/// These tests assume a "vanilla" rabbitmq instance, using the default port, creds, exchange...
+const BROKER_HOST: &str = "localhost:9094";
+
+fn get_test_plugin(
+    svix_url: String,
+    topic: &str,
+    use_transformation: Option<TransformerInputFormat>,
+) -> KafkaConsumer {
+    KafkaConsumer::new(
+        "test".into(),
+        KafkaInputOpts {
+            bootstrap_brokers: BROKER_HOST.to_owned(),
+            // All tests use different topics, so it's fine to have only one consumer group ID
+            group_id: "svix_bridge_test_group_id".to_owned(),
+            topic: topic.to_owned(),
+            security_protocol: svix_bridge_plugin_kafka::KafkaSecurityProtocol::Plaintext,
+            debug_contexts: None,
+        },
+        use_transformation.map(|format| TransformationConfig::Explicit {
+            format,
+            src: String::from("function handle(x) { return x; }"),
+        }),
+        SenderOutputOpts::Svix(SvixSenderOutputOpts {
+            token: "xxxx".to_string(),
+            options: Some(SvixOptions {
+                server_url: Some(svix_url),
+                ..Default::default()
+            }),
+        }),
+    )
+    .unwrap()
+}
+
+fn kafka_producer() -> FutureProducer {
+    // create does block I/O, but we don't care in tests
+    ClientConfig::new()
+        .set("bootstrap.servers", BROKER_HOST)
+        .create()
+        .unwrap()
+}
+
+fn kafka_admin_client() -> AdminClient<DefaultClientContext> {
+    // create does block I/O, but we don't care in tests
+    ClientConfig::new()
+        .set("bootstrap.servers", BROKER_HOST)
+        .create()
+        .unwrap()
+}
+
+async fn publish(producer: &FutureProducer, topic: &str, payload: &[u8]) {
+    info!(topic, "publishing message");
+    producer
+        .send(
+            FutureRecord::<(), _>::to(topic).payload(payload),
+            Timeout::After(Duration::from_secs(3)),
+        )
+        .await
+        .unwrap();
+}
+
+async fn create_topic(admin_client: &AdminClient<DefaultClientContext>, topic: &str) {
+    let new_topic = NewTopic::new(topic, 1, TopicReplication::Fixed(1));
+    if let Err(e) = admin_client
+        .create_topics(&[new_topic], &Default::default())
+        .await
+    {
+        if e.rdkafka_error_code() != Some(RDKafkaErrorCode::TopicAlreadyExists) {
+            panic!("{e}");
+        }
+    }
+}
+
+async fn delete_topic(admin_client: &AdminClient<DefaultClientContext>, topic: &str) {
+    admin_client
+        .delete_topics(&[topic], &Default::default())
+        .await
+        .unwrap();
+}
+
+macro_rules! unique_topic_name {
+    () => {
+        &format!(
+            "test_{}_{}",
+            file!()
+                .split('/')
+                .next_back()
+                .unwrap()
+                .strip_suffix(".rs")
+                .unwrap(),
+            line!()
+        )
+    };
+}
+
+/// Push a msg on the queue.
+/// Check to see if the svix server sees a request.
+#[tokio::test]
+async fn test_consume_ok() {
+    let topic = unique_topic_name!();
+
+    let admin_client = kafka_admin_client();
+    create_topic(&admin_client, topic).await;
+
+    let producer = kafka_producer();
+
+    let mock_server = MockServer::start().await;
+    // The mock will make asserts on drop (i.e. when the body of the test is returning).
+    // The `expect` call should ensure we see exactly 1 POST request.
+    // <https://docs.rs/wiremock/latest/wiremock/struct.Mock.html#method.expect>
+    let mock = Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+          "eventType": "testing.things",
+          "payload": {
+            "_SVIX_APP_ID": "app_1234",
+            "_SVIX_EVENT_TYPE": "testing.things",
+            "hi": "there",
+          },
+          "id": "msg_xxxx",
+          "timestamp": "2023-04-25T00:00:00Z"
+        })))
+        .named("create_message")
+        .expect(1);
+    mock_server.register(mock).await;
+
+    let plugin = get_test_plugin(mock_server.uri(), topic, None);
+
+    let handle = tokio::spawn(async move {
+        plugin.run().await.unwrap();
+    });
+    // Wait for the consumer to connect
+    tokio::time::sleep(CONNECT_WAIT_TIME).await;
+
+    let msg = CreateMessageRequest {
+        app_id: "app_1234".into(),
+        message: MessageIn::new("testing.things".into(), json!({"hi": "there"})),
+        post_options: None,
+    };
+
+    publish(&producer, topic, &serde_json::to_vec(&msg).unwrap()).await;
+
+    // Wait for the consumer to consume.
+    tokio::time::sleep(CONSUME_WAIT_TIME).await;
+
+    handle.abort();
+    delete_topic(&admin_client, topic).await;
+}
+
+/// Push a msg on the queue.
+/// Check to see if the svix server sees a request, but this time transform the payload.
+#[tokio::test]
+async fn test_consume_transformed_json_ok() {
+    let topic = unique_topic_name!();
+
+    let admin_client = kafka_admin_client();
+    create_topic(&admin_client, topic).await;
+
+    let producer = kafka_producer();
+
+    let mock_server = MockServer::start().await;
+    // The mock will make asserts on drop (i.e. when the body of the test is returning).
+    // The `expect` call should ensure we see exactly 1 POST request.
+    // <https://docs.rs/wiremock/latest/wiremock/struct.Mock.html#method.expect>
+    let mock = Mock::given(method("POST"))
+        .and(body_partial_json(json!({ "payload": { "good": "bye" } })))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+          "eventType": "testing.things",
+          "payload": {
+            // The adjustment made via the transformation...
+            "good": "bye",
+          },
+          "id": "msg_xxxx",
+          "timestamp": "2023-04-25T00:00:00Z"
+        })))
+        .named("create_message")
+        .expect(1);
+    mock_server.register(mock).await;
+
+    let mut plugin = get_test_plugin(mock_server.uri(), topic, Some(TransformerInputFormat::Json));
+    let (transformer_tx, mut transformer_rx) =
+        tokio::sync::mpsc::unbounded_channel::<TransformerJob>();
+    let _handle = tokio::spawn(async move {
+        while let Some(x) = transformer_rx.recv().await {
+            let mut out = match x.input {
+                TransformerInput::JSON(input) => input.as_object().unwrap().clone(),
+                _ => unreachable!(),
+            };
+            // Prune out the "hi" key.
+            out["message"]["payload"]
+                .as_object_mut()
+                .unwrap()
+                .remove("hi");
+            // Add the "good" key.
+            out["message"]["payload"]["good"] = json!("bye");
+            x.callback_tx.send(Ok(TransformerOutput::Object(out))).ok();
+        }
+    });
+    plugin.set_transformer(Some(transformer_tx));
+
+    let handle = tokio::spawn(async move {
+        plugin.run().await.unwrap();
+    });
+    // Wait for the consumer to connect
+    tokio::time::sleep(CONNECT_WAIT_TIME).await;
+
+    let msg = CreateMessageRequest {
+        app_id: "app_1234".into(),
+        message: MessageIn::new("testing.things".into(), json!({"hi": "there"})),
+        post_options: None,
+    };
+
+    publish(&producer, topic, &serde_json::to_vec(&msg).unwrap()).await;
+
+    // Wait for the consumer to consume.
+    tokio::time::sleep(CONSUME_WAIT_TIME).await;
+
+    handle.abort();
+    delete_topic(&admin_client, topic).await;
+}
+
+/// Push a msg on the queue.
+/// Check to see if the svix server sees a request, but this time transform the payload.
+#[tokio::test]
+async fn test_consume_transformed_string_ok() {
+    let topic = unique_topic_name!();
+
+    let admin_client = kafka_admin_client();
+    create_topic(&admin_client, topic).await;
+
+    let producer = kafka_producer();
+
+    let mock_server = MockServer::start().await;
+    // The mock will make asserts on drop (i.e. when the body of the test is returning).
+    // The `expect` call should ensure we see exactly 1 POST request.
+    // <https://docs.rs/wiremock/latest/wiremock/struct.Mock.html#method.expect>
+    let mock = Mock::given(method("POST"))
+        .and(body_partial_json(
+            json!({ "payload": { "hello": "world" } }),
+        ))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+          "eventType": "testing.things",
+          "payload": {
+            // The adjustment made via the transformation...
+            "hello": "world",
+          },
+          "id": "msg_xxxx",
+          "timestamp": "2023-04-25T00:00:00Z"
+        })))
+        .named("create_message")
+        .expect(1);
+    mock_server.register(mock).await;
+
+    let mut plugin = get_test_plugin(
+        mock_server.uri(),
+        topic,
+        Some(TransformerInputFormat::String),
+    );
+    let (transformer_tx, mut transformer_rx) =
+        tokio::sync::mpsc::unbounded_channel::<TransformerJob>();
+    let _handle = tokio::spawn(async move {
+        while let Some(x) = transformer_rx.recv().await {
+            let input = match x.input {
+                TransformerInput::String(input) => input,
+                _ => unreachable!(),
+            };
+            // Build a create-message-compatible object, using the string input as a field in the payload.
+            let out = json!({
+                "appId": "app_1234",
+                "message": {
+                    "eventType": "testing.things",
+                    "payload": {
+                        "hello": input,
+                    }
+                }
+            });
+            x.callback_tx
+                .send(Ok(TransformerOutput::Object(
+                    out.as_object().unwrap().clone(),
+                )))
+                .ok();
+        }
+    });
+    plugin.set_transformer(Some(transformer_tx));
+
+    let handle = tokio::spawn(async move {
+        plugin.run().await.unwrap();
+    });
+    // Wait for the consumer to connect
+    tokio::time::sleep(CONNECT_WAIT_TIME).await;
+
+    publish(&producer, topic, b"world").await;
+
+    // Wait for the consumer to consume.
+    tokio::time::sleep(CONSUME_WAIT_TIME).await;
+
+    handle.abort();
+    delete_topic(&admin_client, topic).await;
+}
+
+#[tokio::test]
+async fn test_missing_app_id_nack() {
+    let topic = unique_topic_name!();
+
+    let admin_client = kafka_admin_client();
+    create_topic(&admin_client, topic).await;
+
+    let producer = kafka_producer();
+
+    let mock_server = MockServer::start().await;
+    let mock = Mock::given(method("POST"))
+        // The response doesn't really matter, but we need to define it to be able to `expect(0)`.
+        .respond_with(ResponseTemplate::new(400))
+        .named("create_message")
+        // No requests should be made when the event type or app id are missing.
+        .expect(0);
+    mock_server.register(mock).await;
+
+    let plugin = get_test_plugin(mock_server.uri(), topic, None);
+
+    let handle = tokio::spawn(async move {
+        plugin.run().await.unwrap();
+    });
+
+    // Wait for the consumer to connect
+    tokio::time::sleep(CONNECT_WAIT_TIME).await;
+
+    publish(
+        &producer,
+        topic,
+        &serde_json::to_vec(&json!({
+            // No app id
+            "message": {
+                "eventType": "testing.things",
+                "payload": {
+                    "hi": "there",
+                }
+            },
+
+        }))
+        .unwrap(),
+    )
+    .await;
+
+    // Wait for the consumer to consume.
+    tokio::time::sleep(CONSUME_WAIT_TIME).await;
+    handle.abort();
+    delete_topic(&admin_client, topic).await;
+}
+
+#[tokio::test]
+async fn test_missing_event_type_nack() {
+    let topic = unique_topic_name!();
+
+    let admin_client = kafka_admin_client();
+    create_topic(&admin_client, topic).await;
+
+    let producer = kafka_producer();
+
+    let mock_server = MockServer::start().await;
+    let mock = Mock::given(method("POST"))
+        // The response doesn't really matter, but we need to define it to be able to `expect(0)`.
+        .respond_with(ResponseTemplate::new(400))
+        .named("create_message")
+        // No requests should be made when the event type or app id are missing.
+        .expect(0);
+    mock_server.register(mock).await;
+
+    let plugin = get_test_plugin(mock_server.uri(), topic, None);
+
+    let handle = tokio::spawn(async move {
+        plugin.run().await.unwrap();
+    });
+
+    // Wait for the consumer to connect
+    tokio::time::sleep(CONNECT_WAIT_TIME).await;
+
+    publish(
+        &producer,
+        topic,
+        &serde_json::to_vec(&json!({
+            "appId": "app_1234",
+            "message": {
+                // No event type
+                "payload": {
+                    "hi": "there",
+                }
+            },
+        }))
+        .unwrap(),
+    )
+    .await;
+
+    // Wait for the consumer to consume.
+    tokio::time::sleep(CONSUME_WAIT_TIME).await;
+    handle.abort();
+    delete_topic(&admin_client, topic).await;
+}
+
+/// Check that the plugin keeps running when it can't send a message to svix
+#[tokio::test]
+async fn test_consume_svix_503() {
+    let topic = unique_topic_name!();
+
+    let admin_client = kafka_admin_client();
+    create_topic(&admin_client, topic).await;
+
+    let producer = kafka_producer();
+
+    let mock_server = MockServer::start().await;
+    // The mock will make asserts on drop (i.e. when the body of the test is returning).
+    // The `expect` call should ensure we see exactly 1 POST request.
+    // <https://docs.rs/wiremock/latest/wiremock/struct.Mock.html#method.expect>
+    let mock = Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(503))
+        .named("create_message")
+        // this was originally 1 but why would we assert the number of retries, zero or otherwise??
+        .expect(3);
+    mock_server.register(mock).await;
+
+    let plugin = get_test_plugin(mock_server.uri(), topic, None);
+
+    let handle = tokio::spawn(async move {
+        plugin.run().await.unwrap();
+    });
+    // Wait for the consumer to connect
+    tokio::time::sleep(CONNECT_WAIT_TIME).await;
+
+    publish(
+        &producer,
+        topic,
+        &serde_json::to_vec(&CreateMessageRequest {
+            app_id: "app_1234".into(),
+            message: MessageIn::new("testing.things".into(), json!({"hi": "there"})),
+            post_options: None,
+        })
+        .unwrap(),
+    )
+    .await;
+
+    // Wait for the consumer to consume.
+    tokio::time::sleep(CONSUME_WAIT_TIME).await;
+
+    assert!(!handle.is_finished());
+    handle.abort();
+    delete_topic(&admin_client, topic).await;
+}
+
+/// Check that the plugin keeps running when it can't send a message to svix because idk, the servers are all offline??
+#[tokio::test]
+async fn test_consume_svix_offline() {
+    let topic = unique_topic_name!();
+
+    let admin_client = kafka_admin_client();
+    create_topic(&admin_client, topic).await;
+
+    let producer = kafka_producer();
+
+    let mock_server = MockServer::start().await;
+
+    let plugin = get_test_plugin(mock_server.uri(), topic, None);
+
+    // bye-bye svix...
+    drop(mock_server);
+
+    let handle = tokio::spawn(async move {
+        plugin.run().await.unwrap();
+    });
+    // Wait for the consumer to connect
+    tokio::time::sleep(CONNECT_WAIT_TIME).await;
+
+    publish(
+        &producer,
+        topic,
+        &serde_json::to_vec(&CreateMessageRequest {
+            app_id: "app_1234".into(),
+            message: MessageIn::new("testing.things".into(), json!({"hi": "there"})),
+            post_options: None,
+        })
+        .unwrap(),
+    )
+    .await;
+
+    // Wait for the consumer to consume.
+    tokio::time::sleep(CONSUME_WAIT_TIME).await;
+
+    assert!(!handle.is_finished());
+    handle.abort();
+    delete_topic(&admin_client, topic).await;
+}

--- a/bridge/svix-bridge-plugin-kafka/tests/it/main.rs
+++ b/bridge/svix-bridge-plugin-kafka/tests/it/main.rs
@@ -1,0 +1,1 @@
+mod kafka_consumer;

--- a/bridge/svix-bridge-types/src/lib.rs
+++ b/bridge/svix-bridge-types/src/lib.rs
@@ -214,7 +214,7 @@ pub struct SvixSenderOutputOpts {
 
 #[derive(Clone, Default, Deserialize, Serialize)]
 pub struct PostOptions {
-    idempotency_key: Option<String>,
+    pub idempotency_key: Option<String>,
 }
 
 impl From<PostOptions> for PostOptions_ {

--- a/bridge/svix-bridge/Cargo.toml
+++ b/bridge/svix-bridge/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1"
 serde_yaml = "0.9"
 svix-ksuid = "0.7.0"
 svix-bridge-plugin-queue = { path = "../svix-bridge-plugin-queue" }
+svix-bridge-plugin-kafka = { optional = true, path = "../svix-bridge-plugin-kafka" }
 svix-bridge-types = { path = "../svix-bridge-types" }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
@@ -41,5 +42,6 @@ chrono = "0.4"
 tower = "0.4"
 
 [features]
-default = ["jemalloc"]
+default = ["kafka", "jemalloc"]
+kafka = ["dep:svix-bridge-plugin-kafka"]
 jemalloc = ["tikv-jemallocator", "tikv-jemalloc-ctl"]

--- a/bridge/testing-docker-compose.yml
+++ b/bridge/testing-docker-compose.yml
@@ -26,3 +26,27 @@ services:
       "--project", "local-project",
       "--host-port", "0.0.0.0:8085"
     ]
+
+  kafka:
+    image: "docker.io/bitnami/kafka:3.5.1"
+    ports:
+      - "9092:9092"
+      - "9094:9094"
+    volumes:
+      - "kafka-data:/bitnami"
+    environment:
+      # KRaft settings
+      - KAFKA_CFG_NODE_ID=0
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093
+      # Listeners
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+      - KAFKA_CFG_LOG_RETENTION_HOURS=336
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+
+volumes:
+  kafka-data:


### PR DESCRIPTION
… that is, support converting Kafka messages into Svix API calls.

Part of https://github.com/svix/monorepo-private/issues/8508.