### PR TITLE
python: Cleanup ListOptions to_dict to use BaseOptions

### DIFF
--- a/python/svix/api/common.py
+++ b/python/svix/api/common.py
@@ -15,21 +15,28 @@ def ensure_tz(x: t.Optional[datetime]) -> t.Optional[datetime]:
     return x
 
 
+def sanitize_field(v: t.Any) -> t.Any:
+    if isinstance(v, datetime):
+        return ensure_tz(v)
+
+    return v
+
+
 @dataclass
-class ListOptions:
+class BaseOptions:
+    def to_dict(self) -> t.Dict[str, t.Any]:
+        return {k: sanitize_field(v) for k, v in asdict(self).items() if v is not None}
+
+
+@dataclass
+class ListOptions(BaseOptions):
     iterator: t.Optional[str] = None
     limit: t.Optional[int] = None
 
-    def to_dict(self) -> t.Dict[str, t.Any]:
-        return {k: v for k, v in asdict(self).items() if v is not None}
-
 
 @dataclass
-class PostOptions:
+class PostOptions(BaseOptions):
     idempotency_key: t.Optional[str] = None
-
-    def to_dict(self) -> t.Dict[str, t.Any]:
-        return {k: v for k, v in asdict(self).items() if v is not None}
 
 
 class ApiBase:


### PR DESCRIPTION
Cleaning up the python client code in preparation for the new codegen code
These changes I will do by hand, and I want the codegen to be able to match the code (or at least have the diff be as small as possible) 