### PR TITLE
rust: Remove some manual changes after codegen

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,9 @@
 * Libs/Kotlin **(Breaking)**: Update `sendExample` to return `MessageOut` (instead of nothing)
 * Libs/Kotlin: Fix the parameter names of `Endpoint.get` - `appId` and `endpointId` were swapped
 * Libs/Kotlin: Fix a bug in `EventType.list` where `options.order` was not getting honored
+* Libs/Rust **(Breaking)**: Add optional `EventTypeDeleteOptions` parameter to `EventType::delete`
+* Libs/Rust **(Breaking)**: Add optional `PostOptions` parameter to `Endpoint::recover`,
+  `Endpoint::rotate_secret`, `Integration::rotate_key` and `MessageAttempt::resend`
 
 ## Version 1.56.0
 * Skipping versions: we had an issue with our CI that created duplicated Go

--- a/rust/src/api/authentication.rs
+++ b/rust/src/api/authentication.rs
@@ -49,6 +49,11 @@ impl<'a> Authentication<'a> {
             .await
     }
 
+    /// DEPRECATED: Please use `app-portal-access` instead.
+    ///
+    /// Use this function to get magic links (and authentication codes) for
+    /// connecting your users to the Consumer Application Portal.
+    #[deprecated]
     pub async fn dashboard_access(
         &self,
         app_id: String,

--- a/rust/src/api/authentication.rs
+++ b/rust/src/api/authentication.rs
@@ -10,23 +10,6 @@ impl<'a> Authentication<'a> {
         Self { cfg }
     }
 
-    pub async fn dashboard_access(
-        &self,
-        app_id: String,
-        options: Option<PostOptions>,
-    ) -> Result<DashboardAccessOut> {
-        let PostOptions { idempotency_key } = options.unwrap_or_default();
-
-        crate::request::Request::new(
-            http1::Method::POST,
-            "/api/v1/auth/dashboard-access/{app_id}",
-        )
-        .with_path_param("app_id", app_id)
-        .with_optional_header_param("idempotency-key", idempotency_key)
-        .execute(self.cfg)
-        .await
-    }
-
     /// Use this function to get magic links (and authentication codes) for
     /// connecting your users to the Consumer Application Portal.
     pub async fn app_portal_access(
@@ -64,6 +47,23 @@ impl<'a> Authentication<'a> {
             .returns_nothing()
             .execute(self.cfg)
             .await
+    }
+
+    pub async fn dashboard_access(
+        &self,
+        app_id: String,
+        options: Option<PostOptions>,
+    ) -> Result<DashboardAccessOut> {
+        let PostOptions { idempotency_key } = options.unwrap_or_default();
+
+        crate::request::Request::new(
+            http1::Method::POST,
+            "/api/v1/auth/dashboard-access/{app_id}",
+        )
+        .with_path_param("app_id", app_id)
+        .with_optional_header_param("idempotency-key", idempotency_key)
+        .execute(self.cfg)
+        .await
     }
 
     /// Logout an app token.

--- a/rust/src/api/endpoint.rs
+++ b/rust/src/api/endpoint.rs
@@ -200,7 +200,10 @@ impl<'a> Endpoint<'a> {
         app_id: String,
         endpoint_id: String,
         recover_in: RecoverIn,
+        options: Option<PostOptions>,
     ) -> Result<RecoverOut> {
+        let PostOptions { idempotency_key } = options.unwrap_or_default();
+
         crate::request::Request::new(
             http1::Method::POST,
             "/api/v1/app/{app_id}/endpoint/{endpoint_id}/recover",
@@ -208,6 +211,7 @@ impl<'a> Endpoint<'a> {
         .with_path_param("app_id", app_id)
         .with_path_param("endpoint_id", endpoint_id)
         .with_body_param(recover_in)
+        .with_optional_header_param("idempotency-key", idempotency_key)
         .execute(self.cfg)
         .await
     }
@@ -264,7 +268,10 @@ impl<'a> Endpoint<'a> {
         app_id: String,
         endpoint_id: String,
         endpoint_secret_rotate_in: EndpointSecretRotateIn,
+        options: Option<PostOptions>,
     ) -> Result<()> {
+        let PostOptions { idempotency_key } = options.unwrap_or_default();
+
         crate::request::Request::new(
             http1::Method::POST,
             "/api/v1/app/{app_id}/endpoint/{endpoint_id}/secret/rotate",
@@ -272,6 +279,7 @@ impl<'a> Endpoint<'a> {
         .with_path_param("app_id", app_id)
         .with_path_param("endpoint_id", endpoint_id)
         .with_body_param(endpoint_secret_rotate_in)
+        .with_optional_header_param("idempotency-key", idempotency_key)
         .returns_nothing()
         .execute(self.cfg)
         .await

--- a/rust/src/api/event_type.rs
+++ b/rust/src/api/event_type.rs
@@ -21,6 +21,13 @@ pub struct EventTypeListOptions {
     pub with_content: Option<bool>,
 }
 
+#[derive(Default)]
+pub struct EventTypeDeleteOptions {
+    /// By default event types are archived when "deleted". Passing this to
+    /// `true` deletes them entirely.
+    pub expunge: Option<bool>,
+}
+
 pub struct EventType<'a> {
     cfg: &'a Configuration,
 }
@@ -119,12 +126,19 @@ impl<'a> EventType<'a> {
     /// do so after archival. However, new messages can not be sent with it
     /// and endpoints can not filter on it. An event type can be unarchived
     /// with the [create operation][Self::create].
-    pub async fn delete(&self, event_type_name: String) -> Result<()> {
+    pub async fn delete(
+        &self,
+        event_type_name: String,
+        options: Option<EventTypeDeleteOptions>,
+    ) -> Result<()> {
+        let EventTypeDeleteOptions { expunge } = options.unwrap_or_default();
+
         crate::request::Request::new(
             http1::Method::DELETE,
             "/api/v1/event-type/{event_type_name}",
         )
         .with_path_param("event_type_name", event_type_name)
+        .with_optional_query_param("expunge", expunge)
         .returns_nothing()
         .execute(self.cfg)
         .await

--- a/rust/src/api/integration.rs
+++ b/rust/src/api/integration.rs
@@ -104,6 +104,7 @@ impl<'a> Integration<'a> {
     }
 
     /// Get an integration's key.
+    #[deprecated]
     pub async fn get_key(&self, app_id: String, integ_id: String) -> Result<IntegrationKeyOut> {
         crate::request::Request::new(
             http1::Method::GET,
@@ -117,13 +118,21 @@ impl<'a> Integration<'a> {
 
     /// Rotate the integration's key. The previous key will be immediately
     /// revoked.
-    pub async fn rotate_key(&self, app_id: String, integ_id: String) -> Result<IntegrationKeyOut> {
+    pub async fn rotate_key(
+        &self,
+        app_id: String,
+        integ_id: String,
+        options: Option<PostOptions>,
+    ) -> Result<IntegrationKeyOut> {
+        let PostOptions { idempotency_key } = options.unwrap_or_default();
+
         crate::request::Request::new(
             http1::Method::POST,
             "/api/v1/app/{app_id}/integration/{integ_id}/key/rotate",
         )
         .with_path_param("app_id", app_id)
         .with_path_param("integ_id", integ_id)
+        .with_optional_header_param("idempotency-key", idempotency_key)
         .execute(self.cfg)
         .await
     }

--- a/rust/src/api/message_attempt.rs
+++ b/rust/src/api/message_attempt.rs
@@ -1,5 +1,6 @@
 use itertools::Itertools;
 
+use super::PostOptions;
 use crate::{error::Result, models::*, Configuration};
 
 #[derive(Default)]
@@ -401,7 +402,15 @@ impl<'a> MessageAttempt<'a> {
     }
 
     /// Resend a message to the specified endpoint.
-    pub async fn resend(&self, app_id: String, msg_id: String, endpoint_id: String) -> Result<()> {
+    pub async fn resend(
+        &self,
+        app_id: String,
+        msg_id: String,
+        endpoint_id: String,
+        options: Option<PostOptions>,
+    ) -> Result<()> {
+        let PostOptions { idempotency_key } = options.unwrap_or_default();
+
         crate::request::Request::new(
             http1::Method::POST,
             "/api/v1/app/{app_id}/msg/{msg_id}/endpoint/{endpoint_id}/resend",
@@ -409,6 +418,7 @@ impl<'a> MessageAttempt<'a> {
         .with_path_param("app_id", app_id)
         .with_path_param("msg_id", msg_id)
         .with_path_param("endpoint_id", endpoint_id)
+        .with_optional_header_param("idempotency-key", idempotency_key)
         .returns_nothing()
         .execute(self.cfg)
         .await

--- a/rust/src/api/mod.rs
+++ b/rust/src/api/mod.rs
@@ -28,7 +28,7 @@ pub use self::{
     authentication::Authentication,
     background_task::{BackgroundTask, BackgroundTaskListOptions},
     endpoint::{Endpoint, EndpointGetStatsOptions, EndpointListOptions},
-    event_type::{EventType, EventTypeListOptions},
+    event_type::{EventType, EventTypeDeleteOptions, EventTypeListOptions},
     integration::{Integration, IntegrationListOptions},
     message::{Message, MessageListOptions},
     message_attempt::{

--- a/svix-cli/src/cmds/api/application.rs
+++ b/svix-cli/src/cmds/api/application.rs
@@ -110,12 +110,7 @@ impl ApplicationCommands {
             } => {
                 let resp = client
                     .application()
-                    .patch(
-                        id,
-                        application_patch
-                            .map(|x| x.into_inner())
-                            .unwrap_or_default(),
-                    )
+                    .patch(id, application_patch.unwrap_or_default().into_inner())
                     .await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }

--- a/svix-cli/src/cmds/api/authentication.rs
+++ b/svix-cli/src/cmds/api/authentication.rs
@@ -52,9 +52,7 @@ impl AuthenticationCommands {
                     .authentication()
                     .app_portal_access(
                         app_id,
-                        app_portal_access_in
-                            .map(|x| x.into_inner())
-                            .unwrap_or_default(),
+                        app_portal_access_in.unwrap_or_default().into_inner(),
                         post_options.map(Into::into),
                     )
                     .await?;
@@ -69,9 +67,7 @@ impl AuthenticationCommands {
                     .authentication()
                     .expire_all(
                         app_id,
-                        application_token_expire_in
-                            .map(|x| x.into_inner())
-                            .unwrap_or_default(),
+                        application_token_expire_in.unwrap_or_default().into_inner(),
                         post_options.map(Into::into),
                     )
                     .await?;

--- a/svix-cli/src/cmds/api/endpoint.rs
+++ b/svix-cli/src/cmds/api/endpoint.rs
@@ -115,6 +115,8 @@ pub enum EndpointCommands {
         app_id: String,
         id: String,
         recover_in: JsonOf<RecoverIn>,
+        #[clap(flatten)]
+        post_options: Option<PostOptions>,
     },
     /// Replays messages to the endpoint.
     ///
@@ -139,6 +141,8 @@ pub enum EndpointCommands {
         app_id: String,
         id: String,
         endpoint_secret_rotate_in: Option<JsonOf<EndpointSecretRotateIn>>,
+        #[clap(flatten)]
+        post_options: Option<PostOptions>,
     },
     /// Send an example message for an event.
     SendExample {
@@ -217,11 +221,7 @@ impl EndpointCommands {
             } => {
                 let resp = client
                     .endpoint()
-                    .patch(
-                        app_id,
-                        id,
-                        endpoint_patch.map(|x| x.into_inner()).unwrap_or_default(),
-                    )
+                    .patch(app_id, id, endpoint_patch.unwrap_or_default().into_inner())
                     .await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
@@ -253,10 +253,16 @@ impl EndpointCommands {
                 app_id,
                 id,
                 recover_in,
+                post_options,
             } => {
                 let resp = client
                     .endpoint()
-                    .recover(app_id, id, recover_in.into_inner())
+                    .recover(
+                        app_id,
+                        id,
+                        recover_in.into_inner(),
+                        post_options.map(Into::into),
+                    )
                     .await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
@@ -285,15 +291,15 @@ impl EndpointCommands {
                 app_id,
                 id,
                 endpoint_secret_rotate_in,
+                post_options,
             } => {
                 client
                     .endpoint()
                     .rotate_secret(
                         app_id,
                         id,
-                        endpoint_secret_rotate_in
-                            .map(|x| x.into_inner())
-                            .unwrap_or_default(),
+                        endpoint_secret_rotate_in.unwrap_or_default().into_inner(),
+                        post_options.map(Into::into),
                     )
                     .await?;
             }
@@ -339,9 +345,7 @@ impl EndpointCommands {
                     .transformation_partial_update(
                         app_id,
                         id,
-                        endpoint_transformation_in
-                            .map(|x| x.into_inner())
-                            .unwrap_or_default(),
+                        endpoint_transformation_in.unwrap_or_default().into_inner(),
                     )
                     .await?;
             }

--- a/svix-cli/src/cmds/api/integration.rs
+++ b/svix-cli/src/cmds/api/integration.rs
@@ -69,7 +69,12 @@ pub enum IntegrationCommands {
     /// Get an integration's key.
     GetKey { app_id: String, id: String },
     /// Rotate the integration's key. The previous key will be immediately revoked.
-    RotateKey { app_id: String, id: String },
+    RotateKey {
+        app_id: String,
+        id: String,
+        #[clap(flatten)]
+        post_options: Option<PostOptions>,
+    },
 }
 
 impl IntegrationCommands {
@@ -120,11 +125,19 @@ impl IntegrationCommands {
                 client.integration().delete(app_id, id).await?;
             }
             Self::GetKey { app_id, id } => {
+                #[allow(deprecated)]
                 let resp = client.integration().get_key(app_id, id).await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
-            Self::RotateKey { app_id, id } => {
-                let resp = client.integration().rotate_key(app_id, id).await?;
+            Self::RotateKey {
+                app_id,
+                id,
+                post_options,
+            } => {
+                let resp = client
+                    .integration()
+                    .rotate_key(app_id, id, post_options.map(Into::into))
+                    .await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
         }

--- a/svix-cli/src/cmds/api/message_attempt.rs
+++ b/svix-cli/src/cmds/api/message_attempt.rs
@@ -2,6 +2,8 @@ use chrono::{DateTime, Utc};
 use clap::{Args, Subcommand};
 use svix::api::*;
 
+use crate::cli_types::PostOptions;
+
 #[derive(Args, Clone)]
 pub struct MessageAttemptListByEndpointOptions {
     /// Limit the number of returned items
@@ -305,6 +307,8 @@ pub enum MessageAttemptCommands {
         app_id: String,
         msg_id: String,
         endpoint_id: String,
+        #[clap(flatten)]
+        post_options: Option<PostOptions>,
     },
 }
 
@@ -384,10 +388,11 @@ impl MessageAttemptCommands {
                 app_id,
                 msg_id,
                 endpoint_id,
+                post_options,
             } => {
                 client
                     .message_attempt()
-                    .resend(app_id, msg_id, endpoint_id)
+                    .resend(app_id, msg_id, endpoint_id, post_options.map(Into::into))
                     .await?;
             }
         }


### PR DESCRIPTION
Introduce some optional parameters that I had been excluding because it was a breaking change. We have now evaluated this sufficiently and have decided to introduce them, even though it is a breaking change (existing uses of these methods need an extra `None` argument).

Also, our code generation now handles deprecated methods. This leads to some things being added to message-attempt that we don't want, but otherwise reduces the amount of manual changes we need to do to clean up the generated code.