### PR TITLE
Libs: change release workflows to be triggered by release published

### DIFF
--- a/.github/workflows/csharp-release.yml
+++ b/.github/workflows/csharp-release.yml
@@ -1,9 +1,8 @@
 name: C# Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 jobs:
   dotnet:

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -1,9 +1,8 @@
 name: Java Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 jobs:
   dotnet:

--- a/.github/workflows/javascript-release.yml
+++ b/.github/workflows/javascript-release.yml
@@ -8,8 +8,8 @@ on:
       - 'openapi.json'
       - 'javascript/**'
       - '.github/workflows/javascript-release.yml'
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/kotlin-release.yml
+++ b/.github/workflows/kotlin-release.yml
@@ -1,9 +1,8 @@
 name: Kotlin Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 jobs:
   kotlin:

--- a/.github/workflows/php-release.yml
+++ b/.github/workflows/php-release.yml
@@ -1,9 +1,8 @@
 name: PHP Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 jobs:
   packagist:

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -1,9 +1,8 @@
 name: Python Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/ruby-release.yml
+++ b/.github/workflows/ruby-release.yml
@@ -1,9 +1,8 @@
 name: Ruby Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 jobs:
   dotnet:

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -1,9 +1,8 @@
 name: Rust Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/update-postman.yml
+++ b/.github/workflows/update-postman.yml
@@ -1,9 +1,8 @@
 name: Update Postman Collection
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 jobs:
   postman:


### PR DESCRIPTION
We had an issue where pushing tags named for version numbers caused unwanted side-effects.

Attempting to avoid this:
- no longer manually push tags.
- let the GitHub release automatically tag when it publishes.
- drive the other release workflows based on release: published events.

By moving the trigger off of tag push, this additionally opens the door for situations where we need to push a tag then create a release for it since the lib workflows won't be triggered until the release is finalized.
