### PR TITLE
Add query parameter docs and reorder some things

### DIFF
--- a/rust/src/api/application.rs
+++ b/rust/src/api/application.rs
@@ -3,8 +3,13 @@ use crate::{apis::application_api, error::Result, models::*, Configuration};
 
 #[derive(Default)]
 pub struct ApplicationListOptions {
-    pub iterator: Option<String>,
+    /// Limit the number of returned items
     pub limit: Option<i32>,
+
+    /// The iterator returned from a prior invocation
+    pub iterator: Option<String>,
+
+    /// The sorting order of the returned items
     pub order: Option<Ordering>,
 }
 
@@ -22,15 +27,16 @@ impl<'a> Application<'a> {
         options: Option<ApplicationListOptions>,
     ) -> Result<ListResponseApplicationOut> {
         let ApplicationListOptions {
-            iterator,
             limit,
+            iterator,
             order,
         } = options.unwrap_or_default();
+
         application_api::v1_period_application_period_list(
             self.cfg,
             application_api::V1PeriodApplicationPeriodListParams {
-                iterator,
                 limit,
+                iterator,
                 order,
             },
         )
@@ -94,6 +100,14 @@ impl<'a> Application<'a> {
         .await
     }
 
+    pub async fn delete(&self, app_id: String) -> Result<()> {
+        application_api::v1_period_application_period_delete(
+            self.cfg,
+            application_api::V1PeriodApplicationPeriodDeleteParams { app_id },
+        )
+        .await
+    }
+
     pub async fn patch(
         &self,
         app_id: String,
@@ -105,14 +119,6 @@ impl<'a> Application<'a> {
                 app_id,
                 application_patch,
             },
-        )
-        .await
-    }
-
-    pub async fn delete(&self, app_id: String) -> Result<()> {
-        application_api::v1_period_application_period_delete(
-            self.cfg,
-            application_api::V1PeriodApplicationPeriodDeleteParams { app_id },
         )
         .await
     }

--- a/rust/src/api/endpoint.rs
+++ b/rust/src/api/endpoint.rs
@@ -3,19 +3,31 @@ use crate::{apis::endpoint_api, error::Result, models::*, Configuration};
 
 #[derive(Default)]
 pub struct EndpointListOptions {
-    pub iterator: Option<String>,
+    /// Limit the number of returned items
     pub limit: Option<i32>,
-    pub order: Option<Ordering>,
-}
 
-pub struct Endpoint<'a> {
-    cfg: &'a Configuration,
+    /// The iterator returned from a prior invocation
+    pub iterator: Option<String>,
+
+    /// The sorting order of the returned items
+    pub order: Option<Ordering>,
 }
 
 #[derive(Default)]
 pub struct EndpointStatsOptions {
+    /// Filter the range to data starting from this date
+    ///
+    /// RFC3339 date string.
     pub since: Option<String>,
+
+    /// Filter the range to data ending by this date
+    ///
+    /// RFC3339 date string.
     pub until: Option<String>,
+}
+
+pub struct Endpoint<'a> {
+    cfg: &'a Configuration,
 }
 
 impl<'a> Endpoint<'a> {
@@ -29,17 +41,18 @@ impl<'a> Endpoint<'a> {
         options: Option<EndpointListOptions>,
     ) -> Result<ListResponseEndpointOut> {
         let EndpointListOptions {
-            iterator,
             limit,
+            iterator,
             order,
         } = options.unwrap_or_default();
+
         endpoint_api::v1_period_endpoint_period_list(
             self.cfg,
             endpoint_api::V1PeriodEndpointPeriodListParams {
                 app_id,
-                order,
-                iterator,
                 limit,
+                iterator,
+                order,
             },
         )
         .await
@@ -52,6 +65,7 @@ impl<'a> Endpoint<'a> {
         options: Option<PostOptions>,
     ) -> Result<EndpointOut> {
         let PostOptions { idempotency_key } = options.unwrap_or_default();
+
         endpoint_api::v1_period_endpoint_period_create(
             self.cfg,
             endpoint_api::V1PeriodEndpointPeriodCreateParams {
@@ -91,6 +105,17 @@ impl<'a> Endpoint<'a> {
         .await
     }
 
+    pub async fn delete(&self, app_id: String, endpoint_id: String) -> Result<()> {
+        endpoint_api::v1_period_endpoint_period_delete(
+            self.cfg,
+            endpoint_api::V1PeriodEndpointPeriodDeleteParams {
+                app_id,
+                endpoint_id,
+            },
+        )
+        .await
+    }
+
     pub async fn patch(
         &self,
         app_id: String,
@@ -103,17 +128,6 @@ impl<'a> Endpoint<'a> {
                 app_id,
                 endpoint_id,
                 endpoint_patch,
-            },
-        )
-        .await
-    }
-
-    pub async fn delete(&self, app_id: String, endpoint_id: String) -> Result<()> {
-        endpoint_api::v1_period_endpoint_period_delete(
-            self.cfg,
-            endpoint_api::V1PeriodEndpointPeriodDeleteParams {
-                app_id,
-                endpoint_id,
             },
         )
         .await

--- a/rust/src/api/event_type.rs
+++ b/rust/src/api/event_type.rs
@@ -3,10 +3,19 @@ use crate::{apis::event_type_api, error::Result, models::*, Configuration};
 
 #[derive(Default)]
 pub struct EventTypeListOptions {
-    pub iterator: Option<String>,
+    /// Limit the number of returned items
     pub limit: Option<i32>,
-    pub with_content: Option<bool>,
+
+    /// The iterator returned from a prior invocation
+    pub iterator: Option<String>,
+
+    /// When `true` archived (deleted but not expunged) items are included in
+    /// the response
     pub include_archived: Option<bool>,
+
+    /// When `true` the full item (including the schema) is included in the
+    /// response
+    pub with_content: Option<bool>,
 }
 
 pub struct EventType<'a> {
@@ -23,19 +32,21 @@ impl<'a> EventType<'a> {
         options: Option<EventTypeListOptions>,
     ) -> Result<ListResponseEventTypeOut> {
         let EventTypeListOptions {
-            iterator,
             limit,
-            with_content,
+            iterator,
             include_archived,
+            with_content,
         } = options.unwrap_or_default();
+
         event_type_api::v1_period_event_type_period_list(
             self.cfg,
             event_type_api::V1PeriodEventTypePeriodListParams {
-                iterator,
                 limit,
-                with_content,
-                include_archived,
+                iterator,
+                // FIXME: not included for backwards compatibility, for now
                 order: None,
+                include_archived,
+                with_content,
             },
         )
         .await
@@ -47,6 +58,7 @@ impl<'a> EventType<'a> {
         options: Option<PostOptions>,
     ) -> Result<EventTypeOut> {
         let PostOptions { idempotency_key } = options.unwrap_or_default();
+
         event_type_api::v1_period_event_type_period_create(
             self.cfg,
             event_type_api::V1PeriodEventTypePeriodCreateParams {
@@ -112,6 +124,7 @@ impl<'a> EventType<'a> {
         options: Option<PostOptions>,
     ) -> Result<EventTypeImportOpenApiOut> {
         let PostOptions { idempotency_key } = options.unwrap_or_default();
+
         event_type_api::v1_period_event_type_period_import_openapi(
             self.cfg,
             event_type_api::V1PeriodEventTypePeriodImportOpenapiParams {

--- a/rust/src/api/integration.rs
+++ b/rust/src/api/integration.rs
@@ -3,8 +3,13 @@ use crate::{apis::integration_api, error::Result, models::*, Configuration};
 
 #[derive(Default)]
 pub struct IntegrationListOptions {
-    pub iterator: Option<String>,
+    /// Limit the number of returned items
     pub limit: Option<i32>,
+
+    /// The iterator returned from a prior invocation
+    pub iterator: Option<String>,
+
+    /// The sorting order of the returned items
     pub order: Option<Ordering>,
 }
 
@@ -23,16 +28,17 @@ impl<'a> Integration<'a> {
         options: Option<IntegrationListOptions>,
     ) -> Result<ListResponseIntegrationOut> {
         let IntegrationListOptions {
-            iterator,
             limit,
+            iterator,
             order,
         } = options.unwrap_or_default();
+
         integration_api::v1_period_integration_period_list(
             self.cfg,
             integration_api::V1PeriodIntegrationPeriodListParams {
                 app_id,
-                iterator,
                 limit,
+                iterator,
                 order,
             },
         )
@@ -46,6 +52,7 @@ impl<'a> Integration<'a> {
         options: Option<PostOptions>,
     ) -> Result<IntegrationOut> {
         let PostOptions { idempotency_key } = options.unwrap_or_default();
+
         integration_api::v1_period_integration_period_create(
             self.cfg,
             integration_api::V1PeriodIntegrationPeriodCreateParams {

--- a/rust/src/api/message.rs
+++ b/rust/src/api/message.rs
@@ -31,27 +31,28 @@ impl<'a> Message<'a> {
         options: Option<MessageListOptions>,
     ) -> Result<ListResponseMessageOut> {
         let MessageListOptions {
-            iterator,
             limit,
-            event_types,
+            iterator,
+            channel,
             before,
             after,
-            channel,
             with_content,
             tag,
+            event_types,
         } = options.unwrap_or_default();
+
         message_api::v1_period_message_period_list(
             self.cfg,
             message_api::V1PeriodMessagePeriodListParams {
                 app_id,
-                iterator,
                 limit,
-                event_types,
+                iterator,
+                channel,
                 before,
                 after,
-                channel,
                 with_content,
                 tag,
+                event_types,
             },
         )
         .await


### PR DESCRIPTION
Adjust some field lists and impl block items to match the order in the spec.

This was done by importing the output of our new codegen tool, then reverting changes we don't (yet) want to import.

Version used: https://github.com/svix/openapi-codegen/commit/fd7dbc40af6badfe0dac8b6ccc1b889c2dd62d1f

Based on #1559.