### PR TITLE
ci: Switch python tests to use public release image

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -20,8 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build svix server image
-        run: docker compose build
+      - name: Pull svix server image (and dependencies)
+        run: docker compose pull
         working-directory: ./server
 
       - uses: actions/setup-python@v5

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -50,12 +50,19 @@ if not TOKEN and not SERVER_URL:
             # fallback on v1 otherwise
             return "docker-compose"
 
+    # `pytest-docker` reads this to override the location of the docker-compose.yml file
     @pytest.fixture(scope="session")
     def docker_compose_file():
         return [
             os.path.join(os.path.dirname(__file__), "../../server/docker-compose.yml"),
             os.path.join(os.path.dirname(__file__), "docker-compose.override.yml"),
         ]
+
+    # `pytest-docker` will use this fixture to override the setup command
+    @pytest.fixture(scope="session")
+    def docker_setup():
+        # Don't include the default --build option in the setup
+        return ["up -d"]
 
     @pytest.fixture(scope="session")
     def docker_compose(docker_services):


### PR DESCRIPTION
When running the python tests, the svix server docker image is executed.
Instead of building the server from scratch each time, use the publicly released image.