### PR TITLE
Upgrade redis to get rid of yanked version

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -14,9 +14,7 @@ yanked = "deny"
 notice = "warn"
 ignore = [
     # TODO: Update dependencies that use rsa crate
-    "RUSTSEC-2023-0071",
-    # TODO: sqlx >=0.8.1
-    "RUSTSEC-2024-0363",
+    "RUSTSEC-2023-0071"
 ]
 
 [licenses]

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -635,7 +635,7 @@ checksum = "1781f22daa0ae97d934fdf04a5c66646f154a164c4bdc157ec8d3c11166c05cc"
 dependencies = [
  "async-trait",
  "bb8",
- "redis 0.27.4",
+ "redis 0.27.5",
 ]
 
 [[package]]
@@ -1978,7 +1978,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2766,7 +2766,7 @@ dependencies = [
  "bytesize",
  "futures-util",
  "lapin",
- "redis 0.27.4",
+ "redis 0.27.5",
  "serde",
  "serde_json",
  "svix-ksuid 0.8.0",
@@ -3506,9 +3506,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.27.4"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6baebe319ef5e4b470f248335620098d1c2e9261e995be05f56f719ca4bdb2"
+checksum = "81cccf17a692ce51b86564334614d72dcae1def0fd5ecebc9f02956da74352b5"
 dependencies = [
  "arc-swap",
  "async-trait",


### PR DESCRIPTION
0.27.4 was yanked due to a bug: https://github.com/redis-rs/redis-rs/releases/tag/redis-0.27.4

0.27.5 has no other changes other than the bug fix. 

Also removes security advisory ignores that are no longer used. 
