### PR TITLE
Revert changes to Python code generation

### DIFF
--- a/python/svix/api.py
+++ b/python/svix/api.py
@@ -1074,7 +1074,7 @@ class MessageAsync(ApiBase):
             with_content=False,
             **options.to_dict(),
         )
-        ret.payload = MessageOutPayload.from_dict(message_in.payload.to_dict())
+        ret.payload = message_in.payload
         return ret
 
     async def get(self, app_id: str, msg_id: str) -> MessageOut:
@@ -1112,7 +1112,7 @@ class Message(ApiBase):
             with_content=False,
             **options.to_dict(),
         )
-        ret.payload = MessageOutPayload.from_dict(message_in.payload.to_dict())
+        ret.payload = message_in.payload
         return ret
 
     def get(self, app_id: str, msg_id: str) -> MessageOut:

--- a/python/templates/model.py.jinja
+++ b/python/templates/model.py.jinja
@@ -1,5 +1,5 @@
 {% set class_name = model.class_info.name %}
-{% if model.required_properties == [] and model.optional_properties == [] and False %}
+{% if model.required_properties == [] and model.optional_properties == [] %}
 from typing import Any, Dict, Type, TypeVar
 
 T = TypeVar("T", bound="{{ class_name }}")


### PR DESCRIPTION
## Motivation

The Python library had a pretty significant breaking change. See #1440.

## Solution

Revert the Python codegen changes from #1423.