### PR TITLE
Libs/JS: Fix package version

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svix",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "description": "Svix webhooks API client and webhook verification library",
   "author": "svix",
   "repository": "https://github.com/svix/svix-libs",


### PR DESCRIPTION
I accidentally changed the version in https://github.com/svix/svix-webhooks/pull/1549