### PR TITLE
CLI: remove badges from readme

### DIFF
--- a/svix-cli/README.md
+++ b/svix-cli/README.md
@@ -7,10 +7,6 @@
 
 # Svix CLI
 
-[![GitHub release (latest by date)][release-img]][release]
-
-
-
 A CLI to interact with the Svix API.
 
 **With the Svix CLI, you can:**
@@ -151,7 +147,3 @@ For detailed instructions on configuring completions for your shell run `svix-cl
 
 For a more information, checkout our [API reference](https://docs.svix.com).
 
-
-
-[release-img]: https://img.shields.io/github/v/release/svix/svix-cli
-[release]: https://github.com/svix/svix-cli/releases


### PR DESCRIPTION
These were copied over as-is from the old svix-cli repo and don't make sense any longer.