### PR TITLE
rust: Fix jq script that removes nullable attributes

### DIFF
--- a/regen_openapi.sh
+++ b/regen_openapi.sh
@@ -31,7 +31,7 @@ yarn openapi-generator-cli generate -i openapi.json -g csharp -o csharp/ -c csha
 jq --indent 4 '.components.schemas |= with_entries(
         if .key | endswith("Patch") then .
         else
-            (.required // []) as $required |
+            (.value.required // []) as $required |
             if .value | has("properties") then
                 .value.properties |= with_entries(
                     if .key | IN($required[]) then .


### PR DESCRIPTION
It was removing it even when the property was marked required, which was not intended.