### PR TITLE
Docker: fix exposed port to be 8071.

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get update && apt-get install -y \
         rm -rf /var/lib/apt/lists/*
 
 USER appuser
-EXPOSE 8080
+EXPOSE 8071
 
 COPY --from=build /app/target/release/svix-server /usr/local/bin/svix-server
 


### PR DESCRIPTION
I don't think exposing 8080 ever did anything as the server is listening on 8071. It looks like a customer has been facing issues with their docker setup not letting them map the port because it doesn't match the exposed from the dockerfile. I'm not sure how it works for everyone else but not here though anyhow it should be fixed.

Ref: https://x.com/0xblacklight/status/1872430388158533871