### PR TITLE
rust: Update openapi codegen script to revert field type changes

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -3,6 +3,7 @@
 Cargo.lock
 
 /.openapi-generator/
+/openapi.json
 
 /src/apis/
 /src/models/

--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -1476,7 +1476,7 @@ impl<'a> Statistics<'a> {
         let options = options.unwrap_or_default();
         let params = statistics_api::V1PeriodStatisticsPeriodAggregateAppStatsParams {
             app_usage_stats_in: AppUsageStatsIn {
-                app_ids: Some(app_ids),
+                app_ids,
                 since,
                 until,
             },

--- a/rust/tests/kitchen_sink.rs
+++ b/rust/tests/kitchen_sink.rs
@@ -83,7 +83,7 @@ async fn test_endpoint_crud() {
         .create(
             app.id.clone(),
             EndpointIn {
-                channels: Some(Some(vec![String::from("ch0"), String::from("ch1")])),
+                channels: Some(vec![String::from("ch0"), String::from("ch1")]),
                 url: String::from("https://example.svix.com/"),
                 ..Default::default()
             },
@@ -95,15 +95,9 @@ async fn test_endpoint_crud() {
     let want_channels: HashSet<_> = [String::from("ch0"), String::from("ch1")]
         .into_iter()
         .collect();
-    let got_channels = ep.channels.clone().unwrap().unwrap().into_iter().collect();
+    let got_channels = ep.channels.clone().unwrap().into_iter().collect();
     assert_eq!(want_channels, got_channels);
-    assert_eq!(
-        0,
-        ep.filter_types
-            .unwrap_or_default()
-            .unwrap_or_default()
-            .len()
-    );
+    assert_eq!(0, ep.filter_types.unwrap_or_default().len());
 
     let ep_patched = client
         .endpoint()
@@ -126,17 +120,10 @@ async fn test_endpoint_crud() {
         [String::from("event.started"), String::from("event.ended")]
             .into_iter()
             .collect();
-    let got_channels = ep_patched
-        .channels
-        .clone()
-        .unwrap()
-        .unwrap()
-        .into_iter()
-        .collect();
+    let got_channels = ep_patched.channels.clone().unwrap().into_iter().collect();
     let got_filter_types = ep_patched
         .filter_types
         .clone()
-        .unwrap()
         .unwrap()
         .into_iter()
         .collect();


### PR DESCRIPTION
The OpenAPI code generator upgrade caused a lot of Rust fields to be double options, but for most of them it just gets in the way. Patch the openapi spec before generating Rust code to revert this.

Closes https://github.com/svix/monorepo-private/issues/9393.
Closes https://github.com/svix/monorepo-private/issues/9398.