### PR TITLE
Server: bump zerovec-derive

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -6249,9 +6249,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Previous version was yanked.

