### PR TITLE
Fix issue with Python client version 1.34 - AttributeError: 'dict' object has no attribute 'to_dict'

### DIFF
--- a/python/svix/api.py
+++ b/python/svix/api.py
@@ -1074,7 +1074,7 @@ class MessageAsync(ApiBase):
             with_content=False,
             **options.to_dict(),
         )
-        ret.payload = MessageOutPayload.from_dict(message_in.payload.to_dict())
+        ret.payload = MessageOutPayload.from_dict(message_in.payload)
         return ret
 
     async def get(self, app_id: str, msg_id: str) -> MessageOut:
@@ -1112,7 +1112,7 @@ class Message(ApiBase):
             with_content=False,
             **options.to_dict(),
         )
-        ret.payload = MessageOutPayload.from_dict(message_in.payload.to_dict())
+        ret.payload = MessageOutPayload.from_dict(message_in.payload)
         return ret
 
     def get(self, app_id: str, msg_id: str) -> MessageOut:


### PR DESCRIPTION
We run Svix in production and when we upgraded to the 1.34 version we started seeing the error:

```
AttributeError: 'dict' object has no attribute 'to_dict'
```

This PR aims to fix the issue - I think `payload` is already a dict when `to_dict` is called.

Thank you!