### PR TITLE
Libs(Go): template overrides for nullable non-required containers

### DIFF
--- a/go/internal/openapi/model_app_usage_stats_in.go
+++ b/go/internal/openapi/model_app_usage_stats_in.go
@@ -17,7 +17,7 @@ import (
 
 // AppUsageStatsIn struct for AppUsageStatsIn
 type AppUsageStatsIn struct {
-	AppIds []string `json:"appIds,omitempty"`
+	AppIds *[]string `json:"appIds,omitempty"`
 	Since time.Time `json:"since"`
 	Until time.Time `json:"until"`
 }
@@ -43,11 +43,11 @@ func NewAppUsageStatsInWithDefaults() *AppUsageStatsIn {
 
 // GetAppIds returns the AppIds field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *AppUsageStatsIn) GetAppIds() []string {
-	if o == nil  {
+	if o == nil || o.AppIds == nil {
 		var ret []string
 		return ret
 	}
-	return o.AppIds
+	return *o.AppIds
 }
 
 // GetAppIdsOk returns a tuple with the AppIds field value if set, nil otherwise
@@ -57,7 +57,7 @@ func (o *AppUsageStatsIn) GetAppIdsOk() (*[]string, bool) {
 	if o == nil || o.AppIds == nil {
 		return nil, false
 	}
-	return &o.AppIds, true
+	return o.AppIds, true
 }
 
 // HasAppIds returns a boolean if a field has been set.
@@ -71,7 +71,7 @@ func (o *AppUsageStatsIn) HasAppIds() bool {
 
 // SetAppIds gets a reference to the given []string and assigns it to the AppIds field.
 func (o *AppUsageStatsIn) SetAppIds(v []string) {
-	o.AppIds = v
+	o.AppIds = &v
 }
 
 // GetSince returns the Since field value

--- a/go/internal/openapi/model_attempt_statistics_data.go
+++ b/go/internal/openapi/model_attempt_statistics_data.go
@@ -16,8 +16,8 @@ import (
 
 // AttemptStatisticsData struct for AttemptStatisticsData
 type AttemptStatisticsData struct {
-	FailureCount []int32 `json:"failureCount,omitempty"`
-	SuccessCount []int32 `json:"successCount,omitempty"`
+	FailureCount *[]int32 `json:"failureCount,omitempty"`
+	SuccessCount *[]int32 `json:"successCount,omitempty"`
 }
 
 // NewAttemptStatisticsData instantiates a new AttemptStatisticsData object
@@ -39,11 +39,11 @@ func NewAttemptStatisticsDataWithDefaults() *AttemptStatisticsData {
 
 // GetFailureCount returns the FailureCount field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *AttemptStatisticsData) GetFailureCount() []int32 {
-	if o == nil  {
+	if o == nil || o.FailureCount == nil {
 		var ret []int32
 		return ret
 	}
-	return o.FailureCount
+	return *o.FailureCount
 }
 
 // GetFailureCountOk returns a tuple with the FailureCount field value if set, nil otherwise
@@ -53,7 +53,7 @@ func (o *AttemptStatisticsData) GetFailureCountOk() (*[]int32, bool) {
 	if o == nil || o.FailureCount == nil {
 		return nil, false
 	}
-	return &o.FailureCount, true
+	return o.FailureCount, true
 }
 
 // HasFailureCount returns a boolean if a field has been set.
@@ -67,16 +67,16 @@ func (o *AttemptStatisticsData) HasFailureCount() bool {
 
 // SetFailureCount gets a reference to the given []int32 and assigns it to the FailureCount field.
 func (o *AttemptStatisticsData) SetFailureCount(v []int32) {
-	o.FailureCount = v
+	o.FailureCount = &v
 }
 
 // GetSuccessCount returns the SuccessCount field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *AttemptStatisticsData) GetSuccessCount() []int32 {
-	if o == nil  {
+	if o == nil || o.SuccessCount == nil {
 		var ret []int32
 		return ret
 	}
-	return o.SuccessCount
+	return *o.SuccessCount
 }
 
 // GetSuccessCountOk returns a tuple with the SuccessCount field value if set, nil otherwise
@@ -86,7 +86,7 @@ func (o *AttemptStatisticsData) GetSuccessCountOk() (*[]int32, bool) {
 	if o == nil || o.SuccessCount == nil {
 		return nil, false
 	}
-	return &o.SuccessCount, true
+	return o.SuccessCount, true
 }
 
 // HasSuccessCount returns a boolean if a field has been set.
@@ -100,7 +100,7 @@ func (o *AttemptStatisticsData) HasSuccessCount() bool {
 
 // SetSuccessCount gets a reference to the given []int32 and assigns it to the SuccessCount field.
 func (o *AttemptStatisticsData) SetSuccessCount(v []int32) {
-	o.SuccessCount = v
+	o.SuccessCount = &v
 }
 
 func (o AttemptStatisticsData) MarshalJSON() ([]byte, error) {

--- a/go/internal/openapi/model_auth_token_out.go
+++ b/go/internal/openapi/model_auth_token_out.go
@@ -22,7 +22,7 @@ type AuthTokenOut struct {
 	// The key's ID
 	Id string `json:"id"`
 	Name NullableString `json:"name,omitempty"`
-	Scopes []string `json:"scopes,omitempty"`
+	Scopes *[]string `json:"scopes,omitempty"`
 	Token string `json:"token"`
 }
 
@@ -180,11 +180,11 @@ func (o *AuthTokenOut) UnsetName() {
 
 // GetScopes returns the Scopes field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *AuthTokenOut) GetScopes() []string {
-	if o == nil  {
+	if o == nil || o.Scopes == nil {
 		var ret []string
 		return ret
 	}
-	return o.Scopes
+	return *o.Scopes
 }
 
 // GetScopesOk returns a tuple with the Scopes field value if set, nil otherwise
@@ -194,7 +194,7 @@ func (o *AuthTokenOut) GetScopesOk() (*[]string, bool) {
 	if o == nil || o.Scopes == nil {
 		return nil, false
 	}
-	return &o.Scopes, true
+	return o.Scopes, true
 }
 
 // HasScopes returns a boolean if a field has been set.
@@ -208,7 +208,7 @@ func (o *AuthTokenOut) HasScopes() bool {
 
 // SetScopes gets a reference to the given []string and assigns it to the Scopes field.
 func (o *AuthTokenOut) SetScopes(v []string) {
-	o.Scopes = v
+	o.Scopes = &v
 }
 
 // GetToken returns the Token field value

--- a/go/internal/openapi/model_endpoint_message_out.go
+++ b/go/internal/openapi/model_endpoint_message_out.go
@@ -18,7 +18,7 @@ import (
 // EndpointMessageOut A model containing information on a given message plus additional fields on the last attempt for that message.
 type EndpointMessageOut struct {
 	// List of free-form identifiers that endpoints can filter by
-	Channels []string `json:"channels,omitempty"`
+	Channels *[]string `json:"channels,omitempty"`
 	// Optional unique identifier for the message
 	EventId NullableString `json:"eventId,omitempty"`
 	// The event type's name
@@ -28,7 +28,7 @@ type EndpointMessageOut struct {
 	NextAttempt NullableTime `json:"nextAttempt,omitempty"`
 	Payload map[string]interface{} `json:"payload"`
 	Status MessageStatus `json:"status"`
-	Tags []string `json:"tags,omitempty"`
+	Tags *[]string `json:"tags,omitempty"`
 	Timestamp time.Time `json:"timestamp"`
 }
 
@@ -56,11 +56,11 @@ func NewEndpointMessageOutWithDefaults() *EndpointMessageOut {
 
 // GetChannels returns the Channels field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EndpointMessageOut) GetChannels() []string {
-	if o == nil  {
+	if o == nil || o.Channels == nil {
 		var ret []string
 		return ret
 	}
-	return o.Channels
+	return *o.Channels
 }
 
 // GetChannelsOk returns a tuple with the Channels field value if set, nil otherwise
@@ -70,7 +70,7 @@ func (o *EndpointMessageOut) GetChannelsOk() (*[]string, bool) {
 	if o == nil || o.Channels == nil {
 		return nil, false
 	}
-	return &o.Channels, true
+	return o.Channels, true
 }
 
 // HasChannels returns a boolean if a field has been set.
@@ -84,7 +84,7 @@ func (o *EndpointMessageOut) HasChannels() bool {
 
 // SetChannels gets a reference to the given []string and assigns it to the Channels field.
 func (o *EndpointMessageOut) SetChannels(v []string) {
-	o.Channels = v
+	o.Channels = &v
 }
 
 // GetEventId returns the EventId field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -269,11 +269,11 @@ func (o *EndpointMessageOut) SetStatus(v MessageStatus) {
 
 // GetTags returns the Tags field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EndpointMessageOut) GetTags() []string {
-	if o == nil  {
+	if o == nil || o.Tags == nil {
 		var ret []string
 		return ret
 	}
-	return o.Tags
+	return *o.Tags
 }
 
 // GetTagsOk returns a tuple with the Tags field value if set, nil otherwise
@@ -283,7 +283,7 @@ func (o *EndpointMessageOut) GetTagsOk() (*[]string, bool) {
 	if o == nil || o.Tags == nil {
 		return nil, false
 	}
-	return &o.Tags, true
+	return o.Tags, true
 }
 
 // HasTags returns a boolean if a field has been set.
@@ -297,7 +297,7 @@ func (o *EndpointMessageOut) HasTags() bool {
 
 // SetTags gets a reference to the given []string and assigns it to the Tags field.
 func (o *EndpointMessageOut) SetTags(v []string) {
-	o.Tags = v
+	o.Tags = &v
 }
 
 // GetTimestamp returns the Timestamp field value

--- a/go/internal/openapi/model_endpoint_oauth_config_in.go
+++ b/go/internal/openapi/model_endpoint_oauth_config_in.go
@@ -22,13 +22,13 @@ type EndpointOauthConfigIn struct {
 	// Optional client secret. This is only used for `clientSecretBasic` and `clientSecretPost`.  For `clientSecretBasic`, the secret will be appended to the `Authorization` header. For `clientSecretPost`, this will be added to the body in a `client_secret` parameter.
 	ClientSecret NullableString `json:"clientSecret,omitempty"`
 	// Extra parameters added to the request body as key-value pairs.
-	ExtraParams map[string]string `json:"extraParams,omitempty"`
+	ExtraParams *map[string]string `json:"extraParams,omitempty"`
 	GrantType Oauth2GrantTypeIn `json:"grantType"`
 	JwtParams *ClientSecretJwtParamsIn `json:"jwtParams,omitempty"`
 	// For `refreshToken` grant type
 	RefreshToken NullableString `json:"refreshToken,omitempty"`
 	// Optional OAuth scopes added to the request body.
-	Scopes []string `json:"scopes,omitempty"`
+	Scopes *[]string `json:"scopes,omitempty"`
 	// The URL of the authorization server.
 	TokenUrl string `json:"tokenUrl"`
 }
@@ -146,11 +146,11 @@ func (o *EndpointOauthConfigIn) UnsetClientSecret() {
 
 // GetExtraParams returns the ExtraParams field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EndpointOauthConfigIn) GetExtraParams() map[string]string {
-	if o == nil  {
+	if o == nil || o.ExtraParams == nil {
 		var ret map[string]string
 		return ret
 	}
-	return o.ExtraParams
+	return *o.ExtraParams
 }
 
 // GetExtraParamsOk returns a tuple with the ExtraParams field value if set, nil otherwise
@@ -160,7 +160,7 @@ func (o *EndpointOauthConfigIn) GetExtraParamsOk() (*map[string]string, bool) {
 	if o == nil || o.ExtraParams == nil {
 		return nil, false
 	}
-	return &o.ExtraParams, true
+	return o.ExtraParams, true
 }
 
 // HasExtraParams returns a boolean if a field has been set.
@@ -174,7 +174,7 @@ func (o *EndpointOauthConfigIn) HasExtraParams() bool {
 
 // SetExtraParams gets a reference to the given map[string]string and assigns it to the ExtraParams field.
 func (o *EndpointOauthConfigIn) SetExtraParams(v map[string]string) {
-	o.ExtraParams = v
+	o.ExtraParams = &v
 }
 
 // GetGrantType returns the GrantType field value
@@ -277,11 +277,11 @@ func (o *EndpointOauthConfigIn) UnsetRefreshToken() {
 
 // GetScopes returns the Scopes field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EndpointOauthConfigIn) GetScopes() []string {
-	if o == nil  {
+	if o == nil || o.Scopes == nil {
 		var ret []string
 		return ret
 	}
-	return o.Scopes
+	return *o.Scopes
 }
 
 // GetScopesOk returns a tuple with the Scopes field value if set, nil otherwise
@@ -291,7 +291,7 @@ func (o *EndpointOauthConfigIn) GetScopesOk() (*[]string, bool) {
 	if o == nil || o.Scopes == nil {
 		return nil, false
 	}
-	return &o.Scopes, true
+	return o.Scopes, true
 }
 
 // HasScopes returns a boolean if a field has been set.
@@ -305,7 +305,7 @@ func (o *EndpointOauthConfigIn) HasScopes() bool {
 
 // SetScopes gets a reference to the given []string and assigns it to the Scopes field.
 func (o *EndpointOauthConfigIn) SetScopes(v []string) {
-	o.Scopes = v
+	o.Scopes = &v
 }
 
 // GetTokenUrl returns the TokenUrl field value

--- a/go/internal/openapi/model_endpoint_out.go
+++ b/go/internal/openapi/model_endpoint_out.go
@@ -18,12 +18,12 @@ import (
 // EndpointOut struct for EndpointOut
 type EndpointOut struct {
 	// List of message channels this endpoint listens to (omit for all)
-	Channels []string `json:"channels,omitempty"`
+	Channels *[]string `json:"channels,omitempty"`
 	CreatedAt time.Time `json:"createdAt"`
 	// An example endpoint name
 	Description string `json:"description"`
 	Disabled *bool `json:"disabled,omitempty"`
-	FilterTypes []string `json:"filterTypes,omitempty"`
+	FilterTypes *[]string `json:"filterTypes,omitempty"`
 	// The ep's ID
 	Id string `json:"id"`
 	Metadata map[string]string `json:"metadata"`
@@ -65,11 +65,11 @@ func NewEndpointOutWithDefaults() *EndpointOut {
 
 // GetChannels returns the Channels field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EndpointOut) GetChannels() []string {
-	if o == nil  {
+	if o == nil || o.Channels == nil {
 		var ret []string
 		return ret
 	}
-	return o.Channels
+	return *o.Channels
 }
 
 // GetChannelsOk returns a tuple with the Channels field value if set, nil otherwise
@@ -79,7 +79,7 @@ func (o *EndpointOut) GetChannelsOk() (*[]string, bool) {
 	if o == nil || o.Channels == nil {
 		return nil, false
 	}
-	return &o.Channels, true
+	return o.Channels, true
 }
 
 // HasChannels returns a boolean if a field has been set.
@@ -93,7 +93,7 @@ func (o *EndpointOut) HasChannels() bool {
 
 // SetChannels gets a reference to the given []string and assigns it to the Channels field.
 func (o *EndpointOut) SetChannels(v []string) {
-	o.Channels = v
+	o.Channels = &v
 }
 
 // GetCreatedAt returns the CreatedAt field value
@@ -178,11 +178,11 @@ func (o *EndpointOut) SetDisabled(v bool) {
 
 // GetFilterTypes returns the FilterTypes field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EndpointOut) GetFilterTypes() []string {
-	if o == nil  {
+	if o == nil || o.FilterTypes == nil {
 		var ret []string
 		return ret
 	}
-	return o.FilterTypes
+	return *o.FilterTypes
 }
 
 // GetFilterTypesOk returns a tuple with the FilterTypes field value if set, nil otherwise
@@ -192,7 +192,7 @@ func (o *EndpointOut) GetFilterTypesOk() (*[]string, bool) {
 	if o == nil || o.FilterTypes == nil {
 		return nil, false
 	}
-	return &o.FilterTypes, true
+	return o.FilterTypes, true
 }
 
 // HasFilterTypes returns a boolean if a field has been set.
@@ -206,7 +206,7 @@ func (o *EndpointOut) HasFilterTypes() bool {
 
 // SetFilterTypes gets a reference to the given []string and assigns it to the FilterTypes field.
 func (o *EndpointOut) SetFilterTypes(v []string) {
-	o.FilterTypes = v
+	o.FilterTypes = &v
 }
 
 // GetId returns the Id field value

--- a/go/internal/openapi/model_endpoint_transformation_simulate_in.go
+++ b/go/internal/openapi/model_endpoint_transformation_simulate_in.go
@@ -16,7 +16,7 @@ import (
 
 // EndpointTransformationSimulateIn struct for EndpointTransformationSimulateIn
 type EndpointTransformationSimulateIn struct {
-	Channels []string `json:"channels,omitempty"`
+	Channels *[]string `json:"channels,omitempty"`
 	Code string `json:"code"`
 	// The event type's name
 	EventType string `json:"eventType"`
@@ -45,11 +45,11 @@ func NewEndpointTransformationSimulateInWithDefaults() *EndpointTransformationSi
 
 // GetChannels returns the Channels field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EndpointTransformationSimulateIn) GetChannels() []string {
-	if o == nil  {
+	if o == nil || o.Channels == nil {
 		var ret []string
 		return ret
 	}
-	return o.Channels
+	return *o.Channels
 }
 
 // GetChannelsOk returns a tuple with the Channels field value if set, nil otherwise
@@ -59,7 +59,7 @@ func (o *EndpointTransformationSimulateIn) GetChannelsOk() (*[]string, bool) {
 	if o == nil || o.Channels == nil {
 		return nil, false
 	}
-	return &o.Channels, true
+	return o.Channels, true
 }
 
 // HasChannels returns a boolean if a field has been set.
@@ -73,7 +73,7 @@ func (o *EndpointTransformationSimulateIn) HasChannels() bool {
 
 // SetChannels gets a reference to the given []string and assigns it to the Channels field.
 func (o *EndpointTransformationSimulateIn) SetChannels(v []string) {
-	o.Channels = v
+	o.Channels = &v
 }
 
 // GetCode returns the Code field value

--- a/go/internal/openapi/model_environment_in.go
+++ b/go/internal/openapi/model_environment_in.go
@@ -18,7 +18,7 @@ import (
 // EnvironmentIn struct for EnvironmentIn
 type EnvironmentIn struct {
 	CreatedAt time.Time `json:"createdAt"`
-	EventTypes []EventTypeIn `json:"eventTypes,omitempty"`
+	EventTypes *[]EventTypeIn `json:"eventTypes,omitempty"`
 	Settings *SettingsIn `json:"settings,omitempty"`
 	Version int32 `json:"version"`
 }
@@ -68,11 +68,11 @@ func (o *EnvironmentIn) SetCreatedAt(v time.Time) {
 
 // GetEventTypes returns the EventTypes field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EnvironmentIn) GetEventTypes() []EventTypeIn {
-	if o == nil  {
+	if o == nil || o.EventTypes == nil {
 		var ret []EventTypeIn
 		return ret
 	}
-	return o.EventTypes
+	return *o.EventTypes
 }
 
 // GetEventTypesOk returns a tuple with the EventTypes field value if set, nil otherwise
@@ -82,7 +82,7 @@ func (o *EnvironmentIn) GetEventTypesOk() (*[]EventTypeIn, bool) {
 	if o == nil || o.EventTypes == nil {
 		return nil, false
 	}
-	return &o.EventTypes, true
+	return o.EventTypes, true
 }
 
 // HasEventTypes returns a boolean if a field has been set.
@@ -96,7 +96,7 @@ func (o *EnvironmentIn) HasEventTypes() bool {
 
 // SetEventTypes gets a reference to the given []EventTypeIn and assigns it to the EventTypes field.
 func (o *EnvironmentIn) SetEventTypes(v []EventTypeIn) {
-	o.EventTypes = v
+	o.EventTypes = &v
 }
 
 // GetSettings returns the Settings field value if set, zero value otherwise.

--- a/go/internal/openapi/model_event_type_from_open_api.go
+++ b/go/internal/openapi/model_event_type_from_open_api.go
@@ -20,7 +20,7 @@ type EventTypeFromOpenApi struct {
 	Description string `json:"description"`
 	// The event type's name
 	Name string `json:"name"`
-	Schemas map[string]map[string]interface{} `json:"schemas,omitempty"`
+	Schemas *map[string]map[string]interface{} `json:"schemas,omitempty"`
 }
 
 // NewEventTypeFromOpenApi instantiates a new EventTypeFromOpenApi object
@@ -117,11 +117,11 @@ func (o *EventTypeFromOpenApi) SetName(v string) {
 
 // GetSchemas returns the Schemas field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EventTypeFromOpenApi) GetSchemas() map[string]map[string]interface{} {
-	if o == nil  {
+	if o == nil || o.Schemas == nil {
 		var ret map[string]map[string]interface{}
 		return ret
 	}
-	return o.Schemas
+	return *o.Schemas
 }
 
 // GetSchemasOk returns a tuple with the Schemas field value if set, nil otherwise
@@ -131,7 +131,7 @@ func (o *EventTypeFromOpenApi) GetSchemasOk() (*map[string]map[string]interface{
 	if o == nil || o.Schemas == nil {
 		return nil, false
 	}
-	return &o.Schemas, true
+	return o.Schemas, true
 }
 
 // HasSchemas returns a boolean if a field has been set.
@@ -145,7 +145,7 @@ func (o *EventTypeFromOpenApi) HasSchemas() bool {
 
 // SetSchemas gets a reference to the given map[string]map[string]interface{} and assigns it to the Schemas field.
 func (o *EventTypeFromOpenApi) SetSchemas(v map[string]map[string]interface{}) {
-	o.Schemas = v
+	o.Schemas = &v
 }
 
 func (o EventTypeFromOpenApi) MarshalJSON() ([]byte, error) {

--- a/go/internal/openapi/model_event_type_import_open_api_in.go
+++ b/go/internal/openapi/model_event_type_import_open_api_in.go
@@ -19,7 +19,7 @@ type EventTypeImportOpenApiIn struct {
 	// If `true`, return the event types that would be modified without actually modifying them.
 	DryRun *bool `json:"dry_run,omitempty"`
 	// A pre-parsed JSON spec.
-	Spec map[string]map[string]interface{} `json:"spec,omitempty"`
+	Spec *map[string]map[string]interface{} `json:"spec,omitempty"`
 	// A string, parsed by the server as YAML or JSON.
 	SpecRaw NullableString `json:"specRaw,omitempty"`
 }
@@ -79,11 +79,11 @@ func (o *EventTypeImportOpenApiIn) SetDryRun(v bool) {
 
 // GetSpec returns the Spec field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EventTypeImportOpenApiIn) GetSpec() map[string]map[string]interface{} {
-	if o == nil  {
+	if o == nil || o.Spec == nil {
 		var ret map[string]map[string]interface{}
 		return ret
 	}
-	return o.Spec
+	return *o.Spec
 }
 
 // GetSpecOk returns a tuple with the Spec field value if set, nil otherwise
@@ -93,7 +93,7 @@ func (o *EventTypeImportOpenApiIn) GetSpecOk() (*map[string]map[string]interface
 	if o == nil || o.Spec == nil {
 		return nil, false
 	}
-	return &o.Spec, true
+	return o.Spec, true
 }
 
 // HasSpec returns a boolean if a field has been set.
@@ -107,7 +107,7 @@ func (o *EventTypeImportOpenApiIn) HasSpec() bool {
 
 // SetSpec gets a reference to the given map[string]map[string]interface{} and assigns it to the Spec field.
 func (o *EventTypeImportOpenApiIn) SetSpec(v map[string]map[string]interface{}) {
-	o.Spec = v
+	o.Spec = &v
 }
 
 // GetSpecRaw returns the SpecRaw field value if set, zero value otherwise (both if not set or set to explicit null).

--- a/go/internal/openapi/model_event_type_import_open_api_out_data.go
+++ b/go/internal/openapi/model_event_type_import_open_api_out_data.go
@@ -17,7 +17,7 @@ import (
 // EventTypeImportOpenApiOutData struct for EventTypeImportOpenApiOutData
 type EventTypeImportOpenApiOutData struct {
 	Modified []string `json:"modified"`
-	ToModify []EventTypeFromOpenApi `json:"to_modify,omitempty"`
+	ToModify *[]EventTypeFromOpenApi `json:"to_modify,omitempty"`
 }
 
 // NewEventTypeImportOpenApiOutData instantiates a new EventTypeImportOpenApiOutData object
@@ -64,11 +64,11 @@ func (o *EventTypeImportOpenApiOutData) SetModified(v []string) {
 
 // GetToModify returns the ToModify field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EventTypeImportOpenApiOutData) GetToModify() []EventTypeFromOpenApi {
-	if o == nil  {
+	if o == nil || o.ToModify == nil {
 		var ret []EventTypeFromOpenApi
 		return ret
 	}
-	return o.ToModify
+	return *o.ToModify
 }
 
 // GetToModifyOk returns a tuple with the ToModify field value if set, nil otherwise
@@ -78,7 +78,7 @@ func (o *EventTypeImportOpenApiOutData) GetToModifyOk() (*[]EventTypeFromOpenApi
 	if o == nil || o.ToModify == nil {
 		return nil, false
 	}
-	return &o.ToModify, true
+	return o.ToModify, true
 }
 
 // HasToModify returns a boolean if a field has been set.
@@ -92,7 +92,7 @@ func (o *EventTypeImportOpenApiOutData) HasToModify() bool {
 
 // SetToModify gets a reference to the given []EventTypeFromOpenApi and assigns it to the ToModify field.
 func (o *EventTypeImportOpenApiOutData) SetToModify(v []EventTypeFromOpenApi) {
-	o.ToModify = v
+	o.ToModify = &v
 }
 
 func (o EventTypeImportOpenApiOutData) MarshalJSON() ([]byte, error) {

--- a/go/internal/openapi/model_event_type_in.go
+++ b/go/internal/openapi/model_event_type_in.go
@@ -25,7 +25,7 @@ type EventTypeIn struct {
 	// The event type's name
 	Name string `json:"name"`
 	// The schema for the event type for a specific version as a JSON schema.
-	Schemas map[string]map[string]interface{} `json:"schemas,omitempty"`
+	Schemas *map[string]map[string]interface{} `json:"schemas,omitempty"`
 }
 
 // NewEventTypeIn instantiates a new EventTypeIn object
@@ -253,11 +253,11 @@ func (o *EventTypeIn) SetName(v string) {
 
 // GetSchemas returns the Schemas field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EventTypeIn) GetSchemas() map[string]map[string]interface{} {
-	if o == nil  {
+	if o == nil || o.Schemas == nil {
 		var ret map[string]map[string]interface{}
 		return ret
 	}
-	return o.Schemas
+	return *o.Schemas
 }
 
 // GetSchemasOk returns a tuple with the Schemas field value if set, nil otherwise
@@ -267,7 +267,7 @@ func (o *EventTypeIn) GetSchemasOk() (*map[string]map[string]interface{}, bool) 
 	if o == nil || o.Schemas == nil {
 		return nil, false
 	}
-	return &o.Schemas, true
+	return o.Schemas, true
 }
 
 // HasSchemas returns a boolean if a field has been set.
@@ -281,7 +281,7 @@ func (o *EventTypeIn) HasSchemas() bool {
 
 // SetSchemas gets a reference to the given map[string]map[string]interface{} and assigns it to the Schemas field.
 func (o *EventTypeIn) SetSchemas(v map[string]map[string]interface{}) {
-	o.Schemas = v
+	o.Schemas = &v
 }
 
 func (o EventTypeIn) MarshalJSON() ([]byte, error) {

--- a/go/internal/openapi/model_event_type_out.go
+++ b/go/internal/openapi/model_event_type_out.go
@@ -27,7 +27,7 @@ type EventTypeOut struct {
 	// The event type's name
 	Name string `json:"name"`
 	// The schema for the event type for a specific version as a JSON schema.
-	Schemas map[string]map[string]interface{} `json:"schemas,omitempty"`
+	Schemas *map[string]map[string]interface{} `json:"schemas,omitempty"`
 	UpdatedAt time.Time `json:"updatedAt"`
 }
 
@@ -271,11 +271,11 @@ func (o *EventTypeOut) SetName(v string) {
 
 // GetSchemas returns the Schemas field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EventTypeOut) GetSchemas() map[string]map[string]interface{} {
-	if o == nil  {
+	if o == nil || o.Schemas == nil {
 		var ret map[string]map[string]interface{}
 		return ret
 	}
-	return o.Schemas
+	return *o.Schemas
 }
 
 // GetSchemasOk returns a tuple with the Schemas field value if set, nil otherwise
@@ -285,7 +285,7 @@ func (o *EventTypeOut) GetSchemasOk() (*map[string]map[string]interface{}, bool)
 	if o == nil || o.Schemas == nil {
 		return nil, false
 	}
-	return &o.Schemas, true
+	return o.Schemas, true
 }
 
 // HasSchemas returns a boolean if a field has been set.
@@ -299,7 +299,7 @@ func (o *EventTypeOut) HasSchemas() bool {
 
 // SetSchemas gets a reference to the given map[string]map[string]interface{} and assigns it to the Schemas field.
 func (o *EventTypeOut) SetSchemas(v map[string]map[string]interface{}) {
-	o.Schemas = v
+	o.Schemas = &v
 }
 
 // GetUpdatedAt returns the UpdatedAt field value

--- a/go/internal/openapi/model_event_type_patch.go
+++ b/go/internal/openapi/model_event_type_patch.go
@@ -22,7 +22,7 @@ type EventTypePatch struct {
 	FeatureFlag NullableString `json:"featureFlag,omitempty"`
 	// The event type group's name
 	GroupName NullableString `json:"groupName,omitempty"`
-	Schemas map[string]map[string]interface{} `json:"schemas,omitempty"`
+	Schemas *map[string]map[string]interface{} `json:"schemas,omitempty"`
 }
 
 // NewEventTypePatch instantiates a new EventTypePatch object
@@ -224,11 +224,11 @@ func (o *EventTypePatch) UnsetGroupName() {
 
 // GetSchemas returns the Schemas field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EventTypePatch) GetSchemas() map[string]map[string]interface{} {
-	if o == nil  {
+	if o == nil || o.Schemas == nil {
 		var ret map[string]map[string]interface{}
 		return ret
 	}
-	return o.Schemas
+	return *o.Schemas
 }
 
 // GetSchemasOk returns a tuple with the Schemas field value if set, nil otherwise
@@ -238,7 +238,7 @@ func (o *EventTypePatch) GetSchemasOk() (*map[string]map[string]interface{}, boo
 	if o == nil || o.Schemas == nil {
 		return nil, false
 	}
-	return &o.Schemas, true
+	return o.Schemas, true
 }
 
 // HasSchemas returns a boolean if a field has been set.
@@ -252,7 +252,7 @@ func (o *EventTypePatch) HasSchemas() bool {
 
 // SetSchemas gets a reference to the given map[string]map[string]interface{} and assigns it to the Schemas field.
 func (o *EventTypePatch) SetSchemas(v map[string]map[string]interface{}) {
-	o.Schemas = v
+	o.Schemas = &v
 }
 
 func (o EventTypePatch) MarshalJSON() ([]byte, error) {

--- a/go/internal/openapi/model_event_type_update.go
+++ b/go/internal/openapi/model_event_type_update.go
@@ -23,7 +23,7 @@ type EventTypeUpdate struct {
 	// The event type group's name
 	GroupName NullableString `json:"groupName,omitempty"`
 	// The schema for the event type for a specific version as a JSON schema.
-	Schemas map[string]map[string]interface{} `json:"schemas,omitempty"`
+	Schemas *map[string]map[string]interface{} `json:"schemas,omitempty"`
 }
 
 // NewEventTypeUpdate instantiates a new EventTypeUpdate object
@@ -226,11 +226,11 @@ func (o *EventTypeUpdate) UnsetGroupName() {
 
 // GetSchemas returns the Schemas field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EventTypeUpdate) GetSchemas() map[string]map[string]interface{} {
-	if o == nil  {
+	if o == nil || o.Schemas == nil {
 		var ret map[string]map[string]interface{}
 		return ret
 	}
-	return o.Schemas
+	return *o.Schemas
 }
 
 // GetSchemasOk returns a tuple with the Schemas field value if set, nil otherwise
@@ -240,7 +240,7 @@ func (o *EventTypeUpdate) GetSchemasOk() (*map[string]map[string]interface{}, bo
 	if o == nil || o.Schemas == nil {
 		return nil, false
 	}
-	return &o.Schemas, true
+	return o.Schemas, true
 }
 
 // HasSchemas returns a boolean if a field has been set.
@@ -254,7 +254,7 @@ func (o *EventTypeUpdate) HasSchemas() bool {
 
 // SetSchemas gets a reference to the given map[string]map[string]interface{} and assigns it to the Schemas field.
 func (o *EventTypeUpdate) SetSchemas(v map[string]map[string]interface{}) {
-	o.Schemas = v
+	o.Schemas = &v
 }
 
 func (o EventTypeUpdate) MarshalJSON() ([]byte, error) {

--- a/go/internal/openapi/model_message_attempt_headers_out.go
+++ b/go/internal/openapi/model_message_attempt_headers_out.go
@@ -16,7 +16,7 @@ import (
 
 // MessageAttemptHeadersOut struct for MessageAttemptHeadersOut
 type MessageAttemptHeadersOut struct {
-	ResponseHeaders [][]string `json:"responseHeaders,omitempty"`
+	ResponseHeaders *[][]string `json:"responseHeaders,omitempty"`
 	Sensitive []string `json:"sensitive"`
 	SentHeaders map[string]string `json:"sentHeaders"`
 }
@@ -42,11 +42,11 @@ func NewMessageAttemptHeadersOutWithDefaults() *MessageAttemptHeadersOut {
 
 // GetResponseHeaders returns the ResponseHeaders field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *MessageAttemptHeadersOut) GetResponseHeaders() [][]string {
-	if o == nil  {
+	if o == nil || o.ResponseHeaders == nil {
 		var ret [][]string
 		return ret
 	}
-	return o.ResponseHeaders
+	return *o.ResponseHeaders
 }
 
 // GetResponseHeadersOk returns a tuple with the ResponseHeaders field value if set, nil otherwise
@@ -56,7 +56,7 @@ func (o *MessageAttemptHeadersOut) GetResponseHeadersOk() (*[][]string, bool) {
 	if o == nil || o.ResponseHeaders == nil {
 		return nil, false
 	}
-	return &o.ResponseHeaders, true
+	return o.ResponseHeaders, true
 }
 
 // HasResponseHeaders returns a boolean if a field has been set.
@@ -70,7 +70,7 @@ func (o *MessageAttemptHeadersOut) HasResponseHeaders() bool {
 
 // SetResponseHeaders gets a reference to the given [][]string and assigns it to the ResponseHeaders field.
 func (o *MessageAttemptHeadersOut) SetResponseHeaders(v [][]string) {
-	o.ResponseHeaders = v
+	o.ResponseHeaders = &v
 }
 
 // GetSensitive returns the Sensitive field value

--- a/go/internal/openapi/model_message_broadcast_in.go
+++ b/go/internal/openapi/model_message_broadcast_in.go
@@ -17,7 +17,7 @@ import (
 // MessageBroadcastIn struct for MessageBroadcastIn
 type MessageBroadcastIn struct {
 	// List of free-form identifiers that endpoints can filter by
-	Channels []string `json:"channels,omitempty"`
+	Channels *[]string `json:"channels,omitempty"`
 	// Optional unique identifier for the message
 	EventId NullableString `json:"eventId,omitempty"`
 	// The event type's name
@@ -54,11 +54,11 @@ func NewMessageBroadcastInWithDefaults() *MessageBroadcastIn {
 
 // GetChannels returns the Channels field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *MessageBroadcastIn) GetChannels() []string {
-	if o == nil  {
+	if o == nil || o.Channels == nil {
 		var ret []string
 		return ret
 	}
-	return o.Channels
+	return *o.Channels
 }
 
 // GetChannelsOk returns a tuple with the Channels field value if set, nil otherwise
@@ -68,7 +68,7 @@ func (o *MessageBroadcastIn) GetChannelsOk() (*[]string, bool) {
 	if o == nil || o.Channels == nil {
 		return nil, false
 	}
-	return &o.Channels, true
+	return o.Channels, true
 }
 
 // HasChannels returns a boolean if a field has been set.
@@ -82,7 +82,7 @@ func (o *MessageBroadcastIn) HasChannels() bool {
 
 // SetChannels gets a reference to the given []string and assigns it to the Channels field.
 func (o *MessageBroadcastIn) SetChannels(v []string) {
-	o.Channels = v
+	o.Channels = &v
 }
 
 // GetEventId returns the EventId field value if set, zero value otherwise (both if not set or set to explicit null).

--- a/go/internal/openapi/model_message_endpoint_out.go
+++ b/go/internal/openapi/model_message_endpoint_out.go
@@ -18,12 +18,12 @@ import (
 // MessageEndpointOut struct for MessageEndpointOut
 type MessageEndpointOut struct {
 	// List of message channels this endpoint listens to (omit for all)
-	Channels []string `json:"channels,omitempty"`
+	Channels *[]string `json:"channels,omitempty"`
 	CreatedAt time.Time `json:"createdAt"`
 	// An example endpoint name
 	Description string `json:"description"`
 	Disabled *bool `json:"disabled,omitempty"`
-	FilterTypes []string `json:"filterTypes,omitempty"`
+	FilterTypes *[]string `json:"filterTypes,omitempty"`
 	// The ep's ID
 	Id string `json:"id"`
 	NextAttempt NullableTime `json:"nextAttempt,omitempty"`
@@ -66,11 +66,11 @@ func NewMessageEndpointOutWithDefaults() *MessageEndpointOut {
 
 // GetChannels returns the Channels field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *MessageEndpointOut) GetChannels() []string {
-	if o == nil  {
+	if o == nil || o.Channels == nil {
 		var ret []string
 		return ret
 	}
-	return o.Channels
+	return *o.Channels
 }
 
 // GetChannelsOk returns a tuple with the Channels field value if set, nil otherwise
@@ -80,7 +80,7 @@ func (o *MessageEndpointOut) GetChannelsOk() (*[]string, bool) {
 	if o == nil || o.Channels == nil {
 		return nil, false
 	}
-	return &o.Channels, true
+	return o.Channels, true
 }
 
 // HasChannels returns a boolean if a field has been set.
@@ -94,7 +94,7 @@ func (o *MessageEndpointOut) HasChannels() bool {
 
 // SetChannels gets a reference to the given []string and assigns it to the Channels field.
 func (o *MessageEndpointOut) SetChannels(v []string) {
-	o.Channels = v
+	o.Channels = &v
 }
 
 // GetCreatedAt returns the CreatedAt field value
@@ -179,11 +179,11 @@ func (o *MessageEndpointOut) SetDisabled(v bool) {
 
 // GetFilterTypes returns the FilterTypes field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *MessageEndpointOut) GetFilterTypes() []string {
-	if o == nil  {
+	if o == nil || o.FilterTypes == nil {
 		var ret []string
 		return ret
 	}
-	return o.FilterTypes
+	return *o.FilterTypes
 }
 
 // GetFilterTypesOk returns a tuple with the FilterTypes field value if set, nil otherwise
@@ -193,7 +193,7 @@ func (o *MessageEndpointOut) GetFilterTypesOk() (*[]string, bool) {
 	if o == nil || o.FilterTypes == nil {
 		return nil, false
 	}
-	return &o.FilterTypes, true
+	return o.FilterTypes, true
 }
 
 // HasFilterTypes returns a boolean if a field has been set.
@@ -207,7 +207,7 @@ func (o *MessageEndpointOut) HasFilterTypes() bool {
 
 // SetFilterTypes gets a reference to the given []string and assigns it to the FilterTypes field.
 func (o *MessageEndpointOut) SetFilterTypes(v []string) {
-	o.FilterTypes = v
+	o.FilterTypes = &v
 }
 
 // GetId returns the Id field value

--- a/go/internal/openapi/model_message_in.go
+++ b/go/internal/openapi/model_message_in.go
@@ -18,7 +18,7 @@ import (
 type MessageIn struct {
 	Application *ApplicationIn `json:"application,omitempty"`
 	// List of free-form identifiers that endpoints can filter by
-	Channels []string `json:"channels,omitempty"`
+	Channels *[]string `json:"channels,omitempty"`
 	// Optional unique identifier for the message
 	EventId NullableString `json:"eventId,omitempty"`
 	// The event type's name
@@ -30,9 +30,9 @@ type MessageIn struct {
 	// Optional number of days to retain the message payload. Defaults to 90. Note that this is mutually exclusive with `payloadRetentionHours`.
 	PayloadRetentionPeriod NullableInt64 `json:"payloadRetentionPeriod,omitempty"`
 	// List of free-form tags that can be filtered by when listing messages
-	Tags []string `json:"tags,omitempty"`
+	Tags *[]string `json:"tags,omitempty"`
 	// Extra parameters to pass to Transformations (for future use)
-	TransformationsParams map[string]interface{} `json:"transformationsParams,omitempty"`
+	TransformationsParams *map[string]interface{} `json:"transformationsParams,omitempty"`
 }
 
 // NewMessageIn instantiates a new MessageIn object
@@ -92,11 +92,11 @@ func (o *MessageIn) SetApplication(v ApplicationIn) {
 
 // GetChannels returns the Channels field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *MessageIn) GetChannels() []string {
-	if o == nil  {
+	if o == nil || o.Channels == nil {
 		var ret []string
 		return ret
 	}
-	return o.Channels
+	return *o.Channels
 }
 
 // GetChannelsOk returns a tuple with the Channels field value if set, nil otherwise
@@ -106,7 +106,7 @@ func (o *MessageIn) GetChannelsOk() (*[]string, bool) {
 	if o == nil || o.Channels == nil {
 		return nil, false
 	}
-	return &o.Channels, true
+	return o.Channels, true
 }
 
 // HasChannels returns a boolean if a field has been set.
@@ -120,7 +120,7 @@ func (o *MessageIn) HasChannels() bool {
 
 // SetChannels gets a reference to the given []string and assigns it to the Channels field.
 func (o *MessageIn) SetChannels(v []string) {
-	o.Channels = v
+	o.Channels = &v
 }
 
 // GetEventId returns the EventId field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -299,11 +299,11 @@ func (o *MessageIn) UnsetPayloadRetentionPeriod() {
 
 // GetTags returns the Tags field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *MessageIn) GetTags() []string {
-	if o == nil  {
+	if o == nil || o.Tags == nil {
 		var ret []string
 		return ret
 	}
-	return o.Tags
+	return *o.Tags
 }
 
 // GetTagsOk returns a tuple with the Tags field value if set, nil otherwise
@@ -313,7 +313,7 @@ func (o *MessageIn) GetTagsOk() (*[]string, bool) {
 	if o == nil || o.Tags == nil {
 		return nil, false
 	}
-	return &o.Tags, true
+	return o.Tags, true
 }
 
 // HasTags returns a boolean if a field has been set.
@@ -327,16 +327,16 @@ func (o *MessageIn) HasTags() bool {
 
 // SetTags gets a reference to the given []string and assigns it to the Tags field.
 func (o *MessageIn) SetTags(v []string) {
-	o.Tags = v
+	o.Tags = &v
 }
 
 // GetTransformationsParams returns the TransformationsParams field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *MessageIn) GetTransformationsParams() map[string]interface{} {
-	if o == nil  {
+	if o == nil || o.TransformationsParams == nil {
 		var ret map[string]interface{}
 		return ret
 	}
-	return o.TransformationsParams
+	return *o.TransformationsParams
 }
 
 // GetTransformationsParamsOk returns a tuple with the TransformationsParams field value if set, nil otherwise
@@ -346,7 +346,7 @@ func (o *MessageIn) GetTransformationsParamsOk() (*map[string]interface{}, bool)
 	if o == nil || o.TransformationsParams == nil {
 		return nil, false
 	}
-	return &o.TransformationsParams, true
+	return o.TransformationsParams, true
 }
 
 // HasTransformationsParams returns a boolean if a field has been set.
@@ -360,7 +360,7 @@ func (o *MessageIn) HasTransformationsParams() bool {
 
 // SetTransformationsParams gets a reference to the given map[string]interface{} and assigns it to the TransformationsParams field.
 func (o *MessageIn) SetTransformationsParams(v map[string]interface{}) {
-	o.TransformationsParams = v
+	o.TransformationsParams = &v
 }
 
 func (o MessageIn) MarshalJSON() ([]byte, error) {

--- a/go/internal/openapi/model_message_out.go
+++ b/go/internal/openapi/model_message_out.go
@@ -18,7 +18,7 @@ import (
 // MessageOut struct for MessageOut
 type MessageOut struct {
 	// List of free-form identifiers that endpoints can filter by
-	Channels []string `json:"channels,omitempty"`
+	Channels *[]string `json:"channels,omitempty"`
 	// Optional unique identifier for the message
 	EventId NullableString `json:"eventId,omitempty"`
 	// The event type's name
@@ -26,7 +26,7 @@ type MessageOut struct {
 	// The msg's ID
 	Id string `json:"id"`
 	Payload map[string]interface{} `json:"payload"`
-	Tags []string `json:"tags,omitempty"`
+	Tags *[]string `json:"tags,omitempty"`
 	Timestamp time.Time `json:"timestamp"`
 }
 
@@ -53,11 +53,11 @@ func NewMessageOutWithDefaults() *MessageOut {
 
 // GetChannels returns the Channels field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *MessageOut) GetChannels() []string {
-	if o == nil  {
+	if o == nil || o.Channels == nil {
 		var ret []string
 		return ret
 	}
-	return o.Channels
+	return *o.Channels
 }
 
 // GetChannelsOk returns a tuple with the Channels field value if set, nil otherwise
@@ -67,7 +67,7 @@ func (o *MessageOut) GetChannelsOk() (*[]string, bool) {
 	if o == nil || o.Channels == nil {
 		return nil, false
 	}
-	return &o.Channels, true
+	return o.Channels, true
 }
 
 // HasChannels returns a boolean if a field has been set.
@@ -81,7 +81,7 @@ func (o *MessageOut) HasChannels() bool {
 
 // SetChannels gets a reference to the given []string and assigns it to the Channels field.
 func (o *MessageOut) SetChannels(v []string) {
-	o.Channels = v
+	o.Channels = &v
 }
 
 // GetEventId returns the EventId field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -200,11 +200,11 @@ func (o *MessageOut) SetPayload(v map[string]interface{}) {
 
 // GetTags returns the Tags field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *MessageOut) GetTags() []string {
-	if o == nil  {
+	if o == nil || o.Tags == nil {
 		var ret []string
 		return ret
 	}
-	return o.Tags
+	return *o.Tags
 }
 
 // GetTagsOk returns a tuple with the Tags field value if set, nil otherwise
@@ -214,7 +214,7 @@ func (o *MessageOut) GetTagsOk() (*[]string, bool) {
 	if o == nil || o.Tags == nil {
 		return nil, false
 	}
-	return &o.Tags, true
+	return o.Tags, true
 }
 
 // HasTags returns a boolean if a field has been set.
@@ -228,7 +228,7 @@ func (o *MessageOut) HasTags() bool {
 
 // SetTags gets a reference to the given []string and assigns it to the Tags field.
 func (o *MessageOut) SetTags(v []string) {
-	o.Tags = v
+	o.Tags = &v
 }
 
 // GetTimestamp returns the Timestamp field value

--- a/go/internal/openapi/model_template_in.go
+++ b/go/internal/openapi/model_template_in.go
@@ -18,7 +18,7 @@ import (
 type TemplateIn struct {
 	Description *string `json:"description,omitempty"`
 	FeatureFlag NullableString `json:"featureFlag,omitempty"`
-	FilterTypes []string `json:"filterTypes,omitempty"`
+	FilterTypes *[]string `json:"filterTypes,omitempty"`
 	Instructions *string `json:"instructions,omitempty"`
 	InstructionsLink NullableString `json:"instructionsLink,omitempty"`
 	Kind *TransformationTemplateKind `json:"kind,omitempty"`
@@ -135,11 +135,11 @@ func (o *TemplateIn) UnsetFeatureFlag() {
 
 // GetFilterTypes returns the FilterTypes field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *TemplateIn) GetFilterTypes() []string {
-	if o == nil  {
+	if o == nil || o.FilterTypes == nil {
 		var ret []string
 		return ret
 	}
-	return o.FilterTypes
+	return *o.FilterTypes
 }
 
 // GetFilterTypesOk returns a tuple with the FilterTypes field value if set, nil otherwise
@@ -149,7 +149,7 @@ func (o *TemplateIn) GetFilterTypesOk() (*[]string, bool) {
 	if o == nil || o.FilterTypes == nil {
 		return nil, false
 	}
-	return &o.FilterTypes, true
+	return o.FilterTypes, true
 }
 
 // HasFilterTypes returns a boolean if a field has been set.
@@ -163,7 +163,7 @@ func (o *TemplateIn) HasFilterTypes() bool {
 
 // SetFilterTypes gets a reference to the given []string and assigns it to the FilterTypes field.
 func (o *TemplateIn) SetFilterTypes(v []string) {
-	o.FilterTypes = v
+	o.FilterTypes = &v
 }
 
 // GetInstructions returns the Instructions field value if set, zero value otherwise.

--- a/go/internal/openapi/model_template_out.go
+++ b/go/internal/openapi/model_template_out.go
@@ -20,7 +20,7 @@ type TemplateOut struct {
 	CreatedAt time.Time `json:"createdAt"`
 	Description string `json:"description"`
 	FeatureFlag NullableString `json:"featureFlag,omitempty"`
-	FilterTypes []string `json:"filterTypes,omitempty"`
+	FilterTypes *[]string `json:"filterTypes,omitempty"`
 	Id string `json:"id"`
 	Instructions string `json:"instructions"`
 	InstructionsLink NullableString `json:"instructionsLink,omitempty"`
@@ -151,11 +151,11 @@ func (o *TemplateOut) UnsetFeatureFlag() {
 
 // GetFilterTypes returns the FilterTypes field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *TemplateOut) GetFilterTypes() []string {
-	if o == nil  {
+	if o == nil || o.FilterTypes == nil {
 		var ret []string
 		return ret
 	}
-	return o.FilterTypes
+	return *o.FilterTypes
 }
 
 // GetFilterTypesOk returns a tuple with the FilterTypes field value if set, nil otherwise
@@ -165,7 +165,7 @@ func (o *TemplateOut) GetFilterTypesOk() (*[]string, bool) {
 	if o == nil || o.FilterTypes == nil {
 		return nil, false
 	}
-	return &o.FilterTypes, true
+	return o.FilterTypes, true
 }
 
 // HasFilterTypes returns a boolean if a field has been set.
@@ -179,7 +179,7 @@ func (o *TemplateOut) HasFilterTypes() bool {
 
 // SetFilterTypes gets a reference to the given []string and assigns it to the FilterTypes field.
 func (o *TemplateOut) SetFilterTypes(v []string) {
-	o.FilterTypes = v
+	o.FilterTypes = &v
 }
 
 // GetId returns the Id field value

--- a/go/internal/openapi/model_template_patch.go
+++ b/go/internal/openapi/model_template_patch.go
@@ -18,7 +18,7 @@ import (
 type TemplatePatch struct {
 	Description *string `json:"description,omitempty"`
 	FeatureFlag NullableString `json:"featureFlag,omitempty"`
-	FilterTypes []string `json:"filterTypes,omitempty"`
+	FilterTypes *[]string `json:"filterTypes,omitempty"`
 	Instructions *string `json:"instructions,omitempty"`
 	InstructionsLink NullableString `json:"instructionsLink,omitempty"`
 	Kind *TransformationTemplateKind `json:"kind,omitempty"`
@@ -120,11 +120,11 @@ func (o *TemplatePatch) UnsetFeatureFlag() {
 
 // GetFilterTypes returns the FilterTypes field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *TemplatePatch) GetFilterTypes() []string {
-	if o == nil  {
+	if o == nil || o.FilterTypes == nil {
 		var ret []string
 		return ret
 	}
-	return o.FilterTypes
+	return *o.FilterTypes
 }
 
 // GetFilterTypesOk returns a tuple with the FilterTypes field value if set, nil otherwise
@@ -134,7 +134,7 @@ func (o *TemplatePatch) GetFilterTypesOk() (*[]string, bool) {
 	if o == nil || o.FilterTypes == nil {
 		return nil, false
 	}
-	return &o.FilterTypes, true
+	return o.FilterTypes, true
 }
 
 // HasFilterTypes returns a boolean if a field has been set.
@@ -148,7 +148,7 @@ func (o *TemplatePatch) HasFilterTypes() bool {
 
 // SetFilterTypes gets a reference to the given []string and assigns it to the FilterTypes field.
 func (o *TemplatePatch) SetFilterTypes(v []string) {
-	o.FilterTypes = v
+	o.FilterTypes = &v
 }
 
 // GetInstructions returns the Instructions field value if set, zero value otherwise.

--- a/go/internal/openapi/model_template_update.go
+++ b/go/internal/openapi/model_template_update.go
@@ -18,7 +18,7 @@ import (
 type TemplateUpdate struct {
 	Description *string `json:"description,omitempty"`
 	FeatureFlag NullableString `json:"featureFlag,omitempty"`
-	FilterTypes []string `json:"filterTypes,omitempty"`
+	FilterTypes *[]string `json:"filterTypes,omitempty"`
 	Instructions *string `json:"instructions,omitempty"`
 	InstructionsLink NullableString `json:"instructionsLink,omitempty"`
 	Kind *TransformationTemplateKind `json:"kind,omitempty"`
@@ -134,11 +134,11 @@ func (o *TemplateUpdate) UnsetFeatureFlag() {
 
 // GetFilterTypes returns the FilterTypes field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *TemplateUpdate) GetFilterTypes() []string {
-	if o == nil  {
+	if o == nil || o.FilterTypes == nil {
 		var ret []string
 		return ret
 	}
-	return o.FilterTypes
+	return *o.FilterTypes
 }
 
 // GetFilterTypesOk returns a tuple with the FilterTypes field value if set, nil otherwise
@@ -148,7 +148,7 @@ func (o *TemplateUpdate) GetFilterTypesOk() (*[]string, bool) {
 	if o == nil || o.FilterTypes == nil {
 		return nil, false
 	}
-	return &o.FilterTypes, true
+	return o.FilterTypes, true
 }
 
 // HasFilterTypes returns a boolean if a field has been set.
@@ -162,7 +162,7 @@ func (o *TemplateUpdate) HasFilterTypes() bool {
 
 // SetFilterTypes gets a reference to the given []string and assigns it to the FilterTypes field.
 func (o *TemplateUpdate) SetFilterTypes(v []string) {
-	o.FilterTypes = v
+	o.FilterTypes = &v
 }
 
 // GetInstructions returns the Instructions field value if set, zero value otherwise.

--- a/go/internal/openapi/model_transformation_simulate_in.go
+++ b/go/internal/openapi/model_transformation_simulate_in.go
@@ -16,7 +16,7 @@ import (
 
 // TransformationSimulateIn struct for TransformationSimulateIn
 type TransformationSimulateIn struct {
-	Channels []string `json:"channels,omitempty"`
+	Channels *[]string `json:"channels,omitempty"`
 	Code string `json:"code"`
 	// The event type's name
 	EventType string `json:"eventType"`
@@ -45,11 +45,11 @@ func NewTransformationSimulateInWithDefaults() *TransformationSimulateIn {
 
 // GetChannels returns the Channels field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *TransformationSimulateIn) GetChannels() []string {
-	if o == nil  {
+	if o == nil || o.Channels == nil {
 		var ret []string
 		return ret
 	}
-	return o.Channels
+	return *o.Channels
 }
 
 // GetChannelsOk returns a tuple with the Channels field value if set, nil otherwise
@@ -59,7 +59,7 @@ func (o *TransformationSimulateIn) GetChannelsOk() (*[]string, bool) {
 	if o == nil || o.Channels == nil {
 		return nil, false
 	}
-	return &o.Channels, true
+	return o.Channels, true
 }
 
 // HasChannels returns a boolean if a field has been set.
@@ -73,7 +73,7 @@ func (o *TransformationSimulateIn) HasChannels() bool {
 
 // SetChannels gets a reference to the given []string and assigns it to the Channels field.
 func (o *TransformationSimulateIn) SetChannels(v []string) {
-	o.Channels = v
+	o.Channels = &v
 }
 
 // GetCode returns the Code field value

--- a/go/svix_test.go
+++ b/go/svix_test.go
@@ -1,0 +1,96 @@
+package svix_test
+
+import (
+	"context"
+	"errors"
+	svix "github.com/svix/svix-webhooks/go"
+	"net/http"
+	"net/url"
+	"os"
+	"testing"
+)
+
+// Builds an API client for testing against an arbitrary API server with an arbitrary token.
+//
+// The connection details are pulled from the environment, e.g. `SVIX_TOKEN` and `SVIX_SERVER_URL`.
+// In the case that either are unset, a test that calls this function will automatically skip.
+func getTestClient(t *testing.T) *svix.Svix {
+	t.Helper()
+
+	token, exists := os.LookupEnv("SVIX_TOKEN")
+	if !exists {
+		t.Skipf("Unable to construct test client (`SVIX_TOKEN` unset)")
+		return nil
+	}
+	rawServerUrl, exists := os.LookupEnv("SVIX_SERVER_URL")
+	if !exists {
+		t.Skipf("Unable to construct test client (`SVIX_SERVER_URL` unset)")
+		return nil
+	}
+	serverUrl, err := url.Parse(rawServerUrl)
+	if err != nil {
+		panic(err)
+	}
+	return svix.New(token, &svix.SvixOptions{
+		ServerUrl: serverUrl,
+	})
+}
+
+// Suppresses a request error response if it has an allowed status code.
+func checkErrStatus(err error, allowedStatus int) error {
+	if err != nil {
+		var svixError *svix.Error
+		if errors.As(err, &svixError) {
+			if svixError.Status() == allowedStatus {
+				// Pass if we see the suppressed status
+				return nil
+			}
+		}
+	}
+	return err
+}
+
+// Runs through some common API interactions.
+func TestKitchenSink(t *testing.T) {
+	ctx := context.Background()
+	client := getTestClient(t)
+
+	app, err := client.Application.Create(ctx, &svix.ApplicationIn{
+		Name: "test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.EventType.Create(ctx, &svix.EventTypeIn{Name: "event.started"})
+
+	if checkErrStatus(err, http.StatusConflict) != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.EventType.Create(ctx, &svix.EventTypeIn{Name: "event.ended"})
+	if checkErrStatus(err, http.StatusConflict) != nil {
+		t.Fatal(err)
+	}
+
+	endp, err := client.Endpoint.Create(ctx, app.Id, &svix.EndpointIn{
+		Url: "https://example.svix.com/",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	endpPatch := svix.EndpointPatch{}
+	endpPatch.SetFilterTypes([]string{"event.started", "event.ended"})
+
+	patched, err := client.Endpoint.Patch(ctx, app.Id, endp.Id, &endpPatch)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, typ := range patched.GetFilterTypes() {
+		if !(typ == "event.started" || typ == "event.ended") {
+			t.Fatalf("unexpected filter type: `%s`", typ)
+		}
+	}
+}

--- a/go/templates/model_simple.mustache
+++ b/go/templates/model_simple.mustache
@@ -1,0 +1,391 @@
+// {{classname}}{{#description}} {{{description}}}{{/description}}{{^description}} struct for {{{classname}}}{{/description}}
+type {{classname}} struct {
+{{#parent}}
+{{^isMap}}
+{{^isArray}}
+	{{{parent}}}
+{{/isArray}}
+{{/isMap}}
+{{#isArray}}
+	Items {{{parent}}}
+{{/isArray}}
+{{/parent}}
+{{#vars}}
+{{^-first}}
+{{/-first}}
+{{#description}}
+	// {{{description}}}
+{{/description}}
+	{{name}} {{^required}}{{^isNullable}}*{{/isNullable}}{{/required}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+{{/vars}}
+{{#isAdditionalPropertiesTrue}}
+	AdditionalProperties map[string]interface{}
+{{/isAdditionalPropertiesTrue}}
+}
+
+{{#isAdditionalPropertiesTrue}}
+type _{{{classname}}} {{{classname}}}
+
+{{/isAdditionalPropertiesTrue}}
+// New{{classname}} instantiates a new {{classname}} object
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed
+func New{{classname}}({{#requiredVars}}{{nameInCamelCase}} {{dataType}}{{^-last}}, {{/-last}}{{/requiredVars}}) *{{classname}} {
+	this := {{classname}}{}
+{{#allVars}}
+{{#required}}
+	this.{{name}} = {{nameInCamelCase}}
+{{/required}}
+{{^required}}
+{{#defaultValue}}
+{{^vendorExtensions.x-golang-is-container}}
+{{#isNullable}}
+	var {{nameInCamelCase}} {{{datatypeWithEnum}}} = {{{.}}}
+	this.{{name}} = *New{{{dataType}}}(&{{nameInCamelCase}})
+{{/isNullable}}
+{{^isNullable}}
+	var {{nameInCamelCase}} {{{dataType}}} = {{{.}}}
+	this.{{name}} = &{{nameInCamelCase}}
+{{/isNullable}}
+{{/vendorExtensions.x-golang-is-container}}
+{{/defaultValue}}
+{{/required}}
+{{/allVars}}
+	return &this
+}
+
+// New{{classname}}WithDefaults instantiates a new {{classname}} object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func New{{classname}}WithDefaults() *{{classname}} {
+	this := {{classname}}{}
+{{#vars}}
+{{#defaultValue}}
+{{^vendorExtensions.x-golang-is-container}}
+{{#isNullable}}
+{{!we use datatypeWithEnum here, since it will represent the non-nullable name of the datatype, e.g. int64 for NullableInt64}}
+	var {{nameInCamelCase}} {{{datatypeWithEnum}}} = {{{.}}}
+	this.{{name}} = *New{{{dataType}}}(&{{nameInCamelCase}})
+{{/isNullable}}
+{{^isNullable}}
+	var {{nameInCamelCase}} {{{dataType}}} = {{{.}}}
+	this.{{name}} = {{^required}}&{{/required}}{{nameInCamelCase}}
+{{/isNullable}}
+{{/vendorExtensions.x-golang-is-container}}
+{{/defaultValue}}
+{{/vars}}
+	return &this
+}
+
+{{#vars}}
+{{#required}}
+// Get{{name}} returns the {{name}} field value
+{{#isNullable}}
+// If the value is explicit nil, the zero value for {{vendorExtensions.x-go-base-type}} will be returned
+{{/isNullable}}
+func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
+	if o == nil{{#isNullable}}{{^vendorExtensions.x-golang-is-container}} || o.{{name}}.Get() == nil{{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+		var ret {{vendorExtensions.x-go-base-type}}
+		return ret
+	}
+
+{{#isNullable}}
+{{#vendorExtensions.x-golang-is-container}}
+	return o.{{name}}
+{{/vendorExtensions.x-golang-is-container}}
+{{^vendorExtensions.x-golang-is-container}}
+	return *o.{{name}}.Get()
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+{{^isNullable}}
+	return o.{{name}}
+{{/isNullable}}
+}
+
+// Get{{name}}Ok returns a tuple with the {{name}} field value
+// and a boolean to check if the value has been set.
+{{#isNullable}}
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+{{/isNullable}}
+func (o *{{classname}}) Get{{name}}Ok() (*{{vendorExtensions.x-go-base-type}}, bool) {
+	if o == nil {{#isNullable}}{{#vendorExtensions.x-golang-is-container}}|| o.{{name}} == nil{{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+		return nil, false
+	}
+{{#isNullable}}
+{{#vendorExtensions.x-golang-is-container}}
+	return &o.{{name}}, true
+{{/vendorExtensions.x-golang-is-container}}
+{{^vendorExtensions.x-golang-is-container}}
+	return o.{{name}}.Get(), o.{{name}}.IsSet()
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+{{^isNullable}}
+	return &o.{{name}}, true
+{{/isNullable}}
+}
+
+// Set{{name}} sets field value
+func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-go-base-type}}) {
+{{#isNullable}}
+{{#vendorExtensions.x-golang-is-container}}
+	o.{{name}} = v
+{{/vendorExtensions.x-golang-is-container}}
+{{^vendorExtensions.x-golang-is-container}}
+	o.{{name}}.Set(&v)
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+{{^isNullable}}
+	o.{{name}} = v
+{{/isNullable}}
+}
+
+{{/required}}
+{{^required}}
+// Get{{name}} returns the {{name}} field value if set, zero value otherwise{{#isNullable}} (both if not set or set to explicit null){{/isNullable}}.
+func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
+	if o == nil {{^isNullable}}|| o.{{name}} == nil{{/isNullable}}{{#isNullable}}{{^vendorExtensions.x-golang-is-container}}|| o.{{name}}.Get() == nil{{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+		var ret {{vendorExtensions.x-go-base-type}}
+		return ret
+	}
+{{#isNullable}}
+{{#vendorExtensions.x-golang-is-container}}
+	return o.{{name}}
+{{/vendorExtensions.x-golang-is-container}}
+{{^vendorExtensions.x-golang-is-container}}
+	return *o.{{name}}.Get()
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+{{^isNullable}}
+	return *o.{{name}}
+{{/isNullable}}
+}
+
+// Get{{name}}Ok returns a tuple with the {{name}} field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+{{#isNullable}}
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+{{/isNullable}}
+func (o *{{classname}}) Get{{name}}Ok() (*{{vendorExtensions.x-go-base-type}}, bool) {
+	if o == nil {{^isNullable}}|| o.{{name}} == nil{{/isNullable}}{{#isNullable}}{{#vendorExtensions.x-golang-is-container}}|| o.{{name}} == nil{{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+		return nil, false
+	}
+{{#isNullable}}
+{{#vendorExtensions.x-golang-is-container}}
+	return &o.{{name}}, true
+{{/vendorExtensions.x-golang-is-container}}
+{{^vendorExtensions.x-golang-is-container}}
+	return o.{{name}}.Get(), o.{{name}}.IsSet()
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+{{^isNullable}}
+	return o.{{name}}, true
+{{/isNullable}}
+}
+
+// Has{{name}} returns a boolean if a field has been set.
+func (o *{{classname}}) Has{{name}}() bool {
+	if o != nil && {{^isNullable}}o.{{name}} != nil{{/isNullable}}{{#isNullable}}{{#vendorExtensions.x-golang-is-container}}o.{{name}} != nil{{/vendorExtensions.x-golang-is-container}}{{^vendorExtensions.x-golang-is-container}}o.{{name}}.IsSet(){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+		return true
+	}
+
+	return false
+}
+
+// Set{{name}} gets a reference to the given {{dataType}} and assigns it to the {{name}} field.
+func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-go-base-type}}) {
+{{#isNullable}}
+{{#vendorExtensions.x-golang-is-container}}
+	o.{{name}} = v
+{{/vendorExtensions.x-golang-is-container}}
+{{^vendorExtensions.x-golang-is-container}}
+	o.{{name}}.Set(&v)
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+{{^isNullable}}
+	o.{{name}} = &v
+{{/isNullable}}
+}
+{{#isNullable}}
+{{^vendorExtensions.x-golang-is-container}}
+// Set{{name}}Nil sets the value for {{name}} to be an explicit nil
+func (o *{{classname}}) Set{{name}}Nil() {
+	o.{{name}}.Set(nil)
+}
+
+// Unset{{name}} ensures that no value is present for {{name}}, not even an explicit nil
+func (o *{{classname}}) Unset{{name}}() {
+	o.{{name}}.Unset()
+}
+{{/vendorExtensions.x-golang-is-container}}
+{{/isNullable}}
+
+{{/required}}
+{{/vars}}
+func (o {{classname}}) MarshalJSON() ([]byte, error) {
+	toSerialize := {{#isArray}}make([]interface{}, len(o.Items)){{/isArray}}{{^isArray}}map[string]interface{}{}{{/isArray}}
+	{{#parent}}
+	{{^isMap}}
+	{{^isArray}}
+	serialized{{parent}}, err{{parent}} := json.Marshal(o.{{parent}})
+	if err{{parent}} != nil {
+		return []byte{}, err{{parent}}
+	}
+	err{{parent}} = json.Unmarshal([]byte(serialized{{parent}}), &toSerialize)
+	if err{{parent}} != nil {
+		return []byte{}, err{{parent}}
+	}
+	{{/isArray}}
+	{{/isMap}}
+	{{#isArray}}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	{{/isArray}}
+	{{/parent}}
+	{{#vars}}
+	{{! if argument is nullable, only serialize it if it is set}}
+	{{#isNullable}}
+	{{#vendorExtensions.x-golang-is-container}}
+	{{! support for container fields is not ideal at this point because of lack of Nullable* types}}
+	if o.{{name}} != nil {
+		toSerialize["{{baseName}}"] = o.{{name}}
+	}
+	{{/vendorExtensions.x-golang-is-container}}
+	{{^vendorExtensions.x-golang-is-container}}
+	if {{#required}}true{{/required}}{{^required}}o.{{name}}.IsSet(){{/required}} {
+		toSerialize["{{baseName}}"] = o.{{name}}.Get()
+	}
+	{{/vendorExtensions.x-golang-is-container}}
+	{{/isNullable}}
+	{{! if argument is not nullable, don't set it if it is nil}}
+	{{^isNullable}}
+	if {{#required}}true{{/required}}{{^required}}o.{{name}} != nil{{/required}} {
+		toSerialize["{{baseName}}"] = o.{{name}}
+	}
+	{{/isNullable}}
+	{{/vars}}
+	{{#isAdditionalPropertiesTrue}}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+
+	{{/isAdditionalPropertiesTrue}}
+	return json.Marshal(toSerialize)
+}
+
+{{#isAdditionalPropertiesTrue}}
+func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
+{{#parent}}
+{{^isMap}}
+	type {{classname}}WithoutEmbeddedStruct struct {
+	{{#vars}}
+	{{^-first}}
+	{{/-first}}
+	{{#description}}
+		// {{{description}}}
+	{{/description}}
+		{{name}} {{^required}}{{^isNullable}}*{{/isNullable}}{{/required}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+	{{/vars}}
+	}
+
+	var{{{classname}}}WithoutEmbeddedStruct := {{{classname}}}WithoutEmbeddedStruct{}
+
+	err = json.Unmarshal(bytes, &var{{{classname}}}WithoutEmbeddedStruct)
+	if err == nil {
+		var{{{classname}}} := _{{{classname}}}{}
+		{{#vars}}
+		var{{{classname}}}.{{{name}}} = var{{{classname}}}WithoutEmbeddedStruct.{{{name}}}
+		{{/vars}}
+		*o = {{{classname}}}(var{{{classname}}})
+	} else {
+		return err
+	}
+
+	var{{{classname}}} := _{{{classname}}}{}
+
+	err = json.Unmarshal(bytes, &var{{{classname}}})
+	if err == nil {
+		o.{{{parent}}} = var{{{classname}}}.{{{parent}}}
+	} else {
+		return err
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		{{#vars}}
+		delete(additionalProperties, "{{{baseName}}}")
+		{{/vars}}
+
+		// remove fields from embedded structs
+		reflect{{{parent}}} := reflect.ValueOf(o.{{{parent}}})
+		for i := 0; i < reflect{{{parent}}}.Type().NumField(); i++ {
+			t := reflect{{{parent}}}.Type().Field(i)
+
+			if jsonTag := t.Tag.Get("json"); jsonTag != "" {
+				fieldName := ""
+				if commaIdx := strings.Index(jsonTag, ","); commaIdx > 0 {
+					fieldName = jsonTag[:commaIdx]
+				} else {
+					fieldName = jsonTag
+				}
+				if fieldName != "AdditionalProperties" {
+					delete(additionalProperties, fieldName)
+				}
+			}
+		}
+
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
+{{/isMap}}
+{{#isMap}}
+	var{{{classname}}} := _{{{classname}}}{}
+
+	if err = json.Unmarshal(bytes, &var{{{classname}}}); err == nil {
+		*o = {{{classname}}}(var{{{classname}}})
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		{{#vars}}
+		delete(additionalProperties, "{{{baseName}}}")
+		{{/vars}}
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
+{{/isMap}}
+{{/parent}}
+{{^parent}}
+	var{{{classname}}} := _{{{classname}}}{}
+
+	if err = json.Unmarshal(bytes, &var{{{classname}}}); err == nil {
+		*o = {{{classname}}}(var{{{classname}}})
+	}
+
+	additionalProperties := make(map[string]interface{})
+
+	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+		{{#vars}}
+		delete(additionalProperties, "{{{baseName}}}")
+		{{/vars}}
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return err
+{{/parent}}
+}
+
+{{/isAdditionalPropertiesTrue}}
+{{#isArray}}
+func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
+	return json.Unmarshal(bytes, &o.Items)
+}
+
+{{/isArray}}
+{{>nullable_model}}

--- a/go/templates/model_simple.mustache
+++ b/go/templates/model_simple.mustache
@@ -16,7 +16,7 @@ type {{classname}} struct {
 {{#description}}
 	// {{{description}}}
 {{/description}}
-	{{name}} {{^required}}{{^isNullable}}*{{/isNullable}}{{/required}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+	{{name}} {{^required}}{{^isNullable}}*{{/isNullable}}{{#isNullable}}{{#vendorExtensions.x-golang-is-container}}*{{/vendorExtensions.x-golang-is-container}}{{/isNullable}}{{/required}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
 {{/vars}}
 {{#isAdditionalPropertiesTrue}}
 	AdditionalProperties map[string]interface{}
@@ -144,13 +144,13 @@ func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-go-base-type}}) {
 {{^required}}
 // Get{{name}} returns the {{name}} field value if set, zero value otherwise{{#isNullable}} (both if not set or set to explicit null){{/isNullable}}.
 func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
-	if o == nil {{^isNullable}}|| o.{{name}} == nil{{/isNullable}}{{#isNullable}}{{^vendorExtensions.x-golang-is-container}}|| o.{{name}}.Get() == nil{{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+	if o == nil {{^isNullable}}|| o.{{name}} == nil{{/isNullable}}{{#isNullable}}{{#vendorExtensions.x-golang-is-container}}|| o.{{name}} == nil{{/vendorExtensions.x-golang-is-container}}{{^vendorExtensions.x-golang-is-container}}|| o.{{name}}.Get() == nil{{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
 		var ret {{vendorExtensions.x-go-base-type}}
 		return ret
 	}
 {{#isNullable}}
 {{#vendorExtensions.x-golang-is-container}}
-	return o.{{name}}
+	return *o.{{name}}
 {{/vendorExtensions.x-golang-is-container}}
 {{^vendorExtensions.x-golang-is-container}}
 	return *o.{{name}}.Get()
@@ -172,7 +172,7 @@ func (o *{{classname}}) Get{{name}}Ok() (*{{vendorExtensions.x-go-base-type}}, b
 	}
 {{#isNullable}}
 {{#vendorExtensions.x-golang-is-container}}
-	return &o.{{name}}, true
+	return o.{{name}}, true
 {{/vendorExtensions.x-golang-is-container}}
 {{^vendorExtensions.x-golang-is-container}}
 	return o.{{name}}.Get(), o.{{name}}.IsSet()
@@ -196,7 +196,7 @@ func (o *{{classname}}) Has{{name}}() bool {
 func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-go-base-type}}) {
 {{#isNullable}}
 {{#vendorExtensions.x-golang-is-container}}
-	o.{{name}} = v
+	o.{{name}} = &v
 {{/vendorExtensions.x-golang-is-container}}
 {{^vendorExtensions.x-golang-is-container}}
 	o.{{name}}.Set(&v)


### PR DESCRIPTION
In #1448 the `EndpointIn` model was hand-edited such that `channels` and `filterTypes` were nullable, and thus correctly omitted from request bodies sent to the server.

This series of commits attempts to remove the need to keep reapplying this patch with each spec bump by updating the codegen template used to produce the model code.

This change is comprised of 3 commits:
1. the addition of a template override for `model_simple` ([src](https://github.com/OpenAPITools/openapi-generator/blob/v5.2.0/modules/openapi-generator/src/main/resources/go/model_simple.mustache)) as-is, taken from openapi at the v5.2.0 tag (matching the version of the generator we're using currently).
2. some modifications to said template, i.e. _our patch_.
3. updated go sources from running the generator.

When reviewing the template, it'll therefore be useful to go commit by commit so you can see the diff applied against the upstream.

This change has widespread impact as many models are changing. I'm still trying to figure out how we can prove everything is kosher and not causing accidental breakage. Open to ideas 🤔 

Existing tests are passing, and everything typechecks, so at the very least the codegen output is self-consistent.