### PR TITLE
kotlin: Format with ktfmt --kotlinlang-style

### DIFF
--- a/kotlin/lib/src/main/kotlin/Application.kt
+++ b/kotlin/lib/src/main/kotlin/Application.kt
@@ -17,7 +17,9 @@ class Application internal constructor(token: String, options: SvixOptions) {
         options.numRetries?.let { api.numRetries = it }
     }
 
-    suspend fun list(options: ApplicationListOptions = ApplicationListOptions()): ListResponseApplicationOut {
+    suspend fun list(
+        options: ApplicationListOptions = ApplicationListOptions()
+    ): ListResponseApplicationOut {
         try {
             return api.v1ApplicationList(options.limit, options.iterator, options.order)
         } catch (e: Exception) {
@@ -55,10 +57,7 @@ class Application internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun update(
-        appId: String,
-        applicationIn: ApplicationIn,
-    ): ApplicationOut {
+    suspend fun update(appId: String, applicationIn: ApplicationIn): ApplicationOut {
         try {
             return api.v1ApplicationUpdate(appId, applicationIn)
         } catch (e: Exception) {
@@ -66,10 +65,7 @@ class Application internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun patch(
-        appId: String,
-        applicationPatch: ApplicationPatch,
-    ): ApplicationOut {
+    suspend fun patch(appId: String, applicationPatch: ApplicationPatch): ApplicationOut {
         try {
             return api.v1ApplicationPatch(appId, applicationPatch)
         } catch (e: Exception) {

--- a/kotlin/lib/src/main/kotlin/ApplicationListOptions.kt
+++ b/kotlin/lib/src/main/kotlin/ApplicationListOptions.kt
@@ -7,7 +7,9 @@ class ApplicationListOptions : ListOptions() {
 
     fun order(order: Ordering) = apply { this.order = order }
 
-    override fun iterator(iterator: String): ApplicationListOptions = apply { super.iterator(iterator) }
+    override fun iterator(iterator: String): ApplicationListOptions = apply {
+        super.iterator(iterator)
+    }
 
     override fun limit(limit: Int) = apply { super.limit(limit) }
 }

--- a/kotlin/lib/src/main/kotlin/Authentication.kt
+++ b/kotlin/lib/src/main/kotlin/Authentication.kt
@@ -22,7 +22,11 @@ class Authentication internal constructor(token: String, options: SvixOptions) {
         options: PostOptions = PostOptions(),
     ): AppPortalAccessOut {
         try {
-            return api.v1AuthenticationAppPortalAccess(appId, appPortalAccessIn, options.idempotencyKey)
+            return api.v1AuthenticationAppPortalAccess(
+                appId,
+                appPortalAccessIn,
+                options.idempotencyKey,
+            )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }

--- a/kotlin/lib/src/main/kotlin/BackgroundTask.kt
+++ b/kotlin/lib/src/main/kotlin/BackgroundTask.kt
@@ -15,9 +15,17 @@ class BackgroundTask internal constructor(token: String, options: SvixOptions) {
         options.numRetries?.let { api.numRetries = it }
     }
 
-    suspend fun list(options: BackgroundTaskListOptions = BackgroundTaskListOptions()): ListResponseBackgroundTaskOut {
+    suspend fun list(
+        options: BackgroundTaskListOptions = BackgroundTaskListOptions()
+    ): ListResponseBackgroundTaskOut {
         try {
-            return api.listBackgroundTasks(options.status, options.task, options.limit, options.iterator, options.order)
+            return api.listBackgroundTasks(
+                options.status,
+                options.task,
+                options.limit,
+                options.iterator,
+                options.order,
+            )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }

--- a/kotlin/lib/src/main/kotlin/Endpoint.kt
+++ b/kotlin/lib/src/main/kotlin/Endpoint.kt
@@ -34,12 +34,7 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         options: EndpointListOptions = EndpointListOptions(),
     ): ListResponseEndpointOut {
         try {
-            return api.v1EndpointList(
-                appId,
-                options.limit,
-                options.iterator,
-                options.order,
-            )
+            return api.v1EndpointList(appId, options.limit, options.iterator, options.order)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
@@ -51,20 +46,13 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         options: PostOptions = PostOptions(),
     ): EndpointOut {
         try {
-            return api.v1EndpointCreate(
-                appId,
-                endpointIn,
-                options.idempotencyKey,
-            )
+            return api.v1EndpointCreate(appId, endpointIn, options.idempotencyKey)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
-    suspend fun get(
-        appId: String,
-        endpointId: String,
-    ): EndpointOut {
+    suspend fun get(appId: String, endpointId: String): EndpointOut {
         try {
             return api.v1EndpointGet(endpointId, appId)
         } catch (e: Exception) {
@@ -78,11 +66,7 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         endpointUpdate: EndpointUpdate,
     ): EndpointOut {
         try {
-            return api.v1EndpointUpdate(
-                appId,
-                endpointId,
-                endpointUpdate,
-            )
+            return api.v1EndpointUpdate(appId, endpointId, endpointUpdate)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
@@ -94,20 +78,13 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         endpointPatch: EndpointPatch,
     ): EndpointOut {
         try {
-            return api.v1EndpointPatch(
-                appId,
-                endpointId,
-                endpointPatch,
-            )
+            return api.v1EndpointPatch(appId, endpointId, endpointPatch)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
-    suspend fun delete(
-        appId: String,
-        endpointId: String,
-    ) {
+    suspend fun delete(appId: String, endpointId: String) {
         try {
             api.v1EndpointDelete(appId, endpointId)
         } catch (e: Exception) {
@@ -115,15 +92,9 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun getSecret(
-        appId: String,
-        endpointId: String,
-    ): EndpointSecretOut {
+    suspend fun getSecret(appId: String, endpointId: String): EndpointSecretOut {
         try {
-            return api.v1EndpointGetSecret(
-                appId,
-                endpointId,
-            )
+            return api.v1EndpointGetSecret(appId, endpointId)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
@@ -154,26 +125,15 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         options: PostOptions = PostOptions(),
     ) {
         try {
-            api.v1EndpointRecover(
-                appId,
-                endpointId,
-                recoverIn,
-                options.idempotencyKey,
-            )
+            api.v1EndpointRecover(appId, endpointId, recoverIn, options.idempotencyKey)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
-    suspend fun getHeaders(
-        appId: String,
-        endpointId: String,
-    ): EndpointHeadersOut {
+    suspend fun getHeaders(appId: String, endpointId: String): EndpointHeadersOut {
         try {
-            return api.v1EndpointGetHeaders(
-                appId,
-                endpointId,
-            )
+            return api.v1EndpointGetHeaders(appId, endpointId)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
@@ -185,11 +145,7 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         endpointHeadersIn: EndpointHeadersIn,
     ) {
         try {
-            api.v1EndpointUpdateHeaders(
-                appId,
-                endpointId,
-                endpointHeadersIn,
-            )
+            api.v1EndpointUpdateHeaders(appId, endpointId, endpointHeadersIn)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
@@ -201,11 +157,7 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         endpointHeadersIn: EndpointHeadersPatchIn,
     ) {
         try {
-            api.v1EndpointPatchHeaders(
-                appId,
-                endpointId,
-                endpointHeadersIn,
-            )
+            api.v1EndpointPatchHeaders(appId, endpointId, endpointHeadersIn)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
@@ -217,12 +169,7 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         options: EndpointStatsOptions = EndpointStatsOptions(),
     ): EndpointStats {
         try {
-            return api.v1EndpointGetStats(
-                appId,
-                endpointId,
-                options.since,
-                options.until,
-            )
+            return api.v1EndpointGetStats(appId, endpointId, options.since, options.until)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
@@ -235,26 +182,15 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         options: PostOptions = PostOptions(),
     ) {
         try {
-            api.v1EndpointReplay(
-                appId,
-                endpointId,
-                replayIn,
-                options.idempotencyKey,
-            )
+            api.v1EndpointReplay(appId, endpointId, replayIn, options.idempotencyKey)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
-    suspend fun transformationGet(
-        appId: String,
-        endpointId: String,
-    ): EndpointTransformationOut {
+    suspend fun transformationGet(appId: String, endpointId: String): EndpointTransformationOut {
         try {
-            return api.v1EndpointTransformationGet(
-                appId,
-                endpointId,
-            )
+            return api.v1EndpointTransformationGet(appId, endpointId)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
@@ -266,11 +202,7 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         endpointTransformationIn: EndpointTransformationIn,
     ) {
         try {
-            api.v1EndpointTransformationPartialUpdate(
-                appId,
-                endpointId,
-                endpointTransformationIn,
-            )
+            api.v1EndpointTransformationPartialUpdate(appId, endpointId, endpointTransformationIn)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
@@ -283,12 +215,7 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         options: PostOptions = PostOptions(),
     ) {
         try {
-            api.v1EndpointSendExample(
-                appId,
-                endpointId,
-                eventExampleIn,
-                options.idempotencyKey,
-            )
+            api.v1EndpointSendExample(appId, endpointId, eventExampleIn, options.idempotencyKey)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }

--- a/kotlin/lib/src/main/kotlin/EventType.kt
+++ b/kotlin/lib/src/main/kotlin/EventType.kt
@@ -20,9 +20,17 @@ class EventType internal constructor(token: String, options: SvixOptions) {
         options.numRetries?.let { api.numRetries = it }
     }
 
-    suspend fun list(options: EventTypeListOptions = EventTypeListOptions()): ListResponseEventTypeOut {
+    suspend fun list(
+        options: EventTypeListOptions = EventTypeListOptions()
+    ): ListResponseEventTypeOut {
         try {
-            return api.v1EventTypeList(options.limit, options.iterator, null, options.includeAchived, options.withContent)
+            return api.v1EventTypeList(
+                options.limit,
+                options.iterator,
+                null,
+                options.includeAchived,
+                options.withContent,
+            )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
@@ -47,10 +55,7 @@ class EventType internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun update(
-        eventTypeName: String,
-        eventTypeUpdate: EventTypeUpdate,
-    ): EventTypeOut {
+    suspend fun update(eventTypeName: String, eventTypeUpdate: EventTypeUpdate): EventTypeOut {
         try {
             return api.v1EventTypeUpdate(eventTypeName, eventTypeUpdate)
         } catch (e: Exception) {
@@ -58,10 +63,7 @@ class EventType internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun patch(
-        eventTypeName: String,
-        eventTypePatch: EventTypePatch,
-    ): EventTypeOut {
+    suspend fun patch(eventTypeName: String, eventTypePatch: EventTypePatch): EventTypeOut {
         try {
             return api.v1EventTypePatch(eventTypeName, eventTypePatch)
         } catch (e: Exception) {

--- a/kotlin/lib/src/main/kotlin/Integration.kt
+++ b/kotlin/lib/src/main/kotlin/Integration.kt
@@ -41,10 +41,7 @@ class Integration internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun get(
-        appId: String,
-        integId: String,
-    ): IntegrationOut {
+    suspend fun get(appId: String, integId: String): IntegrationOut {
         try {
             return api.v1IntegrationGet(appId, integId)
         } catch (e: Exception) {
@@ -64,10 +61,7 @@ class Integration internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun delete(
-        appId: String,
-        integId: String,
-    ) {
+    suspend fun delete(appId: String, integId: String) {
         try {
             api.v1IntegrationDelete(appId, integId)
         } catch (e: Exception) {
@@ -75,10 +69,7 @@ class Integration internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun getKey(
-        appId: String,
-        integId: String,
-    ): IntegrationKeyOut {
+    suspend fun getKey(appId: String, integId: String): IntegrationKeyOut {
         try {
             return api.v1IntegrationGetKey(appId, integId)
         } catch (e: Exception) {
@@ -92,11 +83,7 @@ class Integration internal constructor(token: String, options: SvixOptions) {
         options: PostOptions = PostOptions(),
     ): IntegrationKeyOut {
         try {
-            return api.v1IntegrationRotateKey(
-                appId,
-                integId,
-                options.idempotencyKey,
-            )
+            return api.v1IntegrationRotateKey(appId, integId, options.idempotencyKey)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }

--- a/kotlin/lib/src/main/kotlin/Message.kt
+++ b/kotlin/lib/src/main/kotlin/Message.kt
@@ -2,8 +2,8 @@ package com.svix.kotlin
 
 import com.svix.kotlin.exceptions.ApiException
 import com.svix.kotlin.internal.apis.MessageApi
-import com.svix.kotlin.models.ListResponseMessageOut
 import com.svix.kotlin.models.ApplicationIn
+import com.svix.kotlin.models.ListResponseMessageOut
 import com.svix.kotlin.models.MessageIn
 import com.svix.kotlin.models.MessageOut
 
@@ -50,10 +50,7 @@ class Message internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun get(
-        msgId: String,
-        appId: String,
-    ): MessageOut {
+    suspend fun get(msgId: String, appId: String): MessageOut {
         try {
             return api.v1MessageGet(appId, msgId, null)
         } catch (e: Exception) {
@@ -61,10 +58,7 @@ class Message internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun expungeContent(
-        msgId: String,
-        appId: String,
-    ) {
+    suspend fun expungeContent(msgId: String, appId: String) {
         try {
             return api.v1MessageExpungeContent(appId, msgId)
         } catch (e: Exception) {
@@ -76,14 +70,14 @@ class Message internal constructor(token: String, options: SvixOptions) {
 /**
  * Creates a [MessageIn] with a pre-serialized payload.
  *
- * The payload is not normalized on the server. Normally, payloads are
- * required to be JSON, and Svix will minify the payload before sending the
- * webhooks (for example, by removing extraneous whitespace or unnecessarily
- * escaped characters in strings). With this function, the payload will be
- * sent "as is", without any minification or other processing.
+ * The payload is not normalized on the server. Normally, payloads are required to be JSON, and Svix
+ * will minify the payload before sending the webhooks (for example, by removing extraneous
+ * whitespace or unnecessarily escaped characters in strings). With this function, the payload will
+ * be sent "as is", without any minification or other processing.
  *
  * @param payload Serialized message payload
- * @param contentType The value to use for the Content-Type header of the webhook sent by Svix, overwriting the default of `application/json` if specified
+ * @param contentType The value to use for the Content-Type header of the webhook sent by Svix,
+ *   overwriting the default of `application/json` if specified
  *
  * See the class documentation for details about the other parameters.
  */

--- a/kotlin/lib/src/main/kotlin/MessageAttempt.kt
+++ b/kotlin/lib/src/main/kotlin/MessageAttempt.kt
@@ -18,9 +18,7 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
         options.numRetries?.let { api.numRetries = it }
     }
 
-    /**
-     * @deprecated use listByMsg or listByEndpoint instead.
-     */
+    /** @deprecated use listByMsg or listByEndpoint instead. */
     @Deprecated(message = "use listByMsg or listByEndpoint instead.")
     suspend fun list(
         appId: String,
@@ -82,11 +80,7 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun get(
-        appId: String,
-        msgId: String,
-        attemptId: String,
-    ): MessageAttemptOut {
+    suspend fun get(appId: String, msgId: String, attemptId: String): MessageAttemptOut {
         try {
             return api.v1MessageAttemptGet(appId, msgId, attemptId)
         } catch (e: Exception) {
@@ -101,12 +95,7 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
         options: PostOptions = PostOptions(),
     ) {
         try {
-            api.v1MessageAttemptResend(
-                appId,
-                msgId,
-                endpointId,
-                options.idempotencyKey,
-            )
+            api.v1MessageAttemptResend(appId, msgId, endpointId, options.idempotencyKey)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
@@ -178,11 +167,7 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun expungeContent(
-        appId: String,
-        msgId: String,
-        attemptId: String,
-    ) {
+    suspend fun expungeContent(appId: String, msgId: String, attemptId: String) {
         try {
             return api.v1MessageAttemptExpungeContent(appId, msgId, attemptId)
         } catch (e: Exception) {

--- a/kotlin/lib/src/main/kotlin/MessageAttemptListOptions.kt
+++ b/kotlin/lib/src/main/kotlin/MessageAttemptListOptions.kt
@@ -22,7 +22,9 @@ class MessageAttemptListOptions(
 
     fun after(after: OffsetDateTime) = apply { this.after = after }
 
-    fun statusCodeClass(statusCodeClass: StatusCodeClass) = apply { this.statusCodeClass = statusCodeClass }
+    fun statusCodeClass(statusCodeClass: StatusCodeClass) = apply {
+        this.statusCodeClass = statusCodeClass
+    }
 
     fun eventTypes(eventTypes: List<String>) = apply { this.eventTypes = eventTypes }
 

--- a/kotlin/lib/src/main/kotlin/OperationalWebhookEndpoint.kt
+++ b/kotlin/lib/src/main/kotlin/OperationalWebhookEndpoint.kt
@@ -2,12 +2,12 @@ package com.svix.kotlin
 
 import com.svix.kotlin.exceptions.ApiException
 import com.svix.kotlin.internal.apis.WebhookEndpointApi as OperationalWebhookEndpointApi
+import com.svix.kotlin.models.ListResponseOperationalWebhookEndpointOut
 import com.svix.kotlin.models.OperationalWebhookEndpointIn
 import com.svix.kotlin.models.OperationalWebhookEndpointOut
-import com.svix.kotlin.models.OperationalWebhookEndpointSecretOut
 import com.svix.kotlin.models.OperationalWebhookEndpointSecretIn
+import com.svix.kotlin.models.OperationalWebhookEndpointSecretOut
 import com.svix.kotlin.models.OperationalWebhookEndpointUpdate
-import com.svix.kotlin.models.ListResponseOperationalWebhookEndpointOut
 
 class OperationalWebhookEndpoint internal constructor(token: String, options: SvixOptions) {
     val api = OperationalWebhookEndpointApi(options.serverUrl)
@@ -20,7 +20,7 @@ class OperationalWebhookEndpoint internal constructor(token: String, options: Sv
     }
 
     suspend fun list(
-        options: OperationalWebhookEndpointListOptions = OperationalWebhookEndpointListOptions(),
+        options: OperationalWebhookEndpointListOptions = OperationalWebhookEndpointListOptions()
     ): ListResponseOperationalWebhookEndpointOut {
         try {
             return api.listOperationalWebhookEndpoints(
@@ -38,18 +38,13 @@ class OperationalWebhookEndpoint internal constructor(token: String, options: Sv
         options: PostOptions = PostOptions(),
     ): OperationalWebhookEndpointOut {
         try {
-            return api.createOperationalWebhookEndpoint(
-                endpointIn,
-                options.idempotencyKey,
-            )
+            return api.createOperationalWebhookEndpoint(endpointIn, options.idempotencyKey)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
-    suspend fun get(
-        endpointId: String,
-    ): OperationalWebhookEndpointOut {
+    suspend fun get(endpointId: String): OperationalWebhookEndpointOut {
         try {
             return api.getOperationalWebhookEndpoint(endpointId)
         } catch (e: Exception) {
@@ -62,18 +57,13 @@ class OperationalWebhookEndpoint internal constructor(token: String, options: Sv
         endpointUpdate: OperationalWebhookEndpointUpdate,
     ): OperationalWebhookEndpointOut {
         try {
-            return api.updateOperationalWebhookEndpoint(
-                endpointId,
-                endpointUpdate,
-            )
+            return api.updateOperationalWebhookEndpoint(endpointId, endpointUpdate)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
-    suspend fun delete(
-        endpointId: String,
-    ) {
+    suspend fun delete(endpointId: String) {
         try {
             api.deleteOperationalWebhookEndpoint(endpointId)
         } catch (e: Exception) {
@@ -81,13 +71,9 @@ class OperationalWebhookEndpoint internal constructor(token: String, options: Sv
         }
     }
 
-    suspend fun getSecret(
-        endpointId: String,
-    ): OperationalWebhookEndpointSecretOut {
+    suspend fun getSecret(endpointId: String): OperationalWebhookEndpointSecretOut {
         try {
-            return api.getOperationalWebhookEndpointSecret(
-                endpointId,
-            )
+            return api.getOperationalWebhookEndpointSecret(endpointId)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }

--- a/kotlin/lib/src/main/kotlin/Webhook.kt
+++ b/kotlin/lib/src/main/kotlin/Webhook.kt
@@ -15,10 +15,7 @@ class Webhook {
     private val key: ByteArray
 
     @Throws(WebhookVerificationException::class)
-    fun verify(
-        payload: String?,
-        headers: HttpHeaders,
-    ) {
+    fun verify(payload: String?, headers: HttpHeaders) {
         var msgId = headers.firstValue(SVIX_MSG_ID_KEY)
         var msgSignature = headers.firstValue(SVIX_MSG_SIGNATURE_KEY)
         var msgTimestamp = headers.firstValue(SVIX_MSG_TIMESTAMP_KEY)
@@ -57,11 +54,7 @@ class Webhook {
     }
 
     @Throws(WebhookSigningException::class)
-    fun sign(
-        msgId: String?,
-        timestamp: Long,
-        payload: String?,
-    ): String {
+    fun sign(msgId: String?, timestamp: Long, payload: String?): String {
         return try {
             val toSign = String.format("%s.%s.%s", msgId, timestamp, payload)
             val sha512Hmac: Mac = Mac.getInstance(HMAC_SHA256)

--- a/kotlin/lib/src/main/kotlin/exceptions/ApiException.kt
+++ b/kotlin/lib/src/main/kotlin/exceptions/ApiException.kt
@@ -6,9 +6,9 @@ import com.svix.kotlin.internal.infrastructure.Response
 import com.svix.kotlin.internal.infrastructure.ServerError
 import com.svix.kotlin.internal.infrastructure.ServerException
 
-class ApiException internal constructor(message: String? = null, val statusCode: Int = -1, val body: String? = null) : RuntimeException(
-    message,
-) {
+class ApiException
+internal constructor(message: String? = null, val statusCode: Int = -1, val body: String? = null) :
+    RuntimeException(message) {
     companion object {
         private fun extractBody(response: Response?): String? {
             return when (response) {

--- a/kotlin/lib/src/main/kotlin/exceptions/WebhookSigningException.kt
+++ b/kotlin/lib/src/main/kotlin/exceptions/WebhookSigningException.kt
@@ -2,7 +2,10 @@ package com.svix.kotlin.exceptions
 
 class WebhookSigningException : Exception {
     constructor() : super()
+
     constructor(message: String) : super(message)
+
     constructor(message: String, cause: Throwable) : super(message, cause)
+
     constructor(cause: Throwable) : super(cause)
 }

--- a/kotlin/lib/src/test/com/svix/kotlin/BasicTest.kt
+++ b/kotlin/lib/src/test/com/svix/kotlin/BasicTest.kt
@@ -6,10 +6,10 @@ import com.svix.kotlin.models.EndpointIn
 import com.svix.kotlin.models.EndpointPatch
 import com.svix.kotlin.models.EventTypeIn
 import com.svix.kotlin.models.MessageIn
-import kotlinx.coroutines.runBlocking
 import java.net.URI
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlinx.coroutines.runBlocking
 
 class BasicTest {
     companion object {
@@ -19,8 +19,8 @@ class BasicTest {
 
     private fun getTestClient(): Svix? =
         if (AUTH_TOKEN == null || SERVER_URL == null) {
-            // TODO: figure out how to log a warning here to help teach about tests that skip when the env
-            // vars are unset.
+            // TODO: figure out how to log a warning here to help teach about tests that skip when
+            // the env vars are unset.
             null
         } else {
             Svix(AUTH_TOKEN, SvixOptions(SERVER_URL))
@@ -56,21 +56,34 @@ class BasicTest {
             val appOut = svix.application.create(ApplicationIn(name = "App2"))
             try {
                 svix.eventType.create(
-                    EventTypeIn(name = "event.started", description = "Something started"),
+                    EventTypeIn(name = "event.started", description = "Something started")
                 )
             } catch (e: ApiException) {
-                assertEquals(409, e.statusCode, "conflicts are expected but other bad statuses are not")
+                assertEquals(
+                    409,
+                    e.statusCode,
+                    "conflicts are expected but other bad statuses are not",
+                )
             }
             try {
-                svix.eventType.create(EventTypeIn(name = "event.ended", description = "Something ended"))
+                svix.eventType.create(
+                    EventTypeIn(name = "event.ended", description = "Something ended")
+                )
             } catch (e: ApiException) {
-                assertEquals(409, e.statusCode, "conflicts are expected but other bad statuses are not")
+                assertEquals(
+                    409,
+                    e.statusCode,
+                    "conflicts are expected but other bad statuses are not",
+                )
             }
 
             val epOut =
                 svix.endpoint.create(
                     appOut.id,
-                    EndpointIn(url = URI("https://example.svix.com"), channels = setOf("ch0", "ch1")),
+                    EndpointIn(
+                        url = URI("https://example.svix.com"),
+                        channels = setOf("ch0", "ch1"),
+                    ),
                 )
             assertEquals(setOf("ch0", "ch1"), epOut.channels, "initial ep should have 2 channels")
             assertEquals(0, epOut.filterTypes?.size ?: 0, "initial ep should have 0 filter types")
@@ -80,7 +93,11 @@ class BasicTest {
                     epOut.id,
                     EndpointPatch(filterTypes = setOf("event.started", "event.ended")),
                 )
-            assertEquals(setOf("ch0", "ch1"), epPatched.channels, "patched ep should have 2 channels")
+            assertEquals(
+                setOf("ch0", "ch1"),
+                epPatched.channels,
+                "patched ep should have 2 channels",
+            )
             assertEquals(
                 setOf("event.started", "event.ended"),
                 epPatched.filterTypes,

--- a/kotlin/lib/src/test/com/svix/kotlin/WebhookTest.kt
+++ b/kotlin/lib/src/test/com/svix/kotlin/WebhookTest.kt
@@ -50,86 +50,55 @@ class WebhookTest {
     fun verifyMissingIdThrowsException() {
         val testPayload = TestPayload(System.currentTimeMillis())
         testPayload.headerMap.remove("svix-id")
-        assertFailsWith<WebhookVerificationException>(
-            block = {
-                verify(testPayload)
-            },
-        )
+        assertFailsWith<WebhookVerificationException>(block = { verify(testPayload) })
     }
 
     @Test
     fun verifyMissingTimestampThrowsException() {
         val testPayload = TestPayload(System.currentTimeMillis())
         testPayload.headerMap.remove("svix-timestamp")
-        assertFailsWith<WebhookVerificationException>(
-            block = {
-                verify(testPayload)
-            },
-        )
+        assertFailsWith<WebhookVerificationException>(block = { verify(testPayload) })
     }
 
     @Test
     fun verifyMissingSignatureThrowsException() {
         val testPayload = TestPayload(System.currentTimeMillis())
         testPayload.headerMap.remove("svix-signature")
-        assertFailsWith<WebhookVerificationException>(
-            block = {
-                verify(testPayload)
-            },
-        )
+        assertFailsWith<WebhookVerificationException>(block = { verify(testPayload) })
     }
 
     @Test
     fun verifySignatureWithDifferentVersionThrowsException() {
         val testPayload = TestPayload(System.currentTimeMillis())
-        testPayload.headerMap[Webhook.SVIX_MSG_ID_KEY] = ArrayList(listOf("v2,g0hM9SsE+OTPJTGt/tmIKtSyZlE3uFJELVlNIOLJ1OE="))
-        assertFailsWith<WebhookVerificationException>(
-            block = {
-                verify(testPayload)
-            },
-        )
+        testPayload.headerMap[Webhook.SVIX_MSG_ID_KEY] =
+            ArrayList(listOf("v2,g0hM9SsE+OTPJTGt/tmIKtSyZlE3uFJELVlNIOLJ1OE="))
+        assertFailsWith<WebhookVerificationException>(block = { verify(testPayload) })
     }
 
     @Test
     fun verifyMissingPartsInSignatureThrowsException() {
         val testPayload = TestPayload(System.currentTimeMillis())
         testPayload.headerMap[Webhook.SVIX_MSG_ID_KEY] = ArrayList(listOf("invalid_signature"))
-        assertFailsWith<WebhookVerificationException>(
-            block = {
-                verify(testPayload)
-            },
-        )
+        assertFailsWith<WebhookVerificationException>(block = { verify(testPayload) })
     }
 
     @Test
     fun verifySignatureMismatchThrowsException() {
         val testPayload = TestPayload(System.currentTimeMillis())
         testPayload.headerMap[Webhook.SVIX_MSG_ID_KEY] = ArrayList(listOf("v1,invalid_signature"))
-        assertFailsWith<WebhookVerificationException>(
-            block = {
-                verify(testPayload)
-            },
-        )
+        assertFailsWith<WebhookVerificationException>(block = { verify(testPayload) })
     }
 
     @Test
     fun verifyOldTimestampThrowsException() {
         val testPayload = TestPayload(System.currentTimeMillis() + TOLERANCE_IN_MS + SECOND_IN_MS)
-        assertFailsWith<WebhookVerificationException>(
-            block = {
-                verify(testPayload)
-            },
-        )
+        assertFailsWith<WebhookVerificationException>(block = { verify(testPayload) })
     }
 
     @Test
     fun verifyNewTimestampThrowsException() {
         val testPayload = TestPayload(System.currentTimeMillis() - TOLERANCE_IN_MS - SECOND_IN_MS)
-        assertFailsWith<WebhookVerificationException>(
-            block = {
-                verify(testPayload)
-            },
-        )
+        assertFailsWith<WebhookVerificationException>(block = { verify(testPayload) })
     }
 
     @Test
@@ -137,7 +106,8 @@ class WebhookTest {
         val testPayload = TestPayload(System.currentTimeMillis())
         var webhook = Webhook(testPayload.secret)
         webhook.verify(testPayload.payload, testPayload.headers())
-        webhook = Webhook(java.lang.String.format("%s%s", Webhook.SECRET_PREFIX, testPayload.secret))
+        webhook =
+            Webhook(java.lang.String.format("%s%s", Webhook.SECRET_PREFIX, testPayload.secret))
         webhook.verify(testPayload.payload, testPayload.headers())
     }
 
@@ -183,7 +153,8 @@ class WebhookTest {
                 val sha512Hmac: Mac = Mac.getInstance("HmacSHA256")
                 val keySpec = SecretKeySpec(Base64.getDecoder().decode(secret), "HmacSHA256")
                 sha512Hmac.init(keySpec)
-                val macData: ByteArray = sha512Hmac.doFinal(toSign.toByteArray(StandardCharsets.UTF_8))
+                val macData: ByteArray =
+                    sha512Hmac.doFinal(toSign.toByteArray(StandardCharsets.UTF_8))
                 signature = Base64.getEncoder().encodeToString(macData)
             } catch (e: Exception) {
                 // pass


### PR DESCRIPTION
Like https://github.com/svix/svix-webhooks/pull/1574. We want to replace some files with auto-generated ones, to reduce the diff and make it readable once it's generated, we should apply auto-formatting at all times.

I tried setting up a gradle plugin for this, but unfortunately things are a bit broken for me locally, so that didn't work out.