### PR TITLE
Update the base images to bookworm, support kafka plugin

### DIFF
--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -1,13 +1,14 @@
 # Base build
-FROM rust:1.72-slim-bullseye AS build
+FROM rust:1.81-slim-bookworm AS build
 
 RUN apt-get update && apt-get install -y \
     build-essential=12.* \
     checkinstall=1.* \
     curl=7.* \
     libssl-dev=* \
-    pkg-config=0.29.* \
+    pkg-config=1.8.* \
     zlib1g-dev=1:* \
+    cmake=3.* \
     --no-install-recommends
 
 RUN set -ex ; \
@@ -23,12 +24,15 @@ WORKDIR /app
 COPY Cargo.toml .
 COPY Cargo.lock .
 COPY svix-bridge-types/Cargo.toml svix-bridge-types/
+COPY svix-bridge-plugin-kafka/Cargo.toml svix-bridge-plugin-kafka/
 COPY svix-bridge-plugin-queue/Cargo.toml svix-bridge-plugin-queue/
 COPY svix-bridge/Cargo.toml svix-bridge/
 RUN set -ex ;\
+        mkdir svix-bridge-plugin-kafka/src ;\
         mkdir svix-bridge-plugin-queue/src ;\
         mkdir svix-bridge-types/src ;\
         mkdir svix-bridge/src ;\
+        echo '' > svix-bridge-plugin-kafka/src/lib.rs ;\
         echo '' > svix-bridge-plugin-queue/src/lib.rs ;\
         echo '' > svix-bridge-types/src/lib.rs ;\
         echo 'fn main() { println!("Dummy!"); }' > svix-bridge/src/main.rs ;\
@@ -44,7 +48,7 @@ RUN touch */src/lib.rs && touch */src/main.rs
 RUN cargo build --release --frozen
 
 # Production
-FROM debian:bullseye-slim AS prod
+FROM debian:bookworm-slim AS prod
 
 RUN set -ex ; \
         mkdir -p /app ;\

--- a/bridge/svix-bridge-plugin-kafka/Cargo.toml
+++ b/bridge/svix-bridge-plugin-kafka/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-rdkafka = { version = "0.36.0", features = ["cmake-build", "ssl", "tracing"] }
+rdkafka = { version = "0.36.2", features = ["cmake-build", "ssl", "tracing"] }
 serde.workspace = true
 serde_json.workspace = true
 svix-bridge-types.workspace = true


### PR DESCRIPTION
This PR updates Dockerfile  with docker images versions 
and adds the necessary support for the svix kafka plugin
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

The Docker build for the bridge plugin was failing due
to the missing kafka dev library and needed rust version
update for some rust crates.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
This PR updates the rust image version from `rust:1.72-slim-bullseye`
to `rust:1.81-slim-bookworm` as was promted during the test builds for
the underlying crate versions. It installs kafka dev library for supporting
the rdkafka crate. It also adds the associated changes for including the
`svix-bridge-plugin-kafka` and fixes the `cmake` missing error by adding
the `cmake` utility for building the required libraries. Similarly the
`debian:bullseye-slim` is now `debian:bookworm-slim` for the ultimate
prod image
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
