### PR TITLE
Libs(Go): prune out unused import for "time" in codegen output

### DIFF
--- a/regen_openapi.sh
+++ b/regen_openapi.sh
@@ -10,6 +10,13 @@ yarn openapi-generator-cli generate -i openapi.json -g typescript -o javascript/
 
 yarn openapi-generator-cli generate -i openapi.json -g go -o go/internal/openapi -c go/openapi-generator-config.json -t go/templates
 
+# Currently the generator will add unused imports for `time` to some modules.
+ls \
+    go/internal/openapi/model_stream_sink_out.go \
+    go/internal/openapi/model_sink_out.go \
+    | xargs sed -i '0,/"time"/{/"time"/d}'
+
+
 yarn openapi-generator-cli generate -i openapi.json -g java -o java/lib/generated/openapi -c java/openapi-generator-config.json -t java/templates
 
 yarn openapi-generator-cli generate -i openapi.json -g kotlin -o kotlin/lib/generated/openapi -c kotlin/openapi-generator-config.json -t kotlin/templates


### PR DESCRIPTION
Looks like there might be an issue in the Go client generator. There is some older discussion around the template incorrectly inserting imports for `time` in some cases, and this might just be another such case.

For the near term, let's automate removal of the imports. Should the import become necessary later, CI should report a failure at lint time for the missing import.
