### PR TITLE
CLI: change binary name to `svix-cli`

### DIFF
--- a/svix-cli/Cargo.toml
+++ b/svix-cli/Cargo.toml
@@ -8,10 +8,6 @@ license = "MIT"
 keywords = ["svix", "webhooks", "diahook"]
 categories = ["development-tools", "asynchronous", "network-programming", "web-programming"]
 
-[[bin]]
-name = "svix"
-path = "src/main.rs"
-
 [dependencies]
 anyhow = "1.0.94"
 base64 = "0.22.1"


### PR DESCRIPTION
This is to help clarify what the binary actually is among the rest of the svix tooling in the repo.

Looking forward, this will also help to keep the naming scheme consistent between the binary, the package name, and the updater while handling distribution via `dist` (pending PR:
https://github.com/svix/svix-webhooks/pull/1593)