### PR TITLE
Libs(Python): fix datetime serialization for `before`/`after

### DIFF
--- a/python/svix/api.py
+++ b/python/svix/api.py
@@ -1,6 +1,6 @@
 import typing as t
 from dataclasses import asdict, dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 
 from deprecated import deprecated
 
@@ -178,6 +178,14 @@ from .internal.openapi_client.models.status_code_class import StatusCodeClass
 DEFAULT_SERVER_URL = "https://api.svix.com"
 
 
+def dt_format(x: datetime) -> str:
+    return (
+        x.replace(tzinfo=timezone.utc)
+        .isoformat(sep="T", timespec="microseconds")
+        .replace("+00:00", "Z")
+    )
+
+
 @dataclass
 class SvixOptions:
     debug: bool = False
@@ -227,6 +235,14 @@ class MessageListOptions(ListOptions):
     channel: t.Optional[str] = None
     tag: t.Optional[str] = None
 
+    def to_dict(self) -> t.Dict[str, t.Any]:
+        d = super().to_dict()
+        if self.before is not None:
+            d["before"] = dt_format(self.before)
+        if self.after is not None:
+            d["after"] = dt_format(self.after)
+        return d
+
 
 @dataclass
 class ApplicationListOptions(ListOptions):
@@ -268,6 +284,14 @@ class MessageAttemptListOptions(ListOptions):
     after: t.Optional[datetime] = None
     channel: t.Optional[str] = None
     status_code_class: t.Optional[StatusCodeClass] = None
+
+    def to_dict(self) -> t.Dict[str, t.Any]:
+        d = super().to_dict()
+        if self.before is not None:
+            d["before"] = dt_format(self.before)
+        if self.after is not None:
+            d["after"] = dt_format(self.after)
+        return d
 
 
 class ApiBase:


### PR DESCRIPTION
The API server expects timestamps to be formatted a specific way (an RFC 3339, UTC timestamp "with a Z").

This diff tweaks how we produce strings for the `before` and `after` query params for message and attempt list requests, conforming to the expected format.

For `before` and `after` we have a convenient place to influence serialization by overriding the `to_dict` method, but a similar problem exists exists for `since` and `until` used in `EndpointStatsOptions`.

I didn't see a trivial way to influence the serialization in these cases without breaking the typing.

It seems like there should be a more uniform solution, but I don't yet know what it is. Ideally all datetimes we pass through to the openapi codegen API would be encoded the proper way.
