### PR TITLE
[Libs/JS] Revert ESM package update

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -11,21 +11,9 @@
     "typescript"
   ],
   "license": "MIT",
+  "type": "commonjs",
   "main": "./dist/cjs/index.js",
-  "types": "./dist/esm/index.d.ts",
-  "type": "module",
-  "exports": {
-    ".": {
-      "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
-    },
-    "./dist/*": {
-      "types": "./dist/esm/*/index.d.ts",
-      "import": "./dist/esm/*/index.js",
-      "require": "./dist/cjs/*/index.js"
-    }
-  },
+  "typings": "./dist/cjs/index.d.ts",
   "files": [
     "src",
     "dist"


### PR DESCRIPTION
Revert the ESM package update. I'm still investigating some issues with importing the ESM version, but in the meanwhile, let's revert to the previous working state. 
