### PR TITLE
Replace custom `IgnoredResponse` with serde's `IgnoredAny`

### DIFF
--- a/server/svix-server/tests/it/e2e_application.rs
+++ b/server/svix-server/tests/it/e2e_application.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
-
 use reqwest::StatusCode;
+use serde::de::IgnoredAny;
 use svix_server::{
     cfg::CacheType,
     core::{
@@ -13,7 +13,7 @@ use svix_server::{
 
 use crate::utils::{
     common_calls::{application_in, common_test_list, metadata},
-    get_default_test_config, start_svix_server, IgnoredResponse,
+    get_default_test_config, start_svix_server,
 };
 
 // NOTE: PATCHing must be tested exhaustively as if any of the boilerplate is missed then the
@@ -260,21 +260,21 @@ async fn test_crud() {
     );
 
     // DELETE
-    let _: IgnoredResponse = client
+    let _: IgnoredAny = client
         .delete(&format!("api/v1/app/{}/", app_1.id), StatusCode::NO_CONTENT)
         .await
         .unwrap();
-    let _: IgnoredResponse = client
+    let _: IgnoredAny = client
         .delete(&format!("api/v1/app/{}/", app_2.id), StatusCode::NO_CONTENT)
         .await
         .unwrap();
 
     // CONFIRM DELETION
-    let _: IgnoredResponse = client
+    let _: IgnoredAny = client
         .get(&format!("api/v1/app/{}/", app_1.id), StatusCode::NOT_FOUND)
         .await
         .unwrap();
-    let _: IgnoredResponse = client
+    let _: IgnoredAny = client
         .get(&format!("api/v1/app/{}/", app_2.id), StatusCode::NOT_FOUND)
         .await
         .unwrap();
@@ -375,7 +375,7 @@ async fn test_uid() {
     assert_ne!(app.id.0, app.uid.unwrap().0);
 
     // Can't create another app with the same uid twice
-    let _: IgnoredResponse = client
+    let _: IgnoredAny = client
         .post(
             "api/v1/app/",
             ApplicationIn {
@@ -401,7 +401,7 @@ async fn test_uid() {
         .await
         .unwrap();
 
-    let _: IgnoredResponse = client
+    let _: IgnoredAny = client
         .put(
             &format!("api/v1/app/{}/", app2.id),
             ApplicationIn {
@@ -428,7 +428,7 @@ async fn test_uid() {
         .await
         .unwrap();
 
-    let _: IgnoredResponse = client
+    let _: IgnoredAny = client
         .put(
             &format!("api/v1/app/{}/", app2.id),
             ApplicationIn {
@@ -442,7 +442,7 @@ async fn test_uid() {
         .unwrap();
 
     // Delete app1
-    let _: IgnoredResponse = client
+    let _: IgnoredAny = client
         .delete(&format!("api/v1/app/{}/", app.id), StatusCode::NO_CONTENT)
         .await
         .unwrap();
@@ -461,7 +461,7 @@ async fn test_uid() {
         .await
         .unwrap();
 
-    let _: IgnoredResponse = client
+    let _: IgnoredAny = client
         .delete(
             &format!("api/v1/app/{}/", app2.uid.unwrap()),
             StatusCode::NO_CONTENT,
@@ -484,7 +484,7 @@ async fn test_uid() {
         .unwrap();
 
     // Can update an app with a UID
-    let _: IgnoredResponse = client
+    let _: IgnoredAny = client
         .put(
             &format!("api/v1/app/{}/", app.id),
             ApplicationIn {
@@ -542,7 +542,7 @@ async fn test_uid() {
     assert!(app2.uid.is_none());
 
     // Make sure we can't fetch by the old UID
-    let _: IgnoredResponse = client
+    let _: IgnoredAny = client
         .get(&format!("api/v1/app/{}/", "app3"), StatusCode::NOT_FOUND)
         .await
         .unwrap();
@@ -619,7 +619,7 @@ async fn test_get_or_create() {
         )
     );
 
-    let _: IgnoredResponse = client
+    let _: IgnoredAny = client
         .post(
             "api/v1/app/",
             ApplicationIn {

--- a/server/svix-server/tests/it/e2e_attempt.rs
+++ b/server/svix-server/tests/it/e2e_attempt.rs
@@ -4,6 +4,7 @@
 use std::time::Duration;
 
 use reqwest::StatusCode;
+use serde::de::IgnoredAny;
 use svix_server::{
     core::types::{EndpointUid, MessageStatus},
     v1::{
@@ -21,7 +22,7 @@ use crate::utils::{
         endpoint_in, get_msg_attempt_list_and_assert_count,
     },
     get_default_test_config, run_with_retries, start_svix_server, start_svix_server_with_cfg,
-    IgnoredResponse, TestReceiver,
+    TestReceiver,
 };
 
 #[tokio::test]
@@ -66,7 +67,7 @@ async fn test_expunge_attempt_response_body() {
     assert_eq!(sensitive_response_json, attempt_response);
 
     let attempt_id = &attempt.id;
-    let _: IgnoredResponse = client
+    let _: IgnoredAny = client
         .delete(
             &format!("api/v1/app/{app_id}/msg/{msg_id}/attempt/{attempt_id}/content/"),
             StatusCode::NO_CONTENT,

--- a/server/svix-server/tests/it/e2e_auth.rs
+++ b/server/svix-server/tests/it/e2e_auth.rs
@@ -3,6 +3,7 @@
 //! from the endpoint is valid in the process.
 
 use reqwest::StatusCode;
+use serde::de::IgnoredAny;
 use serde_json::Value;
 use svix_server::{
     core::{
@@ -14,7 +15,7 @@ use svix_server::{
 
 use crate::utils::{
     common_calls::{app_portal_access, application_in},
-    get_default_test_config, start_svix_server, IgnoredResponse,
+    get_default_test_config, start_svix_server,
 };
 
 #[tokio::test]
@@ -45,7 +46,7 @@ async fn test_restricted_application_access() {
     let client = app_portal_access(&client, &app_id, Default::default()).await;
 
     // CREATE, UPDATE, DELETE, and LIST ops
-    let _: IgnoredResponse = client
+    let _: IgnoredAny = client
         .post(
             "api/v1/app/",
             application_in("TEST_APP_NAME"),
@@ -53,7 +54,7 @@ async fn test_restricted_application_access() {
         )
         .await
         .unwrap();
-    let _: IgnoredResponse = client
+    let _: IgnoredAny = client
         .put(
             &format!("api/v1/app/{app_id}/"),
             application_in("TEST_APP_NAME"),
@@ -61,17 +62,17 @@ async fn test_restricted_application_access() {
         )
         .await
         .unwrap();
-    let _: IgnoredResponse = client
+    let _: IgnoredAny = client
         .delete(&format!("api/v1/app/{app_id}/"), StatusCode::FORBIDDEN)
         .await
         .unwrap();
-    let _: IgnoredResponse = client
+    let _: IgnoredAny = client
         .get("api/v1/app/", StatusCode::FORBIDDEN)
         .await
         .unwrap();
 
     // READ should succeed when accessing the app_id the token is auhtorized for but no others
-    let _: IgnoredResponse = client
+    let _: IgnoredAny = client
         .get(&format!("api/v1/app/{app_id_2}/"), StatusCode::NOT_FOUND)
         .await
         .unwrap();
@@ -96,7 +97,7 @@ async fn test_dashboard_access_without_body() {
         .id;
 
     // We just need to ensure we get an OK response without a body.
-    let _: IgnoredResponse = client
+    let _: IgnoredAny = client
         .post(
             &format!("api/v1/auth/dashboard-access/{app_id}/"),
             (),

--- a/server/svix-server/tests/it/e2e_event_type.rs
+++ b/server/svix-server/tests/it/e2e_event_type.rs
@@ -4,6 +4,7 @@
 use std::collections::HashSet;
 
 use reqwest::StatusCode;
+use serde::de::IgnoredAny;
 use svix_server::{
     core::types::{ApplicationId, EventTypeName, FeatureFlag, FeatureFlagSet},
     db::models::eventtype::Schema,
@@ -18,7 +19,7 @@ use svix_server::{
 
 use crate::utils::{
     common_calls::{app_portal_access, application_in, common_test_list, event_type_in},
-    start_svix_server, IgnoredResponse,
+    start_svix_server,
 };
 
 #[tokio::test]
@@ -275,7 +276,7 @@ async fn test_event_type_feature_flags() {
             assert!(list.data.contains(&et));
         } else {
             // If the client is not supposed to see it it shouldn't be able to retrieve it
-            let _: IgnoredResponse = client.get(&path, StatusCode::NOT_FOUND).await.unwrap();
+            let _: IgnoredAny = client.get(&path, StatusCode::NOT_FOUND).await.unwrap();
 
             // ... and it shouldn't be in the list.
             assert_eq!(list.data.len(), 1);

--- a/server/svix-server/tests/it/e2e_health.rs
+++ b/server/svix-server/tests/it/e2e_health.rs
@@ -2,14 +2,15 @@
 // SPDX-License-Identifier: MIT
 
 use reqwest::StatusCode;
+use serde::de::IgnoredAny;
 
-use crate::utils::{start_svix_server, IgnoredResponse};
+use crate::utils::start_svix_server;
 
 #[tokio::test]
 async fn ping_with_trailing_slash() {
     let (client, _jh) = start_svix_server().await;
 
-    let _: IgnoredResponse = client
+    let _: IgnoredAny = client
         .get("api/v1/health/ping/", StatusCode::NO_CONTENT)
         .await
         .unwrap();
@@ -19,7 +20,7 @@ async fn ping_with_trailing_slash() {
 async fn ping_without_trailing_slash() {
     let (client, _jh) = start_svix_server().await;
 
-    let _: IgnoredResponse = client
+    let _: IgnoredAny = client
         .get("api/v1/health/ping", StatusCode::NO_CONTENT)
         .await
         .unwrap();

--- a/server/svix-server/tests/it/e2e_message.rs
+++ b/server/svix-server/tests/it/e2e_message.rs
@@ -4,6 +4,7 @@
 use chrono::{Duration, Utc};
 use reqwest::StatusCode;
 use sea_orm::{sea_query::Expr, ColumnTrait, EntityTrait, QueryFilter};
+use serde::de::IgnoredAny;
 use svix_server::{
     db::models::messagecontent,
     expired_message_cleaner,
@@ -18,7 +19,7 @@ use svix_server::{
 
 use crate::utils::{
     common_calls::{create_test_app, create_test_endpoint, create_test_msg_with, message_in},
-    run_with_retries, start_svix_server, IgnoredResponse, TestReceiver,
+    run_with_retries, start_svix_server, TestReceiver,
 };
 
 #[tokio::test]
@@ -454,7 +455,7 @@ async fn test_expunge_message_payload() {
         serde_json::to_string(&payload).unwrap()
     );
 
-    let _: IgnoredResponse = client
+    let _: IgnoredAny = client
         .delete(
             &format!("api/v1/app/{}/msg/{}/content/", &app_id, &msg.id),
             StatusCode::NO_CONTENT,

--- a/server/svix-server/tests/it/e2e_operational_webhooks.rs
+++ b/server/svix-server/tests/it/e2e_operational_webhooks.rs
@@ -6,7 +6,7 @@ use std::{net::TcpListener, sync::Arc, time::Duration};
 use chrono::{DateTime, Utc};
 use http::StatusCode;
 use reqwest::Url;
-use serde::Deserialize;
+use serde::{de::IgnoredAny, Deserialize};
 use svix::api::EventTypeOut;
 use svix_ksuid::KsuidLike;
 use svix_server::{
@@ -28,7 +28,7 @@ use crate::utils::{
     common_calls::{
         create_test_app, create_test_endpoint, create_test_message, default_test_endpoint,
     },
-    get_default_test_config, IgnoredResponse, TestClient, TestReceiver,
+    get_default_test_config, TestClient, TestReceiver,
 };
 
 /// Sent when an endpoint has been automatically disabled after continuous failures.
@@ -239,7 +239,7 @@ async fn test_endpoint_create_update_and_delete() {
     };
 
     // Rotate secrets
-    let _: IgnoredResponse = client_regular
+    let _: IgnoredAny = client_regular
         .post(
             &format!(
                 "api/v1/app/{}/endpoint/{}/secret/rotate/",
@@ -258,7 +258,7 @@ async fn test_endpoint_create_update_and_delete() {
     );
 
     // And finally delete the endpoint
-    let _: IgnoredResponse = client_regular
+    let _: IgnoredAny = client_regular
         .delete(
             &format!(
                 "api/v1/app/{}/endpoint/{}/",

--- a/server/svix-server/tests/it/message_app.rs
+++ b/server/svix-server/tests/it/message_app.rs
@@ -5,6 +5,7 @@
 use std::time::Duration;
 
 use http::StatusCode;
+use serde::de::IgnoredAny;
 use svix_server::{
     cfg::CacheBackend,
     core::{
@@ -17,7 +18,7 @@ use svix_server::{
 
 use crate::utils::{
     common_calls::{create_test_app, create_test_endpoint, create_test_message, message_in},
-    get_default_test_config, start_svix_server_with_cfg_and_org_id, IgnoredResponse, TestReceiver,
+    get_default_test_config, start_svix_server_with_cfg_and_org_id, TestReceiver,
 };
 
 /// Ensures that a deleted application returns `None` when using [`layered_fetch`]
@@ -58,7 +59,7 @@ async fn test_app_deletion() {
     );
 
     client
-        .delete::<IgnoredResponse>(&format!("api/v1/app/{app_id}/"), StatusCode::NO_CONTENT)
+        .delete::<IgnoredAny>(&format!("api/v1/app/{app_id}/"), StatusCode::NO_CONTENT)
         .await
         .unwrap();
 
@@ -81,7 +82,7 @@ async fn test_app_deletion() {
 
     // Assert message creation return a 404 with a deleted application
     client
-        .post::<_, IgnoredResponse>(
+        .post::<_, IgnoredAny>(
             &format!("api/v1/app/{app_id}/msg/"),
             message_in("test.event", payload).unwrap(),
             StatusCode::NOT_FOUND,
@@ -135,7 +136,7 @@ async fn test_endp_deletion() {
     );
 
     client
-        .delete::<IgnoredResponse>(
+        .delete::<IgnoredAny>(
             &format!("api/v1/app/{app_id}/endpoint/{endp_id}/"),
             StatusCode::NO_CONTENT,
         )
@@ -161,7 +162,7 @@ async fn test_endp_deletion() {
 
     // Assert message creation return a 202 with a deleted endpoint
     client
-        .post::<_, IgnoredResponse>(
+        .post::<_, IgnoredAny>(
             &format!("api/v1/app/{app_id}/msg/"),
             message_in("test.event", payload).unwrap(),
             StatusCode::ACCEPTED,

--- a/server/svix-server/tests/it/utils/common_calls.rs
+++ b/server/svix-server/tests/it/utils/common_calls.rs
@@ -6,7 +6,10 @@ use std::{collections::HashSet, time::Duration};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use reqwest::{StatusCode, Url};
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{
+    de::{DeserializeOwned, IgnoredAny},
+    Serialize,
+};
 use svix::api::DashboardAccessOut;
 use svix_server::{
     core::types::{
@@ -26,7 +29,7 @@ use svix_server::{
     },
 };
 
-use super::{run_with_retries, IgnoredResponse, TestClient};
+use super::{run_with_retries, TestClient};
 
 // App
 
@@ -43,7 +46,7 @@ pub async fn create_test_app(client: &TestClient, name: &str) -> Result<Applicat
         .await
 }
 
-pub async fn delete_test_app(client: &TestClient, id: ApplicationId) -> Result<IgnoredResponse> {
+pub async fn delete_test_app(client: &TestClient, id: ApplicationId) -> Result<IgnoredAny> {
     client
         .delete(&format!("api/v1/app/{id}/"), StatusCode::NO_CONTENT)
         .await
@@ -287,7 +290,7 @@ pub async fn common_test_list<
     );
 
     let _list = client
-        .get::<IgnoredResponse>(
+        .get::<IgnoredAny>(
             &format!("{path}?limit=6&iterator=BAD-$$$ITERATOR"),
             StatusCode::UNPROCESSABLE_ENTITY,
         )
@@ -346,7 +349,7 @@ pub async fn common_test_list<
     // If limits are hard, it will be a 422 UNPROCESSABLE_ENTITY response, otherwise it'll be capped
     // to 250
     if client
-        .get::<IgnoredResponse>(
+        .get::<IgnoredAny>(
             &format!("{path}?limit=300"),
             StatusCode::UNPROCESSABLE_ENTITY,
         )

--- a/server/svix-server/tests/it/utils/mod.rs
+++ b/server/svix-server/tests/it/utils/mod.rs
@@ -11,7 +11,7 @@ use anyhow::{Context, Result};
 use axum::response::IntoResponse;
 use http::HeaderMap;
 use reqwest::{Client, RequestBuilder, StatusCode};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Serialize};
 use svix_ksuid::KsuidLike;
 use svix_server::{
     cfg::ConfigurationInner,
@@ -36,18 +36,6 @@ pub struct TestClient {
 impl TestClient {
     pub fn set_auth_header(&mut self, auth_header: String) {
         self.auth_header = format!("Bearer {auth_header}");
-    }
-}
-
-/// This struct accepts any JSON response and just ignores it.
-pub struct IgnoredResponse;
-impl<'de> Deserialize<'de> for IgnoredResponse {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let _ = serde_json::Value::deserialize(deserializer);
-        Ok(IgnoredResponse)
     }
 }
 


### PR DESCRIPTION
Resolves #1373 

This PR refactors the server test suite by replacing the custom `IgnoredResponse` type with serde's built-in `IgnoredAny` type. The `IgnoredAny` type serves the same purpose but does so more efficiently.