### PR TITLE
Improve IDE experience post CLI addition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["svix-cli"]
+members = ["rust", "svix-cli"]
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/contrib/ide/vscode/settings.json
+++ b/contrib/ide/vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "rust-analyzer.linkedProjects": [
+        "Cargo.toml",
+        "bridge/Cargo.toml",
+        "server/Cargo.toml"
+    ]
+}

--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,7 +1,2 @@
-/target/
-**/*.rs.bk
-Cargo.lock
-
 /.openapi-generator/
 /openapi.json
-

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -7,6 +7,7 @@
 //! [`webhooks::Webhook`].
 
 #![warn(clippy::all)]
+#![allow(clippy::literal_string_with_formatting_args)]
 #![forbid(unsafe_code)]
 
 use std::time::Duration;


### PR DESCRIPTION
## Motivation

Since we added the `svix-cli` crate and a root `Cargo.toml`, the rust-analyzer VSCode extension has no longer been analyzing `bridge/*` and `server/*`. Also it's recommended to have all `path` dependencies within a repo in the same workspace, so the same code doesn't end up getting compiled twice.

## Solution

Add recommended VSCode settings (don't commit `.vscode/settings.json` as it can contain extra user-specific configuration), and add the `rust` client lib to the same workspace that `svix-cli` is already in.

## Alternatives

Don't have a root workspace. I'm guessing you added it for `dist` @svix-onelson?