### PR TITLE
csharp: allow verification of webhook signature without the need of a WebHeaderCollection

### DIFF
--- a/csharp/Svix.Tests/WebhookTest.cs
+++ b/csharp/Svix.Tests/WebhookTest.cs
@@ -133,6 +133,36 @@ namespace Svix.Tests
 
             Assert.Throws<WebhookVerificationException>(() => wh.Verify(testPayload.payload, testPayload.headers));
         }
+        
+        [Fact]
+        public void TestWebHeaderCollectionNullThrowsException()
+        {
+            var testPayload = new TestPayload(DateTimeOffset.UtcNow);
+
+            var wh = new Webhook(testPayload.secret);
+
+            Assert.Throws<ArgumentNullException>(() => wh.Verify(testPayload.payload, (WebHeaderCollection)null));
+        }
+        
+        [Fact]
+        public void TestWebHeadersProviderNullThrowsException()
+        {
+            var testPayload = new TestPayload(DateTimeOffset.UtcNow);
+
+            var wh = new Webhook(testPayload.secret);
+
+            Assert.Throws<ArgumentNullException>(() => wh.Verify(testPayload.payload, (Func<string, string>)null));
+        }
+        
+        [Fact]
+        public void TestPayloadNullThrowsException()
+        {
+            var testPayload = new TestPayload(DateTimeOffset.UtcNow);
+
+            var wh = new Webhook(testPayload.secret);
+
+            Assert.Throws<ArgumentNullException>(() => wh.Verify(null, testPayload.headers));
+        }
 
         [Fact]
         public void TestMultiSigPayloadIsValid()
@@ -153,7 +183,7 @@ namespace Svix.Tests
         }
 
         [Fact]
-        public void TestSivnatureVerificationWorksWithoutPrefix()
+        public void TestSignatureVerificationWorksWithoutPrefix()
         {
             var testPayload = new TestPayload(DateTimeOffset.UtcNow);
 
@@ -165,7 +195,7 @@ namespace Svix.Tests
         }
 
         [Fact]
-        public void verifyWebhookSignWorks()
+        public void VerifyWebhookSignWorks()
         {
             var key = "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw";
             var msgId = "msg_p5jXN8AQM9LWM0D4loKWxJek";

--- a/csharp/Svix/Webhook.cs
+++ b/csharp/Svix/Webhook.cs
@@ -37,15 +37,25 @@ namespace Svix
 
         public void Verify(string payload, WebHeaderCollection headers)
         {
-            string msgId = headers.Get(SVIX_ID_HEADER_KEY);
-            string msgSignature = headers.Get(SVIX_SIGNATURE_HEADER_KEY);
-            string msgTimestamp = headers.Get(SVIX_TIMESTAMP_HEADER_KEY);
+            ArgumentNullException.ThrowIfNull(headers);
+            
+            Verify(payload, headers.Get);
+        }
+
+        public void Verify(string payload, Func<string, string> headersProvider)
+        {
+            ArgumentNullException.ThrowIfNull(payload);
+            ArgumentNullException.ThrowIfNull(headersProvider);
+            
+            string msgId = headersProvider(SVIX_ID_HEADER_KEY);
+            string msgSignature = headersProvider(SVIX_SIGNATURE_HEADER_KEY);
+            string msgTimestamp = headersProvider(SVIX_TIMESTAMP_HEADER_KEY);
 
             if (String.IsNullOrEmpty(msgId) || String.IsNullOrEmpty(msgSignature) || String.IsNullOrEmpty(msgTimestamp))
             {
-                msgId = headers.Get(UNBRANDED_ID_HEADER_KEY);
-                msgSignature = headers.Get(UNBRANDED_SIGNATURE_HEADER_KEY);
-                msgTimestamp = headers.Get(UNBRANDED_TIMESTAMP_HEADER_KEY);
+                msgId = headersProvider(UNBRANDED_ID_HEADER_KEY);
+                msgSignature = headersProvider(UNBRANDED_SIGNATURE_HEADER_KEY);
+                msgTimestamp = headersProvider(UNBRANDED_TIMESTAMP_HEADER_KEY);
                 if (String.IsNullOrEmpty(msgId) || String.IsNullOrEmpty(msgSignature) || String.IsNullOrEmpty(msgTimestamp))
                 {
                     throw new WebhookVerificationException("Missing Required Headers");


### PR DESCRIPTION
Provide an overload to the `Webhook.Verify` function to except an `Func<string, string>` function that acts as an function provider.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Creating an extra `WebHeaderCollection` everytime a webhook signature needs to get verified is unnecessary overhead for environments where the `WebHeaderCollection` is not part of underlying http stack; The object needs to get created just for the verification. 

## Solution

Allowing to pass a header provider function to avoid creating a WebHeaderCollection in asp.net core environments

See also #1616
