### PR TITLE
server: add configuration to for changing service name on OpenTelemetry

### DIFF
--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -39,8 +39,7 @@ log_format = "default"
 # always sending. If the OpenTelemetry address is not set, this will do nothing.
 # opentelemetry_sample_ratio = 1.0
 
-# The name of the service to use when sending spans to OpenTelemetry. If not set, the service name
-# will default to "svix_server".
+# The name of the service to use when sending spans to OpenTelemetry.
 opentelemetry_service_name = "svix_server"
 
 # The Sentry DSN to use for error reporting. Disabled when omitted/null

--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -39,6 +39,10 @@ log_format = "default"
 # always sending. If the OpenTelemetry address is not set, this will do nothing.
 # opentelemetry_sample_ratio = 1.0
 
+# The name of the service to use when sending spans to OpenTelemetry. If not set, the service name
+# will default to "svix_server".
+# opentelemetry_service_name = "svix_server"
+
 # The Sentry DSN to use for error reporting. Disabled when omitted/null
 # sentry_dsn = "https://somedsn.ingest.sentry.io/12345"
 

--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -41,7 +41,7 @@ log_format = "default"
 
 # The name of the service to use when sending spans to OpenTelemetry. If not set, the service name
 # will default to "svix_server".
-# opentelemetry_service_name = "svix_server"
+opentelemetry_service_name = "svix_server"
 
 # The Sentry DSN to use for error reporting. Disabled when omitted/null
 # sentry_dsn = "https://somedsn.ingest.sentry.io/12345"

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -109,6 +109,8 @@ pub struct ConfigurationInner {
     /// The ratio at which to sample spans when sending to OpenTelemetry. When not given it defaults
     /// to always sending. If the OpenTelemetry address is not set, this will do nothing.
     pub opentelemetry_sample_ratio: Option<f64>,
+    /// The service name to use for OpenTelemetry. If not provided, it defaults to "svix_server".
+    pub opentelemetry_service_name: Option<String>,
     /// Whether to enable the logging of the databases at the configured log level. This may be
     /// useful for analyzing their response times.
     pub db_tracing: bool,

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -110,7 +110,7 @@ pub struct ConfigurationInner {
     /// to always sending. If the OpenTelemetry address is not set, this will do nothing.
     pub opentelemetry_sample_ratio: Option<f64>,
     /// The service name to use for OpenTelemetry. If not provided, it defaults to "svix_server".
-    pub opentelemetry_service_name: Option<String>,
+    pub opentelemetry_service_name: String,
     /// Whether to enable the logging of the databases at the configured log level. This may be
     /// useful for analyzing their response times.
     pub db_tracing: bool,

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -273,8 +273,7 @@ pub fn setup_tracing(
                         opentelemetry::KeyValue::new(
                             "service.name",
                             cfg.opentelemetry_service_name
-                                .clone()
-                                .unwrap_or_else(|| "svix_server".to_string()),
+                                .clone(),
                         ),
                     ])),
             )

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -272,8 +272,7 @@ pub fn setup_tracing(
                     .with_resource(opentelemetry_sdk::Resource::new(vec![
                         opentelemetry::KeyValue::new(
                             "service.name",
-                            cfg.opentelemetry_service_name
-                                .clone(),
+                            cfg.opentelemetry_service_name.clone(),
                         ),
                     ])),
             )

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -270,7 +270,12 @@ pub fn setup_tracing(
                             .unwrap_or(opentelemetry_sdk::trace::Sampler::AlwaysOn),
                     )
                     .with_resource(opentelemetry_sdk::Resource::new(vec![
-                        opentelemetry::KeyValue::new("service.name", "svix_server"),
+                        opentelemetry::KeyValue::new(
+                            "service.name",
+                            cfg.opentelemetry_service_name
+                                .clone()
+                                .unwrap_or_else(|| "svix_server".to_string()),
+                        ),
                     ])),
             )
             .install_batch(Tokio)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.
Bug fixes and new features should include tests.
-->

## Motivation
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Currently, the OpenTelemetry service name for svix-server is hardcoded to "svix_server". This lack of configurability limits the flexibility for users who want to customize the service name in their OpenTelemetry setup, especially in environments where multiple services are being monitored, like having several servers in "worker mode". 

This change aims to provide users with the ability to set a custom OpenTelemetry service name,  for better integration with their existing monitoring, observability infrastructure or naming convention. 

## Solution
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The solution implements a configurable OpenTelemetry service name for svix-server:

1. Added a new configuration option `opentelemetry_service_name` in the `ConfigurationInner` struct.
2. Updated the default configuration file (`config.default.toml`) to include the new option with a comment explaining its usage.
3. Modified the `setup_tracing` function to use the configured service name when setting up OpenTelemetry.

Users can set a custom OpenTelemetry service name through configuration files or environment variables (e.g., `SVIX_OPENTELEMETRY_SERVICE_NAME`). If not specified, it defaults to "svix_server" to maintain backward compatibility.