### PR TITLE
Libs(Go): edit `EndpointIn` to allow null for channels, filter types

### DIFF
--- a/go/endpoint_test.go
+++ b/go/endpoint_test.go
@@ -1,0 +1,76 @@
+package svix_test
+
+import (
+	"encoding/json"
+	svix "github.com/svix/svix-webhooks/go"
+	"strings"
+	"testing"
+)
+
+func TestEndpoint_Serialization(t *testing.T) {
+	testCases := []struct {
+		name            string
+		testEndpoint    *svix.EndpointIn
+		wantChannels    bool
+		wantFilterTypes bool
+	}{
+		{
+			name: "neither channels or filter types",
+			testEndpoint: &svix.EndpointIn{
+				Url: "https://example.svix.com/",
+			},
+			wantChannels:    false,
+			wantFilterTypes: false,
+		},
+		{
+			name: "channels but not filter types",
+			testEndpoint: &svix.EndpointIn{
+				Url:      "https://example.svix.com/",
+				Channels: &[]string{"ch1", "ch2"},
+			},
+			wantChannels:    true,
+			wantFilterTypes: false,
+		},
+		{
+			name: "filter types but not channels",
+			testEndpoint: &svix.EndpointIn{
+				Url:         "https://example.svix.com/",
+				FilterTypes: &[]string{"et1", "et2"},
+			},
+			wantChannels:    false,
+			wantFilterTypes: true,
+		},
+		{
+			name: "both channels and filter types",
+			testEndpoint: &svix.EndpointIn{
+				Url:         "https://example.svix.com/",
+				Channels:    &[]string{"ch1", "ch2"},
+				FilterTypes: &[]string{"et1", "et2"},
+			},
+			wantChannels:    true,
+			wantFilterTypes: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		b, _ := json.Marshal(tc.testEndpoint)
+		s := string(b)
+
+		gotChannels := strings.Contains(s, "channels")
+		gotFilterTypes := strings.Contains(s, "filterTypes")
+
+		if tc.wantChannels && !gotChannels {
+			t.Errorf("case `%s`: expected EndpointIn to have a channels field", tc.name)
+		}
+		if !tc.wantChannels && gotChannels {
+			t.Errorf("case `%s`: expected EndpointIn to NOT have a channels field", tc.name)
+		}
+
+		if tc.wantFilterTypes && !gotFilterTypes {
+			t.Errorf("case `%s`: expected EndpointIn to have a filterTypes field", tc.name)
+		}
+		if !tc.wantFilterTypes && gotFilterTypes {
+			t.Errorf("case `%s`: expected EndpointIn to NOT have a filterTypes field", tc.name)
+		}
+	}
+}

--- a/go/internal/openapi/model_endpoint_in.go
+++ b/go/internal/openapi/model_endpoint_in.go
@@ -17,10 +17,10 @@ import (
 // EndpointIn struct for EndpointIn
 type EndpointIn struct {
 	// List of message channels this endpoint listens to (omit for all)
-	Channels []string `json:"channels,omitempty"`
+	Channels *[]string `json:"channels,omitempty"`
 	Description *string `json:"description,omitempty"`
 	Disabled *bool `json:"disabled,omitempty"`
-	FilterTypes []string `json:"filterTypes,omitempty"`
+	FilterTypes *[]string `json:"filterTypes,omitempty"`
 	Metadata *map[string]string `json:"metadata,omitempty"`
 	RateLimit NullableInt32 `json:"rateLimit,omitempty"`
 	// The endpoint's verification secret. If `null` is passed, a secret is automatically generated. Format: `base64` encoded random bytes optionally prefixed with `whsec_`. Recommended size: 24.
@@ -63,11 +63,11 @@ func NewEndpointInWithDefaults() *EndpointIn {
 
 // GetChannels returns the Channels field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EndpointIn) GetChannels() []string {
-	if o == nil  {
+	if o == nil || o.Channels == nil {
 		var ret []string
 		return ret
 	}
-	return o.Channels
+	return *o.Channels
 }
 
 // GetChannelsOk returns a tuple with the Channels field value if set, nil otherwise
@@ -77,7 +77,7 @@ func (o *EndpointIn) GetChannelsOk() (*[]string, bool) {
 	if o == nil || o.Channels == nil {
 		return nil, false
 	}
-	return &o.Channels, true
+	return o.Channels, true
 }
 
 // HasChannels returns a boolean if a field has been set.
@@ -91,7 +91,7 @@ func (o *EndpointIn) HasChannels() bool {
 
 // SetChannels gets a reference to the given []string and assigns it to the Channels field.
 func (o *EndpointIn) SetChannels(v []string) {
-	o.Channels = v
+	o.Channels = &v
 }
 
 // GetDescription returns the Description field value if set, zero value otherwise.
@@ -160,11 +160,11 @@ func (o *EndpointIn) SetDisabled(v bool) {
 
 // GetFilterTypes returns the FilterTypes field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EndpointIn) GetFilterTypes() []string {
-	if o == nil  {
+	if o == nil || o.FilterTypes == nil {
 		var ret []string
 		return ret
 	}
-	return o.FilterTypes
+	return *o.FilterTypes
 }
 
 // GetFilterTypesOk returns a tuple with the FilterTypes field value if set, nil otherwise
@@ -174,7 +174,7 @@ func (o *EndpointIn) GetFilterTypesOk() (*[]string, bool) {
 	if o == nil || o.FilterTypes == nil {
 		return nil, false
 	}
-	return &o.FilterTypes, true
+	return o.FilterTypes, true
 }
 
 // HasFilterTypes returns a boolean if a field has been set.
@@ -188,7 +188,7 @@ func (o *EndpointIn) HasFilterTypes() bool {
 
 // SetFilterTypes gets a reference to the given []string and assigns it to the FilterTypes field.
 func (o *EndpointIn) SetFilterTypes(v []string) {
-	o.FilterTypes = v
+	o.FilterTypes = &v
 }
 
 // GetMetadata returns the Metadata field value if set, zero value otherwise.


### PR DESCRIPTION
This is a stop-gap "quick fix" to allow callers to successfully create endpoints without specifying channels and filter types.

Today, they get a 422 response when passing an empty array (as required by our lib).

With this diff, the fields are set to pointers so they can be properly nulled out, as they were prior to #545.

Research required to see what we need to do so the codegen does the right thing given the spec (which produces good output for the other libs).