### PR TITLE
Replace ctype_digit for PHP 8.1 deprecation of non-string arguments

### DIFF
--- a/php/src/Webhook.php
+++ b/php/src/Webhook.php
@@ -70,7 +70,7 @@ class Webhook
 
     public function sign($msgId, $timestamp, $payload)
     {
-        $is_positive_integer = ctype_digit($timestamp);
+        $is_positive_integer = is_numeric($timestamp) && (int) $timestamp == $timestamp && (int) $timestamp > 0;
         if (!$is_positive_integer) {
             throw new Exception\WebhookSigningException("Invalid timestamp");
         }


### PR DESCRIPTION
From [php.net's ctype_digit documentation](https://www.php.net/manual/en/function.ctype-digit.php):

> As of PHP 8.1.0, passing a non-string argument is deprecated. In the future, the argument will be interpreted as a string instead of an ASCII codepoint. Depending on the intended behavior, the argument should either be cast to [string](https://www.php.net/manual/en/language.types.string.php) or an explicit call to [chr()](https://www.php.net/manual/en/function.chr.php) should be made.

## Motivation

Deprecation is throwing a warning when passing a string into ctype_digit when checking the timestamp.

## Solution

Updated the integer check to move away from `ctype_digit`.
