### PR TITLE
server: Use forked validator crate

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -15,10 +15,6 @@ ignore = [
     "RUSTSEC-2023-0071",
     # TODO: Wait for dependencies to upgrade off of proc-macro-error
     "RUSTSEC-2024-0370",
-    # Doesn't affect us, we only use the vulnerable version through validator
-    # and don't use that for any sensitive auth checks.
-    # Details: https://github.com/svix/monorepo-private/issues/9541
-    "RUSTSEC-2024-0421",
 ]
 
 [licenses]

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1783,7 +1783,7 @@ dependencies = [
  "futures-channel",
  "futures-io",
  "futures-util",
- "idna 1.0.3",
+ "idna",
  "ipnet",
  "once_cell",
  "rand",
@@ -2175,16 +2175,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idna"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
 
 [[package]]
 name = "idna"
@@ -5526,7 +5516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
- "idna 1.0.3",
+ "idna",
  "percent-encoding",
  "serde",
 ]
@@ -5562,15 +5552,15 @@ dependencies = [
 [[package]]
 name = "validator"
 version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b92f40481c04ff1f4f61f304d61793c7b56ff76ac1469f1beb199b1445b253bd"
+source = "git+https://github.com/svix/validator.git?rev=aebdc34a4ed72524902ff6d63397b9c435b0578f#aebdc34a4ed72524902ff6d63397b9c435b0578f"
 dependencies = [
- "idna 0.4.0",
+ "idna",
  "lazy_static",
  "regex",
  "serde",
  "serde_derive",
  "serde_json",
+ "tracing",
  "url",
  "validator_derive",
 ]
@@ -5578,8 +5568,7 @@ dependencies = [
 [[package]]
 name = "validator_derive"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc44ca3088bb3ba384d9aecf40c6a23a676ce23e09bdaca2073d99c207f864af"
+source = "git+https://github.com/svix/validator.git?rev=aebdc34a4ed72524902ff6d63397b9c435b0578f#aebdc34a4ed72524902ff6d63397b9c435b0578f"
 dependencies = [
  "if_chain",
  "lazy_static",
@@ -5594,8 +5583,7 @@ dependencies = [
 [[package]]
 name = "validator_types"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111abfe30072511849c5910134e8baf8dc05de4c0e5903d681cbd5c9c4d611e3"
+source = "git+https://github.com/svix/validator.git?rev=aebdc34a4ed72524902ff6d63397b9c435b0578f#aebdc34a4ed72524902ff6d63397b9c435b0578f"
 dependencies = [
  "proc-macro2",
  "syn 1.0.109",

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -41,7 +41,10 @@ opentelemetry = { version = "0.23.0", features = ["metrics"] }
 opentelemetry_sdk = { version = "0.23.0", features = ["rt-tokio"] }
 opentelemetry-http = "0.12.0"
 opentelemetry-otlp = { version = "0.16.0", features = ["metrics"] }
-validator = { version = "0.16.0", features = ["derive"] }
+# Forked version of 0.16 with a small fix and dependency upgrades, since we
+# haven't gotten around to doing a proper upgrade yet (0.17 is a large
+# rewrite with a barely-useful changelog)
+validator = { git = "https://github.com/svix/validator.git", rev = "aebdc34a4ed72524902ff6d63397b9c435b0578f", features = ["derive"] }
 jwt-simple = "0.11.6"
 ed25519-compact = "2.1.1"
 chrono = { version="0.4.26", features = ["serde"] }


### PR DESCRIPTION
## Motivation

The version of validator we were using depends on an old `idna`, and has a bug where it can panic in validation.

## Solution

Because upgrading to v0.17+ is pretty involved, switch to our fork for now which fixes the panic and upgrades dependencies but is otherwise the same as v0.16.1.