### PR TITLE
server: Normalize package metadata

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -16,6 +16,10 @@ nonstandard_macro_braces = "warn"
 todo = "warn"
 uninlined_format_args = "warn"
 
+[workspace.package]
+edition = "2021"
+license = "MIT"
+
 [profile.dev]
 # optimize host dependencies for faster rebuilds.
 # slows down compilation of those dependencies, but they'll not be compiled

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -1,15 +1,10 @@
 [package]
 name = "svix-server"
 version = "1.36.0"
-license = "MIT"
 description = "Svix webhooks server"
-
-authors = ["Svix Inc. <oss@svix.com>"]
-homepage = "https://www.svix.com"
-repository = "https://github.com/svix/svix-webhooks"
-readme = "../README.md"
-edition = "2021"
 publish = false
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 svix-server_derive = { path = "../svix-server_derive" }

--- a/server/svix-server_derive/Cargo.toml
+++ b/server/svix-server_derive/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "svix-server_derive"
 version = "0.1.0"
-edition = "2021"
 publish = false
-license = "MIT"
+edition.workspace = true
+license.workspace = true
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
- Use workspace inheritance for edition and license
- Remove fields that serve no purpose for packages that are never published
