### PR TITLE
Unify rawPayload message docs

### DIFF
--- a/csharp/Svix/Message.cs
+++ b/csharp/Svix/Message.cs
@@ -23,16 +23,18 @@ namespace Svix
             _messageApi = messageApi ?? throw new ArgumentException(nameof(messageApi));
         }
 
-
-        /// <summary>Creates a [MessageIn] with the payload already being serialized.
+        /// <summary>Creates a [MessageIn] with a pre-serialized payload.
         /// <para>
-        /// The payload is not normalized on the server (usually whitespace outside
-        /// of string literals, unnecessarily escaped characters in string and such
-        /// are fixed up by the server), and is not even required to be JSON.
+        /// The payload is not normalized on the server. Normally, payloads are
+        /// required to be JSON, and Svix will minify the payload before sending the
+        /// webhooks (for example, by removing extraneous whitespace or unnecessarily
+        /// escaped characters in strings). With this function, the payload will be
+        /// sent "as is", without any minification or other processing.
         /// </para>
         /// </summary>
         /// <param name="payload">Serialized message payload</param>
-        /// <param name="contentType">Content type of the payload to send as a header. Defaults to `application/json`.</param>
+        /// <param name="contentType">The `content-type` header of the webhook sent by Svix,
+        /// overwriting the default of `application/json` if specified</param>
         public static MessageIn messageInRaw(
             string eventType,
             string payload,

--- a/java/lib/src/main/java/com/svix/Message.java
+++ b/java/lib/src/main/java/com/svix/Message.java
@@ -25,12 +25,13 @@ public final class Message {
 	}
 
 	/**
-	 * Creates a MessageIn with the payload already being serialized.
+	 * Creates a MessageIn with a pre-serialized payload.
 	 *
-	 * The payload is not normalized on the server (usually whitespace outside
-	 * of string literals, unnecessarily escaped characters in string and such
-	 * are fixed up by the server). The default Content-Type of application/json
-	 * is used. See the other overload if you want to send non-JSON payloads.
+	 * The payload is not normalized on the server. Normally, payloads are
+	 * required to be JSON, and Svix will minify the payload before sending the
+	 * webhooks (for example, by removing extraneous whitespace or unnecessarily
+	 * escaped characters in strings). With this function, the payload will be
+	 * sent "as is", without any minification or other processing.
 	 *
 	 * @param payload Serialized message payload
 	 */
@@ -41,12 +42,12 @@ public final class Message {
 	}
 
 	/**
-	 * Creates a MessageIn with the payload already being serialized.
+	 * Creates a MessageIn with a pre-serialized payload.
 	 *
 	 * This overload is intended for non-JSON payloads.
 	 *
 	 * @param payload Serialized message payload
-	 * @param contentType The value to use for the Content-Type header
+	 * @param contentType The value to use for the Content-Type header of the webhook sent by Svix
 	 */
 	public static MessageIn messageInRaw(final String payload, final String contentType) {
 		HashMap<String, Object> trParam = new HashMap<>();

--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -700,14 +700,16 @@ class Message {
 }
 
 /**
- * Creates a `MessageIn` with the payload already being serialized.
+ * Creates a `MessageIn` with a pre-serialized payload.
  *
- * The payload is not normalized on the server (usually whitespace outside
- * of string literals, unnecessarily escaped characters in string and such
- * are fixed up by the server), and is not even required to be JSON.
+ * The payload is not normalized on the server. Normally, payloads are
+ * required to be JSON, and Svix will minify the payload before sending the
+ * webhooks (for example, by removing extraneous whitespace or unnecessarily
+ * escaped characters in strings). With this function, the payload will be
+ * sent "as is", without any minification or other processing.
  *
  * @param payload Serialized message payload
- * @param contentType Content type of the payload to send as a header. Defaults to `application/json`.
+ * @param contentType The value to use for the Content-Type header of the webhook sent by Svix, overwriting the default of `application/json` if specified
  *
  * See the class documentation for details about the other parameters.
  */

--- a/kotlin/lib/src/main/kotlin/Message.kt
+++ b/kotlin/lib/src/main/kotlin/Message.kt
@@ -74,17 +74,18 @@ class Message internal constructor(token: String, options: SvixOptions) {
 }
 
 /**
- * Creates a [MessageIn] with the payload already being serialized.
+ * Creates a [MessageIn] with a pre-serialized payload.
  *
- * The payload is not normalized on the server (usually whitespace outside
- * of string literals, unnecessarily escaped characters in string and such
- * are fixed up by the server), and is not even required to be JSON.
+ * The payload is not normalized on the server. Normally, payloads are
+ * required to be JSON, and Svix will minify the payload before sending the
+ * webhooks (for example, by removing extraneous whitespace or unnecessarily
+ * escaped characters in strings). With this function, the payload will be
+ * sent "as is", without any minification or other processing.
  *
  * @param payload Serialized message payload
- * @param contentType Content type of the payload to send as a header. Defaults to `application/json`.
+ * @param contentType The value to use for the Content-Type header of the webhook sent by Svix, overwriting the default of `application/json` if specified
  *
  * See the class documentation for details about the other parameters.
- *
  */
 fun messageInRaw(
     eventType: String,

--- a/python/svix/api.py
+++ b/python/svix/api.py
@@ -1166,7 +1166,7 @@ def message_in_raw(
     event_type: str, payload: str, content_type: t.Optional[str] = None
 ) -> MessageIn:
     """
-    Creates a `MessageIn` with the payload already being serialized.
+    Creates a `MessageIn` with a pre-serialized payload.
 
     The payload is not normalized on the server. Normally, payloads are required
     to be JSON, and Svix will minify the payload before sending the webhook
@@ -1177,8 +1177,9 @@ def message_in_raw(
     Args:
         event_type (str): The event type's name Example: `user.signup`.
         payload (str): Serialized message payload.
-        content_type (str?): The `content-type` header value Svix uses for
-            the webhook request. If not specified, `application/json` is used.
+        content_type (str?): The value to use for the Content-Type header of the
+            webhook sent by Svix, overwriting the default of `application/json`
+            if specified.
     """
     transformations_params: t.Dict[str, t.Any] = {
         "rawPayload": payload,

--- a/ruby/lib/svix/message_api.rb
+++ b/ruby/lib/svix/message_api.rb
@@ -25,7 +25,7 @@ module Svix
     end
   end
 
-  # Creates a [`MessageIn`] with the payload already being serialized.
+  # Creates a [`MessageIn`] with a pre-serialized payload.
   #
   # The payload is not normalized on the server. Normally, payloads are required
   # to be JSON, and Svix will minify the payload before sending the webhook
@@ -34,9 +34,9 @@ module Svix
   # "as is", without any minification or other processing.
   #
   # `attributes[:payload]` must be a string. An extra attribute `content_type`
-  # is accepted that sets the `content-type` header of the webhook, overwriting
-  # the default of `application/json` if specified. Other than that, the
-  # attributes are forwarded [`MessageIn.new`], so all the same ones are
+  # is accepted that sets the `content-type` header of the webhook sent by Svix,
+  # overwriting the default of `application/json` if specified. Other than that,
+  # the attributes are forwarded [`MessageIn.new`], so all the same ones are
   # accepted.
   def message_in_raw(attributes = {})
     attributes[:transformations_params] ||= {}

--- a/rust/src/model_ext.rs
+++ b/rust/src/model_ext.rs
@@ -7,12 +7,16 @@ use crate::models::MessageIn;
 impl MessageIn {
     /// Create a new message with a pre-serialized payload.
     ///
-    /// The payload is not normalized on the server (usually whitespace outside
-    /// of string literals, unnecessarily escaped characters in string and such
-    /// are fixed up by the server), and is not even required to be JSON.
+    /// The payload is not normalized on the server. Normally, payloads are
+    /// required to be JSON, and Svix will minify the payload before sending
+    /// the webhook (for example, by removing extraneous whitespace or
+    /// unnecessarily escaped characters in strings). With this constructor,
+    /// the payload will be sent "as is", without any minification or other
+    /// processing.
     ///
-    /// The default `content-type` of `application/json` will still be used,
-    /// unless overwritten with [`with_content_type`][Self::with_content_type].
+    /// The default `content-type` of `application/json` will still be used for
+    /// the webhook sent by Svix, unless overwritten with
+    /// [`with_content_type`][Self::with_content_type].
     pub fn new_raw_payload(event_type: String, payload: String) -> Self {
         Self {
             transformations_params: Some(json!({ "rawPayload": payload })),
@@ -20,7 +24,7 @@ impl MessageIn {
         }
     }
 
-    /// Set the `content-type` header to use for the message.
+    /// Set the `content-type` header to use for the webhook sent by Svix.
     pub fn with_content_type(mut self, content_type: String) -> Self {
         let transformations_params = self.transformations_params.get_or_insert_with(|| json!({}));
 


### PR DESCRIPTION
## Motivation

In previous PRs for https://github.com/svix/monorepo-private/issues/9470, some review comments were made for better docs. I also just failed and used different ways of saying the same thing in different places. This all made for pointlessly diverging docs between the different languages.

## Solution

Use the same basic formulation everywhere: "pre-serialized payload", same description of the "as-is" nature of raw payloads, same description of the content-type parameter. A number of language-specific docs remain to cover differences in how these functions work (e.g. for optional content-type, Java has two overloads of one function, Rust has a builder-style method, most other languages use an optional parameter).