### PR TITLE
Libs(Go): add convenience constructor for static nullable strings

### DIFF
--- a/go/svix.go
+++ b/go/svix.go
@@ -41,6 +41,9 @@ func String(s string) *string {
 func NullableString(s *string) *openapi.NullableString {
 	return openapi.NewNullableString(s)
 }
+func StaticNullableString(s string) openapi.NullableString {
+	return *NullableString(String(s))
+}
 func NullableInt32(num *int32) *openapi.NullableInt32 {
 	return openapi.NewNullableInt32(num)
 }

--- a/go/svix_test.go
+++ b/go/svix_test.go
@@ -94,3 +94,23 @@ func TestKitchenSink(t *testing.T) {
 		}
 	}
 }
+
+func TestStaticNullableString(t *testing.T) {
+	app := &svix.ApplicationIn{
+		Name: "test",
+		Uid:  svix.StaticNullableString("my-uid"),
+	}
+
+	if !app.Uid.IsSet() {
+		t.Fatalf("app.Uid is not set but should be")
+	}
+
+	if *app.Uid.Get() != "my-uid" {
+		t.Fatalf("app.Uid has unexpected value: `%s`", *app.Uid.Get())
+	}
+
+	app.Uid.Unset()
+	if app.Uid.IsSet() {
+		t.Fatalf("app.Uid is set but shouldn't be")
+	}
+}


### PR DESCRIPTION
Fixes <https://github.com/svix/svix-webhooks/issues/1198>

While this isn't quite the type of change that was requested in #1198, I'm hopeful it'll reduce a bit of the friction.

A new constructor is now available as `svix.StaticNullableString()` which gives an `openapi.NullableString`.

Note that the return type (not a pointer) is inconsistent with the rest of the functions that act as primative constructors, and in fact goes against the convention of constructors returning pointers to the value they initialize.

The issue was raised, however, that all the places in the lib where a `NullableString` is needed, we'd have to dereference it anyway. 
Since this alt constructor is all about convenience, we may as well break convention. _In for a penny, in for a pound..._

The net effect is instead of:

```go
appIn := svix.ApplicationIn{
	...
	Uid: *svix.NullableString(svix.String("myuid"))
}
```

folks will now be able to write:

```go
appIn := svix.ApplicationIn{
	...
	Uid: svix.StaticNullableString("myuid")
}
```
