### PR TITLE
Remove toplevel span

### DIFF
--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -87,7 +87,6 @@ async fn graceful_shutdown_handler() {
     SHUTTING_DOWN.store(true, Ordering::SeqCst)
 }
 
-#[tracing::instrument(name = "app_start", level = "trace", skip_all)]
 pub async fn run(cfg: Configuration) {
     let _metrics = setup_metrics(&cfg);
     run_with_prefix(None, cfg, None).await


### PR DESCRIPTION
This looks like a probable cause of memory-leaks, since the span will never complete while the application is running.
