### PR TITLE
Redis dlq support

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,10 @@ To support graceful shutdown on the server, all running tasks are finished befor
 One of our main goals with open sourcing the Svix dispatcher is ease of use. The hosted Svix service, however, is quite complex due to our scale and the infrastructure it requires. This complexity is not useful for the vast majority of people and would make this project much harder to use and much more limited.
 This is why this code has been adjusted before being released, and some of the features, optimizations, and behaviors supported by the hosted dispatcher are not yet available in this repo. With that being said, other than some known incompatibilities, the internal Svix test suite passes. This means they are already mostly compatible, and we are working hard on bringing them to full feature parity.
 
+# Re-driving Redis DLQ
+We have an undocumented endpoint for re-driving failed messages that are DLQ'ed. You can do this by calling `POST /api/v1/admin/redrive-dlq/`.
+
+To monitor the DLQ depth, you should monitor the `svix.queue.depth_dlq` metric. Any non-zero values indicate that there is data in the DLQ. 
 
 # Development
 

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -68,7 +68,7 @@ urlencoding = "2.1.2"
 form_urlencoded = "1.1.0"
 lapin = "2.1.1"
 sentry = { version = "0.32.2", features = ["tracing"] }
-omniqueue = { git = "https://github.com/svix/omniqueue-rs", rev = "75e5a9510ad338ac3702b2e911bacf8967ac58d8", default-features = false, features = ["in_memory", "rabbitmq-with-message-ids", "redis_cluster", "redis_sentinel"] }
+omniqueue = { git = "https://github.com/svix/omniqueue-rs", rev = "75e5a9510ad338ac3702b2e911bacf8967ac58d8", default-features = false, features = ["in_memory", "rabbitmq-with-message-ids", "redis_cluster", "redis_sentinel", "beta"] }
 # Not a well-known author, and no longer gets updates => pinned.
 # Switch to hyper-http-proxy when upgrading hyper to 1.0.
 hyper-proxy = { version = "=0.9.1", default-features = false, features = ["openssl-tls"] }

--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -120,3 +120,6 @@ worker_max_tasks = 500
 # Whether or not to disable TLS certificate validation on Webhook dispatch. This is a dangerous flag
 # to set true. This value will default to false.
 # dangerous_disable_tls_verification = false
+
+# Maximum seconds of queue long-poll
+queue_max_poll_secs = 20

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -184,6 +184,9 @@ pub struct ConfigurationInner {
     /// Maximum number of concurrent worker tasks to spawn (0 is unlimited)
     pub worker_max_tasks: u16,
 
+    /// Maximum seconds of a queue long-poll
+    pub queue_max_poll_secs: u16,
+
     /// The address of the rabbitmq exchange
     pub rabbit_dsn: Option<Arc<String>>,
     pub rabbit_consumer_prefetch_size: Option<u16>,

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -69,6 +69,10 @@ const DEFAULTS: &str = include_str!("../config.default.toml");
 
 pub type Configuration = Arc<ConfigurationInner>;
 
+fn default_redis_pending_duration_secs() -> u64 {
+    45
+}
+
 #[derive(Clone, Debug, Deserialize, Validate)]
 #[validate(
     schema(function = "validate_config_complete"),
@@ -199,6 +203,9 @@ pub struct ConfigurationInner {
     /// Optional configuration for sending webhooks through a proxy.
     #[serde(flatten)]
     pub proxy_config: Option<ProxyConfig>,
+
+    #[serde(default = "default_redis_pending_duration_secs")]
+    pub redis_pending_duration_secs: u64,
 
     #[serde(flatten)]
     pub internal: InternalConfig,

--- a/server/svix-server/src/queue/rabbitmq.rs
+++ b/server/svix-server/src/queue/rabbitmq.rs
@@ -186,7 +186,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            producer.send(QueueTask::HealthCheck, None).await.unwrap();
+            producer.send(&QueueTask::HealthCheck, None).await.unwrap();
         }
 
         // Receive with lapin consumer

--- a/server/svix-server/src/v1/endpoints/admin.rs
+++ b/server/svix-server/src/v1/endpoints/admin.rs
@@ -1,0 +1,28 @@
+use aide::{
+    axum::{routing::post_with, ApiRouter},
+    transform::TransformPathItem,
+};
+use axum::extract::State;
+use svix_server_derive::aide_annotate;
+
+use crate::{core::permissions, error::Result, v1::utils::NoContent, AppState};
+
+/// Redrive DLQ
+#[aide_annotate(op_id = "v1.admin.redrive-dlq")]
+pub async fn redrive_dlq(
+    State(AppState { queue_tx, .. }): State<AppState>,
+    _: permissions::Organization,
+) -> Result<NoContent> {
+    if let Err(e) = queue_tx.redrive_dlq().await {
+        tracing::warn!(error = ?e, "DLQ redrive failed");
+    }
+    Ok(NoContent)
+}
+
+pub fn router() -> ApiRouter<AppState> {
+    ApiRouter::new().api_route_with(
+        "/admin/redrive-dlq",
+        post_with(redrive_dlq, redrive_dlq_operation),
+        move |op: TransformPathItem<'_>| op.tag("Admin".as_ref()).hidden(true),
+    )
+}

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -845,7 +845,7 @@ async fn resend_webhook(
 
     queue_tx
         .send(
-            MessageTask::new_task(
+            &MessageTask::new_task(
                 msg.id.clone(),
                 app.id,
                 endp.id,

--- a/server/svix-server/src/v1/endpoints/endpoint/recovery.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/recovery.rs
@@ -53,7 +53,7 @@ async fn bulk_recover_failed_messages(
         for msg_dest in items {
             queue_tx
                 .send(
-                    MessageTask::new_task(
+                    &MessageTask::new_task(
                         msg_dest.msg_id,
                         app.id.clone(),
                         msg_dest.endp_id,

--- a/server/svix-server/src/v1/endpoints/health.rs
+++ b/server/svix-server/src/v1/endpoints/health.rs
@@ -100,7 +100,7 @@ async fn health(
         .into();
 
     // Send a [`HealthCheck`] through the queue
-    let queue: HealthStatus = queue_tx.send(QueueTask::HealthCheck, None).await.into();
+    let queue: HealthStatus = queue_tx.send(&QueueTask::HealthCheck, None).await.into();
 
     // Set a cache value with an expiration to ensure it works
     let cache: HealthStatus = cache

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -376,7 +376,7 @@ pub(crate) async fn create_message_inner(
     {
         queue_tx
             .send(
-                MessageTaskBatch::new_task(
+                &MessageTaskBatch::new_task(
                     msg.id.clone(),
                     app.id.clone(),
                     force_endpoint,

--- a/server/svix-server/src/v1/endpoints/mod.rs
+++ b/server/svix-server/src/v1/endpoints/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
+pub mod admin;
 pub mod application;
 pub mod attempt;
 pub mod auth;

--- a/server/svix-server/src/v1/mod.rs
+++ b/server/svix-server/src/v1/mod.rs
@@ -21,6 +21,7 @@ pub fn router() -> ApiRouter<AppState> {
         .merge(endpoints::event_type::router())
         .merge(endpoints::message::router())
         .merge(endpoints::attempt::router())
+        .merge(endpoints::admin::router())
         .layer(
             TraceLayer::new_for_http()
                 .make_span_with(AxumOtelSpanCreator)

--- a/server/svix-server/tests/it/redis_queue.rs
+++ b/server/svix-server/tests/it/redis_queue.rs
@@ -59,7 +59,7 @@ async fn test_many_queue_consumers_inner(prefix: &str, delay: Option<Duration>) 
     for (index, (p, _c)) in producers_and_consumers.iter().enumerate() {
         for num in 0..200 {
             p.send(
-                QueueTask::MessageV1(MessageTask {
+                &QueueTask::MessageV1(MessageTask {
                     msg_id: MessageId(format!("{}", index * 200 + num)),
                     app_id: ApplicationId("TestApplicationId".to_owned()),
                     endpoint_id: EndpointId("TestEndpointId".to_owned()),
@@ -88,7 +88,12 @@ async fn test_many_queue_consumers_inner(prefix: &str, delay: Option<Duration>) 
                 let mut out = Vec::new();
                 let mut read = 0;
 
-                while let Ok(recv) = timeout(Duration::from_secs(1), c.receive_all()).await {
+                while let Ok(recv) = timeout(
+                    Duration::from_secs(1),
+                    c.receive_all(Duration::from_secs(5)),
+                )
+                .await
+                {
                     let recv = recv.unwrap();
                     read += recv.len();
                     for r in recv {


### PR DESCRIPTION
Add support for moving failed messages to deadletter queue in
Redis. The queue can be re-driven via an undocumented endpoint,
`/api/v1/admin/redrive-dlq`.
