### PR TITLE
Add redis sentinel support

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -639,13 +639,24 @@ dependencies = [
 
 [[package]]
 name = "bb8-redis"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb4f141b33a750b5f667c445bd8588de10b8f2b045cd2aabc040ca746fb53ae"
+checksum = "0c6910977c026bb1d0a6b523508d1a893d6d4c2ba216355e9569d8181d92ccbe"
 dependencies = [
  "async-trait",
  "bb8",
- "redis",
+ "redis 0.26.1",
+]
+
+[[package]]
+name = "bb8-redis"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1781f22daa0ae97d934fdf04a5c66646f154a164c4bdc157ec8d3c11166c05cc"
+dependencies = [
+ "async-trait",
+ "bb8",
+ "redis 0.27.2",
 ]
 
 [[package]]
@@ -2877,18 +2888,19 @@ dependencies = [
 [[package]]
 name = "omniqueue"
 version = "0.2.1"
-source = "git+https://github.com/svix/omniqueue-rs?rev=5ae22000e2ea214ba707cac81657f098e5785a76#5ae22000e2ea214ba707cac81657f098e5785a76"
+source = "git+https://github.com/svix/omniqueue-rs?rev=75e5a9510ad338ac3702b2e911bacf8967ac58d8#75e5a9510ad338ac3702b2e911bacf8967ac58d8"
 dependencies = [
  "async-trait",
  "bb8",
- "bb8-redis",
+ "bb8-redis 0.17.0",
  "bytesize",
  "futures-util",
  "lapin",
- "redis",
+ "redis 0.27.2",
  "serde",
  "serde_json",
  "svix-ksuid 0.8.0",
+ "sync_wrapper 1.0.1",
  "thiserror",
  "time",
  "tokio",
@@ -3586,9 +3598,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.25.4"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d7a6955c7511f60f3ba9e86c6d02b3c3f144f8c24b288d1f4e18074ab8bbec"
+checksum = "e902a69d09078829137b4a5d9d082e0490393537badd7c91a3d69d14639e115f"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3600,6 +3612,7 @@ dependencies = [
  "itoa",
  "log",
  "native-tls",
+ "num-bigint",
  "percent-encoding",
  "pin-project-lite",
  "rand",
@@ -3609,6 +3622,35 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-retry",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "redis"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e86f5670bd8b028edfb240f0616cad620705b31ec389d55e4f3da2c38dcd48"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "combine",
+ "crc16",
+ "futures",
+ "futures-util",
+ "itoa",
+ "log",
+ "native-tls",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "rand",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.5.7",
+ "tokio",
+ "tokio-native-tls",
  "tokio-util",
  "url",
 ]
@@ -4856,7 +4898,7 @@ dependencies = [
  "axum-server",
  "base64 0.13.1",
  "bb8",
- "bb8-redis",
+ "bb8-redis 0.16.0",
  "blake2",
  "bytes",
  "chacha20poly1305",
@@ -4890,7 +4932,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "rand",
- "redis",
+ "redis 0.26.1",
  "regex",
  "reqwest 0.11.27",
  "schemars",

--- a/server/run-tests.sh
+++ b/server/run-tests.sh
@@ -80,3 +80,16 @@ echo "*********** RUN 6 ***********"
         ${TEST_COMMAND} -- --ignored rabbitmq
     fi
 )
+
+echo "*********** RUN 7 ***********"
+(
+    export SVIX_QUEUE_TYPE="redissentinel"
+    export SVIX_CACHE_TYPE="redissentinel"
+    export SVIX_REDIS_DSN="redis://localhost:26379"
+    export SVIX_SENTINEL_SERVICE_NAME="master0"
+
+    ${TEST_COMMAND} "$@"
+    if [[ -z "$@" ]]; then
+        ${TEST_COMMAND} -- --ignored redis
+    fi
+)

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -44,8 +44,8 @@ ed25519-compact = "2.1.1"
 chrono = { version="0.4.26", features = ["serde"] }
 reqwest = { version = "0.11.27", features = ["json", "rustls-tls", "hickory-resolver"], default-features = false }
 bb8 = "0.8"
-bb8-redis = "0.15.0"
-redis = { version = "0.25.4", features = ["tokio-comp", "tokio-native-tls-comp", "streams", "cluster-async", "tcp_nodelay", "connection-manager"] }
+bb8-redis = "0.16.0"
+redis = { version = "0.26", features = ["tokio-comp", "tokio-native-tls-comp", "streams", "cluster-async", "tcp_nodelay", "connection-manager", "sentinel"] }
 thiserror = "1.0.30"
 bytes = "1.1.0"
 blake2 = "0.10.4"
@@ -68,7 +68,7 @@ urlencoding = "2.1.2"
 form_urlencoded = "1.1.0"
 lapin = "2.1.1"
 sentry = { version = "0.32.2", features = ["tracing"] }
-omniqueue = { git = "https://github.com/svix/omniqueue-rs", rev = "5ae22000e2ea214ba707cac81657f098e5785a76", default-features = false, features = ["in_memory", "rabbitmq-with-message-ids", "redis_cluster"] }
+omniqueue = { git = "https://github.com/svix/omniqueue-rs", rev = "75e5a9510ad338ac3702b2e911bacf8967ac58d8", default-features = false, features = ["in_memory", "rabbitmq-with-message-ids", "redis_cluster", "redis_sentinel"] }
 # Not a well-known author, and no longer gets updates => pinned.
 # Switch to hyper-http-proxy when upgrading hyper to 1.0.
 hyper-proxy = { version = "=0.9.1", default-features = false, features = ["openssl-tls"] }

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -111,7 +111,9 @@ pub async fn run_with_prefix(
     let cache = match &cache_backend {
         CacheBackend::None => cache::none::new(),
         CacheBackend::Memory => cache::memory::new(),
-        CacheBackend::Redis(_) | CacheBackend::RedisCluster(_) => {
+        CacheBackend::Redis(_)
+        | CacheBackend::RedisCluster(_)
+        | CacheBackend::RedisSentinel(_, _) => {
             let mgr = RedisManager::from_cache_backend(&cache_backend).await;
             cache::redis::new(mgr)
         }

--- a/server/svix-server/src/queue/mod.rs
+++ b/server/svix-server/src/queue/mod.rs
@@ -33,9 +33,9 @@ pub async fn new_pair(
     prefix: Option<&str>,
 ) -> (TaskQueueProducer, TaskQueueConsumer) {
     match cfg.queue_backend() {
-        QueueBackend::Redis(_) | QueueBackend::RedisCluster(_) => {
-            redis::new_pair(cfg, prefix).await
-        }
+        QueueBackend::Redis(_)
+        | QueueBackend::RedisCluster(_)
+        | QueueBackend::RedisSentinel(_, _) => redis::new_pair(cfg, prefix).await,
         QueueBackend::Memory => {
             let (producer, consumer) = InMemoryBackend::builder()
                 .build_pair()

--- a/server/svix-server/src/redis/sentinel.rs
+++ b/server/svix-server/src/redis/sentinel.rs
@@ -1,0 +1,53 @@
+use axum::async_trait;
+use redis::{
+    sentinel::{SentinelClient, SentinelNodeConnectionInfo, SentinelServerType},
+    ErrorKind, IntoConnectionInfo, RedisError,
+};
+use tokio::sync::Mutex;
+
+struct LockedSentinelClient(pub(crate) Mutex<SentinelClient>);
+
+/// ConnectionManager that implements `bb8::ManageConnection` and supports
+/// asynchronous Sentinel connections via `redis::sentinel::SentinelClient`
+pub struct RedisSentinelConnectionManager {
+    client: LockedSentinelClient,
+}
+
+impl RedisSentinelConnectionManager {
+    pub fn new<T: IntoConnectionInfo>(
+        info: Vec<T>,
+        service_name: String,
+        node_connection_info: Option<SentinelNodeConnectionInfo>,
+    ) -> Result<RedisSentinelConnectionManager, RedisError> {
+        Ok(RedisSentinelConnectionManager {
+            client: LockedSentinelClient(Mutex::new(SentinelClient::build(
+                info,
+                service_name,
+                node_connection_info,
+                SentinelServerType::Master,
+            )?)),
+        })
+    }
+}
+
+#[async_trait]
+impl bb8::ManageConnection for RedisSentinelConnectionManager {
+    type Connection = redis::aio::MultiplexedConnection;
+    type Error = RedisError;
+
+    async fn connect(&self) -> Result<Self::Connection, Self::Error> {
+        self.client.0.lock().await.get_async_connection().await
+    }
+
+    async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
+        let pong: String = redis::cmd("PING").query_async(conn).await?;
+        match pong.as_str() {
+            "PONG" => Ok(()),
+            _ => Err((ErrorKind::ResponseError, "ping request").into()),
+        }
+    }
+
+    fn has_broken(&self, _: &mut Self::Connection) -> bool {
+        false
+    }
+}

--- a/server/svix-server/tests/it/e2e_message.rs
+++ b/server/svix-server/tests/it/e2e_message.rs
@@ -395,6 +395,12 @@ async fn test_payload_retention_period() {
         .unwrap();
     let msg_id = msg.id.clone();
 
+    let content: Option<messagecontent::Model> = messagecontent::Entity::find_by_id(msg_id.clone())
+        .one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(content.unwrap().id, msg_id.clone());
+
     let res = messagecontent::Entity::update_many()
         .col_expr(
             messagecontent::Column::Expiration,
@@ -405,12 +411,6 @@ async fn test_payload_retention_period() {
         .await
         .unwrap();
     assert_eq!(1, res.rows_affected);
-
-    let content: Option<messagecontent::Model> = messagecontent::Entity::find_by_id(msg_id.clone())
-        .one(&pool)
-        .await
-        .unwrap();
-    assert_eq!(content.unwrap().id, msg_id.clone());
 
     expired_message_cleaner::clean_expired_messages(&pool, 5000, false)
         .await

--- a/server/svix-server/tests/it/message_app.rs
+++ b/server/svix-server/tests/it/message_app.rs
@@ -66,7 +66,9 @@ async fn test_app_deletion() {
     // Delete the cached [`CreateMessageApp`] here instead of waiting 30s for it to expire
     let cache = match cfg.cache_backend() {
         CacheBackend::None => cache::none::new(),
-        CacheBackend::Redis(_) | CacheBackend::RedisCluster(_) => {
+        CacheBackend::Redis(_)
+        | CacheBackend::RedisCluster(_)
+        | CacheBackend::RedisSentinel(_, _) => {
             let mgr = RedisManager::from_cache_backend(&cfg.cache_backend()).await;
             cache::redis::new(mgr)
         }
@@ -146,7 +148,9 @@ async fn test_endp_deletion() {
     // Delete the cached [`CreateMessageApp`] here instead of waiting 30s for it to expire
     let cache = match cfg.cache_backend() {
         CacheBackend::None => cache::none::new(),
-        CacheBackend::Redis(_) | CacheBackend::RedisCluster(_) => {
+        CacheBackend::Redis(_)
+        | CacheBackend::RedisCluster(_)
+        | CacheBackend::RedisSentinel(_, _) => {
             let mgr = RedisManager::from_cache_backend(&cfg.cache_backend()).await;
             cache::redis::new(mgr)
         }

--- a/server/testing-docker-compose.yml
+++ b/server/testing-docker-compose.yml
@@ -72,6 +72,42 @@ services:
       ALLOW_EMPTY_PASSWORD: "yes"
       REDIS_NODES: "redis-cluster redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4"
 
+  redis-sentinel:
+    image: docker.io/redis:7
+    ports:
+      - "26379:26379"
+    command: >
+      sh -c 'echo "bind 0.0.0.0" > /etc/sentinel.conf &&
+            echo "sentinel monitor master0 redis-master-0 6379 2" >> /etc/sentinel.conf &&
+            echo "sentinel resolve-hostnames yes" >> /etc/sentinel.conf &&
+            echo "sentinel down-after-milliseconds master0 10000" >> /etc/sentinel.conf &&
+            echo "sentinel failover-timeout master0 10000" >> /etc/sentinel.conf &&
+            echo "sentinel parallel-syncs master0 1" >> /etc/sentinel.conf &&
+            redis-sentinel /etc/sentinel.conf'
+
+  redis-master-0:
+    image: docker.io/redis:7
+    ports:
+      - "6387:6379"
+
+  redis-replica-0:
+    image: docker.io/redis:7
+    ports:
+      - "6388:6379"
+    command:
+      [
+        "redis-server",
+        "--appendonly",
+        "yes",
+        "--replicaof",
+        "redis-master-0",
+        "6379",
+        "--repl-diskless-load",
+        "on-empty-db",
+        "--protected-mode",
+        "no"
+      ]
+
   rabbitmq:
     image: "docker.io/rabbitmq:3.11.13-management-alpine"
     ports:


### PR DESCRIPTION
This adds support for using Redis Sentinel for queuing and caching.
Sentinel potentially requires a lot of additional configuration params,
so support for that that has been added here, although the `redis_dsn`
field has been reused and should point to a sentinel server if using the 
`redissentinel` queue/cache types.
