### PR TITLE
server: Make figment-jailed tests run sequentially

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -4026,6 +4026,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c947adb109a8afce5fc9c7bf951f87f146e9147b3a6a58413105628fb1d1e66"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4087,6 +4096,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a7b59a5d9b0099720b417b6325d91a52cbf5b3dcb5041d864be53eefa58abc"
 
 [[package]]
 name = "sea-bae"
@@ -4412,6 +4427,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4b487fe2acf240a021cf57c6b2b4903b1e78ca0ecd862a71b71d2a51fed77d"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -4899,6 +4939,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
+ "serial_test",
  "sqlx",
  "svix",
  "svix-ksuid 0.5.3",

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -87,6 +87,7 @@ assert_matches = "1.5.0"
 # NOTE: Purposely not the latest version such as not to mess up the `hyper` fork patch
 axum-server = { version = "0.5", features = ["tls-openssl"] }
 ctor = "0.2.7"
+serial_test = "3.1.1"
 
 [features]
 default = ["jemalloc"]

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -458,11 +458,13 @@ mod tests {
         providers::{Format as _, Toml},
         Figment,
     };
+    use serial_test::serial;
 
     use super::{load, CacheBackend, CacheType, QueueBackend, QueueType};
     use crate::core::security::{JWTAlgorithm, JwtSigningConfig};
 
     #[test]
+    #[serial]
     fn test_retry_schedule_parsing() {
         figment::Jail::expect_with(|jail| {
             jail.set_env("SVIX_JWT_SECRET", "x");
@@ -493,6 +495,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_retry_schedule_parsing_legacy() {
         figment::Jail::expect_with(|jail| {
             jail.set_env("SVIX_JWT_SECRET", "x");
@@ -513,6 +516,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_proxy_addr_from_env_parsing() {
         figment::Jail::expect_with(|jail| {
             jail.set_env("SVIX_QUEUE_TYPE", "memory");


### PR DESCRIPTION
## Motivation

figment's Jail does not actually isolate environments, it only stores the initial environment state and restores it after the test. This means that multiple tests using `jail.set_env` can break each other.

## Solution

Make these tests run sequentially.