### PR TITLE
rust: Move query parameter encoding out into request.rs

### DIFF
--- a/rust/src/api/message.rs
+++ b/rust/src/api/message.rs
@@ -1,5 +1,3 @@
-use itertools::Itertools;
-
 use super::PostOptions;
 use crate::{error::Result, models::*, Configuration};
 
@@ -79,10 +77,7 @@ impl<'a> Message<'a> {
             .with_optional_query_param("after", after)
             .with_optional_query_param("with_content", with_content)
             .with_optional_query_param("tag", tag)
-            .with_optional_query_param(
-                "event_types",
-                event_types.map(|types| types.into_iter().format(",")),
-            )
+            .with_optional_query_param("event_types", event_types)
             .execute(self.cfg)
             .await
     }
@@ -166,14 +161,8 @@ impl<'a> Message<'a> {
             .with_path_param("app_id", app_id)
             .with_optional_query_param("limit", limit)
             .with_optional_query_param("iterator", iterator)
-            .with_optional_query_param(
-                "event_types",
-                event_types.map(|types| types.into_iter().format(",")),
-            )
-            .with_optional_query_param(
-                "channels",
-                channels.map(|types| types.into_iter().format(",")),
-            )
+            .with_optional_query_param("event_types", event_types)
+            .with_optional_query_param("channels", channels)
             .with_optional_query_param("after", after)
             .execute(self.cfg)
             .await
@@ -202,14 +191,8 @@ impl<'a> Message<'a> {
         .with_path_param("subscription_id", subscription_id.to_string())
         .with_optional_query_param("limit", limit)
         .with_optional_query_param("iterator", iterator)
-        .with_optional_query_param(
-            "event_types",
-            event_types.map(|types| types.into_iter().format(",")),
-        )
-        .with_optional_query_param(
-            "channels",
-            channels.map(|types| types.into_iter().format(",")),
-        )
+        .with_optional_query_param("event_types", event_types)
+        .with_optional_query_param("channels", channels)
         .with_optional_query_param("after", after)
         .execute(self.cfg)
         .await

--- a/rust/src/api/message_attempt.rs
+++ b/rust/src/api/message_attempt.rs
@@ -1,5 +1,3 @@
-use itertools::Itertools;
-
 use super::PostOptions;
 use crate::{error::Result, models::*, Configuration};
 
@@ -181,10 +179,7 @@ impl<'a> MessageAttempt<'a> {
         .with_optional_query_param("after", after)
         .with_optional_query_param("with_content", with_content)
         .with_optional_query_param("with_msg", with_msg)
-        .with_optional_query_param(
-            "event_types",
-            event_types.map(|types| types.into_iter().format(",")),
-        )
+        .with_optional_query_param("event_types", event_types)
         .execute(self.cfg)
         .await
     }
@@ -232,10 +227,7 @@ impl<'a> MessageAttempt<'a> {
         .with_optional_query_param("before", before)
         .with_optional_query_param("after", after)
         .with_optional_query_param("with_content", with_content)
-        .with_optional_query_param(
-            "event_types",
-            event_types.map(|types| types.into_iter().format(",")),
-        )
+        .with_optional_query_param("event_types", event_types)
         .execute(self.cfg)
         .await
     }
@@ -283,10 +275,7 @@ impl<'a> MessageAttempt<'a> {
         .with_optional_query_param("before", before)
         .with_optional_query_param("after", after)
         .with_optional_query_param("with_content", with_content)
-        .with_optional_query_param(
-            "event_types",
-            event_types.map(|types| types.into_iter().format(",")),
-        )
+        .with_optional_query_param("event_types", event_types)
         .execute(self.cfg)
         .await
     }
@@ -324,10 +313,7 @@ impl<'a> MessageAttempt<'a> {
         .with_optional_query_param("status", status)
         .with_optional_query_param("before", before)
         .with_optional_query_param("after", after)
-        .with_optional_query_param(
-            "event_types",
-            event_types.map(|types| types.into_iter().format(",")),
-        )
+        .with_optional_query_param("event_types", event_types)
         .with_path_param("app_id", app_id.to_string())
         .with_path_param("msg_id", msg_id.to_string())
         .with_path_param("endpoint_id", endpoint_id.to_string())


### PR DESCRIPTION
Get rid of one more discrepancy between generated code and the working status quo.