### PR TITLE
Bridge: log svix client errors as error, not trace

### DIFF
--- a/bridge/svix-bridge/src/webhook_receiver/mod.rs
+++ b/bridge/svix-bridge/src/webhook_receiver/mod.rs
@@ -350,7 +350,7 @@ async fn run_inner(poller: &SvixEventsPoller) -> ! {
             }
 
             Err(err) => {
-                tracing::trace!(
+                tracing::error!(
                     error = ?err,
                     ?iterator,
                     "request failed, retrying current iterator"


### PR DESCRIPTION
We've got 3 places where we log errors in the poller loop and this one somehow wound up logging as `trace!` instead of `error!` like the rest.

Follow-on from https://github.com/svix/svix-webhooks/pull/1363
