### PR TITLE
CI: add something to run php tests

### DIFF
--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -1,0 +1,25 @@
+name: PHP CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'php/**'
+      - '.github/workflows/php-ci.yml'
+  pull_request:
+    paths:
+      - 'php/**'
+      - '.github/workflows/php-ci.yml'
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: PHPUnit Tests
+        uses: php-actions/phpunit@v3
+        with:
+          version: latest
+          configuration: "php/phpunit.xml"
+          test_suffix: "Test.php"

--- a/php/init.php
+++ b/php/init.php
@@ -2,3 +2,4 @@
 
 require __DIR__ . '/src/Webhook.php';
 require __DIR__ . '/src/Exception/WebhookVerificationException.php';
+require __DIR__ . '/src/Exception/WebhookSigningException.php';

--- a/php/phpunit.xml
+++ b/php/phpunit.xml
@@ -1,0 +1,7 @@
+<phpunit bootstrap="tests/bootstrap.php">
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/php/src/Webhook.php
+++ b/php/src/Webhook.php
@@ -70,8 +70,7 @@ class Webhook
 
     public function sign($msgId, $timestamp, $payload)
     {
-        $is_positive_integer = is_numeric($timestamp) && !is_float($timestamp + 0) && (int) $timestamp == $timestamp && (int) $timestamp > 0;
-        if (!$is_positive_integer) {
+        if (!self::isPositiveInteger($timestamp)) {
             throw new Exception\WebhookSigningException("Invalid timestamp");
         }
         $toSign = "{$msgId}.{$timestamp}.{$payload}";
@@ -96,5 +95,10 @@ class Webhook
             throw new Exception\WebhookVerificationException("Message timestamp too new");
         }
         return $timestamp;
+    }
+
+    private function isPositiveInteger($v)
+    {
+        return is_numeric($v) && !is_float($v + 0) && (int) $v == $v && (int) $v > 0;
     }
 }

--- a/php/src/Webhook.php
+++ b/php/src/Webhook.php
@@ -70,7 +70,7 @@ class Webhook
 
     public function sign($msgId, $timestamp, $payload)
     {
-        $is_positive_integer = is_numeric($timestamp) && (int) $timestamp == $timestamp && (int) $timestamp > 0;
+        $is_positive_integer = is_numeric($timestamp) && !is_float($timestamp + 0) && (int) $timestamp == $timestamp && (int) $timestamp > 0;
         if (!$is_positive_integer) {
             throw new Exception\WebhookSigningException("Invalid timestamp");
         }

--- a/php/tests/WebhookTest.php
+++ b/php/tests/WebhookTest.php
@@ -112,6 +112,10 @@ final class WebhookTest extends \PHPUnit\Framework\TestCase
 
     public function testMultiSigPayloadIsValid()
     {
+        // We're checking that `verify()` doesn't throw an exception.
+        // It doesn't return anything we can assert about.
+        $this->expectNotToPerformAssertions();
+
         $testPayload = new TestPayload(time());
         $sigs = [
             "v1,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
@@ -127,6 +131,10 @@ final class WebhookTest extends \PHPUnit\Framework\TestCase
 
     public function testSignatureVerificationWithAndWithoutPrefix()
     {
+        // We're checking that `verify()` doesn't throw an exception.
+        // It doesn't return anything we can assert about.
+        $this->expectNotToPerformAssertions();
+
         $testPayload = new TestPayload(time());
 
         $wh = new \Svix\Webhook($testPayload->secret);

--- a/php/tests/bootstrap.php
+++ b/php/tests/bootstrap.php
@@ -1,3 +1,4 @@
 <?php
 
 require_once __DIR__ . '/../init.php';
+require_once __DIR__ . '/TestPayload.php';


### PR DESCRIPTION
## Motivation

We recently had a contribution to the PHP lib and verifying the change was sound turned out to be a bit of a wild goose chase.

## Solution

We already had some tests in place so it felt natural to get the suite running in CI.
After getting that going, there were a few warnings and failures that needed fixing up.
