### PR TITLE
Rust: derive Clone and Debug on Webhook struct

### DIFF
--- a/rust/src/webhooks.rs
+++ b/rust/src/webhooks.rs
@@ -30,6 +30,7 @@ pub enum WebhookError {
     InvalidPayload,
 }
 
+#[derive(Debug, Clone)]
 pub struct Webhook {
     key: Vec<u8>,
 }


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

- Since the Webhook struct is quite simple, there is no reason not to have Clone implemented on it
- My use case for Clone was to use Webhook as a `Data` in poem: https://docs.rs/poem/latest/poem/struct.Request.html#method.set_data

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- derive Clone on Webhook
- Also derive Debug because why not?