### PR TITLE
js: Add generated query parameter types

### DIFF
--- a/javascript/src/api/application.ts
+++ b/javascript/src/api/application.ts
@@ -1,7 +1,12 @@
 import { ApplicationApi, ApplicationIn, ApplicationOut, ApplicationPatch, Configuration, ListResponseApplicationOut, Ordering } from "../openapi";
-import { ListOptions, PostOptions } from "../util";
+import { PostOptions } from "../util";
 
-export interface ApplicationListOptions extends ListOptions {
+export interface ApplicationListOptions {
+    /// Limit the number of returned items
+    limit?: number;
+    /// The iterator returned from a prior invocation
+    iterator?: string | null;
+    /// The sorting order of the returned items
     order?: Ordering;
 }
 

--- a/javascript/src/api/background_task.ts
+++ b/javascript/src/api/background_task.ts
@@ -6,9 +6,10 @@ import {
     ListResponseBackgroundTaskOut,
     BackgroundTasksApi,
 } from "../openapi";
-import { ListOptions } from "../util";
 
-export interface BackgroundTaskListOptions extends ListOptions {
+export interface BackgroundTaskListOptions {
+    iterator?: string | null;
+    limit?: number;
     status?: BackgroundTaskStatus;
     task?: BackgroundTaskType;
 }

--- a/javascript/src/api/endpoint.ts
+++ b/javascript/src/api/endpoint.ts
@@ -21,9 +21,14 @@ import {
     EndpointPatch,
     EndpointOauthConfigIn,
 } from "../openapi";
-import { ListOptions, PostOptions } from "../util";
+import { PostOptions } from "../util";
 
-export interface EndpointListOptions extends ListOptions {
+export interface EndpointListOptions {
+    /// Limit the number of returned items
+    limit?: number;
+    /// The iterator returned from a prior invocation
+    iterator?: string | null;
+    /// The sorting order of the returned items
     order?: Ordering;
 }
 

--- a/javascript/src/api/event_type.ts
+++ b/javascript/src/api/event_type.ts
@@ -8,12 +8,21 @@ import {
     EventTypePatch,
     EventTypeImportOpenApiIn,
     EventTypeImportOpenApiOut,
+    Ordering,
 } from "../openapi";
-import { ListOptions, PostOptions } from "../util";
+import { PostOptions } from "../util";
 
-export interface EventTypeListOptions extends ListOptions {
-    withContent?: boolean;
+export interface EventTypeListOptions {
+    /// Limit the number of returned items
+    limit?: number;
+    /// The iterator returned from a prior invocation
+    iterator?: string | null;
+    /// The sorting order of the returned items
+    order?: Ordering;
+    /// When `true` archived (deleted but not expunged) items are included in the response
     includeArchived?: boolean;
+    /// When `true` the full item (including the schema) is included in the response
+    withContent?: boolean;
 }
 
 export class EventType {

--- a/javascript/src/api/integration.ts
+++ b/javascript/src/api/integration.ts
@@ -6,10 +6,18 @@ import {
     IntegrationIn,
     IntegrationUpdate,
     IntegrationKeyOut,
+    Ordering,
 } from "../openapi";
-import { ListOptions, PostOptions } from "../util";
+import { PostOptions } from "../util";
 
-export type IntegrationListOptions = ListOptions;
+export interface IntegrationListOptions {
+    /// Limit the number of returned items
+    limit?: number;
+    /// The iterator returned from a prior invocation
+    iterator?: string | null;
+    /// The sorting order of the returned items
+    order?: Ordering;
+}
 
 export class Integration {
     private readonly api: IntegrationApi;

--- a/javascript/src/api/message.ts
+++ b/javascript/src/api/message.ts
@@ -5,15 +5,25 @@ import {
     MessageIn,
     ListResponseMessageOut,
 } from "../openapi";
-import { ListOptions, PostOptions } from "../util";
+import { PostOptions } from "../util";
 
-export interface MessageListOptions extends ListOptions {
-    eventTypes?: string[];
-    before?: Date | null;
-    after?: Date | null;
+export interface MessageListOptions {
+    /// Limit the number of returned items
+    limit?: number;
+    /// The iterator returned from a prior invocation
+    iterator?: string | null;
+    /// Filter response based on the channel
     channel?: string;
+    /// Only include items created before a certain date
+    before?: Date | null;
+    /// Only include items created after a certain date
+    after?: Date | null;
+    /// When `true` message payloads are included in the response
     withContent?: boolean;
+    /// Filter messages matching the provided tag
     tag?: string;
+    /// Filter response based on the event type
+    eventTypes?: string[];
 }
 
 export class Message {

--- a/javascript/src/api/message_attempt.ts
+++ b/javascript/src/api/message_attempt.ts
@@ -9,9 +9,11 @@ import {
     MessageStatus,
     StatusCodeClass,
 } from "../openapi";
-import { ListOptions, PostOptions } from "../util";
+import { PostOptions } from "../util";
 
-export interface MessageAttemptListOptions extends ListOptions {
+export interface MessageAttemptListOptions {
+    iterator?: string | null;
+    limit?: number;
     status?: MessageStatus;
     eventTypes?: string[];
     before?: Date | null;
@@ -21,8 +23,82 @@ export interface MessageAttemptListOptions extends ListOptions {
     withContent?: boolean;
 }
 
-export interface MessageAttemptListByEndpointOptions extends MessageAttemptListOptions {
+export interface MessageAttemptListByEndpointOptions {
+    /// Limit the number of returned items
+    limit?: number;
+    /// The iterator returned from a prior invocation
+    iterator?: string | null;
+    /// Filter response based on the status of the attempt: Success (0), Pending (1), Failed (2), or Sending (3)
+    status?: MessageStatus;
+    /// Filter response based on the HTTP status code
+    statusCodeClass?: StatusCodeClass;
+    /// Filter response based on the channel
+    channel?: string;
+    /// Filter response based on the tag
+    tag?: string;
+    /// Only include items created before a certain date
+    before?: Date | null;
+    /// Only include items created after a certain date
+    after?: Date | null;
+    /// When `true` attempt content is included in the response
+    withContent?: boolean;
+    /// When `true`, the message information is included in the response
     withMsg?: boolean;
+    /// Filter response based on the event type
+    eventTypes?: string[];
+}
+
+export interface MessageAttemptListByMsgOptions {
+    /// Limit the number of returned items
+    limit?: number;
+    /// The iterator returned from a prior invocation
+    iterator?: string | null;
+    /// Filter response based on the status of the attempt: Success (0), Pending (1), Failed (2), or Sending (3)
+    status?: MessageStatus;
+    /// Filter response based on the HTTP status code
+    statusCodeClass?: StatusCodeClass;
+    /// Filter response based on the channel
+    channel?: string;
+    /// Filter response based on the tag
+    tag?: string;
+    /// Filter the attempts based on the attempted endpoint
+    endpointId?: string;
+    /// Only include items created before a certain date
+    before?: Date | null;
+    /// Only include items created after a certain date
+    after?: Date | null;
+    /// When `true` attempt content is included in the response
+    withContent?: boolean;
+    /// Filter response based on the event type
+    eventTypes?: string[];
+}
+
+export interface MessageAttemptListAttemptedMessagesOptions {
+    /// Limit the number of returned items
+    limit?: number;
+    /// The iterator returned from a prior invocation
+    iterator?: string | null;
+    /// Filter response based on the channel
+    channel?: string;
+    /// Filter response based on the message tags
+    tag?: string;
+    /// Filter response based on the status of the attempt: Success (0), Pending (1), Failed (2), or Sending (3)
+    status?: MessageStatus;
+    /// Only include items created before a certain date
+    before?: Date | null;
+    /// Only include items created after a certain date
+    after?: Date | null;
+    /// When `true` message payloads are included in the response
+    withContent?: boolean;
+    /// Filter response based on the event type
+    eventTypes?: string[];
+}
+
+export interface MessageAttemptListAttemptedDestinationsOptions {
+    /// Limit the number of returned items
+    limit?: number;
+    /// The iterator returned from a prior invocation
+    iterator?: string | null;
 }
 
 export class MessageAttempt {
@@ -38,7 +114,7 @@ export class MessageAttempt {
     public list(
         appId: string,
         msgId: string,
-        options?: MessageAttemptListOptions
+        options?: MessageAttemptListByMsgOptions
     ): Promise<ListResponseMessageAttemptOut> {
         return this.listByMsg(appId, msgId, options);
     }
@@ -46,7 +122,7 @@ export class MessageAttempt {
     public listByMsg(
         appId: string,
         msgId: string,
-        options?: MessageAttemptListOptions
+        options?: MessageAttemptListByMsgOptions
     ): Promise<ListResponseMessageAttemptOut> {
         return this.api.v1MessageAttemptListByMsg({
             appId,
@@ -102,7 +178,7 @@ export class MessageAttempt {
     public listAttemptedMessages(
         appId: string,
         endpointId: string,
-        options?: MessageAttemptListOptions
+        options?: MessageAttemptListAttemptedMessagesOptions
     ): Promise<ListResponseEndpointMessageOut> {
         return this.api.v1MessageAttemptListAttemptedMessages({
             appId,
@@ -117,7 +193,7 @@ export class MessageAttempt {
     public listAttemptedDestinations(
         appId: string,
         msgId: string,
-        options?: MessageAttemptListOptions
+        options?: MessageAttemptListAttemptedDestinationsOptions
     ): Promise<ListResponseMessageEndpointOut> {
         return this.api.v1MessageAttemptListAttemptedDestinations({
             appId,

--- a/javascript/src/api/op_webhook_endpoint.ts
+++ b/javascript/src/api/op_webhook_endpoint.ts
@@ -9,9 +9,14 @@ import {
     OperationalWebhookEndpointUpdate,
     ListResponseOperationalWebhookEndpointOut,
 } from "../openapi";
-import { ListOptions, PostOptions } from "../util";
+import { PostOptions } from "../util";
 
-export interface OperationalWebhookEndpointListOptions extends ListOptions {
+export interface OperationalWebhookEndpointListOptions {
+    /// Limit the number of returned items
+    limit?: number;
+    /// The iterator returned from a prior invocation
+    iterator?: string | null;
+    /// The sorting order of the returned items
     order?: Ordering;
 }
 

--- a/javascript/src/util.ts
+++ b/javascript/src/util.ts
@@ -1,8 +1,3 @@
 export interface PostOptions {
     idempotencyKey?: string;
 }
-
-export interface ListOptions {
-    iterator?: string | null;
-    limit?: number;
-}


### PR DESCRIPTION
And get rid of internal ListOptions type.

The ones without docs are not getting generated yet for various reasons, but I think this is a good enough start for replacing the high-level JS API with generated code.