### PR TITLE
Return 413 on large payloads

### DIFF
--- a/server/svix-server/src/error.rs
+++ b/server/svix-server/src/error.rs
@@ -379,6 +379,14 @@ impl HttpError {
             detail.unwrap_or_else(|| "This API endpoint is not yet implemented.".to_owned()),
         )
     }
+
+    pub fn too_large(code: Option<String>, detail: Option<String>) -> Self {
+        Self::new_standard(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            code.unwrap_or_else(|| "payload_too_large".to_owned()),
+            detail.unwrap_or_else(|| "Request payload is too large.".to_owned()),
+        )
+    }
 }
 
 impl From<HttpError> for Error {

--- a/server/svix-server/src/v1/utils/mod.rs
+++ b/server/svix-server/src/v1/utils/mod.rs
@@ -13,6 +13,7 @@ use aide::{
     transform::{TransformOperation, TransformPathItem},
     OperationInput, OperationIo, OperationOutput,
 };
+use axum::extract::rejection::{BytesRejection, FailedToBufferBody};
 use axum::{
     async_trait,
     body::HttpBody,
@@ -555,7 +556,17 @@ where
     async fn from_request(req: Request<B>, state: &S) -> Result<Self> {
         let b = bytes::Bytes::from_request(req, state).await.map_err(|e| {
             tracing::error!("Error reading body as bytes: {}", e);
-            HttpError::internal_server_error(None, Some("Failed to read request body".to_owned()))
+
+            match e {
+                BytesRejection::FailedToBufferBody(FailedToBufferBody::LengthLimitError(_)) => {
+                    HttpError::too_large(None, None)
+                }
+
+                _ => HttpError::internal_server_error(
+                    None,
+                    Some("Failed to read request body".to_owned()),
+                ),
+            }
         })?;
         let mut de = serde_json::Deserializer::from_slice(&b);
 

--- a/server/svix-server/src/v1/utils/mod.rs
+++ b/server/svix-server/src/v1/utils/mod.rs
@@ -13,11 +13,13 @@ use aide::{
     transform::{TransformOperation, TransformPathItem},
     OperationInput, OperationIo, OperationOutput,
 };
-use axum::extract::rejection::{BytesRejection, FailedToBufferBody};
 use axum::{
     async_trait,
     body::HttpBody,
-    extract::{FromRequest, FromRequestParts, Query},
+    extract::{
+        rejection::{BytesRejection, FailedToBufferBody},
+        FromRequest, FromRequestParts, Query,
+    },
     response::IntoResponse,
     BoxError,
 };

--- a/server/svix-server/tests/it/e2e_message.rs
+++ b/server/svix-server/tests/it/e2e_message.rs
@@ -521,7 +521,7 @@ async fn test_message_validation() {
     let (client, _jh) = start_svix_server().await;
 
     let app_id = create_test_app(&client, "testApp").await.unwrap().id;
-    let payload = serde_json::json!({"large_payload": std::iter::repeat("payload-").take(1_000_000).collect::<String>()});
+    let payload = serde_json::json!({"large_payload": "payload-".repeat(1_000_000)});
 
     client
         .post::<_, IgnoredAny>(

--- a/server/svix-server/tests/it/e2e_message.rs
+++ b/server/svix-server/tests/it/e2e_message.rs
@@ -515,3 +515,20 @@ async fn test_message_conflict() {
         .await
         .unwrap();
 }
+
+#[tokio::test]
+async fn test_message_validation() {
+    let (client, _jh) = start_svix_server().await;
+
+    let app_id = create_test_app(&client, "testApp").await.unwrap().id;
+    let payload = serde_json::json!({"large_payload": std::iter::repeat("payload-").take(1_000_000).collect::<String>()});
+
+    client
+        .post::<_, IgnoredAny>(
+            &format!("api/v1/app/{}/msg/", &app_id),
+            message_in(&app_id, payload).unwrap(),
+            StatusCode::PAYLOAD_TOO_LARGE,
+        )
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
## Motivation

On large payloads, the server now returns 500

<img width="581" alt="image" src="https://github.com/user-attachments/assets/6f7d7e0c-2949-4cf5-a189-8b6070f63010">


## Solution

Return 413 instead of 500. Also added a test that checks that. 