### PR TITLE
Bridge(kafka): guard kafka-related symbols with cfg attrs

### DIFF
--- a/bridge/svix-bridge/src/config/mod.rs
+++ b/bridge/svix-bridge/src/config/mod.rs
@@ -235,6 +235,7 @@ pub enum ReceiverOutputOpts {
 impl WebhookReceiverConfig {
     pub async fn into_receiver_output(self) -> anyhow::Result<Box<dyn ReceiverOutput>> {
         match self.output {
+            #[cfg(feature = "kafka")]
             ReceiverOutputOpts::Kafka(opts) => {
                 svix_bridge_plugin_kafka::into_receiver_output(self.name, opts).map_err(Into::into)
             }
@@ -313,6 +314,7 @@ impl PollerReceiverConfig {
     // FIXME: duplicate from WebhookReceiverConfig. Extract/refactor as TryFrom ReceiverOutputOpts?
     pub async fn into_receiver_output(self) -> anyhow::Result<Box<dyn ReceiverOutput>> {
         match self.output {
+            #[cfg(feature = "kafka")]
             ReceiverOutputOpts::Kafka(opts) => {
                 svix_bridge_plugin_kafka::into_receiver_output(self.name, opts).map_err(Into::into)
             }


### PR DESCRIPTION
Adds a few more `cfg` attributes to hide kafka-related things at compile time when needed.