### PR TITLE
Libs(Go): adjust Go linter

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -10,8 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           working-directory: go
-
+          args: --verbose

--- a/.github/workflows/other-lint.yml
+++ b/.github/workflows/other-lint.yml
@@ -40,6 +40,7 @@ jobs:
           VALIDATE_PYTHON_MYPY: false
           VALIDATE_PYTHON_PYLINT: false
           VALIDATE_GO: false
+          VALIDATE_GO_MODULE: false
           VALIDATE_JSCPD: false
           VALIDATE_PHP_PHPSTAN: false
           VALIDATE_PHP_PSALM: false


### PR DESCRIPTION
Stops using superlinter, relying solely on golangci-lint.

N.b. superlinter was tuned by default to use a much more exhaustive golangci-lint configuration. Still, we should not be invoking golangci-lint from two separate workflows with two different configurations.