### PR TITLE
kotlin: Replace most of MessageAttempt.kt by generated code

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,9 @@
 * Libs/Kotlin **(Breaking)**: Update `recover` to return `RecoverOut` (instead of nothing)
 * Libs/Kotlin **(Breaking)**: Update `replayMissing` to return `ReplayOut` (instead of nothing)
 * Libs/Kotlin **(Breaking)**: Update `sendExample` to return `MessageOut` (instead of nothing)
+* Libs/Kotlin **(Breaking)**: Update `MessageAttempt` list methods to each have its own type for
+  list options, since they don't all support the exact same set of parameters and some of the
+  parameters that could be set before would just get ignored
 * Libs/Kotlin: Fix the parameter names of `Endpoint.get` - `appId` and `endpointId` were swapped
 * Libs/Kotlin: Fix a bug in `EventType.list` where `options.order` was not getting honored
 

--- a/kotlin/lib/src/main/kotlin/MessageAttempt.kt
+++ b/kotlin/lib/src/main/kotlin/MessageAttempt.kt
@@ -72,32 +72,6 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
         return this.listByMsg(appId, msgId, options)
     }
 
-    suspend fun listByMsg(
-        appId: String,
-        msgId: String,
-        options: MessageAttemptListOptions = MessageAttemptListOptions(),
-    ): ListResponseMessageAttemptOut {
-        try {
-            return api.v1MessageAttemptListByMsg(
-                appId,
-                msgId,
-                options.limit,
-                options.iterator,
-                options.messageStatus,
-                options.statusCodeClass,
-                options.channel,
-                options.tag,
-                options.endpointId,
-                options.before,
-                options.after,
-                options.withContent,
-                HashSet(options.eventTypes),
-            )
-        } catch (e: Exception) {
-            throw ApiException.wrap(e)
-        }
-    }
-
     suspend fun listByEndpoint(
         appId: String,
         endpointId: String,
@@ -124,22 +98,27 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun get(appId: String, msgId: String, attemptId: String): MessageAttemptOut {
-        try {
-            return api.v1MessageAttemptGet(appId, msgId, attemptId)
-        } catch (e: Exception) {
-            throw ApiException.wrap(e)
-        }
-    }
-
-    suspend fun resend(
+    suspend fun listByMsg(
         appId: String,
         msgId: String,
-        endpointId: String,
-        options: PostOptions = PostOptions(),
-    ) {
+        options: MessageAttemptListOptions = MessageAttemptListOptions(),
+    ): ListResponseMessageAttemptOut {
         try {
-            api.v1MessageAttemptResend(appId, msgId, endpointId, options.idempotencyKey)
+            return api.v1MessageAttemptListByMsg(
+                appId,
+                msgId,
+                options.limit,
+                options.iterator,
+                options.messageStatus,
+                options.statusCodeClass,
+                options.channel,
+                options.tag,
+                options.endpointId,
+                options.before,
+                options.after,
+                options.withContent,
+                HashSet(options.eventTypes),
+            )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
@@ -164,6 +143,22 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
                 options.withContent,
                 HashSet(options.eventTypes),
             )
+        } catch (e: Exception) {
+            throw ApiException.wrap(e)
+        }
+    }
+
+    suspend fun get(appId: String, msgId: String, attemptId: String): MessageAttemptOut {
+        try {
+            return api.v1MessageAttemptGet(appId, msgId, attemptId)
+        } catch (e: Exception) {
+            throw ApiException.wrap(e)
+        }
+    }
+
+    suspend fun expungeContent(appId: String, msgId: String, attemptId: String) {
+        try {
+            return api.v1MessageAttemptExpungeContent(appId, msgId, attemptId)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
@@ -211,9 +206,14 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun expungeContent(appId: String, msgId: String, attemptId: String) {
+    suspend fun resend(
+        appId: String,
+        msgId: String,
+        endpointId: String,
+        options: PostOptions = PostOptions(),
+    ) {
         try {
-            return api.v1MessageAttemptExpungeContent(appId, msgId, attemptId)
+            api.v1MessageAttemptResend(appId, msgId, endpointId, options.idempotencyKey)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }

--- a/kotlin/lib/src/main/kotlin/MessageAttempt.kt
+++ b/kotlin/lib/src/main/kotlin/MessageAttempt.kt
@@ -1,3 +1,4 @@
+// this file is @generated (with manual changes)
 package com.svix.kotlin
 
 import com.svix.kotlin.exceptions.ApiException
@@ -10,6 +11,163 @@ import com.svix.kotlin.models.MessageAttemptOut
 import com.svix.kotlin.models.MessageStatus
 import com.svix.kotlin.models.StatusCodeClass
 import java.time.OffsetDateTime
+
+class MessageAttemptListByEndpointOptions {
+    var limit: Int? = null
+    var iterator: String? = null
+    var status: MessageStatus? = null
+    var statusCodeClass: StatusCodeClass? = null
+    var channel: String? = null
+    var tag: String? = null
+    var before: OffsetDateTime? = null
+    var after: OffsetDateTime? = null
+    var withContent: Boolean? = null
+    var withMsg: Boolean? = null
+    var eventTypes: List<String>? = null
+
+    /** Limit the number of returned items */
+    fun limit(limit: Int) = apply { this.limit = limit }
+
+    /** The iterator returned from a prior invocation */
+    fun iterator(iterator: String) = apply { this.iterator = iterator }
+
+    /**
+     * Filter response based on the status of the attempt: Success (0), Pending (1), Failed (2), or
+     * Sending (3)
+     */
+    fun status(status: MessageStatus) = apply { this.status = status }
+
+    /** Filter response based on the HTTP status code */
+    fun statusCodeClass(statusCodeClass: StatusCodeClass) = apply {
+        this.statusCodeClass = statusCodeClass
+    }
+
+    /** Filter response based on the channel */
+    fun channel(channel: String) = apply { this.channel = channel }
+
+    /** Filter response based on the tag */
+    fun tag(tag: String) = apply { this.tag = tag }
+
+    /** Only include items created before a certain date */
+    fun before(before: OffsetDateTime) = apply { this.before = before }
+
+    /** Only include items created after a certain date */
+    fun after(after: OffsetDateTime) = apply { this.after = after }
+
+    /** When `true` attempt content is included in the response */
+    fun withContent(withContent: Boolean) = apply { this.withContent = withContent }
+
+    /** When `true`, the message information is included in the response */
+    fun withMsg(withMsg: Boolean) = apply { this.withMsg = withMsg }
+
+    /** Filter response based on the event type */
+    fun eventTypes(eventTypes: List<String>) = apply { this.eventTypes = eventTypes }
+}
+
+class MessageAttemptListByMsgOptions {
+    var limit: Int? = null
+    var iterator: String? = null
+    var status: MessageStatus? = null
+    var statusCodeClass: StatusCodeClass? = null
+    var channel: String? = null
+    var tag: String? = null
+    var endpointId: String? = null
+    var before: OffsetDateTime? = null
+    var after: OffsetDateTime? = null
+    var withContent: Boolean? = null
+    var eventTypes: List<String>? = null
+
+    /** Limit the number of returned items */
+    fun limit(limit: Int) = apply { this.limit = limit }
+
+    /** The iterator returned from a prior invocation */
+    fun iterator(iterator: String) = apply { this.iterator = iterator }
+
+    /**
+     * Filter response based on the status of the attempt: Success (0), Pending (1), Failed (2), or
+     * Sending (3)
+     */
+    fun status(status: MessageStatus) = apply { this.status = status }
+
+    /** Filter response based on the HTTP status code */
+    fun statusCodeClass(statusCodeClass: StatusCodeClass) = apply {
+        this.statusCodeClass = statusCodeClass
+    }
+
+    /** Filter response based on the channel */
+    fun channel(channel: String) = apply { this.channel = channel }
+
+    /** Filter response based on the tag */
+    fun tag(tag: String) = apply { this.tag = tag }
+
+    /** Filter the attempts based on the attempted endpoint */
+    fun endpointId(endpointId: String) = apply { this.endpointId = endpointId }
+
+    /** Only include items created before a certain date */
+    fun before(before: OffsetDateTime) = apply { this.before = before }
+
+    /** Only include items created after a certain date */
+    fun after(after: OffsetDateTime) = apply { this.after = after }
+
+    /** When `true` attempt content is included in the response */
+    fun withContent(withContent: Boolean) = apply { this.withContent = withContent }
+
+    /** Filter response based on the event type */
+    fun eventTypes(eventTypes: List<String>) = apply { this.eventTypes = eventTypes }
+}
+
+class MessageAttemptListAttemptedMessagesOptions {
+    var limit: Int? = null
+    var iterator: String? = null
+    var channel: String? = null
+    var tag: String? = null
+    var status: MessageStatus? = null
+    var before: OffsetDateTime? = null
+    var after: OffsetDateTime? = null
+    var withContent: Boolean? = null
+    var eventTypes: List<String>? = null
+
+    /** Limit the number of returned items */
+    fun limit(limit: Int) = apply { this.limit = limit }
+
+    /** The iterator returned from a prior invocation */
+    fun iterator(iterator: String) = apply { this.iterator = iterator }
+
+    /** Filter response based on the channel */
+    fun channel(channel: String) = apply { this.channel = channel }
+
+    /** Filter response based on the message tags */
+    fun tag(tag: String) = apply { this.tag = tag }
+
+    /**
+     * Filter response based on the status of the attempt: Success (0), Pending (1), Failed (2), or
+     * Sending (3)
+     */
+    fun status(status: MessageStatus) = apply { this.status = status }
+
+    /** Only include items created before a certain date */
+    fun before(before: OffsetDateTime) = apply { this.before = before }
+
+    /** Only include items created after a certain date */
+    fun after(after: OffsetDateTime) = apply { this.after = after }
+
+    /** When `true` message payloads are included in the response */
+    fun withContent(withContent: Boolean) = apply { this.withContent = withContent }
+
+    /** Filter response based on the event type */
+    fun eventTypes(eventTypes: List<String>) = apply { this.eventTypes = eventTypes }
+}
+
+class MessageAttemptListAttemptedDestinationsOptions {
+    var limit: Int? = null
+    var iterator: String? = null
+
+    /** Limit the number of returned items */
+    fun limit(limit: Int) = apply { this.limit = limit }
+
+    /** The iterator returned from a prior invocation */
+    fun iterator(iterator: String) = apply { this.iterator = iterator }
+}
 
 class MessageAttemptListOptions(
     var iterator: String? = null,
@@ -67,15 +225,23 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
     suspend fun list(
         appId: String,
         msgId: String,
-        options: MessageAttemptListOptions = MessageAttemptListOptions(),
+        options: MessageAttemptListByMsgOptions = MessageAttemptListByMsgOptions(),
     ): ListResponseMessageAttemptOut {
         return this.listByMsg(appId, msgId, options)
     }
 
+    /**
+     * List attempts by endpoint id
+     *
+     * Note that by default this endpoint is limited to retrieving 90 days' worth of data relative
+     * to now or, if an iterator is provided, 90 days before/after the time indicated by the
+     * iterator ID. If you require data beyond those time ranges, you will need to explicitly set
+     * the `before` or `after` parameter as appropriate.
+     */
     suspend fun listByEndpoint(
         appId: String,
         endpointId: String,
-        options: MessageAttemptListOptions = MessageAttemptListOptions(),
+        options: MessageAttemptListByEndpointOptions = MessageAttemptListByEndpointOptions(),
     ): ListResponseMessageAttemptOut {
         try {
             return api.v1MessageAttemptListByEndpoint(
@@ -83,7 +249,7 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
                 endpointId,
                 options.limit,
                 options.iterator,
-                options.messageStatus,
+                options.status,
                 options.statusCodeClass,
                 options.channel,
                 options.tag,
@@ -98,10 +264,18 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /**
+     * List attempts by message ID.
+     *
+     * Note that by default this endpoint is limited to retrieving 90 days' worth of data relative
+     * to now or, if an iterator is provided, 90 days before/after the time indicated by the
+     * iterator ID. If you require data beyond those time ranges, you will need to explicitly set
+     * the `before` or `after` parameter as appropriate.
+     */
     suspend fun listByMsg(
         appId: String,
         msgId: String,
-        options: MessageAttemptListOptions = MessageAttemptListOptions(),
+        options: MessageAttemptListByMsgOptions = MessageAttemptListByMsgOptions(),
     ): ListResponseMessageAttemptOut {
         try {
             return api.v1MessageAttemptListByMsg(
@@ -109,7 +283,7 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
                 msgId,
                 options.limit,
                 options.iterator,
-                options.messageStatus,
+                options.status,
                 options.statusCodeClass,
                 options.channel,
                 options.tag,
@@ -124,10 +298,23 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /**
+     * List messages for a particular endpoint. Additionally includes metadata about the latest
+     * message attempt.
+     *
+     * The `before` parameter lets you filter all items created before a certain date and is ignored
+     * if an iterator is passed.
+     *
+     * Note that by default this endpoint is limited to retrieving 90 days' worth of data relative
+     * to now or, if an iterator is provided, 90 days before/after the time indicated by the
+     * iterator ID. If you require data beyond those time ranges, you will need to explicitly set
+     * the `before` or `after` parameter as appropriate.
+     */
     suspend fun listAttemptedMessages(
         appId: String,
         endpointId: String,
-        options: MessageAttemptListOptions = MessageAttemptListOptions(),
+        options: MessageAttemptListAttemptedMessagesOptions =
+            MessageAttemptListAttemptedMessagesOptions(),
     ): ListResponseEndpointMessageOut {
         try {
             return api.v1MessageAttemptListAttemptedMessages(
@@ -137,7 +324,7 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
                 options.iterator,
                 options.channel,
                 options.tag,
-                options.messageStatus,
+                options.status,
                 options.before,
                 options.after,
                 options.withContent,
@@ -148,6 +335,7 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /** `msg_id`: Use a message id or a message `eventId` */
     suspend fun get(appId: String, msgId: String, attemptId: String): MessageAttemptOut {
         try {
             return api.v1MessageAttemptGet(appId, msgId, attemptId)
@@ -156,18 +344,31 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /**
+     * Deletes the given attempt's response body.
+     *
+     * Useful when an endpoint accidentally returned sensitive content. The message can't be
+     * replayed or resent once its payload has been deleted or expired.
+     */
     suspend fun expungeContent(appId: String, msgId: String, attemptId: String) {
         try {
-            return api.v1MessageAttemptExpungeContent(appId, msgId, attemptId)
+            api.v1MessageAttemptExpungeContent(appId, msgId, attemptId)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
+    /**
+     * List endpoints attempted by a given message.
+     *
+     * Additionally includes metadata about the latest message attempt. By default, endpoints are
+     * listed in ascending order by ID.
+     */
     suspend fun listAttemptedDestinations(
         appId: String,
         msgId: String,
-        options: MessageAttemptListOptions = MessageAttemptListOptions(),
+        options: MessageAttemptListAttemptedDestinationsOptions =
+            MessageAttemptListAttemptedDestinationsOptions(),
     ): ListResponseMessageEndpointOut {
         try {
             return api.v1MessageAttemptListAttemptedDestinations(
@@ -181,6 +382,7 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    @Deprecated(message = "use listByEndpoint instead.")
     suspend fun listAttemptsForEndpoint(
         appId: String,
         endpointId: String,
@@ -206,6 +408,7 @@ class MessageAttempt internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /** Resend a message to the specified endpoint. */
     suspend fun resend(
         appId: String,
         msgId: String,


### PR DESCRIPTION
Follow-up to https://github.com/svix/svix-webhooks/pull/1618.
Part of https://github.com/svix/monorepo-private/issues/9576.