### PR TITLE
`Recover Failed Webhooks` use configurable `until`

### DIFF
--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1985,6 +1985,11 @@
                     "since": {
                         "format": "date-time",
                         "type": "string"
+                    },
+                    "until": {
+                        "format": "date-time",
+                        "nullable": true,
+                        "type": "string"
                     }
                 },
                 "required": [

--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -542,6 +542,7 @@ pub struct EndpointSecretOut {
 #[serde(rename_all = "camelCase")]
 pub struct RecoverIn {
     pub since: DateTime<Utc>,
+    pub until: Option<DateTime<Utc>>,
 }
 
 fn endpoint_headers_example() -> HashMap<&'static str, &'static str> {

--- a/server/svix-server/tests/it/e2e_endpoint.rs
+++ b/server/svix-server/tests/it/e2e_endpoint.rs
@@ -979,6 +979,7 @@ async fn test_recovery_should_fail_if_start_time_too_old() {
             &format!("api/v1/app/{app_id}/endpoint/{endp_id}/recover/"),
             RecoverIn {
                 since: Utc::now() - chrono::Duration::weeks(3),
+                until: None,
             },
             StatusCode::UNPROCESSABLE_ENTITY,
         )

--- a/server/svix-server/tests/it/utils/common_calls.rs
+++ b/server/svix-server/tests/it/utils/common_calls.rs
@@ -368,7 +368,7 @@ pub async fn common_test_list<
 
 pub async fn recover_webhooks(client: &TestClient, since: DateTime<Utc>, url: &str) {
     client
-        .post_without_response(url, RecoverIn { since }, StatusCode::ACCEPTED)
+        .post_without_response(url, RecoverIn { since, until: None }, StatusCode::ACCEPTED)
         .await
         .unwrap();
 }


### PR DESCRIPTION
Our API docs support an optional `until` parameter. This adds support for it in the backend.