### PR TITLE
Remove description from openapi.json before using it for codegen

### DIFF
--- a/regen_openapi.sh
+++ b/regen_openapi.sh
@@ -9,8 +9,8 @@ fi
 cd $(dirname "$0")
 mkdir -p .codegen-tmp
 # OpenAPI version has to be overwritten to avoid broken codegen paths in OpenAPI generator.
-# Spec version is overwritten to avoid unnecessary diffs on comments.
-jq --indent 4 '.openapi = "3.0.2" | .info.version = "1.1.1"' \
+# Spec version is overwritten to avoid unnecessary diffs on comments. Same for description.
+jq --indent 4 '.openapi = "3.0.2" | .info.version = "1.1.1" | del(.info.description)' \
     < openapi.json \
     > .codegen-tmp/openapi.json
 


### PR DESCRIPTION
We can remove all these weird hacks once we get rid of OpenAPI generator, but for now we should avoid inflating every single generated file with our doc string / make sure we don't have it in diffs when we ship a less hacky `openapi.json` to this repo.