### PR TITLE
CLI: show websocket connection failure details

### DIFF
--- a/svix-cli/src/relay/mod.rs
+++ b/svix-cli/src/relay/mod.rs
@@ -316,6 +316,7 @@ impl WsConnection {
         let request = websocket_url.to_string().into_client_request()?;
         let (stream, _resp) = connect_async(request)
             .await
+            .inspect_err(|e| eprintln!("{e}"))
             .context("failed to connect to websocket server")?;
 
         Ok(Self { stream })


### PR DESCRIPTION
For whatever reason the error detail wasn't surfaced while I was debugging some TLS things.

This `.inspect_err()` gave me what I needed. Let's keep it in there.