### PR TITLE
c# lib: add GetAppPortalAccess* methods to IAuthentication interface

### DIFF
--- a/csharp/Svix/Abstractions/IAuthentication.cs
+++ b/csharp/Svix/Abstractions/IAuthentication.cs
@@ -6,6 +6,11 @@ namespace Svix.Abstractions
 {
     public interface IAuthentication
     {
+        AppPortalAccessOut GetAppPortalAccess(string appId, AppPortalAccessIn appPortalAccess, string idempotencyKey = default);
+
+        Task<AppPortalAccessOut> GetAppPortalAccessAsync(string appId, AppPortalAccessIn appPortalAccess,
+            string idempotencyKey = default, CancellationToken cancellationToken = default);
+
         DashboardAccessOut GetDashboardAccess(string appId, string idempotencyKey = default);
 
         Task<DashboardAccessOut> GetDashboardAccessAsync(string appId, string idempotencyKey = default,


### PR DESCRIPTION
## Motivation

This closes https://github.com/svix/svix-webhooks/issues/1272

## Solution

Basically what the ticket asks for. This extends the `IAuthentication` interface with the requested `AppPortalAccess` methods.
