### PR TITLE
CLI: update codegen again

### DIFF
--- a/svix-cli/src/cmds/api/application.rs
+++ b/svix-cli/src/cmds/api/application.rs
@@ -1,5 +1,5 @@
 use clap::{Args, Subcommand};
-use svix::api::{self, Ordering};
+use svix::api::*;
 
 use crate::{cli_types::PostOptions, json::JsonOf};
 
@@ -16,7 +16,7 @@ pub struct ApplicationListOptions {
     pub order: Option<Ordering>,
 }
 
-impl From<ApplicationListOptions> for api::ApplicationListOptions {
+impl From<ApplicationListOptions> for svix::api::ApplicationListOptions {
     fn from(
         ApplicationListOptions {
             limit,
@@ -49,7 +49,7 @@ pub enum ApplicationCommands {
     },
     /// Create a new application.
     Create {
-        application_in: JsonOf<api::ApplicationIn>,
+        application_in: JsonOf<ApplicationIn>,
         #[clap(flatten)]
         post_options: Option<PostOptions>,
     },
@@ -58,21 +58,21 @@ pub enum ApplicationCommands {
     /// Update an application.
     Update {
         id: String,
-        application_in: JsonOf<api::ApplicationIn>,
+        application_in: JsonOf<ApplicationIn>,
     },
     /// Delete an application.
     Delete { id: String },
     /// Partially update an application.
     Patch {
         id: String,
-        application_patch: JsonOf<api::ApplicationPatch>,
+        application_patch: JsonOf<ApplicationPatch>,
     },
 }
 
 impl ApplicationCommands {
     pub async fn exec(
         self,
-        client: &api::Svix,
+        client: &Svix,
         color_mode: colored_json::ColorMode,
     ) -> anyhow::Result<()> {
         match self {

--- a/svix-cli/src/cmds/api/authentication.rs
+++ b/svix-cli/src/cmds/api/authentication.rs
@@ -1,5 +1,5 @@
 use clap::{Args, Subcommand};
-use svix::api::{self};
+use svix::api::*;
 
 use crate::{cli_types::PostOptions, json::JsonOf};
 
@@ -16,14 +16,14 @@ pub enum AuthenticationCommands {
     /// Use this function to get magic links (and authentication codes) for connecting your users to the Consumer Application Portal.
     AppPortalAccess {
         app_id: String,
-        app_portal_access_in: JsonOf<api::AppPortalAccessIn>,
+        app_portal_access_in: JsonOf<AppPortalAccessIn>,
         #[clap(flatten)]
         post_options: Option<PostOptions>,
     },
     /// Expire all of the tokens associated with a specific application.
     ExpireAll {
         app_id: String,
-        application_token_expire_in: JsonOf<api::ApplicationTokenExpireIn>,
+        application_token_expire_in: JsonOf<ApplicationTokenExpireIn>,
         #[clap(flatten)]
         post_options: Option<PostOptions>,
     },
@@ -39,7 +39,7 @@ pub enum AuthenticationCommands {
 impl AuthenticationCommands {
     pub async fn exec(
         self,
-        client: &api::Svix,
+        client: &Svix,
         color_mode: colored_json::ColorMode,
     ) -> anyhow::Result<()> {
         match self {

--- a/svix-cli/src/cmds/api/endpoint.rs
+++ b/svix-cli/src/cmds/api/endpoint.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use clap::{Args, Subcommand};
-use svix::api::{self, Ordering};
+use svix::api::*;
 
 use crate::{cli_types::PostOptions, json::JsonOf};
 
@@ -17,7 +17,7 @@ pub struct EndpointListOptions {
     pub order: Option<Ordering>,
 }
 
-impl From<EndpointListOptions> for api::EndpointListOptions {
+impl From<EndpointListOptions> for svix::api::EndpointListOptions {
     fn from(
         EndpointListOptions {
             limit,
@@ -43,7 +43,7 @@ pub struct EndpointGetStatsOptions {
     pub until: Option<DateTime<Utc>>,
 }
 
-impl From<EndpointGetStatsOptions> for api::EndpointGetStatsOptions {
+impl From<EndpointGetStatsOptions> for svix::api::EndpointGetStatsOptions {
     fn from(EndpointGetStatsOptions { since, until }: EndpointGetStatsOptions) -> Self {
         Self {
             since: since.map(|dt| dt.to_rfc3339()),
@@ -74,7 +74,7 @@ pub enum EndpointCommands {
     /// When `secret` is `null` the secret is automatically generated (recommended).
     Create {
         app_id: String,
-        endpoint_in: JsonOf<api::EndpointIn>,
+        endpoint_in: JsonOf<EndpointIn>,
         #[clap(flatten)]
         post_options: Option<PostOptions>,
     },
@@ -84,7 +84,7 @@ pub enum EndpointCommands {
     Update {
         app_id: String,
         id: String,
-        endpoint_update: JsonOf<api::EndpointUpdate>,
+        endpoint_update: JsonOf<EndpointUpdate>,
     },
     /// Delete an endpoint.
     Delete { app_id: String, id: String },
@@ -92,7 +92,7 @@ pub enum EndpointCommands {
     Patch {
         app_id: String,
         id: String,
-        endpoint_patch: JsonOf<api::EndpointPatch>,
+        endpoint_patch: JsonOf<EndpointPatch>,
     },
     /// Get the additional headers to be sent with the webhook.
     GetHeaders { app_id: String, id: String },
@@ -100,13 +100,13 @@ pub enum EndpointCommands {
     UpdateHeaders {
         app_id: String,
         id: String,
-        endpoint_headers_in: JsonOf<api::EndpointHeadersIn>,
+        endpoint_headers_in: JsonOf<EndpointHeadersIn>,
     },
     /// Partially set the additional headers to be sent with the webhook.
     PatchHeaders {
         app_id: String,
         id: String,
-        endpoint_headers_patch_in: JsonOf<api::EndpointHeadersPatchIn>,
+        endpoint_headers_patch_in: JsonOf<EndpointHeadersPatchIn>,
     },
     /// Resend all failed messages since a given time.
     ///
@@ -114,7 +114,7 @@ pub enum EndpointCommands {
     Recover {
         app_id: String,
         id: String,
-        recover_in: JsonOf<api::RecoverIn>,
+        recover_in: JsonOf<RecoverIn>,
     },
     /// Replays messages to the endpoint.
     ///
@@ -123,7 +123,7 @@ pub enum EndpointCommands {
     ReplayMissing {
         app_id: String,
         id: String,
-        replay_in: JsonOf<api::ReplayIn>,
+        replay_in: JsonOf<ReplayIn>,
         #[clap(flatten)]
         post_options: Option<PostOptions>,
     },
@@ -138,13 +138,13 @@ pub enum EndpointCommands {
     RotateSecret {
         app_id: String,
         id: String,
-        endpoint_secret_rotate_in: JsonOf<api::EndpointSecretRotateIn>,
+        endpoint_secret_rotate_in: JsonOf<EndpointSecretRotateIn>,
     },
     /// Send an example message for an event.
     SendExample {
         app_id: String,
         id: String,
-        event_example_in: JsonOf<api::EventExampleIn>,
+        event_example_in: JsonOf<EventExampleIn>,
         #[clap(flatten)]
         post_options: Option<PostOptions>,
     },
@@ -162,14 +162,14 @@ pub enum EndpointCommands {
     TransformationPartialUpdate {
         app_id: String,
         id: String,
-        endpoint_transformation_in: JsonOf<api::EndpointTransformationIn>,
+        endpoint_transformation_in: JsonOf<EndpointTransformationIn>,
     },
 }
 
 impl EndpointCommands {
     pub async fn exec(
         self,
-        client: &api::Svix,
+        client: &Svix,
         color_mode: colored_json::ColorMode,
     ) -> anyhow::Result<()> {
         match self {
@@ -245,7 +245,6 @@ impl EndpointCommands {
                     .patch_headers(app_id, id, endpoint_headers_patch_in.into_inner())
                     .await?;
             }
-
             Self::Recover {
                 app_id,
                 id,

--- a/svix-cli/src/cmds/api/event_type.rs
+++ b/svix-cli/src/cmds/api/event_type.rs
@@ -1,5 +1,5 @@
 use clap::{Args, Subcommand};
-use svix::api::{self, Ordering};
+use svix::api::*;
 
 use crate::{cli_types::PostOptions, json::JsonOf};
 
@@ -22,7 +22,7 @@ pub struct EventTypeListOptions {
     pub with_content: Option<bool>,
 }
 
-impl From<EventTypeListOptions> for api::EventTypeListOptions {
+impl From<EventTypeListOptions> for svix::api::EventTypeListOptions {
     fn from(
         EventTypeListOptions {
             limit,
@@ -63,7 +63,7 @@ pub enum EventTypeCommands {
     /// Endpoints filtering on the event type before archival will continue to filter on it.
     /// This operation does not preserve the description and schemas.
     Create {
-        event_type_in: JsonOf<api::EventTypeIn>,
+        event_type_in: JsonOf<EventTypeIn>,
         #[clap(flatten)]
         post_options: Option<PostOptions>,
     },
@@ -73,17 +73,16 @@ pub enum EventTypeCommands {
     /// The importer will convert all webhooks found in the either the `webhooks` or `x-webhooks`
     /// top-level.
     ImportOpenapi {
-        event_type_import_open_api_in: JsonOf<api::EventTypeImportOpenApiIn>,
+        event_type_import_open_api_in: JsonOf<EventTypeImportOpenApiIn>,
         #[clap(flatten)]
         post_options: Option<PostOptions>,
     },
-
     /// Get an event type.
     Get { event_type_name: String },
     /// Update an event type.
     Update {
         event_type_name: String,
-        event_type_update: JsonOf<api::EventTypeUpdate>,
+        event_type_update: JsonOf<EventTypeUpdate>,
     },
     /// Archive an event type.
     ///
@@ -100,14 +99,14 @@ pub enum EventTypeCommands {
     /// Partially update an event type.
     Patch {
         event_type_name: String,
-        event_type_patch: JsonOf<api::EventTypePatch>,
+        event_type_patch: JsonOf<EventTypePatch>,
     },
 }
 
 impl EventTypeCommands {
     pub async fn exec(
         self,
-        client: &api::Svix,
+        client: &Svix,
         color_mode: colored_json::ColorMode,
     ) -> anyhow::Result<()> {
         match self {

--- a/svix-cli/src/cmds/api/integration.rs
+++ b/svix-cli/src/cmds/api/integration.rs
@@ -1,5 +1,5 @@
 use clap::{Args, Subcommand};
-use svix::api::{self, Ordering};
+use svix::api::*;
 
 use crate::{cli_types::PostOptions, json::JsonOf};
 
@@ -16,7 +16,7 @@ pub struct IntegrationListOptions {
     pub order: Option<Ordering>,
 }
 
-impl From<IntegrationListOptions> for api::IntegrationListOptions {
+impl From<IntegrationListOptions> for svix::api::IntegrationListOptions {
     fn from(
         IntegrationListOptions {
             limit,
@@ -52,7 +52,7 @@ pub enum IntegrationCommands {
     /// Create an integration.
     Create {
         app_id: String,
-        integration_in: JsonOf<api::IntegrationIn>,
+        integration_in: JsonOf<IntegrationIn>,
         #[clap(flatten)]
         post_options: Option<PostOptions>,
     },
@@ -62,7 +62,7 @@ pub enum IntegrationCommands {
     Update {
         app_id: String,
         id: String,
-        integration_update: JsonOf<api::IntegrationUpdate>,
+        integration_update: JsonOf<IntegrationUpdate>,
     },
     /// Delete an integration.
     Delete { app_id: String, id: String },
@@ -75,7 +75,7 @@ pub enum IntegrationCommands {
 impl IntegrationCommands {
     pub async fn exec(
         self,
-        client: &api::Svix,
+        client: &Svix,
         color_mode: colored_json::ColorMode,
     ) -> anyhow::Result<()> {
         match self {

--- a/svix-cli/src/cmds/api/message.rs
+++ b/svix-cli/src/cmds/api/message.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use clap::{Args, Subcommand};
-use svix::api::{self};
+use svix::api::*;
 
 use crate::{cli_types::PostOptions, json::JsonOf};
 
@@ -32,7 +32,7 @@ pub struct MessageListOptions {
     pub event_types: Option<Vec<String>>,
 }
 
-impl From<MessageListOptions> for api::MessageListOptions {
+impl From<MessageListOptions> for svix::api::MessageListOptions {
     fn from(
         MessageListOptions {
             limit,
@@ -94,7 +94,7 @@ pub enum MessageCommands {
     /// The `payload` property is the webhook's body (the actual webhook message). Svix supports payload sizes of up to ~350kb, though it's generally a good idea to keep webhook payloads small, probably no larger than 40kb.
     Create {
         app_id: String,
-        message_in: JsonOf<api::MessageIn>,
+        message_in: JsonOf<MessageIn>,
         #[clap(flatten)]
         post_options: Option<PostOptions>,
     },
@@ -110,7 +110,7 @@ pub enum MessageCommands {
 impl MessageCommands {
     pub async fn exec(
         self,
-        client: &api::Svix,
+        client: &Svix,
         color_mode: colored_json::ColorMode,
     ) -> anyhow::Result<()> {
         match self {

--- a/svix-cli/src/cmds/api/message_attempt.rs
+++ b/svix-cli/src/cmds/api/message_attempt.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use clap::{Args, Subcommand};
-use svix::api::{self};
+use svix::api::*;
 
 #[derive(Args, Clone)]
 pub struct MessageAttemptListByEndpointOptions {
@@ -12,10 +12,10 @@ pub struct MessageAttemptListByEndpointOptions {
     pub iterator: Option<String>,
     /// Filter response based on the status of the attempt: Success (0), Pending (1), Failed (2), or Sending (3)
     #[arg(long)]
-    pub status: Option<api::MessageStatus>,
+    pub status: Option<MessageStatus>,
     /// Filter response based on the HTTP status code
     #[arg(long)]
-    pub status_code_class: Option<api::StatusCodeClass>,
+    pub status_code_class: Option<StatusCodeClass>,
     /// Filter response based on the channel
     #[arg(long)]
     pub channel: Option<String>,
@@ -39,7 +39,7 @@ pub struct MessageAttemptListByEndpointOptions {
     pub event_types: Option<Vec<String>>,
 }
 
-impl From<MessageAttemptListByEndpointOptions> for api::MessageAttemptListByEndpointOptions {
+impl From<MessageAttemptListByEndpointOptions> for svix::api::MessageAttemptListByEndpointOptions {
     fn from(
         MessageAttemptListByEndpointOptions {
             limit,
@@ -81,10 +81,10 @@ pub struct MessageAttemptListByMsgOptions {
     pub iterator: Option<String>,
     /// Filter response based on the status of the attempt: Success (0), Pending (1), Failed (2), or Sending (3)
     #[arg(long)]
-    pub status: Option<api::MessageStatus>,
+    pub status: Option<MessageStatus>,
     /// Filter response based on the HTTP status code
     #[arg(long)]
-    pub status_code_class: Option<api::StatusCodeClass>,
+    pub status_code_class: Option<StatusCodeClass>,
     /// Filter response based on the channel
     #[arg(long)]
     pub channel: Option<String>,
@@ -108,7 +108,7 @@ pub struct MessageAttemptListByMsgOptions {
     pub event_types: Option<Vec<String>>,
 }
 
-impl From<MessageAttemptListByMsgOptions> for api::MessageAttemptListByMsgOptions {
+impl From<MessageAttemptListByMsgOptions> for svix::api::MessageAttemptListByMsgOptions {
     fn from(
         MessageAttemptListByMsgOptions {
             limit,
@@ -156,7 +156,7 @@ pub struct MessageAttemptListAttemptedMessagesOptions {
     pub tag: Option<String>,
     /// Filter response based on the status of the attempt: Success (0), Pending (1), Failed (2), or Sending (3)
     #[arg(long)]
-    pub status: Option<api::MessageStatus>,
+    pub status: Option<MessageStatus>,
     /// Only include items created before a certain date
     #[arg(long)]
     pub before: Option<DateTime<Utc>>,
@@ -172,7 +172,7 @@ pub struct MessageAttemptListAttemptedMessagesOptions {
 }
 
 impl From<MessageAttemptListAttemptedMessagesOptions>
-    for api::MessageAttemptListAttemptedMessagesOptions
+    for svix::api::MessageAttemptListAttemptedMessagesOptions
 {
     fn from(
         MessageAttemptListAttemptedMessagesOptions {
@@ -212,7 +212,7 @@ pub struct MessageAttemptListAttemptedDestinationsOptions {
 }
 
 impl From<MessageAttemptListAttemptedDestinationsOptions>
-    for api::MessageAttemptListAttemptedDestinationsOptions
+    for svix::api::MessageAttemptListAttemptedDestinationsOptions
 {
     fn from(
         MessageAttemptListAttemptedDestinationsOptions {
@@ -311,7 +311,7 @@ pub enum MessageAttemptCommands {
 impl MessageAttemptCommands {
     pub async fn exec(
         self,
-        client: &api::Svix,
+        client: &Svix,
         color_mode: colored_json::ColorMode,
     ) -> anyhow::Result<()> {
         match self {


### PR DESCRIPTION
Continued refinement of the generator templates to help reduce friction.

Some imports have been reworked to make them more stable diff-to-diff with fully-qualified paths used as needed (i.e. when we shadow models and convert them via a `From` impl).