### PR TITLE
Server: exit early if endpoints don't exist

### DIFF
--- a/server/svix-server/src/worker.rs
+++ b/server/svix-server/src/worker.rs
@@ -860,6 +860,11 @@ async fn process_queue_task_inner(
                 })
                 .collect();
 
+            if destinations.is_empty() {
+                tracing::debug!("No destinations for message. Returning");
+                return Ok(());
+            }
+
             messagedestination::Entity::insert_many(destinations.clone())
                 .exec(db)
                 .await?;


### PR DESCRIPTION
Ensure that we don't try to process a message for which endpoints 
no longer exist. Fixes #1511.
