### PR TITLE
server: Fix flaky attempt test

### DIFF
--- a/server/svix-server/tests/it/e2e_attempt.rs
+++ b/server/svix-server/tests/it/e2e_attempt.rs
@@ -56,7 +56,9 @@ async fn test_expunge_attempt_response_body() {
             )
             .await
             .unwrap();
-        assert_eq!(1, attempts.data.len());
+        if attempts.data.len() != 1 {
+            anyhow::bail!("list len {}, not 1", attempts.data.len());
+        }
         Ok(attempts.data[0].clone())
     })
     .await


### PR DESCRIPTION
## Motivation

We have a flaky message-attempt test. Nobody likes flaky tests.

## Solution

Make sure the retrying in the test actually happens if first attempt at getting message attempts fails.