### PR TITLE
go: Put parameters on separate lines for API methods

### DIFF
--- a/go/application.go
+++ b/go/application.go
@@ -19,7 +19,10 @@ type ApplicationListOptions struct {
 	Order *Ordering
 }
 
-func (a *Application) List(ctx context.Context, options *ApplicationListOptions) (*ListResponseApplicationOut, error) {
+func (a *Application) List(
+	ctx context.Context,
+	options *ApplicationListOptions,
+) (*ListResponseApplicationOut, error) {
 	req := a.api.ApplicationAPI.V1ApplicationList(ctx)
 	if options != nil {
 		if options.Iterator != nil {
@@ -39,11 +42,18 @@ func (a *Application) List(ctx context.Context, options *ApplicationListOptions)
 	return ret, nil
 }
 
-func (a *Application) Create(ctx context.Context, applicationIn *ApplicationIn) (*ApplicationOut, error) {
+func (a *Application) Create(
+	ctx context.Context,
+	applicationIn *ApplicationIn,
+) (*ApplicationOut, error) {
 	return a.CreateWithOptions(ctx, applicationIn, nil)
 }
 
-func (a *Application) CreateWithOptions(ctx context.Context, applicationIn *ApplicationIn, options *PostOptions) (*ApplicationOut, error) {
+func (a *Application) CreateWithOptions(
+	ctx context.Context,
+	applicationIn *ApplicationIn,
+	options *PostOptions,
+) (*ApplicationOut, error) {
 	req := a.api.ApplicationAPI.V1ApplicationCreate(ctx)
 	req = req.ApplicationIn(*applicationIn)
 	if options != nil {
@@ -58,11 +68,18 @@ func (a *Application) CreateWithOptions(ctx context.Context, applicationIn *Appl
 	return ret, nil
 }
 
-func (a *Application) GetOrCreate(ctx context.Context, applicationIn *ApplicationIn) (*ApplicationOut, error) {
+func (a *Application) GetOrCreate(
+	ctx context.Context,
+	applicationIn *ApplicationIn,
+) (*ApplicationOut, error) {
 	return a.GetOrCreateWithOptions(ctx, applicationIn, nil)
 }
 
-func (a *Application) GetOrCreateWithOptions(ctx context.Context, applicationIn *ApplicationIn, options *PostOptions) (*ApplicationOut, error) {
+func (a *Application) GetOrCreateWithOptions(
+	ctx context.Context,
+	applicationIn *ApplicationIn,
+	options *PostOptions,
+) (*ApplicationOut, error) {
 	req := a.api.ApplicationAPI.V1ApplicationCreate(ctx)
 	req = req.ApplicationIn(*applicationIn)
 	req = req.GetIfExists(true)
@@ -78,7 +95,10 @@ func (a *Application) GetOrCreateWithOptions(ctx context.Context, applicationIn 
 	return ret, nil
 }
 
-func (a *Application) Get(ctx context.Context, appId string) (*ApplicationOut, error) {
+func (a *Application) Get(
+	ctx context.Context,
+	appId string,
+) (*ApplicationOut, error) {
 	req := a.api.ApplicationAPI.V1ApplicationGet(ctx, appId)
 	ret, res, err := req.Execute()
 	if err != nil {
@@ -87,7 +107,11 @@ func (a *Application) Get(ctx context.Context, appId string) (*ApplicationOut, e
 	return ret, nil
 }
 
-func (a *Application) Update(ctx context.Context, appId string, applicationIn *ApplicationIn) (*ApplicationOut, error) {
+func (a *Application) Update(
+	ctx context.Context,
+	appId string,
+	applicationIn *ApplicationIn,
+) (*ApplicationOut, error) {
 	req := a.api.ApplicationAPI.V1ApplicationUpdate(ctx, appId)
 	req = req.ApplicationIn(*applicationIn)
 	ret, res, err := req.Execute()
@@ -97,7 +121,11 @@ func (a *Application) Update(ctx context.Context, appId string, applicationIn *A
 	return ret, nil
 }
 
-func (a *Application) Patch(ctx context.Context, appId string, applicationPatch *ApplicationPatch) (*ApplicationOut, error) {
+func (a *Application) Patch(
+	ctx context.Context,
+	appId string,
+	applicationPatch *ApplicationPatch,
+) (*ApplicationOut, error) {
 	req := a.api.ApplicationAPI.V1ApplicationPatch(ctx, appId)
 	req = req.ApplicationPatch(*applicationPatch)
 	ret, res, err := req.Execute()
@@ -107,7 +135,10 @@ func (a *Application) Patch(ctx context.Context, appId string, applicationPatch 
 	return ret, nil
 }
 
-func (a *Application) Delete(ctx context.Context, appId string) error {
+func (a *Application) Delete(
+	ctx context.Context,
+	appId string,
+) error {
 	req := a.api.ApplicationAPI.V1ApplicationDelete(ctx, appId)
 	res, err := req.Execute()
 	return wrapError(err, res)

--- a/go/authentication.go
+++ b/go/authentication.go
@@ -10,11 +10,20 @@ type Authentication struct {
 	api *openapi.APIClient
 }
 
-func (a *Authentication) AppPortalAccess(ctx context.Context, appId string, appPortalAccessIn *AppPortalAccessIn) (*AppPortalAccessOut, error) {
+func (a *Authentication) AppPortalAccess(
+	ctx context.Context,
+	appId string,
+	appPortalAccessIn *AppPortalAccessIn,
+) (*AppPortalAccessOut, error) {
 	return a.AppPortalAccessWithOptions(ctx, appId, appPortalAccessIn, nil)
 }
 
-func (a *Authentication) AppPortalAccessWithOptions(ctx context.Context, appId string, appPortalAccessIn *AppPortalAccessIn, options *PostOptions) (*AppPortalAccessOut, error) {
+func (a *Authentication) AppPortalAccessWithOptions(
+	ctx context.Context,
+	appId string,
+	appPortalAccessIn *AppPortalAccessIn,
+	options *PostOptions,
+) (*AppPortalAccessOut, error) {
 	req := a.api.AuthenticationAPI.V1AuthenticationAppPortalAccess(ctx, appId)
 	req = req.AppPortalAccessIn(*appPortalAccessIn)
 	if options != nil {
@@ -29,11 +38,18 @@ func (a *Authentication) AppPortalAccessWithOptions(ctx context.Context, appId s
 	return ret, nil
 }
 
-func (a *Authentication) DashboardAccess(ctx context.Context, appId string) (*DashboardAccessOut, error) {
+func (a *Authentication) DashboardAccess(
+	ctx context.Context,
+	appId string,
+) (*DashboardAccessOut, error) {
 	return a.DashboardAccessWithOptions(ctx, appId, nil)
 }
 
-func (a *Authentication) DashboardAccessWithOptions(ctx context.Context, appId string, options *PostOptions) (*DashboardAccessOut, error) {
+func (a *Authentication) DashboardAccessWithOptions(
+	ctx context.Context,
+	appId string,
+	options *PostOptions,
+) (*DashboardAccessOut, error) {
 	req := a.api.AuthenticationAPI.V1AuthenticationDashboardAccess(ctx, appId)
 	if options != nil {
 		if options.IdempotencyKey != nil {
@@ -47,11 +63,16 @@ func (a *Authentication) DashboardAccessWithOptions(ctx context.Context, appId s
 	return ret, nil
 }
 
-func (a *Authentication) Logout(ctx context.Context) error {
+func (a *Authentication) Logout(
+	ctx context.Context,
+) error {
 	return a.LogoutWithOptions(ctx, nil)
 }
 
-func (a *Authentication) LogoutWithOptions(ctx context.Context, options *PostOptions) error {
+func (a *Authentication) LogoutWithOptions(
+	ctx context.Context,
+	options *PostOptions,
+) error {
 	req := a.api.AuthenticationAPI.V1AuthenticationLogout(ctx)
 	if options != nil {
 		if options.IdempotencyKey != nil {

--- a/go/backgroundtask.go
+++ b/go/backgroundtask.go
@@ -18,7 +18,10 @@ type BackgroundTaskListOptions struct {
 	Task     *BackgroundTaskType
 }
 
-func (a *BackgroundTask) List(ctx context.Context, options *BackgroundTaskListOptions) (*ListResponseBackgroundTaskOut, error) {
+func (a *BackgroundTask) List(
+	ctx context.Context,
+	options *BackgroundTaskListOptions,
+) (*ListResponseBackgroundTaskOut, error) {
 	req := a.api.BackgroundTasksAPI.ListBackgroundTasks(ctx)
 	if options != nil {
 		if options.Iterator != nil {
@@ -44,7 +47,10 @@ func (a *BackgroundTask) List(ctx context.Context, options *BackgroundTaskListOp
 	return ret, nil
 }
 
-func (a *BackgroundTask) Get(ctx context.Context, taskId string) (*BackgroundTaskOut, error) {
+func (a *BackgroundTask) Get(
+	ctx context.Context,
+	taskId string,
+) (*BackgroundTaskOut, error) {
 	req := a.api.BackgroundTasksAPI.GetBackgroundTask(ctx, taskId)
 	ret, res, err := req.Execute()
 	if err != nil {

--- a/go/endpoint.go
+++ b/go/endpoint.go
@@ -27,7 +27,11 @@ type EndpointStatsOptions struct {
 	Until *time.Time
 }
 
-func (e *Endpoint) List(ctx context.Context, appId string, options *EndpointListOptions) (*ListResponseEndpointOut, error) {
+func (e *Endpoint) List(
+	ctx context.Context,
+	appId string,
+	options *EndpointListOptions,
+) (*ListResponseEndpointOut, error) {
 	req := e.api.EndpointAPI.V1EndpointList(ctx, appId)
 	if options != nil {
 		if options.Iterator != nil {
@@ -47,11 +51,20 @@ func (e *Endpoint) List(ctx context.Context, appId string, options *EndpointList
 	return ret, nil
 }
 
-func (e *Endpoint) Create(ctx context.Context, appId string, endpointIn *EndpointIn) (*EndpointOut, error) {
+func (e *Endpoint) Create(
+	ctx context.Context,
+	appId string,
+	endpointIn *EndpointIn,
+) (*EndpointOut, error) {
 	return e.CreateWithOptions(ctx, appId, endpointIn, nil)
 }
 
-func (e *Endpoint) CreateWithOptions(ctx context.Context, appId string, endpointIn *EndpointIn, options *PostOptions) (*EndpointOut, error) {
+func (e *Endpoint) CreateWithOptions(
+	ctx context.Context,
+	appId string,
+	endpointIn *EndpointIn,
+	options *PostOptions,
+) (*EndpointOut, error) {
 	req := e.api.EndpointAPI.V1EndpointCreate(ctx, appId)
 	req = req.EndpointIn(*endpointIn)
 	if options != nil {
@@ -66,7 +79,11 @@ func (e *Endpoint) CreateWithOptions(ctx context.Context, appId string, endpoint
 	return ret, nil
 }
 
-func (e *Endpoint) Get(ctx context.Context, appId string, endpointId string) (*EndpointOut, error) {
+func (e *Endpoint) Get(
+	ctx context.Context,
+	appId string,
+	endpointId string,
+) (*EndpointOut, error) {
 	req := e.api.EndpointAPI.V1EndpointGet(ctx, appId, endpointId)
 	ret, res, err := req.Execute()
 	if err != nil {
@@ -75,7 +92,12 @@ func (e *Endpoint) Get(ctx context.Context, appId string, endpointId string) (*E
 	return ret, nil
 }
 
-func (e *Endpoint) Update(ctx context.Context, appId string, endpointId string, endpointUpdate *EndpointUpdate) (*EndpointOut, error) {
+func (e *Endpoint) Update(
+	ctx context.Context,
+	appId string,
+	endpointId string,
+	endpointUpdate *EndpointUpdate,
+) (*EndpointOut, error) {
 	req := e.api.EndpointAPI.V1EndpointUpdate(ctx, appId, endpointId)
 	req = req.EndpointUpdate(*endpointUpdate)
 	ret, res, err := req.Execute()
@@ -85,7 +107,12 @@ func (e *Endpoint) Update(ctx context.Context, appId string, endpointId string, 
 	return ret, nil
 }
 
-func (e *Endpoint) Patch(ctx context.Context, appId string, endpointId string, endpointPatch *EndpointPatch) (*EndpointOut, error) {
+func (e *Endpoint) Patch(
+	ctx context.Context,
+	appId string,
+	endpointId string,
+	endpointPatch *EndpointPatch,
+) (*EndpointOut, error) {
 	req := e.api.EndpointAPI.V1EndpointPatch(ctx, appId, endpointId)
 	req = req.EndpointPatch(*endpointPatch)
 	ret, res, err := req.Execute()
@@ -95,13 +122,21 @@ func (e *Endpoint) Patch(ctx context.Context, appId string, endpointId string, e
 	return ret, nil
 }
 
-func (e *Endpoint) Delete(ctx context.Context, appId string, endpointId string) error {
+func (e *Endpoint) Delete(
+	ctx context.Context,
+	appId string,
+	endpointId string,
+) error {
 	req := e.api.EndpointAPI.V1EndpointDelete(ctx, appId, endpointId)
 	res, err := req.Execute()
 	return wrapError(err, res)
 }
 
-func (e *Endpoint) GetSecret(ctx context.Context, appId string, endpointId string) (*EndpointSecretOut, error) {
+func (e *Endpoint) GetSecret(
+	ctx context.Context,
+	appId string,
+	endpointId string,
+) (*EndpointSecretOut, error) {
 	req := e.api.EndpointAPI.V1EndpointGetSecret(ctx, appId, endpointId)
 	ret, res, err := req.Execute()
 	if err != nil {
@@ -110,11 +145,22 @@ func (e *Endpoint) GetSecret(ctx context.Context, appId string, endpointId strin
 	return ret, nil
 }
 
-func (e *Endpoint) RotateSecret(ctx context.Context, appId string, endpointId string, endpointSecretRotateIn *EndpointSecretRotateIn) error {
+func (e *Endpoint) RotateSecret(
+	ctx context.Context,
+	appId string,
+	endpointId string,
+	endpointSecretRotateIn *EndpointSecretRotateIn,
+) error {
 	return e.RotateSecretWithOptions(ctx, appId, endpointId, endpointSecretRotateIn, nil)
 }
 
-func (e *Endpoint) RotateSecretWithOptions(ctx context.Context, appId string, endpointId string, endpointSecretRotateIn *EndpointSecretRotateIn, options *PostOptions) error {
+func (e *Endpoint) RotateSecretWithOptions(
+	ctx context.Context,
+	appId string,
+	endpointId string,
+	endpointSecretRotateIn *EndpointSecretRotateIn,
+	options *PostOptions,
+) error {
 	req := e.api.EndpointAPI.V1EndpointRotateSecret(ctx, appId, endpointId)
 	req = req.EndpointSecretRotateIn(*endpointSecretRotateIn)
 	if options != nil {
@@ -129,11 +175,22 @@ func (e *Endpoint) RotateSecretWithOptions(ctx context.Context, appId string, en
 	return nil
 }
 
-func (e *Endpoint) Recover(ctx context.Context, appId string, endpointId string, recoverIn *RecoverIn) (*RecoverOut, error) {
+func (e *Endpoint) Recover(
+	ctx context.Context,
+	appId string,
+	endpointId string,
+	recoverIn *RecoverIn,
+) (*RecoverOut, error) {
 	return e.RecoverWithOptions(ctx, appId, endpointId, recoverIn, nil)
 }
 
-func (e *Endpoint) RecoverWithOptions(ctx context.Context, appId string, endpointId string, recoverIn *RecoverIn, options *PostOptions) (*RecoverOut, error) {
+func (e *Endpoint) RecoverWithOptions(
+	ctx context.Context,
+	appId string,
+	endpointId string,
+	recoverIn *RecoverIn,
+	options *PostOptions,
+) (*RecoverOut, error) {
 	req := e.api.EndpointAPI.V1EndpointRecover(ctx, appId, endpointId)
 	req = req.RecoverIn(*recoverIn)
 	if options != nil {
@@ -148,7 +205,11 @@ func (e *Endpoint) RecoverWithOptions(ctx context.Context, appId string, endpoin
 	return ret, nil
 }
 
-func (e *Endpoint) GetHeaders(ctx context.Context, appId string, endpointId string) (*EndpointHeadersOut, error) {
+func (e *Endpoint) GetHeaders(
+	ctx context.Context,
+	appId string,
+	endpointId string,
+) (*EndpointHeadersOut, error) {
 	req := e.api.EndpointAPI.V1EndpointGetHeaders(ctx, appId, endpointId)
 	ret, res, err := req.Execute()
 	if err != nil {
@@ -157,7 +218,12 @@ func (e *Endpoint) GetHeaders(ctx context.Context, appId string, endpointId stri
 	return ret, nil
 }
 
-func (e *Endpoint) UpdateHeaders(ctx context.Context, appId string, endpointId string, endpointHeadersIn *EndpointHeadersIn) error {
+func (e *Endpoint) UpdateHeaders(
+	ctx context.Context,
+	appId string,
+	endpointId string,
+	endpointHeadersIn *EndpointHeadersIn,
+) error {
 	req := e.api.EndpointAPI.V1EndpointUpdateHeaders(ctx, appId, endpointId)
 	req = req.EndpointHeadersIn(*endpointHeadersIn)
 	res, err := req.Execute()
@@ -167,7 +233,12 @@ func (e *Endpoint) UpdateHeaders(ctx context.Context, appId string, endpointId s
 	return nil
 }
 
-func (e *Endpoint) PatchHeaders(ctx context.Context, appId string, endpointId string, endpointHeadersIn *EndpointHeadersPatchIn) error {
+func (e *Endpoint) PatchHeaders(
+	ctx context.Context,
+	appId string,
+	endpointId string,
+	endpointHeadersIn *EndpointHeadersPatchIn,
+) error {
 	req := e.api.EndpointAPI.V1EndpointPatchHeaders(ctx, appId, endpointId)
 	req = req.EndpointHeadersPatchIn(*endpointHeadersIn)
 	res, err := req.Execute()
@@ -177,11 +248,20 @@ func (e *Endpoint) PatchHeaders(ctx context.Context, appId string, endpointId st
 	return nil
 }
 
-func (e *Endpoint) GetStats(ctx context.Context, appId string, endpointId string) (*EndpointStats, error) {
+func (e *Endpoint) GetStats(
+	ctx context.Context,
+	appId string,
+	endpointId string,
+) (*EndpointStats, error) {
 	return e.GetStatsWithOptions(ctx, appId, endpointId, EndpointStatsOptions{})
 }
 
-func (e *Endpoint) GetStatsWithOptions(ctx context.Context, appId string, endpointId string, options EndpointStatsOptions) (*EndpointStats, error) {
+func (e *Endpoint) GetStatsWithOptions(
+	ctx context.Context,
+	appId string,
+	endpointId string,
+	options EndpointStatsOptions,
+) (*EndpointStats, error) {
 	req := e.api.EndpointAPI.V1EndpointGetStats(ctx, appId, endpointId)
 	if options.Since != nil {
 		req = req.Since(*options.Since)
@@ -196,7 +276,12 @@ func (e *Endpoint) GetStatsWithOptions(ctx context.Context, appId string, endpoi
 	return ret, nil
 }
 
-func (e *Endpoint) ReplayMissing(ctx context.Context, appId string, endpointId string, replayIn *ReplayIn) (*ReplayOut, error) {
+func (e *Endpoint) ReplayMissing(
+	ctx context.Context,
+	appId string,
+	endpointId string,
+	replayIn *ReplayIn,
+) (*ReplayOut, error) {
 	return e.ReplayMissingWithOptions(ctx, appId, endpointId, replayIn, nil)
 }
 
@@ -221,7 +306,11 @@ func (e *Endpoint) ReplayMissingWithOptions(
 	return ret, nil
 }
 
-func (e *Endpoint) TransformationGet(ctx context.Context, appId string, endpointId string) (*EndpointTransformationOut, error) {
+func (e *Endpoint) TransformationGet(
+	ctx context.Context,
+	appId string,
+	endpointId string,
+) (*EndpointTransformationOut, error) {
 	req := e.api.EndpointAPI.V1EndpointTransformationGet(ctx, appId, endpointId)
 	ret, res, err := req.Execute()
 	if err != nil {
@@ -230,7 +319,11 @@ func (e *Endpoint) TransformationGet(ctx context.Context, appId string, endpoint
 	return ret, nil
 }
 
-func (e *Endpoint) TransformationPartialUpdate(ctx context.Context, appId string, endpointId string, transformation *EndpointTransformationIn) error {
+func (e *Endpoint) TransformationPartialUpdate(
+	ctx context.Context,
+	appId string,
+	endpointId string, transformation *EndpointTransformationIn,
+) error {
 	req := e.api.EndpointAPI.V1EndpointTransformationPartialUpdate(ctx, appId, endpointId)
 	req = req.EndpointTransformationIn(*transformation)
 
@@ -242,7 +335,12 @@ func (e *Endpoint) TransformationPartialUpdate(ctx context.Context, appId string
 	return nil
 }
 
-func (e *Endpoint) SendExample(ctx context.Context, appId string, endpointId string, eventExampleIn *EventExampleIn) (*MessageOut, error) {
+func (e *Endpoint) SendExample(
+	ctx context.Context,
+	appId string,
+	endpointId string,
+	eventExampleIn *EventExampleIn,
+) (*MessageOut, error) {
 	return e.SendExampleWithOptions(ctx, appId, endpointId, eventExampleIn, nil)
 }
 

--- a/go/event_type.go
+++ b/go/event_type.go
@@ -23,7 +23,10 @@ type EventTypeListOptions struct {
 	WithContent *bool
 }
 
-func (e *EventType) List(ctx context.Context, options *EventTypeListOptions) (*ListResponseEventTypeOut, error) {
+func (e *EventType) List(
+	ctx context.Context,
+	options *EventTypeListOptions,
+) (*ListResponseEventTypeOut, error) {
 	req := e.api.EventTypeAPI.V1EventTypeList(ctx)
 	if options != nil {
 		if options.Iterator != nil {
@@ -49,11 +52,17 @@ func (e *EventType) List(ctx context.Context, options *EventTypeListOptions) (*L
 	return ret, nil
 }
 
-func (e *EventType) Create(ctx context.Context, eventTypeIn *EventTypeIn) (*EventTypeOut, error) {
+func (e *EventType) Create(
+	ctx context.Context,
+	eventTypeIn *EventTypeIn,
+) (*EventTypeOut, error) {
 	return e.CreateWithOptions(ctx, eventTypeIn, nil)
 }
 
-func (e *EventType) CreateWithOptions(ctx context.Context, eventTypeIn *EventTypeIn, options *PostOptions) (*EventTypeOut, error) {
+func (e *EventType) CreateWithOptions(
+	ctx context.Context,
+	eventTypeIn *EventTypeIn, options *PostOptions,
+) (*EventTypeOut, error) {
 	req := e.api.EventTypeAPI.V1EventTypeCreate(ctx)
 	req = req.EventTypeIn(*eventTypeIn)
 	if options != nil {
@@ -68,7 +77,10 @@ func (e *EventType) CreateWithOptions(ctx context.Context, eventTypeIn *EventTyp
 	return ret, nil
 }
 
-func (e *EventType) Get(ctx context.Context, eventTypeName string) (*EventTypeOut, error) {
+func (e *EventType) Get(
+	ctx context.Context,
+	eventTypeName string,
+) (*EventTypeOut, error) {
 	req := e.api.EventTypeAPI.V1EventTypeGet(ctx, eventTypeName)
 	ret, res, err := req.Execute()
 	if err != nil {
@@ -77,7 +89,11 @@ func (e *EventType) Get(ctx context.Context, eventTypeName string) (*EventTypeOu
 	return ret, nil
 }
 
-func (e *EventType) Update(ctx context.Context, eventTypeName string, eventTypeUpdate *EventTypeUpdate) (*EventTypeOut, error) {
+func (e *EventType) Update(
+	ctx context.Context,
+	eventTypeName string,
+	eventTypeUpdate *EventTypeUpdate,
+) (*EventTypeOut, error) {
 	req := e.api.EventTypeAPI.V1EventTypeUpdate(ctx, eventTypeName)
 	req = req.EventTypeUpdate(*eventTypeUpdate)
 	ret, res, err := req.Execute()
@@ -87,7 +103,11 @@ func (e *EventType) Update(ctx context.Context, eventTypeName string, eventTypeU
 	return ret, nil
 }
 
-func (e *EventType) Patch(ctx context.Context, eventTypeName string, eventTypePatch *EventTypePatch) (*EventTypeOut, error) {
+func (e *EventType) Patch(
+	ctx context.Context,
+	eventTypeName string,
+	eventTypePatch *EventTypePatch,
+) (*EventTypeOut, error) {
 	req := e.api.EventTypeAPI.V1EventTypePatch(ctx, eventTypeName)
 	req = req.EventTypePatch(*eventTypePatch)
 	ret, res, err := req.Execute()
@@ -97,7 +117,10 @@ func (e *EventType) Patch(ctx context.Context, eventTypeName string, eventTypePa
 	return ret, nil
 }
 
-func (e *EventType) Delete(ctx context.Context, eventTypeName string) error {
+func (e *EventType) Delete(
+	ctx context.Context,
+	eventTypeName string,
+) error {
 	return e.DeleteWithOptions(ctx, eventTypeName, nil)
 }
 
@@ -105,7 +128,11 @@ type EventTypeDeleteOptions struct {
 	Expunge *bool
 }
 
-func (e *EventType) DeleteWithOptions(ctx context.Context, eventTypeName string, options *EventTypeDeleteOptions) error {
+func (e *EventType) DeleteWithOptions(
+	ctx context.Context,
+	eventTypeName string,
+	options *EventTypeDeleteOptions,
+) error {
 	req := e.api.EventTypeAPI.V1EventTypeDelete(ctx, eventTypeName)
 	if options != nil {
 		if options.Expunge != nil {
@@ -116,11 +143,18 @@ func (e *EventType) DeleteWithOptions(ctx context.Context, eventTypeName string,
 	return wrapError(err, res)
 }
 
-func (e *EventType) ImportOpenApi(ctx context.Context, eventTypeImportOpenApiIn EventTypeImportOpenApiIn) (*EventTypeImportOpenApiOut, error) {
+func (e *EventType) ImportOpenApi(
+	ctx context.Context,
+	eventTypeImportOpenApiIn EventTypeImportOpenApiIn,
+) (*EventTypeImportOpenApiOut, error) {
 	return e.ImportOpenApiWithOptions(ctx, eventTypeImportOpenApiIn, nil)
 }
 
-func (e *EventType) ImportOpenApiWithOptions(ctx context.Context, eventTypeImportOpenApiIn EventTypeImportOpenApiIn, options *PostOptions) (*EventTypeImportOpenApiOut, error) {
+func (e *EventType) ImportOpenApiWithOptions(
+	ctx context.Context,
+	eventTypeImportOpenApiIn EventTypeImportOpenApiIn,
+	options *PostOptions,
+) (*EventTypeImportOpenApiOut, error) {
 	req := e.api.EventTypeAPI.V1EventTypeImportOpenapi(ctx).EventTypeImportOpenApiIn(eventTypeImportOpenApiIn)
 	if options != nil && options.IdempotencyKey != nil {
 		req = req.IdempotencyKey(*options.IdempotencyKey)

--- a/go/integration.go
+++ b/go/integration.go
@@ -19,7 +19,11 @@ type IntegrationListOptions struct {
 	Order *Ordering
 }
 
-func (e *Integration) List(ctx context.Context, appId string, options *IntegrationListOptions) (*ListResponseIntegrationOut, error) {
+func (e *Integration) List(
+	ctx context.Context,
+	appId string,
+	options *IntegrationListOptions,
+) (*ListResponseIntegrationOut, error) {
 	req := e.api.IntegrationAPI.V1IntegrationList(ctx, appId)
 	if options != nil {
 		if options.Iterator != nil {
@@ -39,11 +43,20 @@ func (e *Integration) List(ctx context.Context, appId string, options *Integrati
 	return ret, nil
 }
 
-func (e *Integration) Create(ctx context.Context, appId string, endpointIn *IntegrationIn) (*IntegrationOut, error) {
+func (e *Integration) Create(
+	ctx context.Context,
+	appId string,
+	endpointIn *IntegrationIn,
+) (*IntegrationOut, error) {
 	return e.CreateWithOptions(ctx, appId, endpointIn, nil)
 }
 
-func (e *Integration) CreateWithOptions(ctx context.Context, appId string, endpointIn *IntegrationIn, options *PostOptions) (*IntegrationOut, error) {
+func (e *Integration) CreateWithOptions(
+	ctx context.Context,
+	appId string,
+	endpointIn *IntegrationIn,
+	options *PostOptions,
+) (*IntegrationOut, error) {
 	req := e.api.IntegrationAPI.V1IntegrationCreate(ctx, appId)
 	req = req.IntegrationIn(*endpointIn)
 	if options != nil {
@@ -58,7 +71,11 @@ func (e *Integration) CreateWithOptions(ctx context.Context, appId string, endpo
 	return ret, nil
 }
 
-func (e *Integration) Get(ctx context.Context, appId string, integId string) (*IntegrationOut, error) {
+func (e *Integration) Get(
+	ctx context.Context,
+	appId string,
+	integId string,
+) (*IntegrationOut, error) {
 	req := e.api.IntegrationAPI.V1IntegrationGet(ctx, appId, integId)
 	ret, res, err := req.Execute()
 	if err != nil {
@@ -67,7 +84,12 @@ func (e *Integration) Get(ctx context.Context, appId string, integId string) (*I
 	return ret, nil
 }
 
-func (e *Integration) Update(ctx context.Context, appId string, integId string, endpointUpdate *IntegrationUpdate) (*IntegrationOut, error) {
+func (e *Integration) Update(
+	ctx context.Context,
+	appId string,
+	integId string,
+	endpointUpdate *IntegrationUpdate,
+) (*IntegrationOut, error) {
 	req := e.api.IntegrationAPI.V1IntegrationUpdate(ctx, appId, integId)
 	req = req.IntegrationUpdate(*endpointUpdate)
 	ret, res, err := req.Execute()
@@ -77,13 +99,21 @@ func (e *Integration) Update(ctx context.Context, appId string, integId string, 
 	return ret, nil
 }
 
-func (e *Integration) Delete(ctx context.Context, appId string, integId string) error {
+func (e *Integration) Delete(
+	ctx context.Context,
+	appId string,
+	integId string,
+) error {
 	req := e.api.IntegrationAPI.V1IntegrationDelete(ctx, appId, integId)
 	res, err := req.Execute()
 	return wrapError(err, res)
 }
 
-func (e *Integration) GetKey(ctx context.Context, appId string, integId string) (*IntegrationKeyOut, error) {
+func (e *Integration) GetKey(
+	ctx context.Context,
+	appId string,
+	integId string,
+) (*IntegrationKeyOut, error) {
 	req := e.api.IntegrationAPI.V1IntegrationGetKey(ctx, appId, integId)
 	ret, res, err := req.Execute()
 	if err != nil {
@@ -92,11 +122,20 @@ func (e *Integration) GetKey(ctx context.Context, appId string, integId string) 
 	return ret, nil
 }
 
-func (e *Integration) RotateKey(ctx context.Context, appId string, integId string) (*IntegrationKeyOut, error) {
+func (e *Integration) RotateKey(
+	ctx context.Context,
+	appId string,
+	integId string,
+) (*IntegrationKeyOut, error) {
 	return e.RotateKeyWithOptions(ctx, appId, integId, nil)
 }
 
-func (e *Integration) RotateKeyWithOptions(ctx context.Context, appId string, integId string, options *PostOptions) (*IntegrationKeyOut, error) {
+func (e *Integration) RotateKeyWithOptions(
+	ctx context.Context,
+	appId string,
+	integId string,
+	options *PostOptions,
+) (*IntegrationKeyOut, error) {
 	req := e.api.IntegrationAPI.V1IntegrationRotateKey(ctx, appId, integId)
 	if options != nil {
 		if options.IdempotencyKey != nil {

--- a/go/message.go
+++ b/go/message.go
@@ -30,7 +30,11 @@ type MessageListOptions struct {
 	EventTypes *[]string
 }
 
-func (m *Message) List(ctx context.Context, appId string, options *MessageListOptions) (*ListResponseMessageOut, error) {
+func (m *Message) List(
+	ctx context.Context,
+	appId string,
+	options *MessageListOptions,
+) (*ListResponseMessageOut, error) {
 	req := m.api.MessageAPI.V1MessageList(ctx, appId)
 	if options != nil {
 		if options.Iterator != nil {
@@ -65,11 +69,20 @@ func (m *Message) List(ctx context.Context, appId string, options *MessageListOp
 	return ret, nil
 }
 
-func (m *Message) Create(ctx context.Context, appId string, messageIn *MessageIn) (*MessageOut, error) {
+func (m *Message) Create(
+	ctx context.Context,
+	appId string,
+	messageIn *MessageIn,
+) (*MessageOut, error) {
 	return m.CreateWithOptions(ctx, appId, messageIn, nil)
 }
 
-func (m *Message) CreateWithOptions(ctx context.Context, appId string, messageIn *MessageIn, options *PostOptions) (*MessageOut, error) {
+func (m *Message) CreateWithOptions(
+	ctx context.Context,
+	appId string,
+	messageIn *MessageIn,
+	options *PostOptions,
+) (*MessageOut, error) {
 	req := m.api.MessageAPI.V1MessageCreate(ctx, appId)
 	req = req.MessageIn(*messageIn)
 	if options != nil {
@@ -84,7 +97,11 @@ func (m *Message) CreateWithOptions(ctx context.Context, appId string, messageIn
 	return ret, nil
 }
 
-func (m *Message) Get(ctx context.Context, appId string, msgId string) (*MessageOut, error) {
+func (m *Message) Get(
+	ctx context.Context,
+	appId string,
+	msgId string,
+) (*MessageOut, error) {
 	req := m.api.MessageAPI.V1MessageGet(ctx, appId, msgId)
 	ret, res, err := req.Execute()
 	if err != nil {
@@ -93,7 +110,11 @@ func (m *Message) Get(ctx context.Context, appId string, msgId string) (*Message
 	return ret, nil
 }
 
-func (m *Message) ExpungeContent(ctx context.Context, appId string, msgId string) error {
+func (m *Message) ExpungeContent(
+	ctx context.Context,
+	appId string,
+	msgId string,
+) error {
 	req := m.api.MessageAPI.V1MessageExpungeContent(ctx, appId, msgId)
 	res, err := req.Execute()
 	return wrapError(err, res)
@@ -111,7 +132,11 @@ func (m *Message) ExpungeContent(ctx context.Context, appId string, msgId string
 // of the webhook sent by Svix overriding the default of `application/json`.
 //
 // See the class documentation for details about the other parameters.
-func NewMessageInRaw(eventType string, payload string, contentType openapi.NullableString) *MessageIn {
+func NewMessageInRaw(
+	eventType string,
+	payload string,
+	contentType openapi.NullableString,
+) *MessageIn {
 	msgIn := openapi.NewMessageIn(eventType, make(map[string]interface{}))
 
 	transformationsParams := map[string]interface{}{

--- a/go/message_attempt.go
+++ b/go/message_attempt.go
@@ -27,11 +27,21 @@ type MessageAttemptListOptions struct {
 }
 
 // Deprecated: use `ListByMsg` or `ListByEndpoint` instead
-func (m *MessageAttempt) List(ctx context.Context, appId string, msgId string, options *MessageAttemptListOptions) (*ListResponseMessageAttemptOut, error) {
+func (m *MessageAttempt) List(
+	ctx context.Context,
+	appId string,
+	msgId string,
+	options *MessageAttemptListOptions,
+) (*ListResponseMessageAttemptOut, error) {
 	return m.ListByMsg(ctx, appId, msgId, options)
 }
 
-func (m *MessageAttempt) ListByMsg(ctx context.Context, appId string, msgId string, options *MessageAttemptListOptions) (*ListResponseMessageAttemptOut, error) {
+func (m *MessageAttempt) ListByMsg(
+	ctx context.Context,
+	appId string,
+	msgId string,
+	options *MessageAttemptListOptions,
+) (*ListResponseMessageAttemptOut, error) {
 	req := m.api.MessageAttemptAPI.V1MessageAttemptListByMsg(ctx, appId, msgId)
 	if options != nil {
 		if options.Iterator != nil {
@@ -75,7 +85,12 @@ func (m *MessageAttempt) ListByMsg(ctx context.Context, appId string, msgId stri
 	return ret, nil
 }
 
-func (m *MessageAttempt) ListByEndpoint(ctx context.Context, appId string, endpointId string, options *MessageAttemptListOptions) (*ListResponseMessageAttemptOut, error) {
+func (m *MessageAttempt) ListByEndpoint(
+	ctx context.Context,
+	appId string,
+	endpointId string,
+	options *MessageAttemptListOptions,
+) (*ListResponseMessageAttemptOut, error) {
 	req := m.api.MessageAttemptAPI.V1MessageAttemptListByEndpoint(ctx, appId, endpointId)
 	if options != nil {
 		if options.Iterator != nil {
@@ -119,7 +134,12 @@ func (m *MessageAttempt) ListByEndpoint(ctx context.Context, appId string, endpo
 	return ret, nil
 }
 
-func (m *MessageAttempt) Get(ctx context.Context, appId string, msgId string, attemptID string) (*MessageAttemptOut, error) {
+func (m *MessageAttempt) Get(
+	ctx context.Context,
+	appId string,
+	msgId string,
+	attemptID string,
+) (*MessageAttemptOut, error) {
 	req := m.api.MessageAttemptAPI.V1MessageAttemptGet(ctx, appId, msgId, attemptID)
 	ret, res, err := req.Execute()
 	if err != nil {
@@ -128,11 +148,22 @@ func (m *MessageAttempt) Get(ctx context.Context, appId string, msgId string, at
 	return ret, nil
 }
 
-func (m *MessageAttempt) Resend(ctx context.Context, appId string, msgId string, endpointId string) error {
+func (m *MessageAttempt) Resend(
+	ctx context.Context,
+	appId string,
+	msgId string,
+	endpointId string,
+) error {
 	return m.ResendWithOptions(ctx, appId, msgId, endpointId, nil)
 }
 
-func (m *MessageAttempt) ResendWithOptions(ctx context.Context, appId string, msgId string, endpointId string, options *PostOptions) error {
+func (m *MessageAttempt) ResendWithOptions(
+	ctx context.Context,
+	appId string,
+	msgId string,
+	endpointId string,
+	options *PostOptions,
+) error {
 	req := m.api.MessageAttemptAPI.V1MessageAttemptResend(ctx, appId, msgId, endpointId)
 	if options != nil {
 		if options.IdempotencyKey != nil {
@@ -143,7 +174,12 @@ func (m *MessageAttempt) ResendWithOptions(ctx context.Context, appId string, ms
 	return wrapError(err, res)
 }
 
-func (m *MessageAttempt) ListAttemptedMessages(ctx context.Context, appId string, endpointId string, options *MessageAttemptListOptions) (*ListResponseEndpointMessageOut, error) {
+func (m *MessageAttempt) ListAttemptedMessages(
+	ctx context.Context,
+	appId string,
+	endpointId string,
+	options *MessageAttemptListOptions,
+) (*ListResponseEndpointMessageOut, error) {
 	req := m.api.MessageAttemptAPI.V1MessageAttemptListAttemptedMessages(ctx, appId, endpointId)
 	if options != nil {
 		if options.Iterator != nil {
@@ -181,7 +217,12 @@ func (m *MessageAttempt) ListAttemptedMessages(ctx context.Context, appId string
 	return ret, nil
 }
 
-func (m *MessageAttempt) ListAttemptedDestinations(ctx context.Context, appId string, msgId string, options *MessageAttemptListOptions) (*ListResponseMessageEndpointOut, error) {
+func (m *MessageAttempt) ListAttemptedDestinations(
+	ctx context.Context,
+	appId string,
+	msgId string,
+	options *MessageAttemptListOptions,
+) (*ListResponseMessageEndpointOut, error) {
 	req := m.api.MessageAttemptAPI.V1MessageAttemptListAttemptedDestinations(ctx, appId, msgId)
 	if options != nil {
 		if options.Iterator != nil {
@@ -199,7 +240,13 @@ func (m *MessageAttempt) ListAttemptedDestinations(ctx context.Context, appId st
 }
 
 // Deprecated: use `ListByMsg` instead, passing the endpoint ID through options
-func (m *MessageAttempt) ListAttemptsForEndpoint(ctx context.Context, appId string, msgId string, endpointId string, options *MessageAttemptListOptions) (*ListResponseMessageAttemptEndpointOut, error) {
+func (m *MessageAttempt) ListAttemptsForEndpoint(
+	ctx context.Context,
+	appId string,
+	msgId string,
+	endpointId string,
+	options *MessageAttemptListOptions,
+) (*ListResponseMessageAttemptEndpointOut, error) {
 	req := m.api.MessageAttemptAPI.V1MessageAttemptListByEndpointDeprecated(ctx, appId, msgId, endpointId)
 	if options != nil {
 		if options.Iterator != nil {
@@ -234,7 +281,12 @@ func (m *MessageAttempt) ListAttemptsForEndpoint(ctx context.Context, appId stri
 	return ret, nil
 }
 
-func (m *MessageAttempt) ExpungeContent(ctx context.Context, appId string, msgId string, attemptId string) error {
+func (m *MessageAttempt) ExpungeContent(
+	ctx context.Context,
+	appId string,
+	msgId string,
+	attemptId string,
+) error {
 	req := m.api.MessageAttemptAPI.V1MessageAttemptExpungeContent(ctx, appId, msgId, attemptId)
 	res, err := req.Execute()
 	return wrapError(err, res)

--- a/go/operational_webhook_endpoint.go
+++ b/go/operational_webhook_endpoint.go
@@ -19,7 +19,10 @@ type OperationalWebhookEndpointListOptions struct {
 	Order *Ordering
 }
 
-func (e *OperationalWebhookEndpoint) List(ctx context.Context, options *OperationalWebhookEndpointListOptions) (*ListResponseOperationalWebhookEndpointOut, error) {
+func (e *OperationalWebhookEndpoint) List(
+	ctx context.Context,
+	options *OperationalWebhookEndpointListOptions,
+) (*ListResponseOperationalWebhookEndpointOut, error) {
 	req := e.api.WebhookEndpointAPI.ListOperationalWebhookEndpoints(ctx)
 	if options != nil {
 		if options.Iterator != nil {
@@ -39,11 +42,18 @@ func (e *OperationalWebhookEndpoint) List(ctx context.Context, options *Operatio
 	return ret, nil
 }
 
-func (e *OperationalWebhookEndpoint) Create(ctx context.Context, endpointIn *OperationalWebhookEndpointIn) (*OperationalWebhookEndpointOut, error) {
+func (e *OperationalWebhookEndpoint) Create(
+	ctx context.Context,
+	endpointIn *OperationalWebhookEndpointIn,
+) (*OperationalWebhookEndpointOut, error) {
 	return e.CreateWithOptions(ctx, endpointIn, nil)
 }
 
-func (e *OperationalWebhookEndpoint) CreateWithOptions(ctx context.Context, endpointIn *OperationalWebhookEndpointIn, options *PostOptions) (*OperationalWebhookEndpointOut, error) {
+func (e *OperationalWebhookEndpoint) CreateWithOptions(
+	ctx context.Context,
+	endpointIn *OperationalWebhookEndpointIn,
+	options *PostOptions,
+) (*OperationalWebhookEndpointOut, error) {
 	req := e.api.WebhookEndpointAPI.CreateOperationalWebhookEndpoint(ctx)
 	req = req.OperationalWebhookEndpointIn(*endpointIn)
 	if options != nil {
@@ -58,7 +68,10 @@ func (e *OperationalWebhookEndpoint) CreateWithOptions(ctx context.Context, endp
 	return ret, nil
 }
 
-func (e *OperationalWebhookEndpoint) Get(ctx context.Context, endpointId string) (*OperationalWebhookEndpointOut, error) {
+func (e *OperationalWebhookEndpoint) Get(
+	ctx context.Context,
+	endpointId string,
+) (*OperationalWebhookEndpointOut, error) {
 	req := e.api.WebhookEndpointAPI.GetOperationalWebhookEndpoint(ctx, endpointId)
 	ret, res, err := req.Execute()
 	if err != nil {
@@ -67,7 +80,11 @@ func (e *OperationalWebhookEndpoint) Get(ctx context.Context, endpointId string)
 	return ret, nil
 }
 
-func (e *OperationalWebhookEndpoint) Update(ctx context.Context, endpointId string, endpointUpdate *OperationalWebhookEndpointUpdate) (*OperationalWebhookEndpointOut, error) {
+func (e *OperationalWebhookEndpoint) Update(
+	ctx context.Context,
+	endpointId string,
+	endpointUpdate *OperationalWebhookEndpointUpdate,
+) (*OperationalWebhookEndpointOut, error) {
 	req := e.api.WebhookEndpointAPI.UpdateOperationalWebhookEndpoint(ctx, endpointId)
 	req = req.OperationalWebhookEndpointUpdate(*endpointUpdate)
 	ret, res, err := req.Execute()
@@ -77,13 +94,19 @@ func (e *OperationalWebhookEndpoint) Update(ctx context.Context, endpointId stri
 	return ret, nil
 }
 
-func (e *OperationalWebhookEndpoint) Delete(ctx context.Context, endpointId string) error {
+func (e *OperationalWebhookEndpoint) Delete(
+	ctx context.Context,
+	endpointId string,
+) error {
 	req := e.api.WebhookEndpointAPI.DeleteOperationalWebhookEndpoint(ctx, endpointId)
 	res, err := req.Execute()
 	return wrapError(err, res)
 }
 
-func (e *OperationalWebhookEndpoint) GetSecret(ctx context.Context, endpointId string) (*OperationalWebhookEndpointSecretOut, error) {
+func (e *OperationalWebhookEndpoint) GetSecret(
+	ctx context.Context,
+	endpointId string,
+) (*OperationalWebhookEndpointSecretOut, error) {
 	req := e.api.WebhookEndpointAPI.GetOperationalWebhookEndpointSecret(ctx, endpointId)
 	ret, res, err := req.Execute()
 	if err != nil {
@@ -92,11 +115,20 @@ func (e *OperationalWebhookEndpoint) GetSecret(ctx context.Context, endpointId s
 	return ret, nil
 }
 
-func (e *OperationalWebhookEndpoint) RotateSecret(ctx context.Context, endpointId string, endpointSecretRotateIn *OperationalWebhookEndpointSecretIn) error {
+func (e *OperationalWebhookEndpoint) RotateSecret(
+	ctx context.Context,
+	endpointId string,
+	endpointSecretRotateIn *OperationalWebhookEndpointSecretIn,
+) error {
 	return e.RotateSecretWithOptions(ctx, endpointId, endpointSecretRotateIn, nil)
 }
 
-func (e *OperationalWebhookEndpoint) RotateSecretWithOptions(ctx context.Context, endpointId string, endpointSecretRotateIn *OperationalWebhookEndpointSecretIn, options *PostOptions) error {
+func (e *OperationalWebhookEndpoint) RotateSecretWithOptions(
+	ctx context.Context,
+	endpointId string,
+	endpointSecretRotateIn *OperationalWebhookEndpointSecretIn,
+	options *PostOptions,
+) error {
 	req := e.api.WebhookEndpointAPI.RotateOperationalWebhookEndpointSecret(ctx, endpointId)
 	req = req.OperationalWebhookEndpointSecretIn(*endpointSecretRotateIn)
 	if options != nil {

--- a/go/statistics.go
+++ b/go/statistics.go
@@ -10,7 +10,11 @@ type Statistics struct {
 	api *openapi.APIClient
 }
 
-func (s *Statistics) AggregateAppStats(ctx context.Context, appUsageStatsIn *AppUsageStatsIn, options *PostOptions) (*AppUsageStatsOut, error) {
+func (s *Statistics) AggregateAppStats(
+	ctx context.Context,
+	appUsageStatsIn *AppUsageStatsIn,
+	options *PostOptions,
+) (*AppUsageStatsOut, error) {
 	req := s.api.StatisticsAPI.V1StatisticsAggregateAppStats(ctx)
 	if appUsageStatsIn != nil {
 		req = req.AppUsageStatsIn(*appUsageStatsIn)
@@ -27,7 +31,9 @@ func (s *Statistics) AggregateAppStats(ctx context.Context, appUsageStatsIn *App
 	return ret, nil
 }
 
-func (s *Statistics) AggregateEventTypes(ctx context.Context) (*AggregateEventTypesOut, error) {
+func (s *Statistics) AggregateEventTypes(
+	ctx context.Context,
+) (*AggregateEventTypesOut, error) {
 	req := s.api.StatisticsAPI.V1StatisticsAggregateEventTypes(ctx)
 
 	ret, res, err := req.Execute()


### PR DESCRIPTION
… to reduce the diff of the upcoming codegen PR.

Seems like gofmt just doesn't care about how long function signatures are (no line limit at all???), how many parameters are on one line, whether the closing parenthesis is on a new line or not, or whether there are empty lines between the parameters. This was a _true_ chore.