### PR TITLE
Libs(JS): downgrade `@stablelib/base64` avoiding `ERR_REQUIRE_ESM`

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -29,7 +29,7 @@
     "lint:fix": "yarn run lint:prettier --write && yarn run lint:eslint --fix"
   },
   "dependencies": {
-    "@stablelib/base64": "^2.0.0",
+    "@stablelib/base64": "^1.0.0",
     "@types/node": "^22.7.5",
     "es6-promise": "^4.2.8",
     "fast-sha256": "^1.3.0",

--- a/javascript/yarn.lock
+++ b/javascript/yarn.lock
@@ -629,10 +629,10 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@stablelib/base64@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@stablelib/base64/-/base64-2.0.0.tgz#f13a98549cd5ca0750cd177bbd08b599d24e5f8e"
-  integrity sha512-ffSfySa1ZpZYzM5FQ2xILQ2jifQ+GlgbDJzRTCtaB0sqta88KYghB/tlSV2VS2iHRCvMdUvJlLOW1rmSkziWnw==
+"@stablelib/base64@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/base64/-/base64-1.0.1.tgz#bdfc1c6d3a62d7a3b7bbc65b6cce1bb4561641be"
+  integrity sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==
 
 "@stablelib/utf8@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
Fixes https://github.com/svix/svix-webhooks/issues/1505

Big thanks to @ZONGMENG-kaito for the report.

During the work on https://github.com/svix/svix-webhooks/pull/1480 various dependencies were updated to match what is being produced by the upstream code generator. Unfortunately, the version spec change for `@stablelib/base64` up to 2.x means we inherit their ESM requirement.

The local tests (i.e. `SVIX_SERVER_URL=... SVIX_TOKEN=... yarn test`) continue to pass with the downgrade, so it seems like pinning to 1.x will free consumers of _our lib_ of this new requirement for now.

Hopefully in the future we'll find a way to track 2.x without disruption.
