### PR TITLE
Repair broken tests

### DIFF
--- a/server/run-tests.sh
+++ b/server/run-tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eo pipefail
+
 # Run tests with various configurations.
 
 if [[ -z "$TEST_COMMAND" ]]; then

--- a/server/svix-server/tests/it/e2e_application.rs
+++ b/server/svix-server/tests/it/e2e_application.rs
@@ -260,11 +260,11 @@ async fn test_crud() {
     );
 
     // DELETE
-    let _: IgnoredAny = client
+    client
         .delete(&format!("api/v1/app/{}/", app_1.id), StatusCode::NO_CONTENT)
         .await
         .unwrap();
-    let _: IgnoredAny = client
+    client
         .delete(&format!("api/v1/app/{}/", app_2.id), StatusCode::NO_CONTENT)
         .await
         .unwrap();
@@ -442,7 +442,7 @@ async fn test_uid() {
         .unwrap();
 
     // Delete app1
-    let _: IgnoredAny = client
+    client
         .delete(&format!("api/v1/app/{}/", app.id), StatusCode::NO_CONTENT)
         .await
         .unwrap();
@@ -461,7 +461,7 @@ async fn test_uid() {
         .await
         .unwrap();
 
-    let _: IgnoredAny = client
+    client
         .delete(
             &format!("api/v1/app/{}/", app2.uid.unwrap()),
             StatusCode::NO_CONTENT,

--- a/server/svix-server/tests/it/e2e_attempt.rs
+++ b/server/svix-server/tests/it/e2e_attempt.rs
@@ -4,7 +4,6 @@
 use std::time::Duration;
 
 use reqwest::StatusCode;
-use serde::de::IgnoredAny;
 use svix_server::{
     core::types::{EndpointUid, MessageStatus},
     v1::{
@@ -67,7 +66,7 @@ async fn test_expunge_attempt_response_body() {
     assert_eq!(sensitive_response_json, attempt_response);
 
     let attempt_id = &attempt.id;
-    let _: IgnoredAny = client
+    client
         .delete(
             &format!("api/v1/app/{app_id}/msg/{msg_id}/attempt/{attempt_id}/content/"),
             StatusCode::NO_CONTENT,

--- a/server/svix-server/tests/it/e2e_auth.rs
+++ b/server/svix-server/tests/it/e2e_auth.rs
@@ -62,7 +62,7 @@ async fn test_restricted_application_access() {
         )
         .await
         .unwrap();
-    let _: IgnoredAny = client
+    client
         .delete(&format!("api/v1/app/{app_id}/"), StatusCode::FORBIDDEN)
         .await
         .unwrap();

--- a/server/svix-server/tests/it/e2e_endpoint.rs
+++ b/server/svix-server/tests/it/e2e_endpoint.rs
@@ -76,13 +76,12 @@ async fn get_endpoint_404(client: &TestClient, app_id: &str, ep_id: &str) -> Res
 }
 
 async fn delete_endpoint(client: &TestClient, app_id: &ApplicationId, ep_id: &str) -> Result<()> {
-    let _: IgnoredAny = client
+    client
         .delete(
             &format!("api/v1/app/{app_id}/endpoint/{ep_id}/"),
             StatusCode::NO_CONTENT,
         )
-        .await?;
-    Ok(())
+        .await
 }
 
 #[allow(deprecated)]
@@ -916,8 +915,8 @@ async fn test_endpoint_secret_get_and_rotation() {
         .await
         .unwrap();
 
-    let _: IgnoredAny = client
-        .post(
+    client
+        .post_without_response(
             &format!("api/v1/app/{app_id}/endpoint/{}/secret/rotate/", ep.id),
             serde_json::json!({ "key": null }),
             StatusCode::NO_CONTENT,
@@ -936,8 +935,8 @@ async fn test_endpoint_secret_get_and_rotation() {
             .unwrap()
     );
 
-    let _: IgnoredAny = client
-        .post(
+    client
+        .post_without_response(
             &format!("api/v1/app/{app_id}/endpoint/{}/secret/rotate/", ep.id),
             &former_secret,
             StatusCode::NO_CONTENT,
@@ -1055,8 +1054,8 @@ async fn test_endpoint_rotate_max() {
         .id;
 
     for _ in 0..ExpiringSigningKeys::MAX_OLD_KEYS {
-        let _: IgnoredAny = client
-            .post(
+        client
+            .post_without_response(
                 &format!("api/v1/app/{app_id}/endpoint/{endp_id}/secret/rotate/"),
                 serde_json::json!({ "key": null }),
                 StatusCode::NO_CONTENT,
@@ -1095,8 +1094,8 @@ async fn test_endpoint_rotate_signing_e2e() {
         .await
         .unwrap();
 
-    let _: IgnoredAny = client
-        .post(
+    client
+        .post_without_response(
             &format!("api/v1/app/{app_id}/endpoint/{}/secret/rotate/", endp.id),
             serde_json::json!({ "key": null }),
             StatusCode::NO_CONTENT,
@@ -1119,8 +1118,8 @@ async fn test_endpoint_rotate_signing_e2e() {
         .into_endpoint_secret(&Encryption::new_noop())
         .unwrap();
 
-    let _: IgnoredAny = client
-        .post(
+    client
+        .post_without_response(
             &format!("api/v1/app/{app_id}/endpoint/{}/secret/rotate/", endp.id),
             serde_json::json!({ "key": secret3_key }),
             StatusCode::NO_CONTENT,
@@ -1186,8 +1185,8 @@ async fn test_endpoint_rotate_signing_symmetric_and_asymmetric() {
         .unwrap();
 
     // Rotate to asmmetric
-    let _: IgnoredAny = client
-        .post(
+    client
+        .post_without_response(
             &format!("api/v1/app/{app_id}/endpoint/{}/secret/rotate/", endp.id),
             serde_json::json!({ "key": "whsk_6Xb/dCcHpPea21PS1N9VY/NZW723CEc77N4rJCubMbfVKIDij2HKpMKkioLlX0dRqSKJp4AJ6p9lMicMFs6Kvg==" }),
             StatusCode::NO_CONTENT,
@@ -1196,8 +1195,8 @@ async fn test_endpoint_rotate_signing_symmetric_and_asymmetric() {
         .unwrap();
 
     // Rotate back to symmetric
-    let _: IgnoredAny = client
-        .post(
+    client
+        .post_without_response(
             &format!("api/v1/app/{app_id}/endpoint/{}/secret/rotate/", endp.id),
             serde_json::json!({ "key": secret_3.serialize_public_key() }),
             StatusCode::NO_CONTENT,
@@ -1284,8 +1283,8 @@ async fn test_endpoint_secret_config() {
     assert!(key1.starts_with("whpk_"));
 
     // Rotate to asmmetric
-    let _: IgnoredAny = client
-        .post(
+    client
+        .post_without_response(
             &format!("api/v1/app/{app_id}/endpoint/{}/secret/rotate/", ep.id),
             serde_json::json!({ "key": null }),
             StatusCode::NO_CONTENT,
@@ -1343,8 +1342,8 @@ async fn test_custom_endpoint_secret() {
     let endp_3 = post_endpoint(&client, &app_id, ep_in.clone())
         .await
         .unwrap();
-    let _: IgnoredAny = client
-        .post(
+    client
+        .post_without_response(
             &format!("api/v1/app/{app_id}/endpoint/{}/secret/rotate/", endp_3.id),
             serde_json::json!({ "key": "whsk_6Xb/dCcHpPea21PS1N9VY/NZW723CEc77N4rJCubMbfVKIDij2HKpMKkioLlX0dRqSKJp4AJ6p9lMicMFs6Kvg==" }),
             StatusCode::NO_CONTENT,
@@ -1419,8 +1418,8 @@ async fn test_endpoint_secret_encryption() {
     assert_eq!(secret, secret2);
 
     // Generate a new encrypted secret
-    let _: IgnoredAny = client
-        .post(
+    client
+        .post_without_response(
             &format!("api/v1/app/{app_id}/endpoint/{}/secret/rotate/", ep.id),
             serde_json::json!({ "key": secret }),
             StatusCode::NO_CONTENT,
@@ -2099,8 +2098,8 @@ async fn test_endpoint_headers_manipulation() {
         ])),
     };
 
-    let _: IgnoredAny = client
-        .patch(
+    client
+        .patch_without_response(
             &format!("api/v1/app/{app_id}/endpoint/{}/headers/", endp.id),
             patched_headers_in,
             StatusCode::NO_CONTENT,
@@ -2158,8 +2157,8 @@ async fn test_endpoint_headers_manipulation() {
     };
 
     for hdrs in [&org_headers, &updated_headers] {
-        let _: IgnoredAny = client
-            .put(
+        client
+            .put_without_response(
                 &format!("api/v1/app/{app_id}/endpoint/{}/headers/", endp.id),
                 hdrs,
                 StatusCode::NO_CONTENT,
@@ -2185,8 +2184,8 @@ async fn test_endpoint_headers_manipulation() {
         ])),
     };
 
-    let _: IgnoredAny = client
-        .patch(
+    client
+        .patch_without_response(
             &format!("api/v1/app/{app_id}/endpoint/{}/headers/", endp.id),
             &patched_headers_in,
             StatusCode::NO_CONTENT,
@@ -2217,8 +2216,8 @@ async fn test_endpoint_headers_manipulation() {
         ])),
     };
 
-    let _: IgnoredAny = client
-        .put(
+    client
+        .put_without_response(
             &format!("api/v1/app/{app_id}/endpoint/{}/headers/", endp.id),
             redacted_headers,
             StatusCode::NO_CONTENT,
@@ -2264,8 +2263,8 @@ async fn test_endpoint_headers_sending() {
         ])),
     };
 
-    let _: IgnoredAny = client
-        .put(
+    client
+        .put_without_response(
             &format!("api/v1/app/{app_id}/endpoint/{}/headers/", endp.id),
             &headers,
             StatusCode::NO_CONTENT,
@@ -2303,8 +2302,8 @@ async fn test_endpoint_header_key_capitalization() {
         )])),
     };
 
-    let _: IgnoredAny = client
-        .put(
+    client
+        .put_without_response(
             &format!("api/v1/app/{app_id}/endpoint/{}/headers/", endp.id),
             &headers,
             StatusCode::NO_CONTENT,

--- a/server/svix-server/tests/it/e2e_health.rs
+++ b/server/svix-server/tests/it/e2e_health.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 use reqwest::StatusCode;
-use serde::de::IgnoredAny;
 
 use crate::utils::start_svix_server;
 
@@ -10,8 +9,8 @@ use crate::utils::start_svix_server;
 async fn ping_with_trailing_slash() {
     let (client, _jh) = start_svix_server().await;
 
-    let _: IgnoredAny = client
-        .get("api/v1/health/ping/", StatusCode::NO_CONTENT)
+    client
+        .get_without_response("api/v1/health/ping/", StatusCode::NO_CONTENT)
         .await
         .unwrap();
 }
@@ -20,8 +19,8 @@ async fn ping_with_trailing_slash() {
 async fn ping_without_trailing_slash() {
     let (client, _jh) = start_svix_server().await;
 
-    let _: IgnoredAny = client
-        .get("api/v1/health/ping", StatusCode::NO_CONTENT)
+    client
+        .get_without_response("api/v1/health/ping", StatusCode::NO_CONTENT)
         .await
         .unwrap();
 }

--- a/server/svix-server/tests/it/e2e_message.rs
+++ b/server/svix-server/tests/it/e2e_message.rs
@@ -4,7 +4,6 @@
 use chrono::{Duration, Utc};
 use reqwest::StatusCode;
 use sea_orm::{sea_query::Expr, ColumnTrait, EntityTrait, QueryFilter};
-use serde::de::IgnoredAny;
 use svix_server::{
     db::models::messagecontent,
     expired_message_cleaner,
@@ -455,7 +454,7 @@ async fn test_expunge_message_payload() {
         serde_json::to_string(&payload).unwrap()
     );
 
-    let _: IgnoredAny = client
+    client
         .delete(
             &format!("api/v1/app/{}/msg/{}/content/", &app_id, &msg.id),
             StatusCode::NO_CONTENT,

--- a/server/svix-server/tests/it/e2e_operational_webhooks.rs
+++ b/server/svix-server/tests/it/e2e_operational_webhooks.rs
@@ -6,7 +6,7 @@ use std::{net::TcpListener, sync::Arc, time::Duration};
 use chrono::{DateTime, Utc};
 use http::StatusCode;
 use reqwest::Url;
-use serde::{de::IgnoredAny, Deserialize};
+use serde::Deserialize;
 use svix::api::EventTypeOut;
 use svix_ksuid::KsuidLike;
 use svix_server::{
@@ -239,8 +239,8 @@ async fn test_endpoint_create_update_and_delete() {
     };
 
     // Rotate secrets
-    let _: IgnoredAny = client_regular
-        .post(
+    client_regular
+        .post_without_response(
             &format!(
                 "api/v1/app/{}/endpoint/{}/secret/rotate/",
                 regular_app.id, regular_endp.id
@@ -258,7 +258,7 @@ async fn test_endpoint_create_update_and_delete() {
     );
 
     // And finally delete the endpoint
-    let _: IgnoredAny = client_regular
+    client_regular
         .delete(
             &format!(
                 "api/v1/app/{}/endpoint/{}/",

--- a/server/svix-server/tests/it/message_app.rs
+++ b/server/svix-server/tests/it/message_app.rs
@@ -59,7 +59,7 @@ async fn test_app_deletion() {
     );
 
     client
-        .delete::<IgnoredAny>(&format!("api/v1/app/{app_id}/"), StatusCode::NO_CONTENT)
+        .delete(&format!("api/v1/app/{app_id}/"), StatusCode::NO_CONTENT)
         .await
         .unwrap();
 
@@ -136,7 +136,7 @@ async fn test_endp_deletion() {
     );
 
     client
-        .delete::<IgnoredAny>(
+        .delete(
             &format!("api/v1/app/{app_id}/endpoint/{endp_id}/"),
             StatusCode::NO_CONTENT,
         )

--- a/server/svix-server/tests/it/utils/common_calls.rs
+++ b/server/svix-server/tests/it/utils/common_calls.rs
@@ -46,7 +46,7 @@ pub async fn create_test_app(client: &TestClient, name: &str) -> Result<Applicat
         .await
 }
 
-pub async fn delete_test_app(client: &TestClient, id: ApplicationId) -> Result<IgnoredAny> {
+pub async fn delete_test_app(client: &TestClient, id: ApplicationId) -> Result<()> {
     client
         .delete(&format!("api/v1/app/{id}/"), StatusCode::NO_CONTENT)
         .await

--- a/server/svix-server/tests/it/utils/mod.rs
+++ b/server/svix-server/tests/it/utils/mod.rs
@@ -238,11 +238,7 @@ impl TestClient {
         Ok(())
     }
 
-    pub async fn delete<O: DeserializeOwned>(
-        &self,
-        endpoint: &str,
-        expected_code: StatusCode,
-    ) -> Result<O> {
+    pub async fn delete(&self, endpoint: &str, expected_code: StatusCode) -> Result<()> {
         let mut req = self.client.delete(self.build_uri(endpoint));
         req = self.add_headers(req);
 
@@ -256,9 +252,12 @@ impl TestClient {
             );
         }
 
-        resp.json()
-            .await
-            .context("error receiving/parsing response")
+        if expected_code == StatusCode::NO_CONTENT {
+            let res_body = resp.text().await.context("error receiving response")?;
+            anyhow::ensure!(res_body.is_empty());
+        }
+
+        Ok(())
     }
 
     pub async fn patch<I: Serialize, O: DeserializeOwned>(

--- a/server/svix-server/tests/it/utils/mod.rs
+++ b/server/svix-server/tests/it/utils/mod.rs
@@ -79,6 +79,30 @@ impl TestClient {
             .context("error receiving/parsing response")
     }
 
+    pub async fn get_without_response(
+        &self,
+        endpoint: &str,
+        expected_code: StatusCode,
+    ) -> Result<()> {
+        let mut req = self.client.get(self.build_uri(endpoint));
+        req = self.add_headers(req);
+
+        let resp = req.send().await.context("error sending request")?;
+
+        if resp.status() != expected_code {
+            anyhow::bail!(
+                "assertion failed: expected status {}, actual status {}",
+                expected_code,
+                resp.status()
+            );
+        }
+
+        let res_body = resp.text().await.context("error receiving response")?;
+        anyhow::ensure!(res_body.is_empty());
+
+        Ok(())
+    }
+
     pub async fn post<I: Serialize, O: DeserializeOwned>(
         &self,
         endpoint: &str,

--- a/server/svix-server/tests/it/utils/mod.rs
+++ b/server/svix-server/tests/it/utils/mod.rs
@@ -189,6 +189,31 @@ impl TestClient {
             .context("error receiving/parsing response")
     }
 
+    pub async fn put_without_response<I: Serialize>(
+        &self,
+        endpoint: &str,
+        input: I,
+        expected_code: StatusCode,
+    ) -> Result<()> {
+        let mut req = self.client.put(self.build_uri(endpoint));
+        req = self.add_headers(req).json(&input);
+
+        let resp = req.send().await.context("error sending request")?;
+
+        if resp.status() != expected_code {
+            anyhow::bail!(
+                "assertion failed: expected status {}, actual status {}",
+                expected_code,
+                resp.status()
+            );
+        }
+
+        let res_body = resp.text().await.context("error receiving response")?;
+        anyhow::ensure!(res_body.is_empty());
+
+        Ok(())
+    }
+
     pub async fn delete<O: DeserializeOwned>(
         &self,
         endpoint: &str,

--- a/server/svix-server/tests/it/utils/mod.rs
+++ b/server/svix-server/tests/it/utils/mod.rs
@@ -260,6 +260,31 @@ impl TestClient {
             .await
             .context("error receiving/parsing response")
     }
+
+    pub async fn patch_without_response<I: Serialize>(
+        &self,
+        endpoint: &str,
+        input: I,
+        expected_code: StatusCode,
+    ) -> Result<()> {
+        let mut req = self.client.patch(self.build_uri(endpoint));
+        req = self.add_headers(req).json(&input);
+
+        let resp = req.send().await.context("error sending request")?;
+
+        if resp.status() != expected_code {
+            anyhow::bail!(
+                "assertion failed: expected status {}, actual status {}",
+                expected_code,
+                resp.status()
+            );
+        }
+
+        let res_body = resp.text().await.context("error receiving response")?;
+        anyhow::ensure!(res_body.is_empty());
+
+        Ok(())
+    }
 }
 
 pub fn get_default_test_config() -> ConfigurationInner {


### PR DESCRIPTION
## Motivation

Our test script was broken :facepalm: 
A lot of tests were failing because they were asserting wrong things about server responses.
We didn't see it in CI because the script was missing `set -e`.

## Solution

Make it actually fail if a command other than the last one fails. Repair broken tests.