### PR TITLE
Add support for http proxies

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2101,6 +2101,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-proxy"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca815a891b24fdfb243fa3239c86154392b0953ee584aa1a2a1f66d20cbe75cc"
+dependencies = [
+ "bytes",
+ "futures",
+ "headers",
+ "http 0.2.12",
+ "hyper 0.14.28",
+ "openssl",
+ "tokio",
+ "tokio-openssl",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4857,6 +4874,7 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.28",
  "hyper-openssl",
+ "hyper-proxy",
  "hyper-socks2",
  "indexmap 1.9.3",
  "ipnet",

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -74,6 +74,9 @@ form_urlencoded = "1.1.0"
 lapin = "2.1.1"
 sentry = { version = "0.32.2", features = ["tracing"] }
 omniqueue = { git = "https://github.com/svix/omniqueue-rs", rev = "5ae22000e2ea214ba707cac81657f098e5785a76", default-features = false, features = ["in_memory", "rabbitmq-with-message-ids", "redis_cluster"] }
+# Not a well-known author, and no longer gets updates => pinned.
+# Switch to hyper-http-proxy when upgrading hyper to 1.0.
+hyper-proxy = { version = "=0.9.1", default-features = false, features = ["openssl-tls"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.5", optional = true }

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -7,7 +7,6 @@ use figment::{
     providers::{Env, Format, Toml},
     Figment,
 };
-use http::uri::InvalidUri;
 use ipnet::IpNet;
 use serde::{Deserialize, Deserializer};
 use tracing::Level;
@@ -199,28 +198,36 @@ pub struct ConfigurationInner {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct ProxyConfig {
-    /// SOCKS5 proxy address.
+    /// Proxy address.
     ///
-    /// More proxy types may be supported in the future.
+    /// Currently supported proxy types are:
+    /// - `socks5://`, i.e. a SOCKS5 proxy, with domain name resolution being
+    ///   done before the proxy gets involved
+    /// - `http://` or `https://` proxy, sending HTTP requests to the proxy;
+    ///   both HTTP and HTTPS targets are supported
     #[serde(rename = "proxy_addr")]
     pub addr: ProxyAddr,
 }
 
 #[derive(Clone, Debug)]
-pub struct ProxyAddr {
-    parsed: http::Uri,
+pub enum ProxyAddr {
+    /// A SOCKS5 proxy.
+    Socks5(http::Uri),
+    /// An HTTP / HTTPs proxy.
+    Http(http::Uri),
 }
 
 impl ProxyAddr {
-    pub fn new(raw: impl AsRef<str>) -> Result<Self, InvalidUri> {
-        let parsed = raw.as_ref().parse()?;
-        Ok(Self { parsed })
-    }
-}
-
-impl From<ProxyAddr> for http::Uri {
-    fn from(value: ProxyAddr) -> Self {
-        value.parsed
+    pub fn new(raw: impl Into<String>) -> Result<Self, Box<dyn std::error::Error>> {
+        let raw = raw.into();
+        let parsed: http::Uri = raw.parse()?;
+        match parsed.scheme_str().unwrap_or("") {
+            "socks5" => Ok(Self::Socks5(parsed)),
+            "http" | "https" => Ok(Self::Http(parsed)),
+            _ => Err("Unsupported proxy scheme. \
+                Supported schemes are `socks5://`, `http://` and `https://`."
+                .into()),
+        }
     }
 }
 
@@ -510,7 +517,7 @@ mod tests {
         figment::Jail::expect_with(|jail| {
             jail.set_env("SVIX_QUEUE_TYPE", "memory");
             jail.set_env("SVIX_JWT_SECRET", "x");
-            jail.set_env("SVIX_PROXY_ADDR", "x");
+            jail.set_env("SVIX_PROXY_ADDR", "socks5://127.0.0.1");
 
             let cfg = load().unwrap();
             assert!(cfg.proxy_config.is_some());

--- a/server/svix-server/src/worker.rs
+++ b/server/svix-server/src/worker.rs
@@ -901,7 +901,7 @@ pub async fn queue_handler(
         cfg.whitelist_subnets.clone(),
         Some(Arc::new(vec!["backend".to_owned()])),
         cfg.dangerous_disable_tls_verification,
-        cfg.proxy_config.clone(),
+        cfg.proxy_config.as_ref(),
     );
 
     tokio::spawn(

--- a/server/svix-server/tests/it/e2e_proxy.rs
+++ b/server/svix-server/tests/it/e2e_proxy.rs
@@ -17,21 +17,38 @@ async fn test_message_delivery_via_socks5() {
     use crate::utils::start_svix_server_with_cfg;
 
     let mut cfg = get_default_test_config();
-    cfg.proxy_config = Some(proxy_config());
+    cfg.proxy_config = Some(socks_proxy_config());
     let (client, _) = start_svix_server_with_cfg(&cfg).await;
-    run_socks5_test(&client).await;
+    run_proxy_test(&client).await;
 }
 
-fn proxy_config() -> ProxyConfig {
+fn socks_proxy_config() -> ProxyConfig {
     ProxyConfig {
         addr: ProxyAddr::new("socks5://localhost:1080").unwrap(),
     }
 }
 
-async fn run_socks5_test(client: &TestClient) {
+#[ignore] // requires an http proxy to be running
+#[tokio::test]
+async fn test_message_delivery_via_http_proxy() {
+    use crate::utils::start_svix_server_with_cfg;
+
+    let mut cfg = get_default_test_config();
+    cfg.proxy_config = Some(http_proxy_config());
+    let (client, _) = start_svix_server_with_cfg(&cfg).await;
+    run_proxy_test(&client).await;
+}
+
+fn http_proxy_config() -> ProxyConfig {
+    ProxyConfig {
+        addr: ProxyAddr::new("http://localhost:8888").unwrap(),
+    }
+}
+
+async fn run_proxy_test(client: &TestClient) {
     let mut receiver = TestReceiver::start(StatusCode::OK);
 
-    let app_id = create_test_app(client, "kafkaSinkTest").await.unwrap().id;
+    let app_id = create_test_app(client, "proxyTest").await.unwrap().id;
     create_test_endpoint(client, &app_id, &receiver.endpoint)
         .await
         .unwrap();


### PR DESCRIPTION
Adds support for HTTP(S) proxies, in addition to SOCKS5 proxies that we've been supporting for a little while.

Closes https://github.com/svix/monorepo-private/issues/8990.