### PR TITLE
More redis refactors

### DIFF
--- a/server/svix-server/src/core/cache/redis.rs
+++ b/server/svix-server/src/core/cache/redis.rs
@@ -59,7 +59,7 @@ impl CacheBehavior for RedisCache {
 
         cmd.arg("NX");
 
-        let res: Option<()> = pool.query_async(cmd).await?;
+        let res: Option<()> = cmd.query_async(&mut pool).await?;
 
         Ok(res.is_some())
     }


### PR DESCRIPTION
This removes a lot of the needless indirection/structs that were obscuring what should be a pretty simple thing -- i.e., the different variants for `ConnectionManager`s and `RedisConnection`s.

Note also that by moving some of the `query_async` calls to the `Cmd` rather than the connection, we can completely remove the `*Connection` types and associated macros.

There's definitely some more cleanup that can be done here, but I think this is good for one PR.
