### PR TITLE
Libs/JS: Publish src to npm to make it available for source maps

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -15,7 +15,8 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "files": [
-    "dist/**/*"
+    "src",
+    "dist"
   ],
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Motivation
We export source maps with the `svix` javascript package, but not the corresponding source files. 

Something like `{"version":3,"file":"index.js","sourceRoot":"","sources":["../src/index.ts"],"names":[].....` in `index.js.map` throws an error since `../src/index.ts` can't be found. This causes several warnings in certain bundlers.
 
## Solution
Add the source files to the files published to npm. 

Closes #1299 