### PR TITLE
Bridge: add a test to check process liveness

### DIFF
--- a/.github/workflows/bridge-ci.yml
+++ b/.github/workflows/bridge-ci.yml
@@ -88,6 +88,11 @@ jobs:
     - name: Stop required services
       run: docker compose -f "bridge/testing-docker-compose.yml" down
 
+    - name: Idle Test
+      working-directory: bridge
+      run: ./run-idle-test.sh
+
+
 #  deny-check:
 #    name: cargo-deny check
 #    runs-on: ubuntu-24.04

--- a/bridge/run-idle-test.sh
+++ b/bridge/run-idle-test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+cargo build
+
+# We've seen some segfauls from deno that require the interpreter running
+# for a period. The test here is to watch the bridge process and make sure
+# it is still alive after some time has passed.
+RUST_LOG="notset" target/debug/svix-bridge --cfg '{}' &
+SVIX_BRIDGE_PID=$!
+echo "Monitoring PID=$SVIX_BRIDGE_PID"
+sleep 15
+ps $SVIX_BRIDGE_PID > /dev/null
+if [ "$?" -ne 0 ]; then
+    echo "fail: process terminated prematurely"
+    exit 1
+fi
+echo "success: process stayed up"
+kill $SVIX_BRIDGE_PID


### PR DESCRIPTION
Mentioned in the script comments, we've seen segfaults in bridge coming from deno, and only after the interpreter has had some time to achieve steady-state.

This diff adds a script to run a check where we launch the process with an empty config (no senders or receivers registered), and send it to the background.
Bridge should be able to stay up indefinitely like this. If the process ends before we check on it (after sleeping a spell), that's probably a bug.

I reverted the last deno downgrade to try this script out in the failing state. It seemed to catch the issue well.

```
$ ./run-idle-test.sh
   Compiling svix-bridge v1.39.0 (/home/onelson/Projects/svix-webhooks/bridge/svix-bridge)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.29s
Monitoring PID=189293
fail: process terminated prematurely
```