### PR TITLE
Libs(Go): expose `with_msg` param on `MessageAttempt.ListByEndpoint`

### DIFF
--- a/go/messageattempt.go
+++ b/go/messageattempt.go
@@ -35,6 +35,7 @@ type MessageAttemptListOptions struct {
 	Channel         *string
 	EndpointId      *string
 	WithContent     *bool
+	WithMsg         *bool
 }
 
 // Deprecated: use `ListByMsg` or `ListByEndpoint` instead
@@ -113,6 +114,9 @@ func (m *MessageAttempt) ListByEndpoint(ctx context.Context, appId string, endpo
 		}
 		if options.WithContent != nil {
 			req = req.WithContent(*options.WithContent)
+		}
+		if options.WithMsg != nil {
+			req = req.WithMsg(*options.WithMsg)
 		}
 	}
 	out, res, err := req.Execute()


### PR DESCRIPTION
Helps with https://github.com/svix/svix-webhooks/issues/1381

Query params in the Go client need to be added to the high-level API manually.

This diff plugs a hole for `MessageAttempt` where `with_msg` is available in the internal API, but not exposed as public.
