### PR TITLE
Patch OpenAPI versions for codegen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,16 @@
 # Javascript
 /node_modules
 
-#PHP
+# PHP
 /vendor/
 composer.lock
 
-#IDE
+# IDE
 .vscode
 .idea
 
 # Rust
 target/
+
+# Codegen script
+/.codegen-tmp/

--- a/go/.gitignore
+++ b/go/.gitignore
@@ -1,1 +1,0 @@
-/openapi.json

--- a/regen_openapi.sh
+++ b/regen_openapi.sh
@@ -6,6 +6,14 @@ if [ -n "$1" ]; then
     curl "$1" | python -m json.tool > openapi.json
 fi
 
+cd $(dirname "$0")
+mkdir -p .codegen-tmp
+# OpenAPI version has to be overwritten to avoid broken codegen paths in OpenAPI generator.
+# Spec version is overwritten to avoid unnecessary diffs on comments.
+jq --indent 4 '.openapi = "3.0.2" | .info.version = "1.1.1"' \
+    < openapi.json \
+    > .codegen-tmp/openapi.json
+
 # For some languages, write a separate OpenAPI spec file where optional fields
 # of non-`Patch` schemas are set to not be nullable, so the codegen doesn't wrap
 # the struct fields in double options.
@@ -27,28 +35,29 @@ jq --indent 4 '.components.schemas |= with_entries(
             end
         end
     )' \
-    < openapi.json \
+    < .codegen-tmp/openapi.json \
     | tee go/openapi.json \
     > rust/openapi.json
 
-yarn openapi-generator-cli generate -i openapi.json -g typescript -o javascript/src/openapi -c javascript/openapi-generator-config.json --type-mappings=set=Array -t javascript/templates
+yarn openapi-generator-cli generate -i .codegen-tmp/openapi.json -g typescript -o javascript/src/openapi -c javascript/openapi-generator-config.json --type-mappings=set=Array -t javascript/templates
 
 # Cleanup previous codegen, allowing us to spot removals.
 # If the removals are expected, stage them eg. `git add -u`, then commit them.
 rm -f go/internal/openapi/*.go
 yarn openapi-generator-cli generate -i go/openapi.json -g go -o go/internal/openapi -c go/openapi-generator-config.json -t go/templates
 
-yarn openapi-generator-cli generate -i openapi.json -g java -o java/lib/generated/openapi -c java/openapi-generator-config.json -t java/templates
+yarn openapi-generator-cli generate -i .codegen-tmp/openapi.json -g java -o java/lib/generated/openapi -c java/openapi-generator-config.json -t java/templates
 
-yarn openapi-generator-cli generate -i openapi.json -g kotlin -o kotlin/lib/generated/openapi -c kotlin/openapi-generator-config.json -t kotlin/templates
+yarn openapi-generator-cli generate -i .codegen-tmp/openapi.json -g kotlin -o kotlin/lib/generated/openapi -c kotlin/openapi-generator-config.json -t kotlin/templates
 
-yarn openapi-generator-cli generate -i openapi.json -g ruby -o ruby -c ruby/openapi-generator-config.json -t ruby/templates
+yarn openapi-generator-cli generate -i .codegen-tmp/openapi.json -g ruby -o ruby -c ruby/openapi-generator-config.json -t ruby/templates
 
-yarn openapi-generator-cli generate -i openapi.json -g csharp -o csharp/ -c csharp/openapi-generator-config.json --global-property apis,models,supportingFiles,apiTests=false,apiDocs=false,modelTests=false,modelDocs=false
+yarn openapi-generator-cli generate -i .codegen-tmp/openapi.json -g csharp -o csharp/ -c csharp/openapi-generator-config.json --global-property apis,models,supportingFiles,apiTests=false,apiDocs=false,modelTests=false,modelDocs=false
 
 # Cleanup previous codegen, allowing us to spot removals.
 # If the removals are expected, stage them eg. `git add -u`, then commit them.
 rm -rf rust/src/models
 yarn openapi-generator-cli generate -i rust/openapi.json -g rust -o rust/ -c rust/openapi-generator-config.json -t rust/templates
 
+rm -rf .codegen-tmp
 echo Note: Python generation is not executed automatically.

--- a/regen_openapi.sh
+++ b/regen_openapi.sh
@@ -36,15 +36,14 @@ jq --indent 4 '.components.schemas |= with_entries(
         end
     )' \
     < .codegen-tmp/openapi.json \
-    | tee go/openapi.json \
-    > rust/openapi.json
+    > .codegen-tmp/openapi-less-null.json
 
 yarn openapi-generator-cli generate -i .codegen-tmp/openapi.json -g typescript -o javascript/src/openapi -c javascript/openapi-generator-config.json --type-mappings=set=Array -t javascript/templates
 
 # Cleanup previous codegen, allowing us to spot removals.
 # If the removals are expected, stage them eg. `git add -u`, then commit them.
 rm -f go/internal/openapi/*.go
-yarn openapi-generator-cli generate -i go/openapi.json -g go -o go/internal/openapi -c go/openapi-generator-config.json -t go/templates
+yarn openapi-generator-cli generate -i .codegen-tmp/openapi-less-null.json -g go -o go/internal/openapi -c go/openapi-generator-config.json -t go/templates
 
 yarn openapi-generator-cli generate -i .codegen-tmp/openapi.json -g java -o java/lib/generated/openapi -c java/openapi-generator-config.json -t java/templates
 
@@ -57,7 +56,7 @@ yarn openapi-generator-cli generate -i .codegen-tmp/openapi.json -g csharp -o cs
 # Cleanup previous codegen, allowing us to spot removals.
 # If the removals are expected, stage them eg. `git add -u`, then commit them.
 rm -rf rust/src/models
-yarn openapi-generator-cli generate -i rust/openapi.json -g rust -o rust/ -c rust/openapi-generator-config.json -t rust/templates
+yarn openapi-generator-cli generate -i .codegen-tmp/openapi-less-null.json -g rust -o rust/ -c rust/openapi-generator-config.json -t rust/templates
 
 rm -rf .codegen-tmp
 echo Note: Python generation is not executed automatically.

--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -3,5 +3,3 @@
 Cargo.lock
 
 /.openapi-generator/
-/openapi.json
-

--- a/tools/bump_version.js
+++ b/tools/bump_version.js
@@ -34,7 +34,11 @@ const filesPaths = [
     "python/svix/__init__.py",
     // Ruby
     "ruby/Gemfile.lock",
-    "ruby/lib/svix/version.rb"
+    "ruby/lib/svix/version.rb",
+    // OpenAPI spec
+    "server/openapi.json",
+    // Cloud OpenAPI spec - not necessary but any other time of updating seems weirder
+    "openapi.json",
 ];
 
 const rootDir = join(__dirname, "..");


### PR DESCRIPTION
So we no longer need to patch these in the file committed to the repository root.
Part of https://github.com/svix/monorepo-private/issues/9734.