### PR TITLE
Libs(all): set `explode: false` for `MessageStatus`

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7629,7 +7629,8 @@
                             "description": "Filter response based on the status of the attempt: Success (0), Pending (1), Failed (2), or Sending (3)",
                             "nullable": true
                         },
-                        "style": "form"
+                        "style": "form",
+                        "explode": false
                     },
                     {
                         "description": "Filter response based on the HTTP status code",
@@ -7960,7 +7961,8 @@
                             "description": "Filter response based on the status of the attempt: Success (0), Pending (1), Failed (2), or Sending (3)",
                             "nullable": true
                         },
-                        "style": "form"
+                        "style": "form",
+                        "explode": false
                     },
                     {
                         "description": "Filter response based on the HTTP status code",
@@ -10084,7 +10086,8 @@
                             "description": "Filter response based on the status of the attempt: Success (0), Pending (1), Failed (2), or Sending (3)",
                             "nullable": true
                         },
-                        "style": "form"
+                        "style": "form",
+                        "explode": false
                     },
                     {
                         "description": "Only include items created before a certain date",
@@ -16452,7 +16455,8 @@
                             "description": "Filter response based on the status of the attempt: Success (0), Pending (1), Failed (2), or Sending (3)",
                             "nullable": true
                         },
-                        "style": "form"
+                        "style": "form",
+                        "explode": false
                     },
                     {
                         "description": "Only include items created before a certain date",
@@ -17764,7 +17768,8 @@
                             "description": "Filter response based on the status of the attempt: Success (0), Pending (1), Failed (2), or Sending (3)",
                             "nullable": true
                         },
-                        "style": "form"
+                        "style": "form",
+                        "explode": false
                     },
                     {
                         "description": "Only include items created before a certain date",


### PR DESCRIPTION
Avoids a problem with the codegen output for JS specifically, and possibly others, where query params for `status` could be left unset by the client.

This is a stop-gap. Changes are WIP to get the spec generation to maintain this change moving forward more exhaustively. In the meantime, this should set the codegen right for `MessageStatus`.
