### PR TITLE
Libs(Go): unestting nullable array fields via PATCH request

### DIFF
--- a/go/endpoint_test.go
+++ b/go/endpoint_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestEndpoint_Serialization(t *testing.T) {
+func TestEndpointIn_Serialization(t *testing.T) {
 	testCases := []struct {
 		name            string
 		testEndpoint    *svix.EndpointIn
@@ -71,6 +71,46 @@ func TestEndpoint_Serialization(t *testing.T) {
 		}
 		if !tc.wantFilterTypes && gotFilterTypes {
 			t.Errorf("case `%s`: expected EndpointIn to NOT have a filterTypes field", tc.name)
+		}
+	}
+}
+
+func TestEndpointPatch_Serialization(t *testing.T) {
+	testCases := []struct {
+		name            string
+		testEndpoint    *svix.EndpointPatch
+		wantChannels    bool
+		wantFilterTypes bool
+	}{
+		{
+			name: "explicitly setting channels to null",
+			testEndpoint: &svix.EndpointPatch{
+				Channels: nil,
+			},
+			wantChannels:    true,
+			wantFilterTypes: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		b, _ := json.Marshal(tc.testEndpoint)
+		s := string(b)
+
+		gotChannels := strings.Contains(s, "channels")
+		gotFilterTypes := strings.Contains(s, "filterTypes")
+
+		if tc.wantChannels && !gotChannels {
+			t.Errorf("case `%s`: expected EndpointPatch to have a channels field", tc.name)
+		}
+		if !tc.wantChannels && gotChannels {
+			t.Errorf("case `%s`: expected EndpointPatch to NOT have a channels field", tc.name)
+		}
+
+		if tc.wantFilterTypes && !gotFilterTypes {
+			t.Errorf("case `%s`: expected EndpointPatch to have a filterTypes field", tc.name)
+		}
+		if !tc.wantFilterTypes && gotFilterTypes {
+			t.Errorf("case `%s`: expected EndpointPatch to NOT have a filterTypes field", tc.name)
 		}
 	}
 }

--- a/go/svix_test.go
+++ b/go/svix_test.go
@@ -74,12 +74,19 @@ func TestKitchenSink(t *testing.T) {
 	}
 
 	endp, err := client.Endpoint.Create(ctx, app.Id, &svix.EndpointIn{
-		Url: "https://example.svix.com/",
+		Url:      "https://example.svix.com/",
+		Channels: []string{"ch0", "ch1"},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	if len(endp.GetChannels()) != 2 {
+		t.Errorf("got %d channels, want 2", len(endp.Channels))
+	}
+	if len(endp.GetFilterTypes()) != 0 {
+		t.Errorf("got %d filter types, want 0", len(endp.GetFilterTypes()))
+	}
 	endpPatch := svix.EndpointPatch{}
 	endpPatch.SetFilterTypes([]string{"event.started", "event.ended"})
 
@@ -92,5 +99,21 @@ func TestKitchenSink(t *testing.T) {
 		if !(typ == "event.started" || typ == "event.ended") {
 			t.Fatalf("unexpected filter type: `%s`", typ)
 		}
+	}
+
+	endpPatch2 := svix.EndpointPatch{
+		Channels: nil,
+	}
+	patched2, err := client.Endpoint.Patch(ctx, app.Id, endp.Id, &endpPatch2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(patched2.Channels) > 0 {
+		t.Fatalf("expected patched channels to be empty: %v", patched2.Channels)
+	}
+
+	err = client.Endpoint.Delete(ctx, app.Id, endp.Id)
+	if err != nil {
+		t.Fatalf("unexpected error on delete: %s", err.Error())
 	}
 }


### PR DESCRIPTION
Work was done previously [1] to make nullable containers (arrays, maps) generate as refs. This avoided a problem where the JSON serialization code incrrectly sent an empty array for cases where a field was left unset. This would result in requests incorrectly failing with a 422 response when it should have been OK.

During the openapi generator update [2], the resulting codegen no longer had the 422 issue since it correctly omitted empty arrays from the body for PATCH requests. However, this now means we have no way to explicitly set a field to `null`. This specific issue was fixed in the some other langs with the work done to update the generator, but the Go generator seems to have fallen behind.

This rev adds tests to demonstrate the shortfall. We may need to rework the template patch made for the old 5.x generator to solve this in the meantime.

- 1: https://github.com/svix/svix-webhooks/pull/1450
- 2: https://github.com/svix/svix-webhooks/pull/1480

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
