### PR TITLE
Libs(Go): get go tests running in CI

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -1,0 +1,30 @@
+name: Go CI
+
+on:
+  pull_request:
+    paths:
+      - "go/**"
+      - "go.sum"
+      - "go.mod"
+      - "openapi.json"
+      - ".github/workflows/go-ci.yml"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23.x"
+          cache-dependency-path: ./go.sum
+      - name: Display Go version
+        run: go version
+      - name: Install dependencies
+        run: go get ./go/...
+      - name: Build
+        run: go build -v ./go/...
+      - name: Test
+        run: go test -v ./go/...


### PR DESCRIPTION
We've got a handful of unit test that could catch problems when the Go sources are changing, so let's run them as a part of CI.

This doesn't re-run the OpenAPI codegen (but it could later). It would be nice to know if the checked in sources were not aligned with whatever the generator produces, for example if a recent spec bump PR neglected to check them in.