### PR TITLE
Upgrade cargo-deny

### DIFF
--- a/.github/workflows/bridge-ci.yml
+++ b/.github/workflows/bridge-ci.yml
@@ -104,7 +104,7 @@ jobs:
 #          - bans licenses sources
 #    steps:
 #      - uses: actions/checkout@v4
-#      - uses: EmbarkStudios/cargo-deny-action@v1
+#      - uses: EmbarkStudios/cargo-deny-action@v2
 #        with:
 #          command: check ${{ matrix.checks }}
 #          arguments: --all-features --manifest-path axum/Cargo.toml

--- a/.github/workflows/bridge-ci.yml
+++ b/.github/workflows/bridge-ci.yml
@@ -91,20 +91,3 @@ jobs:
     - name: Idle Test
       working-directory: bridge
       run: ./run-idle-test.sh
-
-
-#  deny-check:
-#    name: cargo-deny check
-#    runs-on: ubuntu-24.04
-#    continue-on-error: ${{ matrix.checks == 'advisories' }}
-#    strategy:
-#      matrix:
-#        checks:
-#          - advisories
-#          - bans licenses sources
-#    steps:
-#      - uses: actions/checkout@v4
-#      - uses: EmbarkStudios/cargo-deny-action@v2
-#        with:
-#          command: check ${{ matrix.checks }}
-#          arguments: --all-features --manifest-path axum/Cargo.toml

--- a/.github/workflows/bridge-security.yml
+++ b/.github/workflows/bridge-security.yml
@@ -24,6 +24,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           manifest-path: bridge/Cargo.toml

--- a/.github/workflows/rust-security.yml
+++ b/.github/workflows/rust-security.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           manifest-path: rust/Cargo.toml

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -97,18 +97,3 @@ jobs:
 
     - name: Stop dependencies
       run: docker compose -f "server/testing-docker-compose.yml" down
-#  deny-check:
-#    name: cargo-deny check
-#    runs-on: ubuntu-24.04
-#    continue-on-error: ${{ matrix.checks == 'advisories' }}
-#    strategy:
-#      matrix:
-#        checks:
-#          - advisories
-#          - bans licenses sources
-#    steps:
-#      - uses: actions/checkout@v4
-#      - uses: EmbarkStudios/cargo-deny-action@v2
-#        with:
-#          command: check ${{ matrix.checks }}
-#          arguments: --all-features --manifest-path axum/Cargo.toml

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -108,7 +108,7 @@ jobs:
 #          - bans licenses sources
 #    steps:
 #      - uses: actions/checkout@v4
-#      - uses: EmbarkStudios/cargo-deny-action@v1
+#      - uses: EmbarkStudios/cargo-deny-action@v2
 #        with:
 #          command: check ${{ matrix.checks }}
 #          arguments: --all-features --manifest-path axum/Cargo.toml

--- a/.github/workflows/server-security.yml
+++ b/.github/workflows/server-security.yml
@@ -24,6 +24,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           manifest-path: server/Cargo.toml

--- a/deny.toml
+++ b/deny.toml
@@ -12,7 +12,9 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
 ignore = [
     # TODO: Update dependencies that use rsa crate
-    "RUSTSEC-2023-0071"
+    "RUSTSEC-2023-0071",
+    # TODO: Wait for dependencies to upgrade off of proc-macro-error
+    "RUSTSEC-2024-0370",
 ]
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,4 @@
+[graph]
 targets = [
     { triple = "x86_64-pc-windows-gnu" },
     { triple = "x86_64-unknown-linux-musl" },

--- a/deny.toml
+++ b/deny.toml
@@ -8,17 +8,13 @@ targets = [
 [advisories]
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-vulnerability = "deny"
-unmaintained = "warn"
 yanked = "deny"
-notice = "warn"
 ignore = [
     # TODO: Update dependencies that use rsa crate
     "RUSTSEC-2023-0071"
 ]
 
 [licenses]
-unlicensed = "deny"
 allow = [
     "Apache-2.0",
     "BSD-2-Clause",
@@ -31,10 +27,6 @@ allow = [
     "Unicode-DFS-2016",
     "CC0-1.0",
 ]
-deny = []
-copyleft = "deny"
-allow-osi-fsf-free = "neither"
-default = "deny"
 confidence-threshold = 0.8
 exceptions = [
     #{ allow = ["Zlib"], name = "adler32", version = "*" },


### PR DESCRIPTION
Current Rust nightly toolchains have updated the default lockfile version (written whenever any changes to the lockfile are made), to a version that the older `cargo-deny` we were using doesn't understand. This requires manual fiddling and is only going to get worse as time goes on.

Fixes the CI errors in #1528.