### PR TITLE
Libs(Go): pluralize GO_MODULES in superlinter

### DIFF
--- a/.github/workflows/other-lint.yml
+++ b/.github/workflows/other-lint.yml
@@ -40,7 +40,7 @@ jobs:
           VALIDATE_PYTHON_MYPY: false
           VALIDATE_PYTHON_PYLINT: false
           VALIDATE_GO: false
-          VALIDATE_GO_MODULE: false
+          VALIDATE_GO_MODULES: false
           VALIDATE_JSCPD: false
           VALIDATE_PHP_PHPSTAN: false
           VALIDATE_PHP_PSALM: false


### PR DESCRIPTION
Follow-on from https://github.com/svix/svix-webhooks/pull/1351 which I didn't catch because editing the linter doesn't run the lints for the different langs, so problems only surfaced when I rebased the other branch... 😢 