### PR TITLE
python: add generated client code for application.py

### DIFF
--- a/python/svix/api/__init__.py
+++ b/python/svix/api/__init__.py
@@ -3,7 +3,13 @@
 import typing as t
 from dataclasses import dataclass, field
 
-from .application import ApplicationAsync, Application, ApplicationListOptions
+from .application import (
+    ApplicationAsync,
+    Application,
+    ApplicationListOptions,
+    ApplicationCreateOptions,
+    ApplicationGetOrCreateOptions,
+)
 from .authentication import AuthenticationAsync, Authentication
 from .endpoint import EndpointAsync, Endpoint, EndpointListOptions
 from .event_type import EventTypeAsync, EventType, EventTypeListOptions
@@ -275,6 +281,8 @@ __all__ = [
     "ApplicationIn",
     "ApplicationOut",
     "ApplicationPatch",
+    "ApplicationCreateOptions",
+    "ApplicationGetOrCreateOptions",
     "ListResponseApplicationOut",
     "DashboardAccessOut",
     "EndpointHeadersIn",

--- a/python/svix/api/application.py
+++ b/python/svix/api/application.py
@@ -1,6 +1,8 @@
 import typing as t
 from dataclasses import dataclass
 
+from .common import ApiBase, BaseOptions
+from ..internal.openapi_client import models
 
 from ..internal.openapi_client.api.application import (
     v1_application_create,
@@ -16,14 +18,27 @@ from ..internal.openapi_client.models.application_patch import ApplicationPatch
 from ..internal.openapi_client.models.list_response_application_out import (
     ListResponseApplicationOut,
 )
-from ..internal.openapi_client.models.ordering import Ordering
 
-from .common import PostOptions, ApiBase, ListOptions
 
 
 @dataclass
-class ApplicationListOptions(ListOptions):
-    order: t.Optional[Ordering] = None
+class ApplicationListOptions(BaseOptions):
+    # Limit the number of returned items
+    limit: t.Optional[int] = None
+    # The iterator returned from a prior invocation
+    iterator: t.Optional[str] = None
+    # The sorting order of the returned items
+    order: t.Optional[models.Ordering] = None
+
+
+@dataclass
+class ApplicationCreateOptions(BaseOptions):
+    idempotency_key: t.Optional[str] = None
+
+
+@dataclass
+class ApplicationGetOrCreateOptions(BaseOptions):
+    idempotency_key: t.Optional[str] = None
 
 
 class ApplicationAsync(ApiBase):
@@ -35,7 +50,9 @@ class ApplicationAsync(ApiBase):
         )
 
     async def create(
-        self, application_in: ApplicationIn, options: PostOptions = PostOptions()
+        self,
+        application_in: ApplicationIn,
+        options: ApplicationCreateOptions = ApplicationCreateOptions(),
     ) -> ApplicationOut:
         return await v1_application_create.request_asyncio(
             client=self._client, json_body=application_in, **options.to_dict()
@@ -47,7 +64,9 @@ class ApplicationAsync(ApiBase):
         )
 
     async def get_or_create(
-        self, application_in: ApplicationIn, options: PostOptions = PostOptions()
+        self,
+        application_in: ApplicationIn,
+        options: ApplicationGetOrCreateOptions = ApplicationGetOrCreateOptions(),
     ) -> ApplicationOut:
         return await v1_application_create.request_asyncio(
             client=self._client,
@@ -85,7 +104,9 @@ class Application(ApiBase):
         )
 
     def create(
-        self, application_in: ApplicationIn, options: PostOptions = PostOptions()
+        self,
+        application_in: ApplicationIn,
+        options: ApplicationListOptions = ApplicationListOptions(),
     ) -> ApplicationOut:
         return v1_application_create.request_sync(
             client=self._client, json_body=application_in, **options.to_dict()
@@ -95,7 +116,9 @@ class Application(ApiBase):
         return v1_application_get.request_sync(client=self._client, app_id=app_id)
 
     def get_or_create(
-        self, application_in: ApplicationIn, options: PostOptions = PostOptions()
+        self,
+        application_in: ApplicationIn,
+        options: ApplicationGetOrCreateOptions = ApplicationGetOrCreateOptions(),
     ) -> ApplicationOut:
         return v1_application_create.request_sync(
             client=self._client,

--- a/python/svix/api/application.py
+++ b/python/svix/api/application.py
@@ -87,7 +87,7 @@ class ApplicationAsync(ApiBase):
             client=self._client, app_id=app_id, json_body=application_in
         )
 
-    async def delete(self, app_id: str) -> ApplicationOut:
+    async def delete(self, app_id: str) -> None:
         """Delete an application."""
         return await v1_application_delete.request_asyncio(
             client=self._client, app_id=app_id
@@ -143,7 +143,7 @@ class Application(ApiBase):
             client=self._client, app_id=app_id, json_body=application_in
         )
 
-    def delete(self, app_id: str) -> ApplicationOut:
+    def delete(self, app_id: str) -> None:
         """Delete an application."""
         return v1_application_delete.request_sync(client=self._client, app_id=app_id)
 

--- a/python/svix/api/application.py
+++ b/python/svix/api/application.py
@@ -4,21 +4,22 @@ from dataclasses import dataclass
 from .common import ApiBase, BaseOptions
 from ..internal.openapi_client import models
 
+
 from ..internal.openapi_client.api.application import (
-    v1_application_create,
-    v1_application_delete,
-    v1_application_get,
     v1_application_list,
-    v1_application_patch,
+    v1_application_create,
+    v1_application_get,
     v1_application_update,
+    v1_application_delete,
+    v1_application_patch,
+)
+
+from ..internal.openapi_client.models.list_response_application_out import (
+    ListResponseApplicationOut,
 )
 from ..internal.openapi_client.models.application_in import ApplicationIn
 from ..internal.openapi_client.models.application_out import ApplicationOut
 from ..internal.openapi_client.models.application_patch import ApplicationPatch
-from ..internal.openapi_client.models.list_response_application_out import (
-    ListResponseApplicationOut,
-)
-
 
 
 @dataclass
@@ -45,6 +46,7 @@ class ApplicationAsync(ApiBase):
     async def list(
         self, options: ApplicationListOptions = ApplicationListOptions()
     ) -> ListResponseApplicationOut:
+        """List of all the organization's applications."""
         return await v1_application_list.request_asyncio(
             client=self._client, **options.to_dict()
         )
@@ -54,11 +56,13 @@ class ApplicationAsync(ApiBase):
         application_in: ApplicationIn,
         options: ApplicationCreateOptions = ApplicationCreateOptions(),
     ) -> ApplicationOut:
+        """Create a new application."""
         return await v1_application_create.request_asyncio(
             client=self._client, json_body=application_in, **options.to_dict()
         )
 
     async def get(self, app_id: str) -> ApplicationOut:
+        """Get an application."""
         return await v1_application_get.request_asyncio(
             client=self._client, app_id=app_id
         )
@@ -78,20 +82,23 @@ class ApplicationAsync(ApiBase):
     async def update(
         self, app_id: str, application_in: ApplicationIn
     ) -> ApplicationOut:
+        """Update an application."""
         return await v1_application_update.request_asyncio(
             client=self._client, app_id=app_id, json_body=application_in
+        )
+
+    async def delete(self, app_id: str) -> ApplicationOut:
+        """Delete an application."""
+        return await v1_application_delete.request_asyncio(
+            client=self._client, app_id=app_id
         )
 
     async def patch(
         self, app_id: str, application_patch: ApplicationPatch
     ) -> ApplicationOut:
+        """Partially update an application."""
         return await v1_application_patch.request_asyncio(
             client=self._client, app_id=app_id, json_body=application_patch
-        )
-
-    async def delete(self, app_id: str) -> None:
-        return await v1_application_delete.request_asyncio(
-            client=self._client, app_id=app_id
         )
 
 
@@ -99,6 +106,7 @@ class Application(ApiBase):
     def list(
         self, options: ApplicationListOptions = ApplicationListOptions()
     ) -> ListResponseApplicationOut:
+        """List of all the organization's applications."""
         return v1_application_list.request_sync(
             client=self._client, **options.to_dict()
         )
@@ -106,13 +114,15 @@ class Application(ApiBase):
     def create(
         self,
         application_in: ApplicationIn,
-        options: ApplicationListOptions = ApplicationListOptions(),
+        options: ApplicationCreateOptions = ApplicationCreateOptions(),
     ) -> ApplicationOut:
+        """Create a new application."""
         return v1_application_create.request_sync(
             client=self._client, json_body=application_in, **options.to_dict()
         )
 
     def get(self, app_id: str) -> ApplicationOut:
+        """Get an application."""
         return v1_application_get.request_sync(client=self._client, app_id=app_id)
 
     def get_or_create(
@@ -128,17 +138,20 @@ class Application(ApiBase):
         )
 
     def update(self, app_id: str, application_in: ApplicationIn) -> ApplicationOut:
+        """Update an application."""
         return v1_application_update.request_sync(
             client=self._client, app_id=app_id, json_body=application_in
         )
 
+    def delete(self, app_id: str) -> ApplicationOut:
+        """Delete an application."""
+        return v1_application_delete.request_sync(client=self._client, app_id=app_id)
+
     def patch(self, app_id: str, application_patch: ApplicationPatch) -> ApplicationOut:
+        """Partially update an application."""
         return v1_application_patch.request_sync(
             client=self._client, app_id=app_id, json_body=application_patch
         )
-
-    def delete(self, app_id: str) -> None:
-        return v1_application_delete.request_sync(client=self._client, app_id=app_id)
 
 
 __all__ = ["ApplicationIn", "ApplicationOut", "ApplicationPatch"]


### PR DESCRIPTION
Most of the code is generated by the codegen, excluding the `get_or_create` code and the `__all__` export