### PR TITLE
[Lib/JS] Compile svix package for ESM and CommonJS

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,10 +1,9 @@
 {
   "name": "svix",
-  "version": "1.42.0",
+  "version": "1.41.0",
   "description": "Svix webhooks API client and webhook verification library",
   "author": "svix",
   "repository": "https://github.com/svix/svix-libs",
-  "type": "commonjs",
   "keywords": [
     "svix",
     "diahook",
@@ -12,14 +11,26 @@
     "typescript"
   ],
   "license": "MIT",
-  "main": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
+  "main": "./dist/cjs/index.js",
+  "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/esm/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    },
+    "./dist/*": {
+      "types": "./dist/esm/*/index.d.ts",
+      "import": "./dist/esm/*/index.js",
+      "require": "./dist/cjs/*/index.js"
+    }
+  },
   "files": [
     "src",
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --project tsconfig.cjs.json && tsc --project tsconfig.esm.json",
     "prepare": "yarn run build",
     "test": "jest",
     "prepublishOnly": "yarn lint",

--- a/javascript/tsconfig.cjs.json
+++ b/javascript/tsconfig.cjs.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    /* Basic Options */
+    "target": "es6",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "declaration": true,
+    "allowJs": true,
+    /* Additional Checks */
+    "noUnusedLocals": false /* Report errors on unused locals. */, // TODO: reenable (unused imports!)
+    "noUnusedParameters": false /* Report errors on unused parameters. */, // TODO: set to true again
+    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
+    "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
+    "removeComments": true,
+    "sourceMap": true,
+    "outDir": "./dist/cjs",
+    "noLib": false,
+    "lib": [
+      "es6",
+      "dom"
+    ]
+  },
+  "exclude": [
+    "dist",
+    "node_modules",
+    "jest.config.js",
+    "src/**/*.test.ts",
+  ],
+  "filesGlob": [
+    "./src/**/*.ts"
+  ]
+}

--- a/javascript/tsconfig.esm.json
+++ b/javascript/tsconfig.esm.json
@@ -3,22 +3,23 @@
     "strict": true,
     /* Basic Options */
     "target": "es6",
-    "module": "CommonJS",
+    "module": "ESNext",
     "moduleResolution": "node",
     "declaration": true,
     "allowJs": true,
-
     /* Additional Checks */
     "noUnusedLocals": false /* Report errors on unused locals. */, // TODO: reenable (unused imports!)
     "noUnusedParameters": false /* Report errors on unused parameters. */, // TODO: set to true again
     "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
     "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
-
     "removeComments": true,
     "sourceMap": true,
-    "outDir": "./dist",
+    "outDir": "./dist/esm",
     "noLib": false,
-    "lib": ["es6", "dom"]
+    "lib": [
+      "es6",
+      "dom"
+    ]
   },
   "exclude": [
     "dist",
@@ -26,5 +27,7 @@
     "jest.config.js",
     "src/**/*.test.ts",
   ],
-  "filesGlob": ["./src/**/*.ts"]
+  "filesGlob": [
+    "./src/**/*.ts"
+  ]
 }


### PR DESCRIPTION
Closes https://github.com/svix/svix-webhooks/issues/1483

Compile the svix JavaScript package in `ESM` and `CommonJS` simultaneously. This should solve the issues with tree-shaking (since it can only be done when the package is compiled with ESM). Also keeps the CommonJS version for backwards compatibility.

Tested this locally and all the usual imports (`import { EventTypeOut } from "svix"`) work as expected, with no changes whatsoever.

