### PR TITLE
Add responseDurationMs to MessageAttempt

### DIFF
--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1504,6 +1504,11 @@
                         "example": "{}",
                         "type": "string"
                     },
+                    "responseDurationMs": {
+                        "description": "Response duration in milliseconds.\n\nCurrently, this is not actually recorded in the OSS version of Svix, so this field always has a value of `0`.",
+                        "format": "int64",
+                        "type": "integer"
+                    },
                     "responseStatusCode": {
                         "example": 200,
                         "format": "int16",
@@ -1532,6 +1537,7 @@
                     "id",
                     "msgId",
                     "response",
+                    "responseDurationMs",
                     "responseStatusCode",
                     "status",
                     "timestamp",
@@ -1684,6 +1690,11 @@
                         "example": "{}",
                         "type": "string"
                     },
+                    "responseDurationMs": {
+                        "description": "Response duration in milliseconds.\n\nCurrently, this is not actually recorded in the OSS version of Svix, so this field always has a value of `0`.",
+                        "format": "int64",
+                        "type": "integer"
+                    },
                     "responseStatusCode": {
                         "example": 200,
                         "format": "int16",
@@ -1712,6 +1723,7 @@
                     "id",
                     "msgId",
                     "response",
+                    "responseDurationMs",
                     "responseStatusCode",
                     "status",
                     "timestamp",

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -65,6 +65,11 @@ pub struct MessageAttemptOut {
     pub response: String,
     #[schemars(example = "example_status_code")]
     pub response_status_code: i16,
+    /// Response duration in milliseconds.
+    ///
+    /// Currently, this is not actually recorded in the OSS version of Svix, so
+    /// this field always has a value of `0`.
+    pub response_duration_ms: i64,
     pub status: MessageStatus,
     pub trigger_type: MessageAttemptTriggerType,
     pub msg_id: MessageId,
@@ -83,6 +88,7 @@ impl From<messageattempt::Model> for MessageAttemptOut {
             url: model.url,
             response: model.response,
             response_status_code: model.response_status_code,
+            response_duration_ms: 0,
             status: model.status,
             trigger_type: model.trigger_type,
             msg_id: model.msg_id,


### PR DESCRIPTION
… to unbreak client libraries that expect this field now.


## Motivation

Since we added this field to Svix'es cloud offering and updated the client libraries accordingly, they are now expecting it to be present, meaning they don't work correctly against the OSS version.

This bug was reported in #1415.

## Solution

Make the OSS server emit this field with a value of `0`. A future version might start recording and properly reporting response durations.