### PR TITLE
Libs(Go): hand-edit `EndpointUpdate` and `EndpointPatch` for nulls

### DIFF
--- a/go/internal/openapi/model_endpoint_patch.go
+++ b/go/internal/openapi/model_endpoint_patch.go
@@ -16,10 +16,10 @@ import (
 
 // EndpointPatch struct for EndpointPatch
 type EndpointPatch struct {
-	Channels []string `json:"channels,omitempty"`
+	Channels *[]string `json:"channels,omitempty"`
 	Description *string `json:"description,omitempty"`
 	Disabled *bool `json:"disabled,omitempty"`
-	FilterTypes []string `json:"filterTypes,omitempty"`
+	FilterTypes *[]string `json:"filterTypes,omitempty"`
 	Metadata *map[string]string `json:"metadata,omitempty"`
 	RateLimit NullableInt32 `json:"rateLimit,omitempty"`
 	// The endpoint's verification secret. If `null` is passed, a secret is automatically generated. Format: `base64` encoded random bytes optionally prefixed with `whsec_`. Recommended size: 24.
@@ -49,11 +49,11 @@ func NewEndpointPatchWithDefaults() *EndpointPatch {
 
 // GetChannels returns the Channels field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EndpointPatch) GetChannels() []string {
-	if o == nil  {
+	if o == nil || o.Channels == nil {
 		var ret []string
 		return ret
 	}
-	return o.Channels
+	return *o.Channels
 }
 
 // GetChannelsOk returns a tuple with the Channels field value if set, nil otherwise
@@ -63,7 +63,7 @@ func (o *EndpointPatch) GetChannelsOk() (*[]string, bool) {
 	if o == nil || o.Channels == nil {
 		return nil, false
 	}
-	return &o.Channels, true
+	return o.Channels, true
 }
 
 // HasChannels returns a boolean if a field has been set.
@@ -77,7 +77,7 @@ func (o *EndpointPatch) HasChannels() bool {
 
 // SetChannels gets a reference to the given []string and assigns it to the Channels field.
 func (o *EndpointPatch) SetChannels(v []string) {
-	o.Channels = v
+	o.Channels = &v
 }
 
 // GetDescription returns the Description field value if set, zero value otherwise.
@@ -146,11 +146,11 @@ func (o *EndpointPatch) SetDisabled(v bool) {
 
 // GetFilterTypes returns the FilterTypes field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EndpointPatch) GetFilterTypes() []string {
-	if o == nil  {
+	if o == nil || o.FilterTypes == nil {
 		var ret []string
 		return ret
 	}
-	return o.FilterTypes
+	return *o.FilterTypes
 }
 
 // GetFilterTypesOk returns a tuple with the FilterTypes field value if set, nil otherwise
@@ -160,7 +160,7 @@ func (o *EndpointPatch) GetFilterTypesOk() (*[]string, bool) {
 	if o == nil || o.FilterTypes == nil {
 		return nil, false
 	}
-	return &o.FilterTypes, true
+	return o.FilterTypes, true
 }
 
 // HasFilterTypes returns a boolean if a field has been set.
@@ -174,7 +174,7 @@ func (o *EndpointPatch) HasFilterTypes() bool {
 
 // SetFilterTypes gets a reference to the given []string and assigns it to the FilterTypes field.
 func (o *EndpointPatch) SetFilterTypes(v []string) {
-	o.FilterTypes = v
+	o.FilterTypes = &v
 }
 
 // GetMetadata returns the Metadata field value if set, zero value otherwise.
@@ -469,5 +469,3 @@ func (v *NullableEndpointPatch) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
-

--- a/go/internal/openapi/model_endpoint_update.go
+++ b/go/internal/openapi/model_endpoint_update.go
@@ -17,10 +17,10 @@ import (
 // EndpointUpdate struct for EndpointUpdate
 type EndpointUpdate struct {
 	// List of message channels this endpoint listens to (omit for all)
-	Channels []string `json:"channels,omitempty"`
+	Channels *[]string `json:"channels,omitempty"`
 	Description *string `json:"description,omitempty"`
 	Disabled *bool `json:"disabled,omitempty"`
-	FilterTypes []string `json:"filterTypes,omitempty"`
+	FilterTypes *[]string `json:"filterTypes,omitempty"`
 	Metadata *map[string]string `json:"metadata,omitempty"`
 	RateLimit NullableInt32 `json:"rateLimit,omitempty"`
 	// Optional unique identifier for the endpoint
@@ -61,11 +61,11 @@ func NewEndpointUpdateWithDefaults() *EndpointUpdate {
 
 // GetChannels returns the Channels field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EndpointUpdate) GetChannels() []string {
-	if o == nil  {
+	if o == nil || o.Channels == nil {
 		var ret []string
 		return ret
 	}
-	return o.Channels
+	return *o.Channels
 }
 
 // GetChannelsOk returns a tuple with the Channels field value if set, nil otherwise
@@ -75,7 +75,7 @@ func (o *EndpointUpdate) GetChannelsOk() (*[]string, bool) {
 	if o == nil || o.Channels == nil {
 		return nil, false
 	}
-	return &o.Channels, true
+	return o.Channels, true
 }
 
 // HasChannels returns a boolean if a field has been set.
@@ -89,7 +89,7 @@ func (o *EndpointUpdate) HasChannels() bool {
 
 // SetChannels gets a reference to the given []string and assigns it to the Channels field.
 func (o *EndpointUpdate) SetChannels(v []string) {
-	o.Channels = v
+	o.Channels = &v
 }
 
 // GetDescription returns the Description field value if set, zero value otherwise.
@@ -158,11 +158,11 @@ func (o *EndpointUpdate) SetDisabled(v bool) {
 
 // GetFilterTypes returns the FilterTypes field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *EndpointUpdate) GetFilterTypes() []string {
-	if o == nil  {
+	if o == nil || o.FilterTypes == nil {
 		var ret []string
 		return ret
 	}
-	return o.FilterTypes
+	return *o.FilterTypes
 }
 
 // GetFilterTypesOk returns a tuple with the FilterTypes field value if set, nil otherwise
@@ -172,7 +172,7 @@ func (o *EndpointUpdate) GetFilterTypesOk() (*[]string, bool) {
 	if o == nil || o.FilterTypes == nil {
 		return nil, false
 	}
-	return &o.FilterTypes, true
+	return o.FilterTypes, true
 }
 
 // HasFilterTypes returns a boolean if a field has been set.
@@ -186,7 +186,7 @@ func (o *EndpointUpdate) HasFilterTypes() bool {
 
 // SetFilterTypes gets a reference to the given []string and assigns it to the FilterTypes field.
 func (o *EndpointUpdate) SetFilterTypes(v []string) {
-	o.FilterTypes = v
+	o.FilterTypes = &v
 }
 
 // GetMetadata returns the Metadata field value if set, zero value otherwise.
@@ -438,5 +438,3 @@ func (v *NullableEndpointUpdate) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
-


### PR DESCRIPTION
Pairs with <https://github.com/svix/svix-webhooks/pull/1448>

This is effectively the same change we made for `EndpointIn`, but for the request bodies for `PUT` and `PATCH` requests.

This is still a workaround with a more comprehensive fix expected via <https://github.com/svix/svix-webhooks/pull/1450> (once some additional testing has been done).