### PR TITLE
Mark a few deprecated methods as such

### DIFF
--- a/csharp/Svix/MessageAttempt.cs
+++ b/csharp/Svix/MessageAttempt.cs
@@ -265,6 +265,7 @@ namespace Svix
         }
 
         // Deprecated
+        [Obsolete("Use ListAttemptsByMessage instead, passing the endpoint ID through options")]
         public ListResponseMessageAttemptEndpointOut ListAttemptsForEndpoint(string appId, string messageId,
             string endpointId, AttemptsByEndpointListOptions options = null, string idempotencyKey = default)
         {
@@ -297,6 +298,7 @@ namespace Svix
         }
 
         // Deprecated
+        [Obsolete("Use ListAttemptsByMessageAsync instead, passing the endpoint ID through options")]
         public async Task<ListResponseMessageAttemptEndpointOut> ListAttemptsForEndpointAsync(string appId,
             string messageId, string endpointId, AttemptsByEndpointListOptions options = null, string idempotencyKey = default,
             CancellationToken cancellationToken = default)
@@ -331,6 +333,7 @@ namespace Svix
         }
 
         // Deprecated
+        [Obsolete("Use ListAttemptsByEndpoint or ListAttemptsByMessage instead")]
         public ListResponseMessageAttemptOut ListAttempts(string appId, string messageId, MessageAttemptListOptions options = null,
             string idempotencyKey = default)
         {
@@ -364,6 +367,7 @@ namespace Svix
         }
 
         // Deprecated
+        [Obsolete("Use ListAttemptsByEndpointAsync or ListAttemptsByMessageAsync instead")]
         public async Task<ListResponseMessageAttemptOut> ListAttemptsAsync(string appId, string messageId, MessageAttemptListOptions options = null,
             string idempotencyKey = default, CancellationToken cancellationToken = default)
         {

--- a/go/message_attempt.go
+++ b/go/message_attempt.go
@@ -211,6 +211,7 @@ func (m *MessageAttempt) ListAttemptedDestinations(ctx context.Context, appId st
 	return ret, nil
 }
 
+// Deprecated: use `ListByMsg` instead, passing the endpoint ID through options
 func (m *MessageAttempt) ListAttemptsForEndpoint(ctx context.Context, appId string, msgId string, endpointId string, options *MessageAttemptListOptions) (*ListResponseMessageAttemptEndpointOut, error) {
 	req := m.api.MessageAttemptAPI.V1MessageAttemptListByEndpointDeprecated(ctx, appId, msgId, endpointId)
 	if options != nil {

--- a/java/lib/src/main/java/com/svix/MessageAttempt.java
+++ b/java/lib/src/main/java/com/svix/MessageAttempt.java
@@ -118,6 +118,10 @@ public final class MessageAttempt {
 		}
 	}
 
+	/*
+	 * @deprecated: use listByMsg instead, passing the endpoint ID through options
+	 */
+	@Deprecated
 	public ListResponseMessageAttemptEndpointOut listAttemptsForEndpoint(final String appId, final String msgId, final String endpointId,
 		final MessageAttemptListOptions options) throws ApiException {
 			try {

--- a/python/svix/api.py
+++ b/python/svix/api.py
@@ -1267,6 +1267,9 @@ class MessageAttemptAsync(ApiBase):
             **options.to_dict(),
         )
 
+    @deprecated(
+        reason="use list_by_msg instead, passing the endpoint id through options"
+    )
     async def list_attempts_for_endpoint(
         self,
         app_id: str,
@@ -1378,6 +1381,9 @@ class MessageAttempt(ApiBase):
             **options.to_dict(),
         )
 
+    @deprecated(
+        reason="use list_by_msg instead, passing the endpoint id through options"
+    )
     def list_attempts_for_endpoint(
         self,
         app_id: str,


### PR DESCRIPTION
These have been deprecated in the spec for years.
