### PR TITLE
js: Let tsc infer type of resp in isomorphic-fetch code

### DIFF
--- a/javascript/templates/http/isomorphic-fetch.mustache
+++ b/javascript/templates/http/isomorphic-fetch.mustache
@@ -49,7 +49,7 @@ export class IsomorphicFetchHttpLibrary implements HttpLibrary {
             credentials: isCredentialsSupported ? "same-origin" : undefined
             {{/browser}}
             {{/platforms}}
-        }).then((resp: any) => {
+        }).then(resp => {
             const headers: { [name: string]: string } = {};
             resp.headers.forEach((value: string, name: string) => {
               headers[name] = value;


### PR DESCRIPTION
Found while looking into https://github.com/svix/monorepo-private/issues/9283.