### PR TITLE
Bridge: Surface kafka error

### DIFF
--- a/bridge/svix-bridge-plugin-kafka/src/error.rs
+++ b/bridge/svix-bridge-plugin-kafka/src/error.rs
@@ -5,7 +5,7 @@ use svix_bridge_types::svix::error::Error as SvixClientError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("kafka error")]
+    #[error("kafka error: {0}")]
     Kafka(#[from] KafkaError),
 
     #[error("svix client error")]


### PR DESCRIPTION
It's difficult to troubleshoot when you can't see the original error.
