### PR TITLE
Upgrade Node version in Javascript release action

### DIFF
--- a/.github/workflows/javascript-lint.yml
+++ b/.github/workflows/javascript-lint.yml
@@ -10,6 +10,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'latest'
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Regen openapi libs
         run: |
           yarn

--- a/.github/workflows/javascript-release.yml
+++ b/.github/workflows/javascript-release.yml
@@ -19,9 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
-          node-version: '14.x'
+          node-version: 'latest'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Regen openapi libs


### PR DESCRIPTION
The latest version of `openapi-generator-cli` requires a newer version of Node. We can just use LTS/latest, no need to pin to an older version. 

https://github.com/svix/svix-webhooks/actions/runs/11404529698/job/31733893512