### PR TITLE
kotlin: Pull in some changes from codegen

### DIFF
--- a/kotlin/lib/src/main/kotlin/Authentication.kt
+++ b/kotlin/lib/src/main/kotlin/Authentication.kt
@@ -1,4 +1,4 @@
-// this file is @generated (with minor manual changes)
+// this file is @generated
 package com.svix.kotlin
 
 import com.svix.kotlin.exceptions.ApiException
@@ -38,17 +38,6 @@ class Authentication internal constructor(token: String, options: SvixOptions) {
         }
     }
 
-    suspend fun dashboardAccess(
-        appId: String,
-        options: PostOptions = PostOptions(),
-    ): DashboardAccessOut {
-        try {
-            return api.v1AuthenticationDashboardAccess(appId, options.idempotencyKey)
-        } catch (e: Exception) {
-            throw ApiException.wrap(e)
-        }
-    }
-
     /** Expire all of the tokens associated with a specific application. */
     suspend fun expireAll(
         appId: String,
@@ -57,6 +46,26 @@ class Authentication internal constructor(token: String, options: SvixOptions) {
     ) {
         try {
             api.v1AuthenticationExpireAll(appId, applicationTokenExpireIn, options.idempotencyKey)
+        } catch (e: Exception) {
+            throw ApiException.wrap(e)
+        }
+    }
+
+    /**
+     * DEPRECATED: Please use `app-portal-access` instead.
+     *
+     * Use this function to get magic links (and authentication codes) for connecting your users to
+     * the Consumer Application Portal.
+     *
+     * @deprecated
+     */
+    @Deprecated(message = "Use appPortalAccess instead.")
+    suspend fun dashboardAccess(
+        appId: String,
+        options: PostOptions = PostOptions(),
+    ): DashboardAccessOut {
+        try {
+            return api.v1AuthenticationDashboardAccess(appId, options.idempotencyKey)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }

--- a/kotlin/lib/src/main/kotlin/BackgroundTask.kt
+++ b/kotlin/lib/src/main/kotlin/BackgroundTask.kt
@@ -1,3 +1,4 @@
+// this file is @generated
 package com.svix.kotlin
 
 import com.svix.kotlin.exceptions.ApiException
@@ -9,21 +10,26 @@ import com.svix.kotlin.models.ListResponseBackgroundTaskOut
 import com.svix.kotlin.models.Ordering
 
 class BackgroundTaskListOptions {
-    var iterator: String? = null
-    var limit: Int? = null
     var status: BackgroundTaskStatus? = null
     var task: BackgroundTaskType? = null
+    var limit: Int? = null
+    var iterator: String? = null
     var order: Ordering? = null
 
-    fun order(order: Ordering) = apply { this.order = order }
-
+    /** Filter the response based on the status. */
     fun status(status: BackgroundTaskStatus) = apply { this.status = status }
 
+    /** Filter the response based on the type. */
     fun task(task: BackgroundTaskType) = apply { this.task = task }
 
+    /** Limit the number of returned items */
+    fun limit(limit: Int) = apply { this.limit = limit }
+
+    /** The iterator returned from a prior invocation */
     fun iterator(iterator: String) = apply { this.iterator = iterator }
 
-    fun limit(limit: Int) = apply { this.limit = limit }
+    /** The sorting order of the returned items */
+    fun order(order: Ordering) = apply { this.order = order }
 }
 
 class BackgroundTask internal constructor(token: String, options: SvixOptions) {
@@ -36,6 +42,7 @@ class BackgroundTask internal constructor(token: String, options: SvixOptions) {
         options.numRetries?.let { api.numRetries = it }
     }
 
+    /** List background tasks executed in the past 90 days. */
     suspend fun list(
         options: BackgroundTaskListOptions = BackgroundTaskListOptions()
     ): ListResponseBackgroundTaskOut {
@@ -52,6 +59,7 @@ class BackgroundTask internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /** Get a background task by ID. */
     suspend fun get(taskId: String): BackgroundTaskOut {
         try {
             return api.v1BackgroundTaskGet(taskId)

--- a/kotlin/lib/src/main/kotlin/EventType.kt
+++ b/kotlin/lib/src/main/kotlin/EventType.kt
@@ -38,6 +38,16 @@ class EventTypeListOptions {
     fun withContent(withContent: Boolean) = apply { this.withContent = withContent }
 }
 
+class EventTypeDeleteOptions {
+    var expunge: Boolean? = null
+
+    /**
+     * By default event types are archived when "deleted". Passing this to `true` deletes them
+     * entirely.
+     */
+    fun expunge(expunge: Boolean) = apply { this.expunge = expunge }
+}
+
 class EventType internal constructor(token: String, options: SvixOptions) {
     private val api = EventTypeApi(options.serverUrl)
 
@@ -127,9 +137,12 @@ class EventType internal constructor(token: String, options: SvixOptions) {
      * An event type can be unarchived with the
      * [create operation](#operation/create_event_type_api_v1_event_type__post).
      */
-    suspend fun delete(eventTypeName: String) {
+    suspend fun delete(
+        eventTypeName: String,
+        options: EventTypeDeleteOptions = EventTypeDeleteOptions(),
+    ) {
         try {
-            api.v1EventTypeDelete(eventTypeName, null)
+            api.v1EventTypeDelete(eventTypeName, options.expunge)
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }

--- a/kotlin/lib/src/main/kotlin/Integration.kt
+++ b/kotlin/lib/src/main/kotlin/Integration.kt
@@ -1,4 +1,4 @@
-// this file is @generated (with minor manual changes)
+// this file is @generated
 package com.svix.kotlin
 
 import com.svix.kotlin.exceptions.ApiException
@@ -91,6 +91,12 @@ class Integration internal constructor(token: String, options: SvixOptions) {
         }
     }
 
+    /**
+     * Get an integration's key.
+     *
+     * @deprecated
+     */
+    @Deprecated(message = "This endpoint is deprecated.")
     suspend fun getKey(appId: String, integId: String): IntegrationKeyOut {
         try {
             return api.v1IntegrationGetKey(appId, integId)

--- a/kotlin/lib/src/main/kotlin/OperationalWebhookEndpoint.kt
+++ b/kotlin/lib/src/main/kotlin/OperationalWebhookEndpoint.kt
@@ -1,8 +1,11 @@
+// this file is @generated
 package com.svix.kotlin
 
 import com.svix.kotlin.exceptions.ApiException
 import com.svix.kotlin.internal.apis.WebhookEndpointApi as OperationalWebhookEndpointApi
 import com.svix.kotlin.models.ListResponseOperationalWebhookEndpointOut
+import com.svix.kotlin.models.OperationalWebhookEndpointHeadersIn
+import com.svix.kotlin.models.OperationalWebhookEndpointHeadersOut
 import com.svix.kotlin.models.OperationalWebhookEndpointIn
 import com.svix.kotlin.models.OperationalWebhookEndpointOut
 import com.svix.kotlin.models.OperationalWebhookEndpointSecretIn
@@ -26,7 +29,7 @@ class OperationalWebhookEndpointListOptions {
 }
 
 class OperationalWebhookEndpoint internal constructor(token: String, options: SvixOptions) {
-    val api = OperationalWebhookEndpointApi(options.serverUrl)
+    private val api = OperationalWebhookEndpointApi(options.serverUrl)
 
     init {
         api.accessToken = token
@@ -35,6 +38,7 @@ class OperationalWebhookEndpoint internal constructor(token: String, options: Sv
         options.numRetries?.let { api.numRetries = it }
     }
 
+    /** List operational webhook endpoints. */
     suspend fun list(
         options: OperationalWebhookEndpointListOptions = OperationalWebhookEndpointListOptions()
     ): ListResponseOperationalWebhookEndpointOut {
@@ -49,17 +53,22 @@ class OperationalWebhookEndpoint internal constructor(token: String, options: Sv
         }
     }
 
+    /** Create an operational webhook endpoint. */
     suspend fun create(
-        endpointIn: OperationalWebhookEndpointIn,
+        operationalWebhookEndpointIn: OperationalWebhookEndpointIn,
         options: PostOptions = PostOptions(),
     ): OperationalWebhookEndpointOut {
         try {
-            return api.v1OperationalWebhookEndpointCreate(endpointIn, options.idempotencyKey)
+            return api.v1OperationalWebhookEndpointCreate(
+                operationalWebhookEndpointIn,
+                options.idempotencyKey,
+            )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
+    /** Get an operational webhook endpoint. */
     suspend fun get(endpointId: String): OperationalWebhookEndpointOut {
         try {
             return api.v1OperationalWebhookEndpointGet(endpointId)
@@ -68,17 +77,22 @@ class OperationalWebhookEndpoint internal constructor(token: String, options: Sv
         }
     }
 
+    /** Update an operational webhook endpoint. */
     suspend fun update(
         endpointId: String,
-        endpointUpdate: OperationalWebhookEndpointUpdate,
+        operationalWebhookEndpointUpdate: OperationalWebhookEndpointUpdate,
     ): OperationalWebhookEndpointOut {
         try {
-            return api.v1OperationalWebhookEndpointUpdate(endpointId, endpointUpdate)
+            return api.v1OperationalWebhookEndpointUpdate(
+                endpointId,
+                operationalWebhookEndpointUpdate,
+            )
         } catch (e: Exception) {
             throw ApiException.wrap(e)
         }
     }
 
+    /** Delete an operational webhook endpoint. */
     suspend fun delete(endpointId: String) {
         try {
             api.v1OperationalWebhookEndpointDelete(endpointId)
@@ -87,6 +101,36 @@ class OperationalWebhookEndpoint internal constructor(token: String, options: Sv
         }
     }
 
+    /** Get the additional headers to be sent with the operational webhook. */
+    suspend fun getHeaders(endpointId: String): OperationalWebhookEndpointHeadersOut {
+        try {
+            return api.v1OperationalWebhookEndpointGetHeaders(endpointId)
+        } catch (e: Exception) {
+            throw ApiException.wrap(e)
+        }
+    }
+
+    /** Set the additional headers to be sent with the operational webhook. */
+    suspend fun updateHeaders(
+        endpointId: String,
+        operationalWebhookEndpointHeadersIn: OperationalWebhookEndpointHeadersIn,
+    ) {
+        try {
+            api.v1OperationalWebhookEndpointUpdateHeaders(
+                endpointId,
+                operationalWebhookEndpointHeadersIn,
+            )
+        } catch (e: Exception) {
+            throw ApiException.wrap(e)
+        }
+    }
+
+    /**
+     * Get an operational webhook endpoint's signing secret.
+     *
+     * This is used to verify the authenticity of the webhook. For more information please refer to
+     * [the consuming webhooks docs](https://docs.svix.com/consuming-webhooks/).
+     */
     suspend fun getSecret(endpointId: String): OperationalWebhookEndpointSecretOut {
         try {
             return api.v1OperationalWebhookEndpointGetSecret(endpointId)
@@ -95,15 +139,20 @@ class OperationalWebhookEndpoint internal constructor(token: String, options: Sv
         }
     }
 
+    /**
+     * Rotates an operational webhook endpoint's signing secret.
+     *
+     * The previous secret will remain valid for the next 24 hours.
+     */
     suspend fun rotateSecret(
         endpointId: String,
-        endpointSecretRotateIn: OperationalWebhookEndpointSecretIn,
+        operationalWebhookEndpointSecretIn: OperationalWebhookEndpointSecretIn,
         options: PostOptions = PostOptions(),
     ) {
         try {
             api.v1OperationalWebhookEndpointRotateSecret(
                 endpointId,
-                endpointSecretRotateIn,
+                operationalWebhookEndpointSecretIn,
                 options.idempotencyKey,
             )
         } catch (e: Exception) {


### PR DESCRIPTION
A bunch of manual changes were unfortunately still required, in particular because Kotlin has some path parameters backwards, which would be a rather nasty breaking change if we fixed it.

```json
{
  "file-generated-at": "2025-01-30T13:42:23.808674168+00:00",
  "git-rev": "de9e055e589b036eb3ec562c96ca86c83dc91b74",
  "openapi-codegen-version": "0.1.0",
  "openapi.json-sha256": "316e0fad86746b428a23d871e6148b12e35ac955a9fc57945e2b29a4a43da7c1"
}
```