### PR TITLE
Fix `Recover Failed Webhooks` response

### DIFF
--- a/server/openapi.json
+++ b/server/openapi.json
@@ -149,6 +149,18 @@
                 },
                 "type": "object"
             },
+            "BackgroundTaskStatus": {
+                "enum": [
+                    "running"
+                ],
+                "type": "string"
+            },
+            "BackgroundTaskType": {
+                "enum": [
+                    "endpoint.recover"
+                ],
+                "type": "string"
+            },
             "DashboardAccessOut": {
                 "properties": {
                     "token": {
@@ -1977,6 +1989,25 @@
                 },
                 "required": [
                     "since"
+                ],
+                "type": "object"
+            },
+            "RecoverOut": {
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/BackgroundTaskStatus"
+                    },
+                    "task": {
+                        "$ref": "#/components/schemas/BackgroundTaskType"
+                    }
+                },
+                "required": [
+                    "id",
+                    "status",
+                    "task"
                 ],
                 "type": "object"
             },
@@ -4402,7 +4433,14 @@
                 },
                 "responses": {
                     "202": {
-                        "description": "no content"
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RecoverOut"
+                                }
+                            }
+                        },
+                        "description": ""
                     },
                     "401": {
                         "content": {

--- a/server/svix-server/src/core/types/mod.rs
+++ b/server/svix-server/src/core/types/mod.rs
@@ -550,6 +550,7 @@ create_id_type!(
 );
 create_id_type!(MessageEndpointId, "msgep_");
 create_id_type!(EventTypeId, "evtype_");
+create_id_type!(QueueBackgroundTaskId, "qtask_");
 
 create_all_id_types!(ApplicationId, ApplicationUid, ApplicationIdOrUid, "app_");
 create_all_id_types!(EndpointId, EndpointUid, EndpointIdOrUid, "ep_");


### PR DESCRIPTION
The current response doesn't match what our libraries expect, which results in exceptions when calling this endpoint with our libraries. This adds the minimal changes necessary to make the endpoint compliant.
