### PR TITLE
python: Fix sync / async mismatch for op-webhook-endpoint API

### DIFF
--- a/python/svix/api.py
+++ b/python/svix/api.py
@@ -1657,8 +1657,8 @@ class Svix(ClientBase):
         return Statistics(self._client)
 
     @property
-    def operational_webhook_endpoint(self) -> OperationalWebhookEndpointAsync:
-        return OperationalWebhookEndpointAsync(self._client)
+    def operational_webhook_endpoint(self) -> OperationalWebhookEndpoint:
+        return OperationalWebhookEndpoint(self._client)
 
 
 __all__ = [


### PR DESCRIPTION
We were returning the `Async` API object from the sync client's method.