### PR TITLE
Bridge: use batch count=0 to signal backoff, not "done"

### DIFF
--- a/bridge/svix-bridge/src/webhook_receiver/mod.rs
+++ b/bridge/svix-bridge/src/webhook_receiver/mod.rs
@@ -288,7 +288,8 @@ async fn run_inner(poller: &SvixEventsPoller) -> ! {
         {
             Ok(resp) => {
                 let mut has_failure = false;
-                tracing::trace!(count = resp.data.len(), "got messages");
+                let count = resp.data.len();
+                tracing::trace!(count, "got messages");
                 'inner: for msg in resp.data.into_iter() {
                     let payload = match parse_payload(
                         &SerializablePayload::Standard(
@@ -339,8 +340,8 @@ async fn run_inner(poller: &SvixEventsPoller) -> ! {
                     );
                     // Update the iterator _after we've handled all the messages in the batch_.
                     iterator = Some(resp.iterator.clone());
-                    // If the iterator is "done" we can backoff to wait for new messages to arrive.
-                    sleep_time = if resp.done {
+                    // If the iterator is empty we can backoff to wait for new messages to arrive.
+                    sleep_time = if count == 0 {
                         // BACKOFF
                         (sleep_time * 2).clamp(MIN_SLEEP, MAX_SLEEP)
                     } else {


### PR DESCRIPTION
Looks like the `done` field doesn't signify we're at the end of the topic like I originally thought.

Using the count as a proxy for this works well enough for now, but may not in the future if we expose filters like channels/event types.

Follow-on from https://github.com/svix/svix-webhooks/pull/1363