### PR TITLE
Upgrade CI to run on Ubuntu 24.04

### DIFF
--- a/.github/workflows/bridge-ci.yml
+++ b/.github/workflows/bridge-ci.yml
@@ -75,7 +75,7 @@ jobs:
           checkinstall=1.* \
           curl \
           libssl-dev=* \
-          pkg-config=0.29.* \
+          pkg-config=1.8.* \
           zlib1g-dev=1:*
 
     - name: Start required services

--- a/.github/workflows/bridge-ci.yml
+++ b/.github/workflows/bridge-ci.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   check-fmt:
     name: Check formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -40,7 +40,7 @@ jobs:
 
   test-versions:
     name: Webhook Bridge CI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         rust: [stable, beta]
@@ -90,7 +90,7 @@ jobs:
 
 #  deny-check:
 #    name: cargo-deny check
-#    runs-on: ubuntu-latest
+#    runs-on: ubuntu-24.04
 #    continue-on-error: ${{ matrix.checks == 'advisories' }}
 #    strategy:
 #      matrix:

--- a/.github/workflows/bridge-release.yml
+++ b/.github/workflows/bridge-release.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   release:
     name: release x86_64-unknown-linux-gnu
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: release
 
     strategy:
@@ -18,7 +18,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-24.04
             extension: ""
 
           - target: aarch64-apple-darwin
@@ -43,7 +43,7 @@ jobs:
 
   docker:
     name: release docker
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/bridge-release.yml
+++ b/.github/workflows/bridge-release.yml
@@ -51,13 +51,13 @@ jobs:
         uses: docker/setup-qemu-action@v2
 
       - name: Login Docker
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Derive Version Numbers
         run: |

--- a/.github/workflows/bridge-security.yml
+++ b/.github/workflows/bridge-security.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   security_audit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/csharp-lint.yml
+++ b/.github/workflows/csharp-lint.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   dotnet:
     name: C# Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/csharp-release.yml
+++ b/.github/workflows/csharp-release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   dotnet:
     name: C# Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: release
 
     steps:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -6,7 +6,7 @@ on:
       - "openapi.json"
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: golangci-lint

--- a/.github/workflows/java-lint.yml
+++ b/.github/workflows/java-lint.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/.github/workflows/java-lint.yml
+++ b/.github/workflows/java-lint.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   dotnet:
     name: Java Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   dotnet:
     name: Java Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: release
 
     steps:

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/.github/workflows/javascript-lint.yml
+++ b/.github/workflows/javascript-lint.yml
@@ -6,7 +6,7 @@ on:
       - "openapi.json"
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/javascript-release.yml
+++ b/.github/workflows/javascript-release.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: release
 
     steps:

--- a/.github/workflows/javascript-release.yml
+++ b/.github/workflows/javascript-release.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/kotlin-lint.yml
+++ b/.github/workflows/kotlin-lint.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   kotlin:
     name: Kotlin Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/kotlin-lint.yml
+++ b/.github/workflows/kotlin-lint.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/.github/workflows/kotlin-release.yml
+++ b/.github/workflows/kotlin-release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   kotlin:
     name: Kotlin Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: release
 
     steps:

--- a/.github/workflows/kotlin-release.yml
+++ b/.github/workflows/kotlin-release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/.github/workflows/other-lint.yml
+++ b/.github/workflows/other-lint.yml
@@ -54,4 +54,5 @@ jobs:
           VALIDATE_SHELL_SHFMT: false
           VALIDATE_SQL: false
           VALIDATE_SQLFLUFF: false
+          VALIDATE_YAML_PRETTIER: false
           FILTER_REGEX_EXCLUDE: (gradlew|javascript/tsconfig.json)

--- a/.github/workflows/other-lint.yml
+++ b/.github/workflows/other-lint.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: Lint Code Base
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/other-lint.yml
+++ b/.github/workflows/other-lint.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: super-linter/super-linter@v6.0.0
+        uses: super-linter/super-linter@v7.1.0
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -13,7 +13,7 @@ on:
       - '.github/workflows/php-ci.yml'
 jobs:
   build-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/php-release.yml
+++ b/.github/workflows/php-release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   packagist:
     name: Update Packagist
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: release
 
     steps:

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -14,7 +14,7 @@ on:
       - ".github/workflows/python-lint.yml"
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build source distribution
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: release
 
     steps:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,7 +16,7 @@ on:
       - ".github/workflows/python-tests.yml"
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ruby-lint.yml
+++ b/.github/workflows/ruby-lint.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   dotnet:
     name: Ruby Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ruby-release.yml
+++ b/.github/workflows/ruby-release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   dotnet:
     name: Ruby Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: release
 
     steps:

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   check-fmt:
     name: Check formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -40,7 +40,7 @@ jobs:
 
   test-versions:
     name: Rust Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         rust: [stable, beta]

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: release
 
     steps:

--- a/.github/workflows/rust-security.yml
+++ b/.github/workflows/rust-security.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   security_audit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   check-fmt:
     name: Check formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -40,7 +40,7 @@ jobs:
 
   test-versions:
     name: Server CI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         rust: [stable, beta]
@@ -99,7 +99,7 @@ jobs:
       run: docker compose -f "server/testing-docker-compose.yml" down
 #  deny-check:
 #    name: cargo-deny check
-#    runs-on: ubuntu-latest
+#    runs-on: ubuntu-24.04
 #    continue-on-error: ${{ matrix.checks == 'advisories' }}
 #    strategy:
 #      matrix:

--- a/.github/workflows/server-docker-image.yml
+++ b/.github/workflows/server-docker-image.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   test-image:
     name: Server docker image CI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   release:
     name: release x86_64-unknown-linux-gnu
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: release
 
     steps:
@@ -32,7 +32,7 @@ jobs:
 
   docker:
     name: release docker
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -37,16 +37,16 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Login Docker
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Derive Version Numbers
         run: |

--- a/.github/workflows/server-security.yml
+++ b/.github/workflows/server-security.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   security_audit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   typos:
     name: Check for typos
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/update-postman.yml
+++ b/.github/workflows/update-postman.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   postman:
     name: Update Postman Collection
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: release
 
     steps:

--- a/server/generate-openapi.sh
+++ b/server/generate-openapi.sh
@@ -14,7 +14,11 @@ export SVIX_REDIS_DSN="redis://localhost:6379"
 server_path=$(dirname "$0")
 openapi_path=$server_path/openapi.json
 # Do not output the entire thing
-output=$(cargo run --manifest-path "$server_path"/Cargo.toml -- generate-openapi | jq -S --indent 4 '.openapi = "3.0.2" | .info.version = "1.1.1" | .info.description = ""')
+output=$(
+    cargo run --manifest-path "$server_path"/Cargo.toml -- generate-openapi \
+        | jq -S --indent 4 '.openapi = "3.0.2" | .info.version = "1.1.1" | .info.description = ""' \
+        | sed 's/\.0,$/,/' # Remove trailing '.0' from numerals to paper over jq version differences
+)
 
 if [[ "$1" = "--check" ]]; then
     # Do not quit immediately if the diff fails, we check status afterwards


### PR DESCRIPTION
## Motivation

Ubuntu 24.04 is now available as a GH actions runner. It was supposed to become the default soon, but has been postponed as it's breaking many people's workflows (surprise!). Let's see whether we're ready to upgrade right away.

## Solution

Bump the version in the `yml` files and see what happens.