### PR TITLE
bridge: Upgrade dependencies

### DIFF
--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -186,6 +186,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "asn1-rs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,19 +760,20 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.20"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
 dependencies = [
  "async-trait",
  "axum-core",
  "axum-macros",
- "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.30",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -778,37 +785,41 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.1",
  "tokio",
- "tower",
+ "tower 0.5.1",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.3.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
 dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
  "mime",
+ "pin-project-lite",
  "rustversion",
+ "sync_wrapper 1.0.1",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "axum-macros"
-version = "0.3.8"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdca6a10ecad987bda04e95606ef85a5417dcaac1a78455242d72e031e2b6b62"
+checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
- "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
@@ -892,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "bb8-redis"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb4f141b33a750b5f667c445bd8588de10b8f2b045cd2aabc040ca746fb53ae"
+checksum = "1781f22daa0ae97d934fdf04a5c66646f154a164c4bdc157ec8d3c11166c05cc"
 dependencies = [
  "async-trait",
  "bb8",
@@ -921,14 +932,14 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.4"
+version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -1119,9 +1130,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.19"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1129,9 +1140,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.19"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1260,15 +1271,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1308,24 +1310,22 @@ checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 
 [[package]]
 name = "deadpool"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
-dependencies = [
- "async-trait",
- "deadpool-runtime",
- "num_cpus",
- "retain_mut",
- "tokio",
-]
-
-[[package]]
-name = "deadpool"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490"
 dependencies = [
  "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6541a3916932fe57768d4be0b1ffb5ec7cbf74ca8c903fdfd5c0fe8aa958f0ed"
+dependencies = [
  "deadpool-runtime",
  "num_cpus",
  "tokio",
@@ -1352,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ast"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ea2fd038c9c7e3e87e624fd708303cd33f39c33707f6c48fa9a65d65fefc47"
+checksum = "b2b9d03b1bbeeecdac54367f075d572131736d06c5be3bc49037855bc5ab1bbb"
 dependencies = [
  "deno_media_type",
  "deno_terminal",
@@ -1888,9 +1888,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "google-cloud-auth"
-version = "0.14.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe54dd8b6eb2bcd5390998238bcc39d1daed4dbb70df2845832532540384fc41"
+checksum = "357160f51a60ec3e32169ad687f4abe0ee1e90c73b449aa5d11256c4f1cf2ff6"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -1910,36 +1910,36 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax"
-version = "0.17.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb60314136e37de9e2a05ddb427b9c5a39c3d188de2e2f026c6af74425eef44"
+checksum = "c929076122a1839455cfe6c030278f10a400dd4dacc11d2ca46c20c47dc05996"
 dependencies = [
  "google-cloud-token",
- "http 0.2.12",
+ "http 1.1.0",
  "thiserror",
  "tokio",
- "tokio-retry",
- "tonic 0.10.2",
- "tower",
+ "tokio-retry2",
+ "tonic",
+ "tower 0.4.13",
  "tracing",
 ]
 
 [[package]]
 name = "google-cloud-googleapis"
-version = "0.12.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8a478015d079296167e3f08e096dc99cffc2cb50fa203dd38aaa9dd37f8354"
+checksum = "0ae8ab26ef7c7c3f7dfb9cc3982293d031d8e78c85d00ddfb704b5c35aeff7c8"
 dependencies = [
  "prost",
  "prost-types",
- "tonic 0.10.2",
+ "tonic",
 ]
 
 [[package]]
 name = "google-cloud-metadata"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc279bfb50487d7bcd900e8688406475fc750fe474a835b2ab9ade9eb1fc90e2"
+checksum = "04f945a208886a13d07636f38fb978da371d0abc3e34bad338124b9f8c135a8f"
 dependencies = [
  "reqwest",
  "thiserror",
@@ -1948,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-pubsub"
-version = "0.24.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2184a5c70b994e6d77eb1c140e193e7f5fe6015e9115322fac24f7e33f003c"
+checksum = "045a337f4f21327a27721df5699d395d7f5b56be6e1d5fcb35591364d5d02147"
 dependencies = [
  "async-channel 1.9.0",
  "async-stream",
@@ -2261,27 +2261,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-timeout"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
 dependencies = [
- "hyper 0.14.30",
+ "hyper 1.4.1",
+ "hyper-util",
  "pin-project-lite",
  "tokio",
- "tokio-io-timeout",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.30",
- "native-tls",
- "tokio",
- "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -2437,6 +2425,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2764,9 +2761,8 @@ dependencies = [
 [[package]]
 name = "omniqueue"
 version = "0.2.1"
-source = "git+https://github.com/svix/omniqueue-rs?rev=62ca8fa5cb0ac47bbfbad4b1939bcfe7d4cdfb6b#62ca8fa5cb0ac47bbfbad4b1939bcfe7d4cdfb6b"
+source = "git+https://github.com/svix/omniqueue-rs?rev=e953ce07621a33708a4c28d9a5cfe431ede45dee#e953ce07621a33708a4c28d9a5cfe431ede45dee"
 dependencies = [
- "async-trait",
  "aws-config",
  "aws-sdk-sqs",
  "bb8",
@@ -2779,7 +2775,8 @@ dependencies = [
  "redis",
  "serde",
  "serde_json",
- "svix-ksuid 0.8.0",
+ "svix-ksuid",
+ "sync_wrapper 1.0.1",
  "thiserror",
  "time",
  "tokio",
@@ -2838,9 +2835,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.22.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
+checksum = "570074cc999d1a58184080966e5bd3bf3a9a4af650c3b05047c2621e7405cd17"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2848,90 +2845,72 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "thiserror",
- "urlencoding",
 ]
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.11.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7690dc77bf776713848c4faa6501157469017eaf332baccd4eb1cea928743d94"
+checksum = "6351496aeaa49d7c267fb480678d85d1cd30c5edb20b497c48c56f62a8c14b99"
 dependencies = [
  "async-trait",
  "bytes",
- "http 0.2.12",
+ "http 1.1.0",
  "opentelemetry",
  "reqwest",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.15.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
+checksum = "29e1f9c8b032d4f635c730c0efcf731d5e2530ea13fa8bef7939ddc8420696bd"
 dependencies = [
  "async-trait",
  "futures-core",
- "http 0.2.12",
+ "http 1.1.0",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
- "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "prost",
  "reqwest",
  "thiserror",
  "tokio",
- "tonic 0.11.0",
+ "tonic",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.5.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
+checksum = "c9d3968ce3aefdcca5c27e3c4ea4391b37547726a70893aab52d3de95d5f8b34"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "prost",
- "tonic 0.11.0",
+ "tonic",
 ]
 
 [[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
-
-[[package]]
 name = "opentelemetry_sdk"
-version = "0.22.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
+checksum = "d2c627d9f4c9cdc1f21a29ee4bfbd6028fcb8bcf2a857b43f3abdf72c9c862f3"
 dependencies = [
  "async-trait",
- "crossbeam-channel",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "glob",
  "once_cell",
  "opentelemetry",
- "ordered-float",
  "percent-encoding",
  "rand",
+ "serde_json",
  "thiserror",
  "tokio",
  "tokio-stream",
-]
-
-[[package]]
-name = "ordered-float"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d501f1a72f71d3c063a6bbc8f7271fa73aa09fe5d6283b6571e2ed176a2537"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -3268,18 +3247,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.12.6"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3287,12 +3266,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.6"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
@@ -3300,9 +3279,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.12.6"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
 dependencies = [
  "prost",
 ]
@@ -3436,16 +3415,18 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.25.4"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d7a6955c7511f60f3ba9e86c6d02b3c3f144f8c24b288d1f4e18074ab8bbec"
+checksum = "92f61607c4c4442b575fbc3f31a5dd4e5dd69cfea8f6afec5b83e24f61c126ab"
 dependencies = [
+ "arc-swap",
  "async-trait",
  "bytes",
  "combine",
  "futures-util",
  "itoa",
  "native-tls",
+ "num-bigint",
  "percent-encoding",
  "pin-project-lite",
  "ryu",
@@ -3518,20 +3499,22 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.30",
- "hyper-tls 0.5.0",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-tls",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -3540,12 +3523,11 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
- "system-configuration",
+ "sync_wrapper 1.0.1",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -3553,14 +3535,8 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
+ "windows-registry",
 ]
-
-[[package]]
-name = "retain_mut"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
 name = "ring"
@@ -3675,6 +3651,7 @@ version = "0.23.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4218,7 +4195,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.4.1",
  "hyper-rustls 0.26.0",
- "hyper-tls 0.6.0",
+ "hyper-tls",
  "hyper-util",
  "serde",
  "serde_derive",
@@ -4239,12 +4216,11 @@ dependencies = [
  "base64 0.13.1",
  "chrono",
  "clap",
- "deadpool 0.9.5",
+ "deadpool 0.12.1",
  "deno_ast",
  "deno_core",
  "enum_dispatch",
- "http 0.2.12",
- "itertools",
+ "itertools 0.13.0",
  "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -4256,11 +4232,11 @@ dependencies = [
  "svix-bridge-plugin-kafka",
  "svix-bridge-plugin-queue",
  "svix-bridge-types",
- "svix-ksuid 0.7.0",
+ "svix-ksuid",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "tokio",
- "tower",
+ "tower 0.5.1",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -4315,18 +4291,6 @@ dependencies = [
  "serde_json",
  "svix",
  "tokio",
-]
-
-[[package]]
-name = "svix-ksuid"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75d773122e48817eb6eb74605cf799574a855bf4c7eb0c1bb06c005067123b13"
-dependencies = [
- "base-encode",
- "byteorder",
- "getrandom",
- "time",
 ]
 
 [[package]]
@@ -4493,6 +4457,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4501,27 +4474,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.79",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -4605,9 +4557,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-ctl"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619bfed27d807b54f7f776b9430d4f8060e66ee138a28632ca898584d462c31c"
+checksum = "f21f216790c8df74ce3ab25b534e0718da5a1916719771d3fec23315c99e468b"
 dependencies = [
  "libc",
  "paste",
@@ -4616,9 +4568,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
 dependencies = [
  "cc",
  "libc",
@@ -4626,9 +4578,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",
@@ -4710,16 +4662,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4755,13 +4697,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-retry"
-version = "0.3.0"
+name = "tokio-retry2"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+checksum = "903934dba1c4c2f2e9cb460ef10b5695e0b0ecad3bf9ee7c8675e540c5e8b2d1"
 dependencies = [
  "pin-project",
- "rand",
  "tokio",
 ]
 
@@ -4782,6 +4723,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
  "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls 0.23.14",
  "rustls-pki-types",
  "tokio",
 ]
@@ -4829,61 +4781,36 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.10.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "flate2",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.30",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
  "hyper-timeout",
+ "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile 2.2.0",
+ "socket2 0.5.7",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls 0.26.0",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
  "webpki-roots",
-]
-
-[[package]]
-name = "tonic"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum",
- "base64 0.21.7",
- "bytes",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.30",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -4901,6 +4828,22 @@ dependencies = [
  "slab",
  "tokio",
  "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 0.1.2",
+ "tokio",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4964,9 +4907,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.23.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
+checksum = "dc58af5d3f6c5811462cabb3289aec0093f7338e367e5a33d28c0433b3c7360b"
 dependencies = [
  "js-sys",
  "once_cell",
@@ -5265,9 +5208,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
+version = "0.26.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "which"
@@ -5330,6 +5276,36 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
  "windows-targets 0.52.6",
 ]
 
@@ -5488,16 +5464,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/bridge/svix-bridge-plugin-queue/Cargo.toml
+++ b/bridge/svix-bridge-plugin-queue/Cargo.toml
@@ -16,7 +16,7 @@ tracing = "0.1"
 
 [dependencies.omniqueue]
 git = "https://github.com/svix/omniqueue-rs"
-rev = "62ca8fa5cb0ac47bbfbad4b1939bcfe7d4cdfb6b"
+rev = "e953ce07621a33708a4c28d9a5cfe431ede45dee"
 default-features = false
 features = ["gcp_pubsub", "rabbitmq", "redis", "sqs"]
 
@@ -24,10 +24,10 @@ features = ["gcp_pubsub", "rabbitmq", "redis", "sqs"]
 aws-config = "1.1.5"
 aws-sdk-sqs = "1.13.0"
 fastrand = "2.0.1"
-google-cloud-googleapis = "0.12.0"
-google-cloud-pubsub = "0.24.0"
+google-cloud-googleapis = "0.15.0"
+google-cloud-pubsub = "0.29.1"
 lapin = "2"
-redis = { version = "0.25.4", features = ["tokio-comp", "streams"] }
+redis = { version = "0.27.2", features = ["tokio-comp", "streams"] }
 tracing-subscriber.workspace = true
 wiremock.workspace = true
 

--- a/bridge/svix-bridge-plugin-queue/src/redis/mod.rs
+++ b/bridge/svix-bridge-plugin-queue/src/redis/mod.rs
@@ -54,6 +54,8 @@ pub async fn consumer(cfg: &RedisInputOpts) -> Result<DynConsumer> {
         // FIXME: expose in config?
         payload_key: "payload".to_string(),
         ack_deadline_ms: cfg.ack_deadline_ms,
+        dlq_config: None,
+        sentinel_config: None,
     })
     .make_dynamic()
     .build_consumer()
@@ -80,6 +82,8 @@ pub async fn producer(cfg: &RedisOutputOpts) -> Result<DynProducer> {
         consumer_group: String::new(),
         consumer_name: String::new(),
         ack_deadline_ms: cfg.ack_deadline_ms,
+        dlq_config: None,
+        sentinel_config: None,
     })
     .make_dynamic()
     .build_producer()

--- a/bridge/svix-bridge/Cargo.toml
+++ b/bridge/svix-bridge/Cargo.toml
@@ -8,39 +8,38 @@ publish = false
 anyhow = "1"
 base64 = "0.13.1"
 clap = { version = "4.2.4", features = ["env", "derive"] }
-axum = { version = "0.6", features = ["macros"] }
+axum = { version = "0.7.7", features = ["macros"] }
 enum_dispatch = "0.3"
-itertools = "0.12.1"
-http = "0.2"
+itertools = "0.13.0"
 once_cell = "1.18.0"
-opentelemetry = "0.22.0"
-opentelemetry_sdk = { version = "0.22.1", features = ["metrics", "rt-tokio"] }
-opentelemetry-otlp = { version = "0.15.0", features = ["metrics", "grpc-tonic", "http-proto", "reqwest-client"] }
+opentelemetry = "0.26.0"
+opentelemetry_sdk = { version = "0.26.0", features = ["metrics", "rt-tokio"] }
+opentelemetry-otlp = { version = "0.26.0", features = ["metrics", "grpc-tonic", "http-proto", "reqwest-client"] }
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml = "0.9"
-svix-ksuid = "0.7.0"
+svix-ksuid = "0.8.0"
 svix-bridge-plugin-queue = { path = "../svix-bridge-plugin-queue" }
 svix-bridge-plugin-kafka = { optional = true, path = "../svix-bridge-plugin-kafka" }
 svix-bridge-types.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-tracing-opentelemetry = "0.23.0"
+tracing-opentelemetry = "0.27.0"
 tracing-subscriber = { workspace = true, features = ["fmt", "json"] }
 # N.b. for newer deno versions (like this) the runtimes must be retained and reused since they will leak memory if you
 # create/drop them.
 deno_core = "0.308.0"
 deno_ast = "0.42.1"
-deadpool = { version = "0.9.5", features = ["unmanaged", "rt_tokio_1"] }
+deadpool = { version = "0.12.1", features = ["unmanaged", "rt_tokio_1"] }
 shellexpand = { version = "3.1.0", default-features = false, features = ["base-0"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { version = "0.5", optional = true }
-tikv-jemalloc-ctl = { version = "0.5", optional = true, features = ["use_std"] }
+tikv-jemallocator = { version = "0.6.0", optional = true }
+tikv-jemalloc-ctl = { version = "0.6.0", optional = true, features = ["use_std", "stats"] }
 
 [dev-dependencies]
 chrono = "0.4"
-tower = "0.4"
+tower = "0.5.1"
 
 [features]
 default = ["kafka", "jemalloc"]

--- a/bridge/svix-bridge/src/main.rs
+++ b/bridge/svix-bridge/src/main.rs
@@ -7,6 +7,7 @@ use std::{
 use clap::Parser;
 use itertools::{Either, Itertools};
 use once_cell::sync::Lazy;
+use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::{
     metrics::{data::Temporality, reader::TemporalitySelector, InstrumentKind, SdkMeterProvider},
@@ -89,7 +90,7 @@ fn setup_tracing(cfg: &Config) {
             .tracing()
             .with_exporter(exporter)
             .with_trace_config(
-                opentelemetry_sdk::trace::config()
+                opentelemetry_sdk::trace::Config::default()
                     .with_sampler(
                         otel_cfg
                             .sample_ratio
@@ -99,7 +100,8 @@ fn setup_tracing(cfg: &Config) {
                     .with_resource(get_svc_identifiers(cfg)),
             )
             .install_batch(Tokio)
-            .unwrap();
+            .unwrap()
+            .tracer("svix_bridge");
 
         tracing_opentelemetry::layer().with_tracer(tracer)
     });

--- a/bridge/svix-bridge/src/webhook_receiver/tests.rs
+++ b/bridge/svix-bridge/src/webhook_receiver/tests.rs
@@ -66,7 +66,7 @@ async fn test_forwarding_no_verification() {
                 .uri("/webhook/a")
                 .method("POST")
                 .header("content-type", "application/json")
-                .body(serde_json::to_vec(&json!({"a": true})).unwrap().into())
+                .body(axum::body::Body::from(json!({ "a": true }).to_string()))
                 .unwrap(),
         )
         .await
@@ -110,7 +110,7 @@ async fn test_forwarding_multiple_receivers() {
         .uri("/webhook/a")
         .method("POST")
         .header("content-type", "application/json")
-        .body(serde_json::to_vec(&json!({"a": true})).unwrap().into())
+        .body(axum::body::Body::from(json!({ "a": true }).to_string()))
         .unwrap();
 
     let response = ServiceExt::<Request<Body>>::ready(&mut app)
@@ -128,7 +128,7 @@ async fn test_forwarding_multiple_receivers() {
         .uri("/webhook/b")
         .method("POST")
         .header("content-type", "application/json")
-        .body(serde_json::to_vec(&json!({"b": true})).unwrap().into())
+        .body(axum::body::Body::from(json!({ "b": true }).to_string()))
         .unwrap();
 
     let response = ServiceExt::<Request<Body>>::ready(&mut app)
@@ -200,7 +200,7 @@ async fn test_transformation_json() {
         .uri("/webhook/transformed")
         .method("POST")
         .header("content-type", "application/json")
-        .body(serde_json::to_vec(&json!({"a": true})).unwrap().into())
+        .body(axum::body::Body::from(json!({ "a": true }).to_string()))
         .unwrap();
 
     let response = ServiceExt::<Request<Body>>::ready(&mut app)
@@ -222,7 +222,7 @@ async fn test_transformation_json() {
         .uri("/webhook/as-is")
         .method("POST")
         .header("content-type", "application/json")
-        .body(serde_json::to_vec(&json!({"b": true})).unwrap().into())
+        .body(axum::body::Body::from(json!({ "b": true }).to_string()))
         .unwrap();
 
     let response = ServiceExt::<Request<Body>>::ready(&mut app)
@@ -280,7 +280,7 @@ async fn test_transformation_string() {
         .uri("/webhook/transformed")
         .method("POST")
         .header("content-type", "text/plain")
-        .body("plain text".as_bytes().into())
+        .body(axum::body::Body::from("plain text"))
         .unwrap();
 
     let response = ServiceExt::<Request<Body>>::ready(&mut app)
@@ -337,7 +337,7 @@ async fn test_forwarding_svix_verification_mismatch() {
                 .header("svix-id", "msg_valid")
                 .header("svix-signature", signature.clone())
                 .header("svix-timestamp", &format!("{timestamp}"))
-                .body(sent_payload_bytes.into())
+                .body(axum::body::Body::from(sent_payload_bytes))
                 .unwrap(),
         )
         .await
@@ -383,13 +383,13 @@ async fn test_forwarding_svix_verification_match() {
                 .header("content-type", "application/json")
                 .header("svix-id", "msg_valid")
                 .header("svix-signature", signature.clone())
-                .header("svix-timestamp", &format!("{timestamp}"))
-                .body(payload_bytes.into())
+                .header("svix-timestamp", timestamp.to_string())
+                .body(axum::body::Body::from(payload_bytes))
                 .unwrap(),
         )
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::NO_CONTENT);
     let forwarded = a_rx.try_recv().unwrap();
-    assert_eq!(json!(forwarded), json!({"a": true}));
+    assert_eq!(json!(forwarded), json!({ "a": true }));
 }

--- a/bridge/svix-bridge/src/webhook_receiver/verification.rs
+++ b/bridge/svix-bridge/src/webhook_receiver/verification.rs
@@ -85,7 +85,7 @@ pub enum Verifier {
 mod tests {
     use std::sync::Arc;
 
-    use axum::extract::FromRequest;
+    use axum::{extract::FromRequest, http};
     use svix_bridge_types::svix::webhooks::Webhook;
 
     use super::{super::types::SerializableRequest, SvixVerifier, VerificationMethod};
@@ -107,7 +107,7 @@ mod tests {
             .header("svix-id", "msg_valid")
             .header("svix-signature", signature.clone())
             .header("svix-timestamp", &format!("{timestamp}"))
-            .body(axum::body::Full::new(payload))
+            .body(axum::body::Body::from(payload))
             .unwrap();
 
         let sr = SerializableRequest::from_request(req, &()).await.unwrap();
@@ -119,7 +119,7 @@ mod tests {
             .header("svix-id", "msg_invalid")
             .header("svix-signature", signature)
             .header("svix-timestamp", &format!("{timestamp}"))
-            .body(axum::body::Full::new(payload))
+            .body(axum::body::Body::from(payload))
             .unwrap();
 
         let sr = SerializableRequest::from_request(req, &()).await.unwrap();


### PR DESCRIPTION
## Motivation

After getting a rustsec warning in #1469, I attempted this upgrade last week, but it failed due to a weird version constraint in opentelemetry (`tokio ~= 1.38.0`). The rustsec ended up being updated so I could merge the other PR w/o these upgrades, but I feel like it still makes sense to get this merged now rather than later.

## Solution

Upgrade most of our dependencies, including axum 0.6 > 0.7.