### PR TITLE
kotlin: Use generated source file for most of the high-level API

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+* Libs/Kotlin **(Breaking)**: Mark `api` field of all API resource classes as `private` (previously
+  only some were private, accidentally)
+* Libs/Kotlin **(Breaking)**: Update `recover` to return `RecoverOut` (instead of nothing)
+* Libs/Kotlin **(Breaking)**: Update `replayMissing` to return `ReplayOut` (instead of nothing)
+* Libs/Kotlin **(Breaking)**: Update `sendExample` to return `MessageOut` (instead of nothing)
+* Libs/Kotlin: Fix the parameter names of `Endpoint.get` - `appId` and `endpointId` were swapped
+* Libs/Kotlin: Fix a bug in `EventType.list` where `options.order` was not getting honored
+
 ## Version 1.56.0
 * Skipping versions: we had an issue with our CI that created duplicated Go
   library releases and forced us to bump the version across the libs and the

--- a/kotlin/lib/src/main/kotlin/Application.kt
+++ b/kotlin/lib/src/main/kotlin/Application.kt
@@ -1,3 +1,4 @@
+// this file is @generated (with minor manual changes)
 package com.svix.kotlin
 
 import com.svix.kotlin.exceptions.ApiException
@@ -33,6 +34,7 @@ class Application internal constructor(token: String, options: SvixOptions) {
         options.numRetries?.let { api.numRetries = it }
     }
 
+    /** List of all the organization's applications. */
     suspend fun list(
         options: ApplicationListOptions = ApplicationListOptions()
     ): ListResponseApplicationOut {
@@ -43,6 +45,7 @@ class Application internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /** Create a new application. */
     suspend fun create(
         applicationIn: ApplicationIn,
         options: PostOptions = PostOptions(),
@@ -65,6 +68,7 @@ class Application internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /** Get an application. */
     suspend fun get(appId: String): ApplicationOut {
         try {
             return api.v1ApplicationGet(appId)
@@ -73,6 +77,7 @@ class Application internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /** Update an application. */
     suspend fun update(appId: String, applicationIn: ApplicationIn): ApplicationOut {
         try {
             return api.v1ApplicationUpdate(appId, applicationIn)
@@ -81,17 +86,19 @@ class Application internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun patch(appId: String, applicationPatch: ApplicationPatch): ApplicationOut {
+    /** Delete an application. */
+    suspend fun delete(appId: String) {
         try {
-            return api.v1ApplicationPatch(appId, applicationPatch)
+            api.v1ApplicationDelete(appId)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
-    suspend fun delete(appId: String) {
+    /** Partially update an application. */
+    suspend fun patch(appId: String, applicationPatch: ApplicationPatch): ApplicationOut {
         try {
-            api.v1ApplicationDelete(appId)
+            return api.v1ApplicationPatch(appId, applicationPatch)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }

--- a/kotlin/lib/src/main/kotlin/Authentication.kt
+++ b/kotlin/lib/src/main/kotlin/Authentication.kt
@@ -1,13 +1,15 @@
+// this file is @generated (with minor manual changes)
 package com.svix.kotlin
 
 import com.svix.kotlin.exceptions.ApiException
 import com.svix.kotlin.internal.apis.AuthenticationApi
 import com.svix.kotlin.models.AppPortalAccessIn
 import com.svix.kotlin.models.AppPortalAccessOut
+import com.svix.kotlin.models.ApplicationTokenExpireIn
 import com.svix.kotlin.models.DashboardAccessOut
 
 class Authentication internal constructor(token: String, options: SvixOptions) {
-    val api = AuthenticationApi(options.serverUrl)
+    private val api = AuthenticationApi(options.serverUrl)
 
     init {
         api.accessToken = token
@@ -16,6 +18,10 @@ class Authentication internal constructor(token: String, options: SvixOptions) {
         options.numRetries?.let { api.numRetries = it }
     }
 
+    /**
+     * Use this function to get magic links (and authentication codes) for connecting your users to
+     * the Consumer Application Portal.
+     */
     suspend fun appPortalAccess(
         appId: String,
         appPortalAccessIn: AppPortalAccessIn,
@@ -43,6 +49,24 @@ class Authentication internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /** Expire all of the tokens associated with a specific application. */
+    suspend fun expireAll(
+        appId: String,
+        applicationTokenExpireIn: ApplicationTokenExpireIn,
+        options: PostOptions = PostOptions(),
+    ) {
+        try {
+            api.v1AuthenticationExpireAll(appId, applicationTokenExpireIn, options.idempotencyKey)
+        } catch (e: Exception) {
+            throw ApiException.wrap(e)
+        }
+    }
+
+    /**
+     * Logout an app token.
+     *
+     * Trying to log out other tokens will fail.
+     */
     suspend fun logout(options: PostOptions = PostOptions()) {
         try {
             api.v1AuthenticationLogout(options.idempotencyKey)

--- a/kotlin/lib/src/main/kotlin/Endpoint.kt
+++ b/kotlin/lib/src/main/kotlin/Endpoint.kt
@@ -1,3 +1,4 @@
+// this file is @generated
 package com.svix.kotlin
 
 import com.svix.kotlin.exceptions.ApiException
@@ -16,9 +17,12 @@ import com.svix.kotlin.models.EndpointTransformationOut
 import com.svix.kotlin.models.EndpointUpdate
 import com.svix.kotlin.models.EventExampleIn
 import com.svix.kotlin.models.ListResponseEndpointOut
+import com.svix.kotlin.models.MessageOut
 import com.svix.kotlin.models.Ordering
 import com.svix.kotlin.models.RecoverIn
+import com.svix.kotlin.models.RecoverOut
 import com.svix.kotlin.models.ReplayIn
+import com.svix.kotlin.models.ReplayOut
 import java.time.OffsetDateTime
 
 class EndpointListOptions {
@@ -48,7 +52,7 @@ class EndpointGetStatsOptions {
 }
 
 class Endpoint internal constructor(token: String, options: SvixOptions) {
-    val api = EndpointApi(options.serverUrl)
+    private val api = EndpointApi(options.serverUrl)
 
     init {
         api.accessToken = token
@@ -57,6 +61,7 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         options.numRetries?.let { api.numRetries = it }
     }
 
+    /** List the application's endpoints. */
     suspend fun list(
         appId: String,
         options: EndpointListOptions = EndpointListOptions(),
@@ -68,6 +73,11 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /**
+     * Create a new endpoint for the application.
+     *
+     * When `secret` is `null` the secret is automatically generated (recommended).
+     */
     suspend fun create(
         appId: String,
         endpointIn: EndpointIn,
@@ -80,14 +90,16 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun get(appId: String, endpointId: String): EndpointOut {
+    /** Get an endpoint. */
+    suspend fun get(endpointId: String, appId: String): EndpointOut {
         try {
-            return api.v1EndpointGet(endpointId, appId)
+            return api.v1EndpointGet(appId, endpointId)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
+    /** Update an endpoint. */
     suspend fun update(
         appId: String,
         endpointId: String,
@@ -100,6 +112,7 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /** Delete an endpoint. */
     suspend fun delete(appId: String, endpointId: String) {
         try {
             api.v1EndpointDelete(appId, endpointId)
@@ -108,6 +121,7 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /** Partially update an endpoint. */
     suspend fun patch(
         appId: String,
         endpointId: String,
@@ -120,6 +134,7 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /** Get the additional headers to be sent with the webhook. */
     suspend fun getHeaders(appId: String, endpointId: String): EndpointHeadersOut {
         try {
             return api.v1EndpointGetHeaders(appId, endpointId)
@@ -128,6 +143,7 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /** Set the additional headers to be sent with the webhook. */
     suspend fun updateHeaders(
         appId: String,
         endpointId: String,
@@ -140,44 +156,62 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /** Partially set the additional headers to be sent with the webhook. */
     suspend fun patchHeaders(
         appId: String,
         endpointId: String,
-        endpointHeadersIn: EndpointHeadersPatchIn,
+        endpointHeadersPatchIn: EndpointHeadersPatchIn,
     ) {
         try {
-            api.v1EndpointPatchHeaders(appId, endpointId, endpointHeadersIn)
+            api.v1EndpointPatchHeaders(appId, endpointId, endpointHeadersPatchIn)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
+    /**
+     * Resend all failed messages since a given time.
+     *
+     * Messages that were sent successfully, even if failed initially, are not resent.
+     */
     suspend fun recover(
         appId: String,
         endpointId: String,
         recoverIn: RecoverIn,
         options: PostOptions = PostOptions(),
-    ) {
+    ): RecoverOut {
         try {
-            api.v1EndpointRecover(appId, endpointId, recoverIn, options.idempotencyKey)
+            return api.v1EndpointRecover(appId, endpointId, recoverIn, options.idempotencyKey)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
+    /**
+     * Replays messages to the endpoint.
+     *
+     * Only messages that were created after `since` will be sent. Messages that were previously
+     * sent to the endpoint are not resent.
+     */
     suspend fun replayMissing(
         appId: String,
         endpointId: String,
         replayIn: ReplayIn,
         options: PostOptions = PostOptions(),
-    ) {
+    ): ReplayOut {
         try {
-            api.v1EndpointReplayMissing(appId, endpointId, replayIn, options.idempotencyKey)
+            return api.v1EndpointReplayMissing(appId, endpointId, replayIn, options.idempotencyKey)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
+    /**
+     * Get the endpoint's signing secret.
+     *
+     * This is used to verify the authenticity of the webhook. For more information please refer to
+     * [the consuming webhooks docs](https://docs.svix.com/consuming-webhooks/).
+     */
     suspend fun getSecret(appId: String, endpointId: String): EndpointSecretOut {
         try {
             return api.v1EndpointGetSecret(appId, endpointId)
@@ -186,6 +220,11 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /**
+     * Rotates the endpoint's signing secret.
+     *
+     * The previous secret will remain valid for the next 24 hours.
+     */
     suspend fun rotateSecret(
         appId: String,
         endpointId: String,
@@ -204,19 +243,26 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /** Send an example message for an event. */
     suspend fun sendExample(
         appId: String,
         endpointId: String,
         eventExampleIn: EventExampleIn,
         options: PostOptions = PostOptions(),
-    ) {
+    ): MessageOut {
         try {
-            api.v1EndpointSendExample(appId, endpointId, eventExampleIn, options.idempotencyKey)
+            return api.v1EndpointSendExample(
+                appId,
+                endpointId,
+                eventExampleIn,
+                options.idempotencyKey,
+            )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
+    /** Get basic statistics for the endpoint. */
     suspend fun getStats(
         appId: String,
         endpointId: String,
@@ -229,6 +275,7 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /** Get the transformation code associated with this endpoint. */
     suspend fun transformationGet(appId: String, endpointId: String): EndpointTransformationOut {
         try {
             return api.v1EndpointTransformationGet(appId, endpointId)
@@ -237,6 +284,7 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /** Set or unset the transformation code associated with this endpoint. */
     suspend fun transformationPartialUpdate(
         appId: String,
         endpointId: String,

--- a/kotlin/lib/src/main/kotlin/Endpoint.kt
+++ b/kotlin/lib/src/main/kotlin/Endpoint.kt
@@ -100,18 +100,6 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun patch(
-        appId: String,
-        endpointId: String,
-        endpointPatch: EndpointPatch,
-    ): EndpointOut {
-        try {
-            return api.v1EndpointPatch(appId, endpointId, endpointPatch)
-        } catch (e: Exception) {
-            throw ApiException.wrap(e)
-        }
-    }
-
     suspend fun delete(appId: String, endpointId: String) {
         try {
             api.v1EndpointDelete(appId, endpointId)
@@ -120,40 +108,13 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun getSecret(appId: String, endpointId: String): EndpointSecretOut {
-        try {
-            return api.v1EndpointGetSecret(appId, endpointId)
-        } catch (e: Exception) {
-            throw ApiException.wrap(e)
-        }
-    }
-
-    suspend fun rotateSecret(
+    suspend fun patch(
         appId: String,
         endpointId: String,
-        endpointSecretRotateIn: EndpointSecretRotateIn,
-        options: PostOptions = PostOptions(),
-    ) {
+        endpointPatch: EndpointPatch,
+    ): EndpointOut {
         try {
-            api.v1EndpointRotateSecret(
-                appId,
-                endpointId,
-                endpointSecretRotateIn,
-                options.idempotencyKey,
-            )
-        } catch (e: Exception) {
-            throw ApiException.wrap(e)
-        }
-    }
-
-    suspend fun recover(
-        appId: String,
-        endpointId: String,
-        recoverIn: RecoverIn,
-        options: PostOptions = PostOptions(),
-    ) {
-        try {
-            api.v1EndpointRecover(appId, endpointId, recoverIn, options.idempotencyKey)
+            return api.v1EndpointPatch(appId, endpointId, endpointPatch)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
@@ -191,13 +152,14 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun getStats(
+    suspend fun recover(
         appId: String,
         endpointId: String,
-        options: EndpointGetStatsOptions = EndpointGetStatsOptions(),
-    ): EndpointStats {
+        recoverIn: RecoverIn,
+        options: PostOptions = PostOptions(),
+    ) {
         try {
-            return api.v1EndpointGetStats(appId, endpointId, options.since, options.until)
+            api.v1EndpointRecover(appId, endpointId, recoverIn, options.idempotencyKey)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
@@ -211,6 +173,57 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
     ) {
         try {
             api.v1EndpointReplayMissing(appId, endpointId, replayIn, options.idempotencyKey)
+        } catch (e: Exception) {
+            throw ApiException.wrap(e)
+        }
+    }
+
+    suspend fun getSecret(appId: String, endpointId: String): EndpointSecretOut {
+        try {
+            return api.v1EndpointGetSecret(appId, endpointId)
+        } catch (e: Exception) {
+            throw ApiException.wrap(e)
+        }
+    }
+
+    suspend fun rotateSecret(
+        appId: String,
+        endpointId: String,
+        endpointSecretRotateIn: EndpointSecretRotateIn,
+        options: PostOptions = PostOptions(),
+    ) {
+        try {
+            api.v1EndpointRotateSecret(
+                appId,
+                endpointId,
+                endpointSecretRotateIn,
+                options.idempotencyKey,
+            )
+        } catch (e: Exception) {
+            throw ApiException.wrap(e)
+        }
+    }
+
+    suspend fun sendExample(
+        appId: String,
+        endpointId: String,
+        eventExampleIn: EventExampleIn,
+        options: PostOptions = PostOptions(),
+    ) {
+        try {
+            api.v1EndpointSendExample(appId, endpointId, eventExampleIn, options.idempotencyKey)
+        } catch (e: Exception) {
+            throw ApiException.wrap(e)
+        }
+    }
+
+    suspend fun getStats(
+        appId: String,
+        endpointId: String,
+        options: EndpointGetStatsOptions = EndpointGetStatsOptions(),
+    ): EndpointStats {
+        try {
+            return api.v1EndpointGetStats(appId, endpointId, options.since, options.until)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
@@ -231,19 +244,6 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
     ) {
         try {
             api.v1EndpointTransformationPartialUpdate(appId, endpointId, endpointTransformationIn)
-        } catch (e: Exception) {
-            throw ApiException.wrap(e)
-        }
-    }
-
-    suspend fun sendExample(
-        appId: String,
-        endpointId: String,
-        eventExampleIn: EventExampleIn,
-        options: PostOptions = PostOptions(),
-    ) {
-        try {
-            api.v1EndpointSendExample(appId, endpointId, eventExampleIn, options.idempotencyKey)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }

--- a/kotlin/lib/src/main/kotlin/EventType.kt
+++ b/kotlin/lib/src/main/kotlin/EventType.kt
@@ -1,3 +1,4 @@
+// this file is @generated (with minor manual changes)
 package com.svix.kotlin
 
 import com.svix.kotlin.exceptions.ApiException
@@ -38,7 +39,7 @@ class EventTypeListOptions {
 }
 
 class EventType internal constructor(token: String, options: SvixOptions) {
-    val api = EventTypeApi(options.serverUrl)
+    private val api = EventTypeApi(options.serverUrl)
 
     init {
         api.accessToken = token
@@ -47,6 +48,7 @@ class EventType internal constructor(token: String, options: SvixOptions) {
         options.numRetries?.let { api.numRetries = it }
     }
 
+    /** Return the list of event types. */
     suspend fun list(
         options: EventTypeListOptions = EventTypeListOptions()
     ): ListResponseEventTypeOut {
@@ -54,7 +56,7 @@ class EventType internal constructor(token: String, options: SvixOptions) {
             return api.v1EventTypeList(
                 options.limit,
                 options.iterator,
-                null,
+                options.order,
                 options.includeArchived,
                 options.withContent,
             )
@@ -63,6 +65,13 @@ class EventType internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /**
+     * Create new or unarchive existing event type.
+     *
+     * Unarchiving an event type will allow endpoints to filter on it and messages to be sent with
+     * it. Endpoints filtering on the event type before archival will continue to filter on it. This
+     * operation does not preserve the description and schemas.
+     */
     suspend fun create(
         eventTypeIn: EventTypeIn,
         options: PostOptions = PostOptions(),
@@ -74,6 +83,25 @@ class EventType internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /**
+     * Given an OpenAPI spec, create new or update existing event types. If an existing `archived`
+     * event type is updated, it will be unarchived.
+     *
+     * The importer will convert all webhooks found in the either the `webhooks` or `x-webhooks`
+     * top-level.
+     */
+    suspend fun importOpenapi(
+        eventTypeImportOpenApiIn: EventTypeImportOpenApiIn,
+        options: PostOptions = PostOptions(),
+    ): EventTypeImportOpenApiOut {
+        try {
+            return api.v1EventTypeImportOpenapi(eventTypeImportOpenApiIn, options.idempotencyKey)
+        } catch (e: Exception) {
+            throw ApiException.wrap(e)
+        }
+    }
+
+    /** Get an event type. */
     suspend fun get(eventTypeName: String): EventTypeOut {
         try {
             return api.v1EventTypeGet(eventTypeName)
@@ -82,6 +110,7 @@ class EventType internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /** Update an event type. */
     suspend fun update(eventTypeName: String, eventTypeUpdate: EventTypeUpdate): EventTypeOut {
         try {
             return api.v1EventTypeUpdate(eventTypeName, eventTypeUpdate)
@@ -90,14 +119,14 @@ class EventType internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun patch(eventTypeName: String, eventTypePatch: EventTypePatch): EventTypeOut {
-        try {
-            return api.v1EventTypePatch(eventTypeName, eventTypePatch)
-        } catch (e: Exception) {
-            throw ApiException.wrap(e)
-        }
-    }
-
+    /**
+     * Archive an event type.
+     *
+     * Endpoints already configured to filter on an event type will continue to do so after
+     * archival. However, new messages can not be sent with it and endpoints can not filter on it.
+     * An event type can be unarchived with the
+     * [create operation](#operation/create_event_type_api_v1_event_type__post).
+     */
     suspend fun delete(eventTypeName: String) {
         try {
             api.v1EventTypeDelete(eventTypeName, null)
@@ -106,12 +135,10 @@ class EventType internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun importOpenApi(
-        eventTypeImportOpenApiIn: EventTypeImportOpenApiIn,
-        options: PostOptions = PostOptions(),
-    ): EventTypeImportOpenApiOut {
+    /** Partially update an event type. */
+    suspend fun patch(eventTypeName: String, eventTypePatch: EventTypePatch): EventTypeOut {
         try {
-            return api.v1EventTypeImportOpenapi(eventTypeImportOpenApiIn, options.idempotencyKey)
+            return api.v1EventTypePatch(eventTypeName, eventTypePatch)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }

--- a/kotlin/lib/src/main/kotlin/Integration.kt
+++ b/kotlin/lib/src/main/kotlin/Integration.kt
@@ -1,3 +1,4 @@
+// this file is @generated (with minor manual changes)
 package com.svix.kotlin
 
 import com.svix.kotlin.exceptions.ApiException
@@ -25,7 +26,7 @@ class IntegrationListOptions {
 }
 
 class Integration internal constructor(token: String, options: SvixOptions) {
-    val api = IntegrationApi(options.serverUrl)
+    private val api = IntegrationApi(options.serverUrl)
 
     init {
         api.accessToken = token
@@ -34,6 +35,7 @@ class Integration internal constructor(token: String, options: SvixOptions) {
         options.numRetries?.let { api.numRetries = it }
     }
 
+    /** List the application's integrations. */
     suspend fun list(
         appId: String,
         options: IntegrationListOptions = IntegrationListOptions(),
@@ -45,18 +47,20 @@ class Integration internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /** Create an integration. */
     suspend fun create(
         appId: String,
-        integIn: IntegrationIn,
+        integrationIn: IntegrationIn,
         options: PostOptions = PostOptions(),
     ): IntegrationOut {
         try {
-            return api.v1IntegrationCreate(appId, integIn, options.idempotencyKey)
+            return api.v1IntegrationCreate(appId, integrationIn, options.idempotencyKey)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
+    /** Get an integration. */
     suspend fun get(appId: String, integId: String): IntegrationOut {
         try {
             return api.v1IntegrationGet(appId, integId)
@@ -65,18 +69,20 @@ class Integration internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /** Update an integration. */
     suspend fun update(
         appId: String,
         integId: String,
-        integUpdate: IntegrationUpdate,
+        integrationUpdate: IntegrationUpdate,
     ): IntegrationOut {
         try {
-            return api.v1IntegrationUpdate(appId, integId, integUpdate)
+            return api.v1IntegrationUpdate(appId, integId, integrationUpdate)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
+    /** Delete an integration. */
     suspend fun delete(appId: String, integId: String) {
         try {
             api.v1IntegrationDelete(appId, integId)
@@ -93,6 +99,7 @@ class Integration internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /** Rotate the integration's key. The previous key will be immediately revoked. */
     suspend fun rotateKey(
         appId: String,
         integId: String,

--- a/kotlin/lib/src/main/kotlin/MessageAttempt.kt
+++ b/kotlin/lib/src/main/kotlin/MessageAttempt.kt
@@ -53,7 +53,7 @@ class MessageAttemptListOptions(
 }
 
 class MessageAttempt internal constructor(token: String, options: SvixOptions) {
-    val api = MessageAttemptApi(options.serverUrl)
+    private val api = MessageAttemptApi(options.serverUrl)
 
     init {
         api.accessToken = token

--- a/kotlin/lib/src/main/kotlin/Statistics.kt
+++ b/kotlin/lib/src/main/kotlin/Statistics.kt
@@ -1,3 +1,4 @@
+// this file is @generated
 package com.svix.kotlin
 
 import com.svix.kotlin.exceptions.ApiException
@@ -16,6 +17,13 @@ class Statistics internal constructor(token: String, options: SvixOptions) {
         options.numRetries?.let { api.numRetries = it }
     }
 
+    /**
+     * Creates a background task to calculate the message destinations for all applications in the
+     * environment.
+     *
+     * Note that this endpoint is asynchronous. You will need to poll the `Get Background Task`
+     * endpoint to retrieve the results of the operation.
+     */
     suspend fun aggregateAppStats(
         appUsageStatsIn: AppUsageStatsIn,
         options: PostOptions = PostOptions(),
@@ -27,6 +35,13 @@ class Statistics internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /**
+     * Creates a background task to calculate the listed event types for all apps in the
+     * organization.
+     *
+     * Note that this endpoint is asynchronous. You will need to poll the `Get Background Task`
+     * endpoint to retrieve the results of the operation.
+     */
     suspend fun aggregateEventTypes(): AggregateEventTypesOut {
         try {
             return api.v1StatisticsAggregateEventTypes()


### PR DESCRIPTION
Like in other languages, `MessageAttempt` is a very large diff so I'd like to handle it separately. There's already enough breaking changes in this one PR :smiling_face_with_tear: 

Part of https://github.com/svix/monorepo-private/issues/9576.