### PR TITLE
Reapply "Libs(CSharp): add kitchen sink test"

### DIFF
--- a/csharp/Svix.Tests/IgnoreIfClientVarsUnset.cs
+++ b/csharp/Svix.Tests/IgnoreIfClientVarsUnset.cs
@@ -1,0 +1,17 @@
+using System;
+using Xunit;
+
+namespace Svix.Tests;
+
+public sealed class IgnoreIfClientVarsUnset : FactAttribute
+{
+    public IgnoreIfClientVarsUnset()
+    {
+        if (
+            Environment.GetEnvironmentVariable("SVIX_TOKEN") == null &&
+            Environment.GetEnvironmentVariable("SVIX_SERVER_URL") == null)
+        {
+            Skip = "Test client cannot be constructed when environment variable SVIX_TOKEN or SVIX_SERVER_URL is unset.";
+        }
+    }
+}

--- a/csharp/Svix.Tests/SvixClientTests.cs
+++ b/csharp/Svix.Tests/SvixClientTests.cs
@@ -1,25 +1,74 @@
-﻿using Microsoft.Extensions.Logging.Abstractions;
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging.Abstractions;
+using Svix.Client;
+using Svix.Model;
 using Svix.Models;
 using Xunit;
 
-namespace Svix.Tests
+namespace Svix.Tests;
+
+public class SvixClientTests
 {
-    public class SvixClientTests
+    [Fact]
+    public void Constructor_WhenCalled_DoesNotNeedLogger()
     {
-        [Fact]
-        public void Constructor_WhenCalled_DoesNotNeedLogger()
-        {
-            var sut = new SvixClient("", new SvixOptions("http://some.url"));
+        var sut = new SvixClient("", new SvixOptions("http://some.url"));
 
-            Assert.NotNull(sut);
+        Assert.NotNull(sut);
+    }
+
+    [Fact]
+    public void Constructor_WhenCalled_AcceptsLogger()
+    {
+        var sut = new SvixClient("", new SvixOptions("http://some.url"), new NullLogger<SvixClient>());
+
+        Assert.NotNull(sut);
+    }
+
+    [IgnoreIfClientVarsUnset]
+    public void KitchenSink_SeemsToWorkOkay()
+    {
+        var token = Environment.GetEnvironmentVariable("SVIX_TOKEN");
+        var url = Environment.GetEnvironmentVariable("SVIX_SERVER_URL");
+        var client = new SvixClient(token, new SvixOptions(url));
+
+        var app = client.Application.Create(new ApplicationIn(name: "App"));
+        try
+        {
+            client.EventType.Create(new EventTypeIn(name: "event.started", description: "Something started"));
+        }
+        catch (ApiException e)
+        {
+            // We expect conflicts, but any other status is an error
+            Assert.Equal(409, e.ErrorCode);
         }
 
-        [Fact]
-        public void Constructor_WhenCalled_AcceptsLogger()
+        try
         {
-            var sut = new SvixClient("", new SvixOptions("http://some.url"), new NullLogger<SvixClient>());
-
-            Assert.NotNull(sut);
+            client.EventType.Create(new EventTypeIn(name: "event.ended", description: "Something ended"));
         }
+        catch (ApiException e)
+        {
+            // We expect conflicts, but any other status is an error
+            Assert.Equal(409, e.ErrorCode);
+        }
+
+        var ep = client.Endpoint.Create(app.Id,
+            new EndpointIn(url: "https://example.svix.com/", channels: new List<string> { "ch0", "ch1" }));
+
+        ep.Channels.Sort();
+        Assert.Equal(new List<string> { "ch0", "ch1" }, ep.Channels);
+        Assert.Null(ep.FilterTypes);
+
+        var epPatched = client.Endpoint.Patch(app.Id, ep.Id,
+            new EndpointPatch(filterTypes: new List<string> { "event.started", "event.ended" }));
+        epPatched.Channels.Sort();
+        epPatched.FilterTypes.Sort();
+        Assert.Equal(new List<string> { "ch0", "ch1" }, epPatched.Channels);
+        Assert.Equal(new List<string> { "event.ended", "event.started" }, epPatched.FilterTypes);
+
+        // Should not throw an exception if the serialization code handles empty bodies properly
+        client.Endpoint.Delete(app.Id, ep.Id);
     }
 }


### PR DESCRIPTION
This reverts commit ec5acbd56a56b12f47c0b9931df567c56ade351a.

Now that the target runtime has been updated, these tests should be compatible with our CI situation.
