### PR TITLE
Server: include JWT secret in the docker compose example.

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       WAIT_FOR: "true"  # We want to wait for the default services
       SVIX_REDIS_DSN: "redis://redis:6379"
       SVIX_DB_DSN: "postgresql://postgres:postgres@pgbouncer/postgres"
+      # SVIX_JWT_SECRET: "x"  # IMPORTANT: uncomment and set a real JWT secret here.
     ports:
       - "8071:8071"
     depends_on:


### PR DESCRIPTION
This docker compose is not really an example per se, but it's being used as a reference one. So it's better to have it include the last missing piece for starting the server, which is setting the JWT secret.
