### PR TITLE
CI: release libs, server, bridge with manual workflows

### DIFF
--- a/.github/workflows/bridge-release.yml
+++ b/.github/workflows/bridge-release.yml
@@ -1,8 +1,13 @@
 name: Bridge Release
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Mega Releaser
+    types:
+      - completed
+
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/csharp-release.yml
+++ b/.github/workflows/csharp-release.yml
@@ -1,8 +1,12 @@
 name: C# Release
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Mega Releaser
+    types:
+      - completed
 
 jobs:
   dotnet:

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -1,8 +1,12 @@
 name: Java Release
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Mega Releaser
+    types:
+      - completed
 
 jobs:
   dotnet:

--- a/.github/workflows/javascript-release.yml
+++ b/.github/workflows/javascript-release.yml
@@ -8,8 +8,12 @@ on:
       - 'openapi.json'
       - 'javascript/**'
       - '.github/workflows/javascript-release.yml'
-  release:
-    types: [published]
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Mega Releaser
+    types:
+      - completed
 
 jobs:
   build:

--- a/.github/workflows/kotlin-release.yml
+++ b/.github/workflows/kotlin-release.yml
@@ -1,8 +1,12 @@
 name: Kotlin Release
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Mega Releaser
+    types:
+      - completed
 
 jobs:
   kotlin:

--- a/.github/workflows/mega-releaser.yml
+++ b/.github/workflows/mega-releaser.yml
@@ -1,0 +1,11 @@
+name: Mega Releaser
+
+on: workflow_dispatch
+
+
+jobs:
+  kick-off:
+    name: Kick-off Releases
+    runs-on: ubuntu-latest
+    steps:
+      - run: /bin/true

--- a/.github/workflows/php-release.yml
+++ b/.github/workflows/php-release.yml
@@ -1,8 +1,12 @@
 name: PHP Release
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Mega Releaser
+    types:
+      - completed
 
 jobs:
   packagist:

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -1,8 +1,12 @@
 name: Python Release
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Mega Releaser
+    types:
+      - completed
 
 jobs:
   build:

--- a/.github/workflows/ruby-release.yml
+++ b/.github/workflows/ruby-release.yml
@@ -1,8 +1,12 @@
 name: Ruby Release
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Mega Releaser
+    types:
+      - completed
 
 jobs:
   dotnet:

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -1,8 +1,12 @@
 name: Rust Release
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Mega Releaser
+    types:
+      - completed
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -1,8 +1,12 @@
 name: Server Release
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Mega Releaser
+    types:
+      - completed
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/update-postman.yml
+++ b/.github/workflows/update-postman.yml
@@ -1,8 +1,12 @@
 name: Update Postman Collection
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Mega Releaser
+    types:
+      - completed
 
 jobs:
   postman:


### PR DESCRIPTION
Changes all workflows related to Releases so they are manually triggered.

Continuing to iron out the kinks of the new `dist` based workflow used for building/releasing the CLI.

It looks as though the "release published" event we tried to trigger these on doesn't fire in some cases. Rumors suggest having a release published by an automation rather than a real person could be the difference.

For now as a workaround, let's trigger these manually. It's tedious, but we can likely add One More Workflow to kick them all off on our behalf as a 2nd step.

Additional: a new workflow called "Mega Releaser" aims to try and kick off all the rest. It might work. It might not. TBD.
