### PR TITLE
Python (async): add missing 'get_stats' function.

### DIFF
--- a/python/svix/api.py
+++ b/python/svix/api.py
@@ -539,6 +539,20 @@ class EndpointAsync(ApiBase):
             json_body=endpoint_headers_in,
         )
 
+    async def get_stats(
+        self,
+        app_id: str,
+        endpoint_id: str,
+        options: EndpointStatsOptions = EndpointStatsOptions(),
+    ) -> EndpointStats:
+        return await v1_endpoint_get_stats.request_asyncio(
+            client=self._client,
+            app_id=app_id,
+            endpoint_id=endpoint_id,
+            since=options.since,
+            until=options.until,
+        )
+
     async def replay_missing(
         self,
         app_id: str,


### PR DESCRIPTION
It already existed in the sync library, but not the async.
