### PR TITLE
Add redis OTEL metrics

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1055,15 +1055,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-queue"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2965,9 +2956,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
+checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2975,14 +2966,13 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "thiserror",
- "urlencoding",
 ]
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7690dc77bf776713848c4faa6501157469017eaf332baccd4eb1cea928743d94"
+checksum = "b0ba633e55c5ea6f431875ba55e71664f2fa5d3a90bd34ec9302eecc41c865dd"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2992,16 +2982,15 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
+checksum = "a94c69209c05319cdf7460c6d4c055ed102be242a0a6245835d7bc42c6ec7f54"
 dependencies = [
  "async-trait",
  "futures-core",
  "http 0.2.12",
  "opentelemetry",
  "opentelemetry-proto",
- "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "prost",
  "thiserror",
@@ -3011,9 +3000,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
+checksum = "984806e6cf27f2b49282e2a05e288f30594f3dbc74eb7a6e99422bc48ed78162"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -3022,23 +3011,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
-
-[[package]]
 name = "opentelemetry_sdk"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
+checksum = "ae312d58eaa90a82d2e627fd86e075cf5230b3f11794e2ed74199ebbe572d4fd"
 dependencies = [
  "async-trait",
- "crossbeam-channel",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "glob",
+ "lazy_static",
  "once_cell",
  "opentelemetry",
  "ordered-float 4.2.1",
@@ -4911,6 +4894,7 @@ dependencies = [
  "figment",
  "form_urlencoded",
  "futures",
+ "hex",
  "hickory-resolver",
  "hmac-sha256",
  "http 0.2.12",
@@ -5442,9 +5426,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
+checksum = "f68803492bf28ab40aeccaecc7021096bd256baf7ca77c3d425d89b35a7be4e4"
 dependencies = [
  "js-sys",
  "once_cell",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1591,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1601,9 +1601,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
@@ -1629,9 +1629,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -1663,9 +1663,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1674,21 +1674,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -33,11 +33,11 @@ once_cell = "1.18.0"
 figment = { version = "0.10", features = ["toml", "env", "test"] }
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-tracing-opentelemetry = "0.23.0"
-opentelemetry = "0.22.0"
-opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio"] }
-opentelemetry-http = "0.11.0"
-opentelemetry-otlp = { version = "0.15.0" }
+tracing-opentelemetry = "0.24.0"
+opentelemetry = { version = "0.23.0", features = ["metrics"] }
+opentelemetry_sdk = { version = "0.23.0", features = ["rt-tokio"] }
+opentelemetry-http = "0.12.0"
+opentelemetry-otlp = { version = "0.16.0", features = ["metrics"] }
 validator = { version = "0.16.0", features = ["derive"] }
 jwt-simple = "0.11.6"
 ed25519-compact = "2.1.1"
@@ -72,6 +72,7 @@ omniqueue = { git = "https://github.com/svix/omniqueue-rs", rev = "75e5a9510ad33
 # Not a well-known author, and no longer gets updates => pinned.
 # Switch to hyper-http-proxy when upgrading hyper to 1.0.
 hyper-proxy = { version = "=0.9.1", default-features = false, features = ["openssl-tls"] }
+hex = "0.4.3"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.5", optional = true }

--- a/server/svix-server/src/metrics/mod.rs
+++ b/server/svix-server/src/metrics/mod.rs
@@ -1,0 +1,13 @@
+mod redis;
+
+pub fn init_metric<T, E: std::fmt::Debug>(result: Result<T, E>) -> Option<T> {
+    match result {
+        Ok(t) => Some(t),
+        Err(e) => {
+            tracing::error!(error = ?e, "Failed to initialize metric");
+            None
+        }
+    }
+}
+
+pub use self::redis::{RedisQueueMetrics, RedisQueueType};

--- a/server/svix-server/src/metrics/redis.rs
+++ b/server/svix-server/src/metrics/redis.rs
@@ -1,0 +1,119 @@
+use opentelemetry::metrics::{Meter, ObservableGauge};
+use redis::{streams::StreamPendingReply, AsyncCommands as _};
+
+use super::init_metric;
+use crate::{
+    error::{Error, Result},
+    redis::RedisManager,
+};
+
+pub enum RedisQueueType<'a> {
+    Stream(&'a str),
+    StreamPending { stream: &'a str, group: &'a str },
+    List(&'a str),
+    SortedSet(&'a str),
+}
+
+impl<'a> RedisQueueType<'a> {
+    pub async fn queue_depth(&self, redis: &RedisManager) -> Result<u64> {
+        let mut conn = redis.get().await?;
+        match self {
+            RedisQueueType::Stream(q) => conn
+                .xlen(q)
+                .await
+                .map_err(|e| Error::queue(format!("Failed to query queue depth: {e}"))),
+            RedisQueueType::StreamPending { stream, group } => {
+                let reply: StreamPendingReply = conn.xpending(stream, group).await?;
+                Ok(reply.count() as _)
+            }
+            RedisQueueType::List(q) => conn
+                .llen(q)
+                .await
+                .map_err(|e| Error::queue(format!("Failed to query queue depth: {e}"))),
+            RedisQueueType::SortedSet(q) => conn
+                .zcard(q)
+                .await
+                .map_err(|e| Error::queue(format!("Failed to query queue depth: {e}"))),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct RedisQueueMetrics {
+    main_queue: Option<ObservableGauge<u64>>,
+    pending_queue: Option<ObservableGauge<u64>>,
+    delayed_queue: Option<ObservableGauge<u64>>,
+}
+
+impl RedisQueueMetrics {
+    pub fn new(meter: &Meter) -> Self {
+        let main_queue = init_metric(
+            meter
+                .u64_observable_gauge("svix.queue.depth_main")
+                .try_init(),
+        );
+
+        let pending_queue = init_metric(
+            meter
+                .u64_observable_gauge("svix.queue.pending_msgs")
+                .try_init(),
+        );
+
+        let delayed_queue = init_metric(
+            meter
+                .u64_observable_gauge("svix.queue.depth_delayed")
+                .try_init(),
+        );
+
+        Self {
+            main_queue,
+            pending_queue,
+            delayed_queue,
+        }
+    }
+    pub async fn record(
+        &self,
+        redis: &RedisManager,
+        main_queue: &RedisQueueType<'_>,
+        pending_queue: &RedisQueueType<'_>,
+        delayed_queue: &RedisQueueType<'_>,
+    ) {
+        main_queue
+            .queue_depth(redis)
+            .await
+            .map(|d| self.record_main_queue_depth(d))
+            .unwrap_or_else(|e| {
+                tracing::warn!("Failed to record queue depth: {e}");
+            });
+        pending_queue
+            .queue_depth(redis)
+            .await
+            .map(|d| self.record_pending_queue_depth(d))
+            .unwrap_or_else(|e| {
+                tracing::warn!("Failed to record queue depth: {e}");
+            });
+        delayed_queue
+            .queue_depth(redis)
+            .await
+            .map(|d| self.record_delayed_queue_depth(d))
+            .unwrap_or_else(|e| {
+                tracing::warn!("Failed to record queue depth: {e}");
+            });
+    }
+
+    fn record_main_queue_depth(&self, value: u64) {
+        if let Some(recorder) = &self.main_queue {
+            recorder.observe(value, &[]);
+        }
+    }
+    fn record_pending_queue_depth(&self, value: u64) {
+        if let Some(recorder) = &self.pending_queue {
+            recorder.observe(value, &[]);
+        }
+    }
+    fn record_delayed_queue_depth(&self, value: u64) {
+        if let Some(recorder) = &self.delayed_queue {
+            recorder.observe(value, &[]);
+        }
+    }
+}

--- a/server/svix-server/src/mod.rs
+++ b/server/svix-server/src/mod.rs
@@ -1,0 +1,9 @@
+mod redis;
+mod worker;
+
+pub use svix_server_core::metrics::*;
+
+pub use self::{
+    redis::{RedisQueueMetrics, RedisQueueType},
+    worker::WorkerMetrics,
+};


### PR DESCRIPTION
This adds support exporting OTEL metrics and adds some basic monitoring of the various redis queues.
