### PR TITLE
ruby: Add convenient construction of rawPayload messages

### DIFF
--- a/ruby/lib/svix/message_api.rb
+++ b/ruby/lib/svix/message_api.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module Svix
+  module_function
+
   class MessageAPI
     def initialize(api_client)
       @api = MessageApi.new(api_client)
@@ -21,5 +23,32 @@ module Svix
     def expunge_content(app_id, msg_id)
       return @api.v1_message_expunge_content(app_id, msg_id)
     end
+  end
+
+  # Creates a [`MessageIn`] with the payload already being serialized.
+  #
+  # The payload is not normalized on the server. Normally, payloads are required
+  # to be JSON, and Svix will minify the payload before sending the webhook
+  # (for example, by removing extraneous whitespace or unnecessarily escaped
+  # characters in strings). With this function, the payload will be sent
+  # "as is", without any minification or other processing.
+  #
+  # `attributes[:payload]` must be a string. An extra attribute `content_type`
+  # is accepted that sets the `content-type` header of the webhook, overwriting
+  # the default of `application/json` if specified. Other than that, the
+  # attributes are forwarded [`MessageIn.new`], so all the same ones are
+  # accepted.
+  def message_in_raw(attributes = {})
+    attributes[:transformations_params] ||= {}
+    attributes[:transformations_params][:rawPayload] = attributes[:payload]
+    attributes[:payload] = {}
+
+    content_type = attributes.delete(:content_type)
+    if content_type != nil
+      attributes[:transformations_params][:headers] ||= {}
+      attributes[:transformations_params][:headers][:'content-type'] = content_type
+    end
+
+    return MessageIn.new(attributes)
   end
 end

--- a/ruby/spec/message_api_spec.rb
+++ b/ruby/spec/message_api_spec.rb
@@ -12,13 +12,59 @@ RSpec.describe Svix::MessageAPI do
   let(:api_instance_mock) { double("MessageApi") }
   let(:api_class_mock) { double("MessageApiClass") }
 
-  # Mock out the API calls
-  before(:each) do
-    stub_const("Svix::MessageApi", api_class_mock)
-    expect(api_class_mock).to receive(:new).with(param_mock).and_return(api_instance_mock)
+  describe "message_in_raw" do
+    it "works without content-type" do
+      payload = "{ \"x\": true }"
+      msg_in = Svix.message_in_raw(event_type: "x", payload: payload)
+
+      expect(msg_in.event_type).to eq("x")
+      expect(msg_in.payload).to eq({})
+      expect(msg_in.transformations_params[:rawPayload]).to eq(payload)
+      expect(msg_in.transformations_params[:headers]).to eq(nil)
+    end
+
+    it "works with content-type" do
+      payload = "Hello, World!"
+      content_type = "text/plain"
+      msg_in = Svix.message_in_raw(event_type: "x", payload: payload, content_type: content_type)
+
+      expect(msg_in.event_type).to eq("x")
+      expect(msg_in.payload).to eq({})
+      expect(msg_in.transformations_params[:rawPayload]).to eq(payload)
+      expect(msg_in.transformations_params[:headers][:'content-type']).to eq(content_type)
+    end
+
+    it "works with other transformations params" do
+      payload = "Hello, World!"
+      content_type = "text/plain"
+      msg_in = Svix.message_in_raw(
+        event_type: "x",
+        payload: payload,
+        content_type: content_type,
+        transformations_params: {
+          :foo => "bar",
+          :headers => {
+            :'x-custom' => "baz",
+          },
+        },
+      )
+
+      expect(msg_in.event_type).to eq("x")
+      expect(msg_in.payload).to eq({})
+      expect(msg_in.transformations_params[:foo]).to eq("bar")
+      expect(msg_in.transformations_params[:rawPayload]).to eq(payload)
+      expect(msg_in.transformations_params[:headers][:'content-type']).to eq(content_type)
+      expect(msg_in.transformations_params[:headers][:'x-custom']).to eq("baz")
+    end
   end
 
   describe "#get" do
+    # Mock out the API calls
+    before(:each) do
+      stub_const("Svix::MessageApi", api_class_mock)
+      expect(api_class_mock).to receive(:new).with(param_mock).and_return(api_instance_mock)
+    end
+
     it "passes it's parameters to the correct method" do
       # Assert that the correct method is called with the correct parameters
       expect(api_instance_mock).to receive(:v1_message_get).with(app_id, msg_id, options)


### PR DESCRIPTION
Part of https://github.com/svix/monorepo-private/issues/9470.
