### PR TITLE
js: Pull in some codegen changes

### DIFF
--- a/javascript/src/api/authentication.ts
+++ b/javascript/src/api/authentication.ts
@@ -1,4 +1,4 @@
-// this file is @generated (with minor manual changes)
+// this file is @generated
 import {
   Configuration,
   AuthenticationApi,
@@ -29,16 +29,6 @@ export class Authentication {
     });
   }
 
-  public dashboardAccess(
-    appId: string,
-    options?: PostOptions
-  ): Promise<DashboardAccessOut> {
-    return this.api.v1AuthenticationDashboardAccess({
-      appId,
-      ...options,
-    });
-  }
-
   /** Expire all of the tokens associated with a specific application. */
   public expireAll(
     appId: string,
@@ -48,6 +38,23 @@ export class Authentication {
     return this.api.v1AuthenticationExpireAll({
       appId,
       applicationTokenExpireIn,
+      ...options,
+    });
+  }
+
+  /**
+   * DEPRECATED: Please use `app-portal-access` instead.
+   *
+   * Use this function to get magic links (and authentication codes) for connecting your users to the Consumer Application Portal.
+   *
+   * @deprecated
+   */
+  public dashboardAccess(
+    appId: string,
+    options?: PostOptions
+  ): Promise<DashboardAccessOut> {
+    return this.api.v1AuthenticationDashboardAccess({
+      appId,
       ...options,
     });
   }

--- a/javascript/src/api/background_task.ts
+++ b/javascript/src/api/background_task.ts
@@ -33,7 +33,7 @@ export class BackgroundTask {
   public list(
     options?: BackgroundTaskListOptions
   ): Promise<ListResponseBackgroundTaskOut> {
-    return this.api.v1BackgroundTaskList({
+    return this.api.listBackgroundTasks({
       ...options,
       iterator: options?.iterator ?? undefined,
     });
@@ -52,7 +52,7 @@ export class BackgroundTask {
 
   /** Get a background task by ID. */
   public get(taskId: string): Promise<BackgroundTaskOut> {
-    return this.api.v1BackgroundTaskGet({
+    return this.api.getBackgroundTask({
       taskId,
     });
   }

--- a/javascript/src/api/background_task.ts
+++ b/javascript/src/api/background_task.ts
@@ -1,17 +1,25 @@
+// this file is @generated
 import {
   Configuration,
+  BackgroundTasksApi,
+  BackgroundTaskOut,
   BackgroundTaskStatus,
   BackgroundTaskType,
-  BackgroundTaskOut,
   ListResponseBackgroundTaskOut,
-  BackgroundTasksApi,
+  Ordering,
 } from "../openapi";
 
 export interface BackgroundTaskListOptions {
-  iterator?: string | null;
-  limit?: number;
+  /** Filter the response based on the status. */
   status?: BackgroundTaskStatus;
+  /** Filter the response based on the type. */
   task?: BackgroundTaskType;
+  /** Limit the number of returned items */
+  limit?: number;
+  /** The iterator returned from a prior invocation */
+  iterator?: string | null;
+  /** The sorting order of the returned items */
+  order?: Ordering;
 }
 
 export class BackgroundTask {
@@ -21,15 +29,30 @@ export class BackgroundTask {
     this.api = new BackgroundTasksApi(config);
   }
 
+  /** List background tasks executed in the past 90 days. */
+  public list(
+    options?: BackgroundTaskListOptions
+  ): Promise<ListResponseBackgroundTaskOut> {
+    return this.api.v1BackgroundTaskList({
+      ...options,
+      iterator: options?.iterator ?? undefined,
+    });
+  }
+
+  /**
+   * List background tasks executed in the past 90 days.
+   *
+   * @deprecated Use list instead.
+   * */
   public listByEndpoint(
     options?: BackgroundTaskListOptions
   ): Promise<ListResponseBackgroundTaskOut> {
-    const iterator = options?.iterator ?? undefined;
-    return this.api.listBackgroundTasks({ ...options, iterator });
+    return this.list(options);
   }
 
+  /** Get a background task by ID. */
   public get(taskId: string): Promise<BackgroundTaskOut> {
-    return this.api.getBackgroundTask({
+    return this.api.v1BackgroundTaskGet({
       taskId,
     });
   }

--- a/javascript/src/api/event_type.ts
+++ b/javascript/src/api/event_type.ts
@@ -1,4 +1,4 @@
-// this file is @generated (with minor manual changes)
+// this file is @generated
 import {
   Configuration,
   EventTypeApi,
@@ -24,6 +24,11 @@ export interface EventTypeListOptions {
   includeArchived?: boolean;
   /** When `true` the full item (including the schema) is included in the response. */
   withContent?: boolean;
+}
+
+export interface EventTypeDeleteOptions {
+  /** By default event types are archived when "deleted". Passing this to `true` deletes them entirely. */
+  expunge?: boolean;
 }
 
 export class EventType {
@@ -98,9 +103,10 @@ export class EventType {
    * An event type can be unarchived with the
    * [create operation](#operation/create_event_type_api_v1_event_type__post).
    */
-  public delete(eventTypeName: string): Promise<void> {
+  public delete(eventTypeName: string, options?: EventTypeDeleteOptions): Promise<void> {
     return this.api.v1EventTypeDelete({
       eventTypeName,
+      ...options,
     });
   }
 

--- a/javascript/src/api/integration.ts
+++ b/javascript/src/api/integration.ts
@@ -1,4 +1,4 @@
-// this file is @generated (with minor manual changes)
+// this file is @generated
 import {
   Configuration,
   IntegrationApi,
@@ -81,10 +81,15 @@ export class Integration {
     });
   }
 
+  /**
+   * Get an integration's key.
+   *
+   * @deprecated
+   */
   public getKey(appId: string, integId: string): Promise<IntegrationKeyOut> {
     return this.api.v1IntegrationGetKey({
-      integId,
       appId,
+      integId,
     });
   }
 

--- a/javascript/src/api/op_webhook_endpoint.ts
+++ b/javascript/src/api/op_webhook_endpoint.ts
@@ -1,22 +1,23 @@
+// this file is @generated
 import {
   Configuration,
-  Ordering,
   WebhookEndpointApi,
+  ListResponseOperationalWebhookEndpointOut,
   OperationalWebhookEndpointIn,
   OperationalWebhookEndpointOut,
   OperationalWebhookEndpointSecretIn,
   OperationalWebhookEndpointSecretOut,
   OperationalWebhookEndpointUpdate,
-  ListResponseOperationalWebhookEndpointOut,
+  Ordering,
 } from "../openapi";
 import { PostOptions } from "../util";
 
 export interface OperationalWebhookEndpointListOptions {
-  /// Limit the number of returned items
+  /** Limit the number of returned items */
   limit?: number;
-  /// The iterator returned from a prior invocation
+  /** The iterator returned from a prior invocation */
   iterator?: string | null;
-  /// The sorting order of the returned items
+  /** The sorting order of the returned items */
   order?: Ordering;
 }
 
@@ -27,53 +28,77 @@ export class OperationalWebhookEndpoint {
     this.api = new WebhookEndpointApi(config);
   }
 
+  /** List operational webhook endpoints. */
   public list(
     options?: OperationalWebhookEndpointListOptions
   ): Promise<ListResponseOperationalWebhookEndpointOut> {
-    const iterator = options?.iterator ?? undefined;
-    return this.api.listOperationalWebhookEndpoints({ ...options, iterator });
+    return this.api.v1OperationalWebhookEndpointList({
+      ...options,
+      iterator: options?.iterator ?? undefined,
+    });
   }
 
+  /** Create an operational webhook endpoint. */
   public create(
-    endpointIn: OperationalWebhookEndpointIn,
+    operationalWebhookEndpointIn: OperationalWebhookEndpointIn,
     options?: PostOptions
   ): Promise<OperationalWebhookEndpointOut> {
-    return this.api.createOperationalWebhookEndpoint({
-      operationalWebhookEndpointIn: endpointIn,
+    return this.api.v1OperationalWebhookEndpointCreate({
+      operationalWebhookEndpointIn,
       ...options,
     });
   }
 
+  /** Get an operational webhook endpoint. */
   public get(endpointId: string): Promise<OperationalWebhookEndpointOut> {
-    return this.api.getOperationalWebhookEndpoint({ endpointId });
-  }
-
-  public update(
-    endpointId: string,
-    endpointUpdate: OperationalWebhookEndpointUpdate
-  ): Promise<OperationalWebhookEndpointOut> {
-    return this.api.updateOperationalWebhookEndpoint({
+    return this.api.v1OperationalWebhookEndpointGet({
       endpointId,
-      operationalWebhookEndpointUpdate: endpointUpdate,
     });
   }
 
+  /** Update an operational webhook endpoint. */
+  public update(
+    endpointId: string,
+    operationalWebhookEndpointUpdate: OperationalWebhookEndpointUpdate
+  ): Promise<OperationalWebhookEndpointOut> {
+    return this.api.v1OperationalWebhookEndpointUpdate({
+      endpointId,
+      operationalWebhookEndpointUpdate,
+    });
+  }
+
+  /** Delete an operational webhook endpoint. */
   public delete(endpointId: string): Promise<void> {
-    return this.api.deleteOperationalWebhookEndpoint({ endpointId });
+    return this.api.v1OperationalWebhookEndpointDelete({
+      endpointId,
+    });
   }
 
+  /**
+   * Get an operational webhook endpoint's signing secret.
+   *
+   * This is used to verify the authenticity of the webhook.
+   * For more information please refer to [the consuming webhooks docs](https://docs.svix.com/consuming-webhooks/).
+   */
   public getSecret(endpointId: string): Promise<OperationalWebhookEndpointSecretOut> {
-    return this.api.getOperationalWebhookEndpointSecret({ endpointId });
+    return this.api.getOperationalWebhookEndpointSecret({
+      endpointId,
+    });
   }
 
+  /**
+   * Rotates an operational webhook endpoint's signing secret.
+   *
+   * The previous secret will remain valid for the next 24 hours.
+   */
   public rotateSecret(
     endpointId: string,
-    endpointSecretIn: OperationalWebhookEndpointSecretIn,
+    operationalWebhookEndpointSecretIn: OperationalWebhookEndpointSecretIn,
     options?: PostOptions
   ): Promise<void> {
     return this.api.rotateOperationalWebhookEndpointSecret({
       endpointId,
-      operationalWebhookEndpointSecretIn: endpointSecretIn,
+      operationalWebhookEndpointSecretIn,
       ...options,
     });
   }

--- a/javascript/src/api/operational_webhook_endpoint.ts
+++ b/javascript/src/api/operational_webhook_endpoint.ts
@@ -32,7 +32,7 @@ export class OperationalWebhookEndpoint {
   public list(
     options?: OperationalWebhookEndpointListOptions
   ): Promise<ListResponseOperationalWebhookEndpointOut> {
-    return this.api.v1OperationalWebhookEndpointList({
+    return this.api.listOperationalWebhookEndpoints({
       ...options,
       iterator: options?.iterator ?? undefined,
     });
@@ -43,7 +43,7 @@ export class OperationalWebhookEndpoint {
     operationalWebhookEndpointIn: OperationalWebhookEndpointIn,
     options?: PostOptions
   ): Promise<OperationalWebhookEndpointOut> {
-    return this.api.v1OperationalWebhookEndpointCreate({
+    return this.api.createOperationalWebhookEndpoint({
       operationalWebhookEndpointIn,
       ...options,
     });
@@ -51,7 +51,7 @@ export class OperationalWebhookEndpoint {
 
   /** Get an operational webhook endpoint. */
   public get(endpointId: string): Promise<OperationalWebhookEndpointOut> {
-    return this.api.v1OperationalWebhookEndpointGet({
+    return this.api.getOperationalWebhookEndpoint({
       endpointId,
     });
   }
@@ -61,7 +61,7 @@ export class OperationalWebhookEndpoint {
     endpointId: string,
     operationalWebhookEndpointUpdate: OperationalWebhookEndpointUpdate
   ): Promise<OperationalWebhookEndpointOut> {
-    return this.api.v1OperationalWebhookEndpointUpdate({
+    return this.api.updateOperationalWebhookEndpoint({
       endpointId,
       operationalWebhookEndpointUpdate,
     });
@@ -69,7 +69,7 @@ export class OperationalWebhookEndpoint {
 
   /** Delete an operational webhook endpoint. */
   public delete(endpointId: string): Promise<void> {
-    return this.api.v1OperationalWebhookEndpointDelete({
+    return this.api.deleteOperationalWebhookEndpoint({
       endpointId,
     });
   }

--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -15,7 +15,7 @@ import { EventType } from "./api/event_type";
 import { Integration } from "./api/integration";
 import { Message } from "./api/message";
 import { MessageAttempt } from "./api/message_attempt";
-import { OperationalWebhookEndpoint } from "./api/op_webhook_endpoint";
+import { OperationalWebhookEndpoint } from "./api/operational_webhook_endpoint";
 import { Statistics } from "./api/statistics";
 
 export * from "./openapi/models/all";
@@ -34,7 +34,7 @@ export {
   MessageAttemptListByEndpointOptions,
   MessageAttemptListOptions,
 } from "./api/message_attempt";
-export { OperationalWebhookEndpointListOptions } from "./api/op_webhook_endpoint";
+export { OperationalWebhookEndpointListOptions } from "./api/operational_webhook_endpoint";
 
 const VERSION = "1.56.0";
 


### PR DESCRIPTION
I don't like the idea of dropping `.codegen.json` files in every subdirectory that contains generated sources, so I'll drop the metadata here instead (and once we have a script for regenerating all the libs + CLI we can have it write a single `.codegen.json`):

```json
{
  "file-generated-at": "2025-01-27T15:49:46.172909034+00:00",
  "git-rev": "bde54facee73c3ae9a4f21159f0f5d08065e91d7",
  "openapi-codegen-version": "0.1.0",
  "openapi.json-sha256": "9fa16f8eb28f617b8495cafc9bd529626145df7af01e5c09acdc2b98e39a4725"
}
```