### PR TITLE
bridge: Cargo manifest cleanup

### DIFF
--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -4535,9 +4535,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.32.1"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777d57dcc6bb4cf084e3212e1858447222aa451f21b5e2452497d9100da65b91"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4575,9 +4575,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
 svix-bridge-types = { path = "svix-bridge-types" }
 thiserror = "1.0.61"
-tokio = "1.38.0"
+tokio = { version = "1.38.0", features = ["macros", "time", "rt-multi-thread", "sync"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 wiremock = "0.6.0"

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -6,11 +6,21 @@
 resolver = "2"
 
 members = [
-    "svix-bridge-types",
     "svix-bridge",
+    "svix-bridge-types",
     "svix-bridge-plugin-queue",
     "svix-bridge-plugin-kafka",
 ]
+
+[workspace.dependencies]
+serde = { version = "1.0.203", features = ["derive"] }
+serde_json = "1.0.117"
+svix-bridge-types = { path = "svix-bridge-types" }
+thiserror = "1.0.61"
+tokio = "1.38.0"
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+wiremock = "0.6.0"
 
 [profile.dev.package]
 quote = { opt-level = 2 }

--- a/bridge/svix-bridge-plugin-kafka/Cargo.toml
+++ b/bridge/svix-bridge-plugin-kafka/Cargo.toml
@@ -2,6 +2,7 @@
 name = "svix-bridge-plugin-kafka"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 rdkafka = { version = "0.36.0", features = ["cmake-build", "ssl", "tracing"] }

--- a/bridge/svix-bridge-plugin-kafka/Cargo.toml
+++ b/bridge/svix-bridge-plugin-kafka/Cargo.toml
@@ -6,14 +6,14 @@ publish = false
 
 [dependencies]
 rdkafka = { version = "0.36.0", features = ["cmake-build", "ssl", "tracing"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.117"
-svix-bridge-types = { path = "../svix-bridge-types" }
-thiserror = "1.0.61"
-tokio = { version = "1.28.1", features = ["time"] }
-tracing = "0.1.40"
+serde.workspace = true
+serde_json.workspace = true
+svix-bridge-types.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["time"] }
+tracing.workspace = true
 
 [dev-dependencies]
 ctor = "0.2.8"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-wiremock = "0.6.0"
+tracing-subscriber.workspace = true
+wiremock.workspace = true

--- a/bridge/svix-bridge-plugin-queue/Cargo.toml
+++ b/bridge/svix-bridge-plugin-queue/Cargo.toml
@@ -2,8 +2,7 @@
 name = "svix-bridge-plugin-queue"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 serde_json = "1.0"

--- a/bridge/svix-bridge-plugin-queue/Cargo.toml
+++ b/bridge/svix-bridge-plugin-queue/Cargo.toml
@@ -9,7 +9,7 @@ serde.workspace = true
 serde_json.workspace = true
 svix-bridge-types.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio.workspace = true
 tokio-executor-trait = "2.1"
 tokio-reactor-trait = "1.1"
 tracing = "0.1"

--- a/bridge/svix-bridge-plugin-queue/Cargo.toml
+++ b/bridge/svix-bridge-plugin-queue/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2021"
 publish = false
 
 [dependencies]
-serde_json = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-svix-bridge-types = { path = "../svix-bridge-types" }
-thiserror = "1.0.61"
-tokio = { version = "1", features = ["full"] }
+serde.workspace = true
+serde_json.workspace = true
+svix-bridge-types.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["full"] }
 tokio-executor-trait = "2.1"
 tokio-reactor-trait = "1.1"
 tracing = "0.1"
@@ -28,5 +28,5 @@ google-cloud-googleapis = "0.12.0"
 google-cloud-pubsub = "0.24.0"
 lapin = "2"
 redis = { version = "0.25.4", features = ["tokio-comp", "streams"] }
-tracing-subscriber = "0.3"
-wiremock = "0.6.0"
+tracing-subscriber.workspace = true
+wiremock.workspace = true

--- a/bridge/svix-bridge-types/Cargo.toml
+++ b/bridge/svix-bridge-types/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 async-trait = "0.1"
-tokio = { workspace = true, features = ["full"] }
+tokio.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 svix = "1.17.0"

--- a/bridge/svix-bridge-types/Cargo.toml
+++ b/bridge/svix-bridge-types/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 async-trait = "0.1"
-tokio = { version = "1", features = ["full"] }
-serde_json = "1"
-serde = { version = "1", features = ["derive"] }
+tokio = { workspace = true, features = ["full"] }
+serde.workspace = true
+serde_json.workspace = true
 svix = "1.17.0"

--- a/bridge/svix-bridge-types/Cargo.toml
+++ b/bridge/svix-bridge-types/Cargo.toml
@@ -2,8 +2,7 @@
 name = "svix-bridge-types"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 async-trait = "0.1"

--- a/bridge/svix-bridge/Cargo.toml
+++ b/bridge/svix-bridge/Cargo.toml
@@ -2,8 +2,7 @@
 name = "svix-bridge"
 version = "1.24.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 anyhow = "1"

--- a/bridge/svix-bridge/Cargo.toml
+++ b/bridge/svix-bridge/Cargo.toml
@@ -21,7 +21,7 @@ svix-ksuid = "0.7.0"
 svix-bridge-plugin-queue = { path = "../svix-bridge-plugin-queue" }
 svix-bridge-plugin-kafka = { optional = true, path = "../svix-bridge-plugin-kafka" }
 svix-bridge-types.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio.workspace = true
 tracing.workspace = true
 tracing-opentelemetry = "0.23.0"
 tracing-subscriber = { workspace = true, features = ["fmt", "json"] }

--- a/bridge/svix-bridge/Cargo.toml
+++ b/bridge/svix-bridge/Cargo.toml
@@ -14,17 +14,17 @@ once_cell = "1.18.0"
 opentelemetry = "0.22.0"
 opentelemetry_sdk = { version = "0.22.1", features = ["metrics", "rt-tokio"] }
 opentelemetry-otlp = { version = "0.15.0", features = ["metrics", "grpc-tonic", "http-proto", "reqwest-client"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde.workspace = true
+serde_json.workspace = true
 serde_yaml = "0.9"
 svix-ksuid = "0.7.0"
 svix-bridge-plugin-queue = { path = "../svix-bridge-plugin-queue" }
 svix-bridge-plugin-kafka = { optional = true, path = "../svix-bridge-plugin-kafka" }
-svix-bridge-types = { path = "../svix-bridge-types" }
-tokio = { version = "1", features = ["full"] }
-tracing = "0.1"
+svix-bridge-types.workspace = true
+tokio = { workspace = true, features = ["full"] }
+tracing.workspace = true
 tracing-opentelemetry = "0.23.0"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
+tracing-subscriber = { workspace = true, features = ["fmt", "json"] }
 # N.b. for newer deno versions (like this) the runtimes must be retained and reused since they will leak memory if you
 # create/drop them.
 deno_core = "0.204.0"


### PR DESCRIPTION
## Motivation

With the introduction of the kafka "plugin" crate, we now have four crates. Seems like it's about time to use workspace dependencies.

## Solution

Move dependency specifications for dependencies used in multiple bridge crates out into the workspace manifest and reference them in the package manifests. Also disable publishing to crates.io and reduce tokio features, because why not.