### PR TITLE
Add support for SOCKS5 proxies

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -400,6 +400,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-socks5"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77f634add2445eb2c1f785642a67ca1073fedd71e73dc3ca69435ef9b9bdedc7"
+dependencies = [
+ "async-trait",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,6 +2134,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-socks2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc38166fc2732d450e9372388d269eb38ff0b75a3cfb4c542e65b2f6893629c4"
+dependencies = [
+ "async-socks5",
+ "futures",
+ "http 0.2.12",
+ "hyper 0.14.28",
+ "hyper-tls 0.5.0",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2132,6 +2158,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.28",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -3676,7 +3715,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.4.1",
- "hyper-tls",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -4753,7 +4792,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.4.1",
  "hyper-rustls 0.26.0",
- "hyper-tls",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "serde",
  "serde_derive",
@@ -4818,6 +4857,7 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.28",
  "hyper-openssl",
+ "hyper-socks2",
  "indexmap 1.9.3",
  "ipnet",
  "jsonschema",

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -23,6 +23,7 @@ axum = { version = "0.6.1", features = ["headers"] }
 base64 = "0.13.0"
 hyper = { version = "=0.14.28", features = ["full"] }
 hyper-openssl = "0.9.2"
+hyper-socks2 = "0.8.0"
 openssl = "0.10.60"
 tokio = { version = "1.24.2", features = ["full"] }
 tower = "0.4.11"

--- a/server/svix-server/src/worker.rs
+++ b/server/svix-server/src/worker.rs
@@ -901,6 +901,7 @@ pub async fn queue_handler(
         cfg.whitelist_subnets.clone(),
         Some(Arc::new(vec!["backend".to_owned()])),
         cfg.dangerous_disable_tls_verification,
+        cfg.proxy_config.clone(),
     );
 
     tokio::spawn(

--- a/server/svix-server/tests/it/e2e_proxy.rs
+++ b/server/svix-server/tests/it/e2e_proxy.rs
@@ -1,0 +1,56 @@
+use std::time::Duration;
+
+use http::StatusCode;
+use serde::de::IgnoredAny;
+use svix_server::cfg::{ProxyAddr, ProxyConfig};
+use tokio::time::timeout;
+
+use crate::utils::{
+    common_calls::{create_test_app, create_test_endpoint, message_in},
+    get_default_test_config, TestClient, TestReceiver,
+};
+
+// I could not get it to work with a dockerized socks5 proxy yet
+#[ignore]
+#[tokio::test]
+async fn test_message_delivery_via_socks5() {
+    use crate::utils::start_svix_server_with_cfg;
+
+    let mut cfg = get_default_test_config();
+    cfg.proxy_config = Some(proxy_config());
+    let (client, _) = start_svix_server_with_cfg(&cfg).await;
+    run_socks5_test(&client).await;
+}
+
+fn proxy_config() -> ProxyConfig {
+    ProxyConfig {
+        addr: ProxyAddr::new("socks5://localhost:1080").unwrap(),
+    }
+}
+
+async fn run_socks5_test(client: &TestClient) {
+    let mut receiver = TestReceiver::start(StatusCode::OK);
+
+    let app_id = create_test_app(client, "kafkaSinkTest").await.unwrap().id;
+    create_test_endpoint(client, &app_id, &receiver.endpoint)
+        .await
+        .unwrap();
+
+    let msg_payload = serde_json::json!({ "test": "value" });
+
+    let _: IgnoredAny = client
+        .post(
+            &format!("api/v1/app/{app_id}/msg/"),
+            message_in(&app_id, msg_payload.clone()).unwrap(),
+            StatusCode::ACCEPTED,
+        )
+        .await
+        .unwrap();
+
+    let received_payload = timeout(Duration::from_secs(2), receiver.data_recv.recv())
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(received_payload, msg_payload);
+}

--- a/server/svix-server/tests/it/integ_webhook_http_client.rs
+++ b/server/svix-server/tests/it/integ_webhook_http_client.rs
@@ -81,6 +81,7 @@ async fn test_client_basic_operation() {
         Some(Arc::new(vec!["127.0.0.1/0".parse().unwrap()])),
         None,
         false,
+        None,
     );
     let reqwest_client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
@@ -133,7 +134,7 @@ async fn test_client_basic_operation() {
 
 #[tokio::test]
 async fn test_filtering() {
-    let our_client = WebhookClient::new(None, None, false);
+    let our_client = WebhookClient::new(None, None, false, None);
 
     let our_req = RequestBuilder::new()
         .uri_str("http://127.0.0.1/")

--- a/server/svix-server/tests/it/main.rs
+++ b/server/svix-server/tests/it/main.rs
@@ -7,6 +7,7 @@ mod e2e_event_type;
 mod e2e_health;
 mod e2e_message;
 mod e2e_operational_webhooks;
+mod e2e_proxy;
 mod integ_webhook_http_client;
 mod message_app;
 mod redis_queue;


### PR DESCRIPTION
Closes https://github.com/svix/monorepo-private/issues/8815.

New ignored test succeeded with a locally-running `microsocks` outside of Docker.