### PR TITLE
CLI: add `authors` to manifest

### DIFF
--- a/svix-cli/Cargo.toml
+++ b/svix-cli/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "svix-cli"
 description = "A CLI to interact with the Svix API."
+authors = ["Svix Inc. <oss@svix.com>"]
 version = "1.44.0"
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
One of the `dist` jobs complains that this is unset.
