### PR TITLE
rust: Add Svix::background_task

### DIFF
--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -75,6 +75,10 @@ impl Svix {
         Application::new(&self.cfg)
     }
 
+    pub fn background_task(&self) -> BackgroundTask<'_> {
+        BackgroundTask::new(&self.cfg)
+    }
+
     pub fn endpoint(&self) -> Endpoint<'_> {
         Endpoint::new(&self.cfg)
     }
@@ -1222,6 +1226,10 @@ pub struct BackgroundTask<'a> {
 }
 
 impl<'a> BackgroundTask<'a> {
+    fn new(cfg: &'a Configuration) -> Self {
+        Self { cfg }
+    }
+
     pub async fn list(
         &self,
         options: Option<BackgroundTaskListOptions>,


### PR DESCRIPTION
## Motivation

We previously had the `BackgroundTask` object as a proxy object for the two background task routes, but no way to construct and thus use it.

## Solution

Add a method to `Svix` like we have for all the other proxy objects.

Closes #1340.