### PR TITLE
server: Improve test_combined_before_after_filtering

### DIFF
--- a/server/run-tests.sh
+++ b/server/run-tests.sh
@@ -27,8 +27,10 @@ echo "*********** RUN 1 ***********"
     export SVIX_QUEUE_TYPE="redis"
     export SVIX_CACHE_TYPE="redis"
     export SVIX_REDIS_DSN="redis://localhost:6379"
-    ${TEST_COMMAND}
-    ${TEST_COMMAND} -- --ignored redis
+    ${TEST_COMMAND} "$@"
+    if [[ -z "$@" ]]; then
+        ${TEST_COMMAND} -- --ignored redis
+    fi
 )
 
 echo "*********** RUN 2 ***********"
@@ -36,7 +38,7 @@ echo "*********** RUN 2 ***********"
     export SVIX_QUEUE_TYPE="redis"
     export SVIX_CACHE_TYPE="memory"
     export SVIX_REDIS_DSN="redis://localhost:6379"
-    ${TEST_COMMAND}
+    ${TEST_COMMAND} "$@"
 )
 
 echo "*********** RUN 3 ***********"
@@ -44,7 +46,7 @@ echo "*********** RUN 3 ***********"
     export SVIX_QUEUE_TYPE="redis"
     export SVIX_CACHE_TYPE="none"
     export SVIX_REDIS_DSN="redis://localhost:6379"
-    ${TEST_COMMAND}
+    ${TEST_COMMAND} "$@"
 )
 
 echo "*********** RUN 4 ***********"
@@ -52,15 +54,17 @@ echo "*********** RUN 4 ***********"
     export SVIX_QUEUE_TYPE="rediscluster"
     export SVIX_CACHE_TYPE="rediscluster"
     export SVIX_REDIS_DSN="redis://localhost:6380"
-    ${TEST_COMMAND}
-    ${TEST_COMMAND} -- --ignored redis
+    ${TEST_COMMAND} "$@"
+    if [[ -z "$@" ]]; then
+        ${TEST_COMMAND} -- --ignored redis
+    fi
 )
 
 echo "*********** RUN 5 ***********"
 (
     export SVIX_QUEUE_TYPE="memory"
     export SVIX_CACHE_TYPE="none"
-    ${TEST_COMMAND}
+    ${TEST_COMMAND} "$@"
 )
 
 echo "*********** RUN 6 ***********"
@@ -69,6 +73,8 @@ echo "*********** RUN 6 ***********"
     export SVIX_CACHE_TYPE="redis"
     export SVIX_REDIS_DSN="redis://localhost:6379"
     export SVIX_RABBIT_DSN="amqp://xivs:xivs@localhost:5672/%2f"
-    ${TEST_COMMAND}
-    ${TEST_COMMAND} -- --ignored rabbitmq
+    ${TEST_COMMAND} "$@"
+    if [[ -z "$@" ]]; then
+        ${TEST_COMMAND} -- --ignored rabbitmq
+    fi
 )


### PR DESCRIPTION
We were only testing that newer attempts weren't returned, not that older attempts weren't. The original bug was actually with the latter.

Follow-up to https://github.com/svix/svix-webhooks/pull/1399.