### PR TITLE
Bridge: add check for missing dynamic libs

### DIFF
--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -65,6 +65,11 @@ RUN apt-get update ;\
 USER appuser
 
 COPY --from=build /app/target/release/svix-bridge /usr/local/bin/svix-bridge
+COPY scripts/check-deps.sh /usr/local/bin/check-deps.sh
+
+# Verify all the dynamic libs we depend on are present in the runtime stage
+RUN /usr/local/bin/check-deps.sh /usr/local/bin/svix-bridge
+
 EXPOSE 5000
 
 # Will fail if there's no `svix-bridge.yaml` in the CWD or `SVIX_BRIDGE_CFG` is not set to a valid

--- a/bridge/scripts/check-deps.sh
+++ b/bridge/scripts/check-deps.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+BINPATH=$1
+
+IFS=
+MISSING="$(ldd $BINPATH | grep 'not found')"
+
+# There'll be 1 linebreak for the empty case. Anything else and it means we
+# caught some unexpected output from ldd.
+if [ "1" != "$(echo $MISSING | wc -l)" ]; then
+    echo "Binary $BINPATH missing dependencies:\n$MISSING"
+    exit 1
+fi


### PR DESCRIPTION
The v1.39 tag on docker hub currently fails with:

```
docker run --rm -it -e SVIX_BRIDGE_CFG='{}' docker.io/svix/svix-bridge:v1.39.0
svix-bridge: error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or directory
```

This diff adds script to look at the output from `ldd` and see if there are libs that aren't found.

The version of the Dockerfile in main currently seems to pass this check. Removing the cacert install gets us back to a failing state, so we can see the script working:

```
Step 17/22 : USER appuser
 ---> Using cache
 ---> 80f72cf25adf
Step 18/22 : COPY --from=build /app/target/release/svix-bridge /usr/local/bin/svix-bridge
 ---> Using cache
 ---> 1bcafc142c09
Step 19/22 : COPY scripts/check-deps.sh /usr/local/bin/check-deps.sh
 ---> bc8108762915
Step 20/22 : RUN /usr/local/bin/check-deps.sh /usr/local/bin/svix-bridge
 ---> Running in 31cae75a107d
Binary /usr/local/bin/svix-bridge missing dependencies:
        libssl.so.3 => not found
        libcrypto.so.3 => not found
The command '/bin/sh -c /usr/local/bin/check-deps.sh /usr/local/bin/svix-bridge' returned a non-zero code: 1
```

This should help to catch other dependency-related problems that will show up at runtime.
