### PR TITLE
python: Refactor models to use `alias_generator`

### DIFF
--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -1,3 +1,2 @@
 [mypy]
 strict = True
-plugins = pydantic.mypy

--- a/python/svix/models/aggregate_event_types_out.py
+++ b/python/svix/models/aggregate_event_types_out.py
@@ -2,10 +2,10 @@
 
 from .background_task_status import BackgroundTaskStatus
 from .background_task_type import BackgroundTaskType
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class AggregateEventTypesOut(SvixBaseModel):
+class AggregateEventTypesOut(BaseModel):
     id: str
 
     status: BackgroundTaskStatus

--- a/python/svix/models/app_portal_access_in.py
+++ b/python/svix/models/app_portal_access_in.py
@@ -1,13 +1,11 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
 from .application_in import ApplicationIn
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class AppPortalAccessIn(SvixBaseModel):
+class AppPortalAccessIn(BaseModel):
     application: t.Optional[ApplicationIn] = None
     """Optionally creates a new application while generating the access link.
 
@@ -18,8 +16,8 @@ class AppPortalAccessIn(SvixBaseModel):
 
     Valid values are between 1 hour and 7 days. The default is 7 days."""
 
-    feature_flags: t.Optional[t.List[str]] = Field(default=None, alias="featureFlags")
+    feature_flags: t.Optional[t.List[str]] = None
     """The set of feature flags the created token will have access to."""
 
-    read_only: t.Optional[bool] = Field(default=None, alias="readOnly")
+    read_only: t.Optional[bool] = None
     """Whether the app portal should be in read-only mode."""

--- a/python/svix/models/app_portal_access_out.py
+++ b/python/svix/models/app_portal_access_out.py
@@ -1,9 +1,9 @@
 # this file is @generated
 
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class AppPortalAccessOut(SvixBaseModel):
+class AppPortalAccessOut(BaseModel):
     token: str
 
     url: str

--- a/python/svix/models/app_usage_stats_in.py
+++ b/python/svix/models/app_usage_stats_in.py
@@ -2,13 +2,11 @@
 import typing as t
 from datetime import datetime
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class AppUsageStatsIn(SvixBaseModel):
-    app_ids: t.Optional[t.List[str]] = Field(default=None, alias="appIds")
+class AppUsageStatsIn(BaseModel):
+    app_ids: t.Optional[t.List[str]] = None
     """Specific app IDs or UIDs to aggregate stats for.
 
     Note that if none of the given IDs or UIDs are resolved, a 422 response will be given."""

--- a/python/svix/models/app_usage_stats_out.py
+++ b/python/svix/models/app_usage_stats_out.py
@@ -1,21 +1,19 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
 from .background_task_status import BackgroundTaskStatus
 from .background_task_type import BackgroundTaskType
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class AppUsageStatsOut(SvixBaseModel):
+class AppUsageStatsOut(BaseModel):
     id: str
 
     status: BackgroundTaskStatus
 
     task: BackgroundTaskType
 
-    unresolved_app_ids: t.List[str] = Field(alias="unresolvedAppIds")
+    unresolved_app_ids: t.List[str]
     """Any app IDs or UIDs received in the request that weren't found.
 
     Stats will be produced for all the others."""

--- a/python/svix/models/application_in.py
+++ b/python/svix/models/application_in.py
@@ -1,17 +1,15 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class ApplicationIn(SvixBaseModel):
+class ApplicationIn(BaseModel):
     metadata: t.Optional[t.Dict[str, str]] = None
 
     name: str
 
-    rate_limit: t.Optional[int] = Field(default=None, alias="rateLimit")
+    rate_limit: t.Optional[int] = None
 
     uid: t.Optional[str] = None
     """Optional unique identifier for the application."""

--- a/python/svix/models/application_out.py
+++ b/python/svix/models/application_out.py
@@ -2,13 +2,11 @@
 import typing as t
 from datetime import datetime
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class ApplicationOut(SvixBaseModel):
-    created_at: datetime = Field(alias="createdAt")
+class ApplicationOut(BaseModel):
+    created_at: datetime
 
     id: str
     """The app's ID"""
@@ -17,9 +15,9 @@ class ApplicationOut(SvixBaseModel):
 
     name: str
 
-    rate_limit: t.Optional[int] = Field(default=None, alias="rateLimit")
+    rate_limit: t.Optional[int] = None
 
     uid: t.Optional[str] = None
     """The app's UID"""
 
-    updated_at: datetime = Field(alias="updatedAt")
+    updated_at: datetime

--- a/python/svix/models/application_patch.py
+++ b/python/svix/models/application_patch.py
@@ -1,17 +1,15 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class ApplicationPatch(SvixBaseModel):
+class ApplicationPatch(BaseModel):
     metadata: t.Optional[t.Dict[str, str]] = None
 
     name: t.Optional[str] = None
 
-    rate_limit: t.Optional[int] = Field(default=None, alias="rateLimit")
+    rate_limit: t.Optional[int] = None
 
     uid: t.Optional[str] = None
     """The app's UID"""

--- a/python/svix/models/application_token_expire_in.py
+++ b/python/svix/models/application_token_expire_in.py
@@ -1,9 +1,9 @@
 # this file is @generated
 import typing as t
 
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class ApplicationTokenExpireIn(SvixBaseModel):
+class ApplicationTokenExpireIn(BaseModel):
     expiry: t.Optional[int] = None
     """How many seconds until the old key is expired."""

--- a/python/svix/models/background_task_out.py
+++ b/python/svix/models/background_task_out.py
@@ -1,13 +1,13 @@
 # this file is @generated
+import typing as t
 
-from .background_task_data import BackgroundTaskData
 from .background_task_status import BackgroundTaskStatus
 from .background_task_type import BackgroundTaskType
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class BackgroundTaskOut(SvixBaseModel):
-    data: BackgroundTaskData
+class BackgroundTaskOut(BaseModel):
+    data: t.Dict[str, t.Any]
 
     id: str
 

--- a/python/svix/models/common.py
+++ b/python/svix/models/common.py
@@ -5,5 +5,6 @@ from pydantic.alias_generators import to_camel
 class BaseModel(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(
         alias_generator=to_camel,
+        populate_by_name=True,
         json_encoders={set: lambda v: list(v)},
     )

--- a/python/svix/models/common.py
+++ b/python/svix/models/common.py
@@ -1,8 +1,9 @@
-from pydantic import BaseModel, ConfigDict
+import pydantic
+from pydantic.alias_generators import to_camel
 
 
-class SvixBaseModel(BaseModel):
-    model_config = ConfigDict(
-        populate_by_name=True,
+class BaseModel(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(
+        alias_generator=to_camel,
         json_encoders={set: lambda v: list(v)},
     )

--- a/python/svix/models/dashboard_access_out.py
+++ b/python/svix/models/dashboard_access_out.py
@@ -1,9 +1,9 @@
 # this file is @generated
 
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class DashboardAccessOut(SvixBaseModel):
+class DashboardAccessOut(BaseModel):
     token: str
 
     url: str

--- a/python/svix/models/endpoint_headers_in.py
+++ b/python/svix/models/endpoint_headers_in.py
@@ -1,8 +1,8 @@
 # this file is @generated
 import typing as t
 
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class EndpointHeadersIn(SvixBaseModel):
+class EndpointHeadersIn(BaseModel):
     headers: t.Dict[str, str]

--- a/python/svix/models/endpoint_headers_out.py
+++ b/python/svix/models/endpoint_headers_out.py
@@ -1,10 +1,10 @@
 # this file is @generated
 import typing as t
 
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class EndpointHeadersOut(SvixBaseModel):
+class EndpointHeadersOut(BaseModel):
     """The value of the headers is returned in the `headers` field.
 
     Sensitive headers that have been redacted are returned in the sensitive field."""

--- a/python/svix/models/endpoint_headers_patch_in.py
+++ b/python/svix/models/endpoint_headers_patch_in.py
@@ -1,8 +1,8 @@
 # this file is @generated
 import typing as t
 
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class EndpointHeadersPatchIn(SvixBaseModel):
+class EndpointHeadersPatchIn(BaseModel):
     headers: t.Dict[str, str]

--- a/python/svix/models/endpoint_in.py
+++ b/python/svix/models/endpoint_in.py
@@ -1,12 +1,10 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class EndpointIn(SvixBaseModel):
+class EndpointIn(BaseModel):
     channels: t.Optional[t.List[str]] = None
     """List of message channels this endpoint listens to (omit for all)."""
 
@@ -14,11 +12,11 @@ class EndpointIn(SvixBaseModel):
 
     disabled: t.Optional[bool] = None
 
-    filter_types: t.Optional[t.List[str]] = Field(default=None, alias="filterTypes")
+    filter_types: t.Optional[t.List[str]] = None
 
     metadata: t.Optional[t.Dict[str, str]] = None
 
-    rate_limit: t.Optional[int] = Field(default=None, alias="rateLimit")
+    rate_limit: t.Optional[int] = None
 
     secret: t.Optional[str] = None
     """The endpoint's verification secret.

--- a/python/svix/models/endpoint_message_out.py
+++ b/python/svix/models/endpoint_message_out.py
@@ -2,28 +2,26 @@
 import typing as t
 from datetime import datetime
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 from .message_status import MessageStatus
 
 
-class EndpointMessageOut(SvixBaseModel):
+class EndpointMessageOut(BaseModel):
     """A model containing information on a given message plus additional fields on the last attempt for that message."""
 
     channels: t.Optional[t.List[str]] = None
     """List of free-form identifiers that endpoints can filter by"""
 
-    event_id: t.Optional[str] = Field(default=None, alias="eventId")
+    event_id: t.Optional[str] = None
     """Optional unique identifier for the message"""
 
-    event_type: str = Field(alias="eventType")
+    event_type: str
     """The event type's name"""
 
     id: str
     """The msg's ID"""
 
-    next_attempt: t.Optional[datetime] = Field(default=None, alias="nextAttempt")
+    next_attempt: t.Optional[datetime] = None
 
     payload: t.Dict[str, t.Any]
 

--- a/python/svix/models/endpoint_out.py
+++ b/python/svix/models/endpoint_out.py
@@ -2,35 +2,33 @@
 import typing as t
 from datetime import datetime
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class EndpointOut(SvixBaseModel):
+class EndpointOut(BaseModel):
     channels: t.Optional[t.List[str]] = None
     """List of message channels this endpoint listens to (omit for all)."""
 
-    created_at: datetime = Field(alias="createdAt")
+    created_at: datetime
 
     description: str
     """An example endpoint name."""
 
     disabled: t.Optional[bool] = None
 
-    filter_types: t.Optional[t.List[str]] = Field(default=None, alias="filterTypes")
+    filter_types: t.Optional[t.List[str]] = None
 
     id: str
     """The ep's ID"""
 
     metadata: t.Dict[str, str]
 
-    rate_limit: t.Optional[int] = Field(default=None, alias="rateLimit")
+    rate_limit: t.Optional[int] = None
 
     uid: t.Optional[str] = None
     """Optional unique identifier for the endpoint."""
 
-    updated_at: datetime = Field(alias="updatedAt")
+    updated_at: datetime
 
     url: str
 

--- a/python/svix/models/endpoint_patch.py
+++ b/python/svix/models/endpoint_patch.py
@@ -1,23 +1,21 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class EndpointPatch(SvixBaseModel):
+class EndpointPatch(BaseModel):
     channels: t.Optional[t.List[str]] = None
 
     description: t.Optional[str] = None
 
     disabled: t.Optional[bool] = None
 
-    filter_types: t.Optional[t.List[str]] = Field(default=None, alias="filterTypes")
+    filter_types: t.Optional[t.List[str]] = None
 
     metadata: t.Optional[t.Dict[str, str]] = None
 
-    rate_limit: t.Optional[int] = Field(default=None, alias="rateLimit")
+    rate_limit: t.Optional[int] = None
 
     secret: t.Optional[str] = None
     """The endpoint's verification secret.

--- a/python/svix/models/endpoint_secret_out.py
+++ b/python/svix/models/endpoint_secret_out.py
@@ -1,9 +1,9 @@
 # this file is @generated
 
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class EndpointSecretOut(SvixBaseModel):
+class EndpointSecretOut(BaseModel):
     key: str
     """The endpoint's verification secret.
 

--- a/python/svix/models/endpoint_secret_rotate_in.py
+++ b/python/svix/models/endpoint_secret_rotate_in.py
@@ -1,10 +1,10 @@
 # this file is @generated
 import typing as t
 
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class EndpointSecretRotateIn(SvixBaseModel):
+class EndpointSecretRotateIn(BaseModel):
     key: t.Optional[str] = None
     """The endpoint's verification secret.
 

--- a/python/svix/models/endpoint_stats.py
+++ b/python/svix/models/endpoint_stats.py
@@ -1,9 +1,9 @@
 # this file is @generated
 
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class EndpointStats(SvixBaseModel):
+class EndpointStats(BaseModel):
     fail: int
 
     pending: int

--- a/python/svix/models/endpoint_transformation_in.py
+++ b/python/svix/models/endpoint_transformation_in.py
@@ -1,10 +1,10 @@
 # this file is @generated
 import typing as t
 
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class EndpointTransformationIn(SvixBaseModel):
+class EndpointTransformationIn(BaseModel):
     code: t.Optional[str] = None
 
     enabled: t.Optional[bool] = None

--- a/python/svix/models/endpoint_transformation_out.py
+++ b/python/svix/models/endpoint_transformation_out.py
@@ -1,10 +1,10 @@
 # this file is @generated
 import typing as t
 
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class EndpointTransformationOut(SvixBaseModel):
+class EndpointTransformationOut(BaseModel):
     code: t.Optional[str] = None
 
     enabled: t.Optional[bool] = None

--- a/python/svix/models/endpoint_update.py
+++ b/python/svix/models/endpoint_update.py
@@ -1,12 +1,10 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class EndpointUpdate(SvixBaseModel):
+class EndpointUpdate(BaseModel):
     channels: t.Optional[t.List[str]] = None
     """List of message channels this endpoint listens to (omit for all)."""
 
@@ -14,11 +12,11 @@ class EndpointUpdate(SvixBaseModel):
 
     disabled: t.Optional[bool] = None
 
-    filter_types: t.Optional[t.List[str]] = Field(default=None, alias="filterTypes")
+    filter_types: t.Optional[t.List[str]] = None
 
     metadata: t.Optional[t.Dict[str, str]] = None
 
-    rate_limit: t.Optional[int] = Field(default=None, alias="rateLimit")
+    rate_limit: t.Optional[int] = None
 
     uid: t.Optional[str] = None
     """Optional unique identifier for the endpoint."""

--- a/python/svix/models/environment_in.py
+++ b/python/svix/models/environment_in.py
@@ -1,20 +1,14 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 from .event_type_in import EventTypeIn
 from .template_in import TemplateIn
 
 
-class EnvironmentIn(SvixBaseModel):
-    event_types: t.Optional[t.List[EventTypeIn]] = Field(
-        default=None, alias="eventTypes"
-    )
+class EnvironmentIn(BaseModel):
+    event_types: t.Optional[t.List[EventTypeIn]] = None
 
     settings: t.Optional[t.Dict[str, t.Any]] = None
 
-    transformation_templates: t.Optional[t.List[TemplateIn]] = Field(
-        default=None, alias="transformationTemplates"
-    )
+    transformation_templates: t.Optional[t.List[TemplateIn]] = None

--- a/python/svix/models/environment_out.py
+++ b/python/svix/models/environment_out.py
@@ -12,7 +12,7 @@ class EnvironmentOut(BaseModel):
 
     event_types: t.List[EventTypeOut]
 
-    settings: t.Optional[t.Dict[str, t.Any]] = None
+    settings: t.Optional[t.Dict[str, t.Any]]
 
     transformation_templates: t.List[TemplateOut]
 

--- a/python/svix/models/environment_out.py
+++ b/python/svix/models/environment_out.py
@@ -2,22 +2,18 @@
 import typing as t
 from datetime import datetime
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 from .event_type_out import EventTypeOut
 from .template_out import TemplateOut
 
 
-class EnvironmentOut(SvixBaseModel):
-    created_at: datetime = Field(alias="createdAt")
+class EnvironmentOut(BaseModel):
+    created_at: datetime
 
-    event_types: t.List[EventTypeOut] = Field(alias="eventTypes")
+    event_types: t.List[EventTypeOut]
 
     settings: t.Dict[str, t.Any]
 
-    transformation_templates: t.List[TemplateOut] = Field(
-        alias="transformationTemplates"
-    )
+    transformation_templates: t.List[TemplateOut]
 
     version: t.Optional[int] = None

--- a/python/svix/models/environment_out.py
+++ b/python/svix/models/environment_out.py
@@ -12,7 +12,7 @@ class EnvironmentOut(BaseModel):
 
     event_types: t.List[EventTypeOut]
 
-    settings: t.Dict[str, t.Any]
+    settings: t.Optional[t.Dict[str, t.Any]] = None
 
     transformation_templates: t.List[TemplateOut]
 

--- a/python/svix/models/event_example_in.py
+++ b/python/svix/models/event_example_in.py
@@ -1,16 +1,14 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class EventExampleIn(SvixBaseModel):
-    event_type: str = Field(alias="eventType")
+class EventExampleIn(BaseModel):
+    event_type: str
     """The event type's name"""
 
-    example_index: t.Optional[int] = Field(default=None, alias="exampleIndex")
+    example_index: t.Optional[int] = None
     """If the event type schema contains an array of examples, chooses which one to send.
 
     Defaults to the first example. Ignored if the schema doesn't contain an array of examples."""

--- a/python/svix/models/event_type_from_open_api.py
+++ b/python/svix/models/event_type_from_open_api.py
@@ -1,19 +1,17 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class EventTypeFromOpenApi(SvixBaseModel):
+class EventTypeFromOpenApi(BaseModel):
     deprecated: bool
 
     description: str
 
-    feature_flag: t.Optional[str] = Field(default=None, alias="featureFlag")
+    feature_flag: t.Optional[str] = None
 
-    group_name: t.Optional[str] = Field(default=None, alias="groupName")
+    group_name: t.Optional[str] = None
     """The event type group's name"""
 
     name: str

--- a/python/svix/models/event_type_import_open_api_in.py
+++ b/python/svix/models/event_type_import_open_api_in.py
@@ -1,24 +1,22 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class EventTypeImportOpenApiIn(SvixBaseModel):
+class EventTypeImportOpenApiIn(BaseModel):
     """Import a list of event types from webhooks defined in an OpenAPI spec.
 
     The OpenAPI spec can be specified as either `spec` given the spec as a JSON object, or as `specRaw` (a `string`) which will be parsed as YAML or JSON by the server. Sending neither or both is invalid, resulting in a `400` **Bad Request**."""
 
-    dry_run: t.Optional[bool] = Field(default=None, alias="dryRun")
+    dry_run: t.Optional[bool] = None
     """If `true`, return the event types that would be modified without actually modifying them."""
 
-    replace_all: t.Optional[bool] = Field(default=None, alias="replaceAll")
+    replace_all: t.Optional[bool] = None
     """If `true`, all existing event types that are not in the spec will be archived."""
 
     spec: t.Optional[t.Dict[str, t.Any]] = None
     """A pre-parsed JSON spec."""
 
-    spec_raw: t.Optional[str] = Field(default=None, alias="specRaw")
+    spec_raw: t.Optional[str] = None
     """A string, parsed by the server as YAML or JSON."""

--- a/python/svix/models/event_type_import_open_api_out.py
+++ b/python/svix/models/event_type_import_open_api_out.py
@@ -1,8 +1,8 @@
 # this file is @generated
 
-from .common import SvixBaseModel
+from .common import BaseModel
 from .event_type_import_open_api_out_data import EventTypeImportOpenApiOutData
 
 
-class EventTypeImportOpenApiOut(SvixBaseModel):
+class EventTypeImportOpenApiOut(BaseModel):
     data: EventTypeImportOpenApiOutData

--- a/python/svix/models/event_type_import_open_api_out_data.py
+++ b/python/svix/models/event_type_import_open_api_out_data.py
@@ -1,11 +1,11 @@
 # this file is @generated
 import typing as t
 
-from .common import SvixBaseModel
+from .common import BaseModel
 from .event_type_from_open_api import EventTypeFromOpenApi
 
 
-class EventTypeImportOpenApiOutData(SvixBaseModel):
+class EventTypeImportOpenApiOutData(BaseModel):
     modified: t.List[str]
 
     to_modify: t.Optional[t.List[EventTypeFromOpenApi]] = None

--- a/python/svix/models/event_type_in.py
+++ b/python/svix/models/event_type_in.py
@@ -1,21 +1,19 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class EventTypeIn(SvixBaseModel):
+class EventTypeIn(BaseModel):
     archived: t.Optional[bool] = None
 
     deprecated: t.Optional[bool] = None
 
     description: str
 
-    feature_flag: t.Optional[str] = Field(default=None, alias="featureFlag")
+    feature_flag: t.Optional[str] = None
 
-    group_name: t.Optional[str] = Field(default=None, alias="groupName")
+    group_name: t.Optional[str] = None
     """The event type group's name"""
 
     name: str

--- a/python/svix/models/event_type_out.py
+++ b/python/svix/models/event_type_out.py
@@ -2,23 +2,21 @@
 import typing as t
 from datetime import datetime
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class EventTypeOut(SvixBaseModel):
+class EventTypeOut(BaseModel):
     archived: t.Optional[bool] = None
 
-    created_at: datetime = Field(alias="createdAt")
+    created_at: datetime
 
     deprecated: bool
 
     description: str
 
-    feature_flag: t.Optional[str] = Field(default=None, alias="featureFlag")
+    feature_flag: t.Optional[str] = None
 
-    group_name: t.Optional[str] = Field(default=None, alias="groupName")
+    group_name: t.Optional[str] = None
     """The event type group's name"""
 
     name: str
@@ -27,4 +25,4 @@ class EventTypeOut(SvixBaseModel):
     schemas: t.Optional[t.Dict[str, t.Any]] = None
     """The schema for the event type for a specific version as a JSON schema."""
 
-    updated_at: datetime = Field(alias="updatedAt")
+    updated_at: datetime

--- a/python/svix/models/event_type_patch.py
+++ b/python/svix/models/event_type_patch.py
@@ -1,21 +1,19 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class EventTypePatch(SvixBaseModel):
+class EventTypePatch(BaseModel):
     archived: t.Optional[bool] = None
 
     deprecated: t.Optional[bool] = None
 
     description: t.Optional[str] = None
 
-    feature_flag: t.Optional[str] = Field(default=None, alias="featureFlag")
+    feature_flag: t.Optional[str] = None
 
-    group_name: t.Optional[str] = Field(default=None, alias="groupName")
+    group_name: t.Optional[str] = None
     """The event type group's name"""
 
     schemas: t.Optional[t.Dict[str, t.Any]] = None

--- a/python/svix/models/event_type_update.py
+++ b/python/svix/models/event_type_update.py
@@ -1,21 +1,19 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class EventTypeUpdate(SvixBaseModel):
+class EventTypeUpdate(BaseModel):
     archived: t.Optional[bool] = None
 
     deprecated: t.Optional[bool] = None
 
     description: str
 
-    feature_flag: t.Optional[str] = Field(default=None, alias="featureFlag")
+    feature_flag: t.Optional[str] = None
 
-    group_name: t.Optional[str] = Field(default=None, alias="groupName")
+    group_name: t.Optional[str] = None
     """The event type group's name"""
 
     schemas: t.Optional[t.Dict[str, t.Any]] = None

--- a/python/svix/models/integration_in.py
+++ b/python/svix/models/integration_in.py
@@ -1,7 +1,7 @@
 # this file is @generated
 
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class IntegrationIn(SvixBaseModel):
+class IntegrationIn(BaseModel):
     name: str

--- a/python/svix/models/integration_key_out.py
+++ b/python/svix/models/integration_key_out.py
@@ -1,7 +1,7 @@
 # this file is @generated
 
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class IntegrationKeyOut(SvixBaseModel):
+class IntegrationKeyOut(BaseModel):
     key: str

--- a/python/svix/models/integration_out.py
+++ b/python/svix/models/integration_out.py
@@ -1,17 +1,15 @@
 # this file is @generated
 from datetime import datetime
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class IntegrationOut(SvixBaseModel):
-    created_at: datetime = Field(alias="createdAt")
+class IntegrationOut(BaseModel):
+    created_at: datetime
 
     id: str
     """The integ's ID"""
 
     name: str
 
-    updated_at: datetime = Field(alias="updatedAt")
+    updated_at: datetime

--- a/python/svix/models/integration_update.py
+++ b/python/svix/models/integration_update.py
@@ -1,7 +1,7 @@
 # this file is @generated
 
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class IntegrationUpdate(SvixBaseModel):
+class IntegrationUpdate(BaseModel):
     name: str

--- a/python/svix/models/list_response_application_out.py
+++ b/python/svix/models/list_response_application_out.py
@@ -10,6 +10,6 @@ class ListResponseApplicationOut(BaseModel):
 
     done: bool
 
-    iterator: str
+    iterator: t.Optional[str] = None
 
     prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_application_out.py
+++ b/python/svix/models/list_response_application_out.py
@@ -10,6 +10,6 @@ class ListResponseApplicationOut(BaseModel):
 
     done: bool
 
-    iterator: t.Optional[str] = None
+    iterator: t.Optional[str]
 
     prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_application_out.py
+++ b/python/svix/models/list_response_application_out.py
@@ -1,17 +1,15 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
 from .application_out import ApplicationOut
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class ListResponseApplicationOut(SvixBaseModel):
+class ListResponseApplicationOut(BaseModel):
     data: t.List[ApplicationOut]
 
     done: bool
 
     iterator: str
 
-    prev_iterator: t.Optional[str] = Field(default=None, alias="prevIterator")
+    prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_background_task_out.py
+++ b/python/svix/models/list_response_background_task_out.py
@@ -1,17 +1,15 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
 from .background_task_out import BackgroundTaskOut
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class ListResponseBackgroundTaskOut(SvixBaseModel):
+class ListResponseBackgroundTaskOut(BaseModel):
     data: t.List[BackgroundTaskOut]
 
     done: bool
 
     iterator: str
 
-    prev_iterator: t.Optional[str] = Field(default=None, alias="prevIterator")
+    prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_background_task_out.py
+++ b/python/svix/models/list_response_background_task_out.py
@@ -10,6 +10,6 @@ class ListResponseBackgroundTaskOut(BaseModel):
 
     done: bool
 
-    iterator: t.Optional[str] = None
+    iterator: t.Optional[str]
 
     prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_background_task_out.py
+++ b/python/svix/models/list_response_background_task_out.py
@@ -10,6 +10,6 @@ class ListResponseBackgroundTaskOut(BaseModel):
 
     done: bool
 
-    iterator: str
+    iterator: t.Optional[str] = None
 
     prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_endpoint_message_out.py
+++ b/python/svix/models/list_response_endpoint_message_out.py
@@ -10,6 +10,6 @@ class ListResponseEndpointMessageOut(BaseModel):
 
     done: bool
 
-    iterator: t.Optional[str] = None
+    iterator: t.Optional[str]
 
     prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_endpoint_message_out.py
+++ b/python/svix/models/list_response_endpoint_message_out.py
@@ -10,6 +10,6 @@ class ListResponseEndpointMessageOut(BaseModel):
 
     done: bool
 
-    iterator: str
+    iterator: t.Optional[str] = None
 
     prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_endpoint_message_out.py
+++ b/python/svix/models/list_response_endpoint_message_out.py
@@ -1,17 +1,15 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 from .endpoint_message_out import EndpointMessageOut
 
 
-class ListResponseEndpointMessageOut(SvixBaseModel):
+class ListResponseEndpointMessageOut(BaseModel):
     data: t.List[EndpointMessageOut]
 
     done: bool
 
     iterator: str
 
-    prev_iterator: t.Optional[str] = Field(default=None, alias="prevIterator")
+    prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_endpoint_out.py
+++ b/python/svix/models/list_response_endpoint_out.py
@@ -1,17 +1,15 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 from .endpoint_out import EndpointOut
 
 
-class ListResponseEndpointOut(SvixBaseModel):
+class ListResponseEndpointOut(BaseModel):
     data: t.List[EndpointOut]
 
     done: bool
 
     iterator: str
 
-    prev_iterator: t.Optional[str] = Field(default=None, alias="prevIterator")
+    prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_endpoint_out.py
+++ b/python/svix/models/list_response_endpoint_out.py
@@ -10,6 +10,6 @@ class ListResponseEndpointOut(BaseModel):
 
     done: bool
 
-    iterator: str
+    iterator: t.Optional[str] = None
 
     prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_endpoint_out.py
+++ b/python/svix/models/list_response_endpoint_out.py
@@ -10,6 +10,6 @@ class ListResponseEndpointOut(BaseModel):
 
     done: bool
 
-    iterator: t.Optional[str] = None
+    iterator: t.Optional[str]
 
     prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_event_type_out.py
+++ b/python/svix/models/list_response_event_type_out.py
@@ -10,6 +10,6 @@ class ListResponseEventTypeOut(BaseModel):
 
     done: bool
 
-    iterator: t.Optional[str] = None
+    iterator: t.Optional[str]
 
     prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_event_type_out.py
+++ b/python/svix/models/list_response_event_type_out.py
@@ -10,6 +10,6 @@ class ListResponseEventTypeOut(BaseModel):
 
     done: bool
 
-    iterator: str
+    iterator: t.Optional[str] = None
 
     prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_event_type_out.py
+++ b/python/svix/models/list_response_event_type_out.py
@@ -1,17 +1,15 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 from .event_type_out import EventTypeOut
 
 
-class ListResponseEventTypeOut(SvixBaseModel):
+class ListResponseEventTypeOut(BaseModel):
     data: t.List[EventTypeOut]
 
     done: bool
 
     iterator: str
 
-    prev_iterator: t.Optional[str] = Field(default=None, alias="prevIterator")
+    prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_integration_out.py
+++ b/python/svix/models/list_response_integration_out.py
@@ -1,17 +1,15 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 from .integration_out import IntegrationOut
 
 
-class ListResponseIntegrationOut(SvixBaseModel):
+class ListResponseIntegrationOut(BaseModel):
     data: t.List[IntegrationOut]
 
     done: bool
 
     iterator: str
 
-    prev_iterator: t.Optional[str] = Field(default=None, alias="prevIterator")
+    prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_integration_out.py
+++ b/python/svix/models/list_response_integration_out.py
@@ -10,6 +10,6 @@ class ListResponseIntegrationOut(BaseModel):
 
     done: bool
 
-    iterator: str
+    iterator: t.Optional[str] = None
 
     prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_integration_out.py
+++ b/python/svix/models/list_response_integration_out.py
@@ -10,6 +10,6 @@ class ListResponseIntegrationOut(BaseModel):
 
     done: bool
 
-    iterator: t.Optional[str] = None
+    iterator: t.Optional[str]
 
     prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_message_attempt_out.py
+++ b/python/svix/models/list_response_message_attempt_out.py
@@ -1,17 +1,15 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 from .message_attempt_out import MessageAttemptOut
 
 
-class ListResponseMessageAttemptOut(SvixBaseModel):
+class ListResponseMessageAttemptOut(BaseModel):
     data: t.List[MessageAttemptOut]
 
     done: bool
 
     iterator: str
 
-    prev_iterator: t.Optional[str] = Field(default=None, alias="prevIterator")
+    prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_message_attempt_out.py
+++ b/python/svix/models/list_response_message_attempt_out.py
@@ -10,6 +10,6 @@ class ListResponseMessageAttemptOut(BaseModel):
 
     done: bool
 
-    iterator: t.Optional[str] = None
+    iterator: t.Optional[str]
 
     prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_message_attempt_out.py
+++ b/python/svix/models/list_response_message_attempt_out.py
@@ -10,6 +10,6 @@ class ListResponseMessageAttemptOut(BaseModel):
 
     done: bool
 
-    iterator: str
+    iterator: t.Optional[str] = None
 
     prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_message_endpoint_out.py
+++ b/python/svix/models/list_response_message_endpoint_out.py
@@ -10,6 +10,6 @@ class ListResponseMessageEndpointOut(BaseModel):
 
     done: bool
 
-    iterator: str
+    iterator: t.Optional[str] = None
 
     prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_message_endpoint_out.py
+++ b/python/svix/models/list_response_message_endpoint_out.py
@@ -1,17 +1,15 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 from .message_endpoint_out import MessageEndpointOut
 
 
-class ListResponseMessageEndpointOut(SvixBaseModel):
+class ListResponseMessageEndpointOut(BaseModel):
     data: t.List[MessageEndpointOut]
 
     done: bool
 
     iterator: str
 
-    prev_iterator: t.Optional[str] = Field(default=None, alias="prevIterator")
+    prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_message_endpoint_out.py
+++ b/python/svix/models/list_response_message_endpoint_out.py
@@ -10,6 +10,6 @@ class ListResponseMessageEndpointOut(BaseModel):
 
     done: bool
 
-    iterator: t.Optional[str] = None
+    iterator: t.Optional[str]
 
     prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_message_out.py
+++ b/python/svix/models/list_response_message_out.py
@@ -10,6 +10,6 @@ class ListResponseMessageOut(BaseModel):
 
     done: bool
 
-    iterator: t.Optional[str] = None
+    iterator: t.Optional[str]
 
     prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_message_out.py
+++ b/python/svix/models/list_response_message_out.py
@@ -10,6 +10,6 @@ class ListResponseMessageOut(BaseModel):
 
     done: bool
 
-    iterator: str
+    iterator: t.Optional[str] = None
 
     prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_message_out.py
+++ b/python/svix/models/list_response_message_out.py
@@ -1,17 +1,15 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 from .message_out import MessageOut
 
 
-class ListResponseMessageOut(SvixBaseModel):
+class ListResponseMessageOut(BaseModel):
     data: t.List[MessageOut]
 
     done: bool
 
     iterator: str
 
-    prev_iterator: t.Optional[str] = Field(default=None, alias="prevIterator")
+    prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_operational_webhook_endpoint_out.py
+++ b/python/svix/models/list_response_operational_webhook_endpoint_out.py
@@ -10,6 +10,6 @@ class ListResponseOperationalWebhookEndpointOut(BaseModel):
 
     done: bool
 
-    iterator: str
+    iterator: t.Optional[str] = None
 
     prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_operational_webhook_endpoint_out.py
+++ b/python/svix/models/list_response_operational_webhook_endpoint_out.py
@@ -1,17 +1,15 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 from .operational_webhook_endpoint_out import OperationalWebhookEndpointOut
 
 
-class ListResponseOperationalWebhookEndpointOut(SvixBaseModel):
+class ListResponseOperationalWebhookEndpointOut(BaseModel):
     data: t.List[OperationalWebhookEndpointOut]
 
     done: bool
 
     iterator: str
 
-    prev_iterator: t.Optional[str] = Field(default=None, alias="prevIterator")
+    prev_iterator: t.Optional[str] = None

--- a/python/svix/models/list_response_operational_webhook_endpoint_out.py
+++ b/python/svix/models/list_response_operational_webhook_endpoint_out.py
@@ -10,6 +10,6 @@ class ListResponseOperationalWebhookEndpointOut(BaseModel):
 
     done: bool
 
-    iterator: t.Optional[str] = None
+    iterator: t.Optional[str]
 
     prev_iterator: t.Optional[str] = None

--- a/python/svix/models/message_attempt_out.py
+++ b/python/svix/models/message_attempt_out.py
@@ -2,16 +2,14 @@
 import typing as t
 from datetime import datetime
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 from .message_attempt_trigger_type import MessageAttemptTriggerType
 from .message_out import MessageOut
 from .message_status import MessageStatus
 
 
-class MessageAttemptOut(SvixBaseModel):
-    endpoint_id: str = Field(alias="endpointId")
+class MessageAttemptOut(BaseModel):
+    endpoint_id: str
     """The ep's ID"""
 
     id: str
@@ -19,20 +17,20 @@ class MessageAttemptOut(SvixBaseModel):
 
     msg: t.Optional[MessageOut] = None
 
-    msg_id: str = Field(alias="msgId")
+    msg_id: str
     """The msg's ID"""
 
     response: str
 
-    response_duration_ms: int = Field(alias="responseDurationMs")
+    response_duration_ms: int
     """Response duration in milliseconds."""
 
-    response_status_code: int = Field(alias="responseStatusCode")
+    response_status_code: int
 
     status: MessageStatus
 
     timestamp: datetime
 
-    trigger_type: MessageAttemptTriggerType = Field(alias="triggerType")
+    trigger_type: MessageAttemptTriggerType
 
     url: str

--- a/python/svix/models/message_endpoint_out.py
+++ b/python/svix/models/message_endpoint_out.py
@@ -2,38 +2,36 @@
 import typing as t
 from datetime import datetime
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 from .message_status import MessageStatus
 
 
-class MessageEndpointOut(SvixBaseModel):
+class MessageEndpointOut(BaseModel):
     channels: t.Optional[t.List[str]] = None
     """List of message channels this endpoint listens to (omit for all)."""
 
-    created_at: datetime = Field(alias="createdAt")
+    created_at: datetime
 
     description: str
     """An example endpoint name."""
 
     disabled: t.Optional[bool] = None
 
-    filter_types: t.Optional[t.List[str]] = Field(default=None, alias="filterTypes")
+    filter_types: t.Optional[t.List[str]] = None
 
     id: str
     """The ep's ID"""
 
-    next_attempt: t.Optional[datetime] = Field(default=None, alias="nextAttempt")
+    next_attempt: t.Optional[datetime] = None
 
-    rate_limit: t.Optional[int] = Field(default=None, alias="rateLimit")
+    rate_limit: t.Optional[int] = None
 
     status: MessageStatus
 
     uid: t.Optional[str] = None
     """Optional unique identifier for the endpoint."""
 
-    updated_at: datetime = Field(alias="updatedAt")
+    updated_at: datetime
 
     url: str
 

--- a/python/svix/models/message_in.py
+++ b/python/svix/models/message_in.py
@@ -1,13 +1,11 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
 from .application_in import ApplicationIn
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class MessageIn(SvixBaseModel):
+class MessageIn(BaseModel):
     application: t.Optional[ApplicationIn] = None
     """Optionally creates a new application alongside the message.
 
@@ -16,10 +14,10 @@ class MessageIn(SvixBaseModel):
     channels: t.Optional[t.List[str]] = None
     """List of free-form identifiers that endpoints can filter by"""
 
-    event_id: t.Optional[str] = Field(default=None, alias="eventId")
+    event_id: t.Optional[str] = None
     """Optional unique identifier for the message"""
 
-    event_type: str = Field(alias="eventType")
+    event_type: str
     """The event type's name"""
 
     payload: t.Dict[str, t.Any]
@@ -27,20 +25,14 @@ class MessageIn(SvixBaseModel):
 
     We also support sending non-JSON payloads. Please contact us for more information."""
 
-    payload_retention_hours: t.Optional[int] = Field(
-        default=None, alias="payloadRetentionHours"
-    )
+    payload_retention_hours: t.Optional[int] = None
     """Optional number of hours to retain the message payload. Note that this is mutually exclusive with `payloadRetentionPeriod`."""
 
-    payload_retention_period: t.Optional[int] = Field(
-        default=None, alias="payloadRetentionPeriod"
-    )
+    payload_retention_period: t.Optional[int] = None
     """Optional number of days to retain the message payload. Defaults to 90. Note that this is mutually exclusive with `payloadRetentionHours`."""
 
     tags: t.Optional[t.List[str]] = None
     """List of free-form tags that can be filtered by when listing messages"""
 
-    transformations_params: t.Optional[t.Dict[str, t.Any]] = Field(
-        default=None, alias="transformationsParams"
-    )
+    transformations_params: t.Optional[t.Dict[str, t.Any]] = None
     """Extra parameters to pass to Transformations (for future use)"""

--- a/python/svix/models/message_out.py
+++ b/python/svix/models/message_out.py
@@ -2,19 +2,17 @@
 import typing as t
 from datetime import datetime
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class MessageOut(SvixBaseModel):
+class MessageOut(BaseModel):
     channels: t.Optional[t.List[str]] = None
     """List of free-form identifiers that endpoints can filter by"""
 
-    event_id: t.Optional[str] = Field(default=None, alias="eventId")
+    event_id: t.Optional[str] = None
     """Optional unique identifier for the message"""
 
-    event_type: str = Field(alias="eventType")
+    event_type: str
     """The event type's name"""
 
     id: str

--- a/python/svix/models/operational_webhook_endpoint_headers_in.py
+++ b/python/svix/models/operational_webhook_endpoint_headers_in.py
@@ -1,8 +1,8 @@
 # this file is @generated
 import typing as t
 
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class OperationalWebhookEndpointHeadersIn(SvixBaseModel):
+class OperationalWebhookEndpointHeadersIn(BaseModel):
     headers: t.Dict[str, str]

--- a/python/svix/models/operational_webhook_endpoint_headers_out.py
+++ b/python/svix/models/operational_webhook_endpoint_headers_out.py
@@ -1,10 +1,10 @@
 # this file is @generated
 import typing as t
 
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class OperationalWebhookEndpointHeadersOut(SvixBaseModel):
+class OperationalWebhookEndpointHeadersOut(BaseModel):
     headers: t.Dict[str, str]
 
     sensitive: t.List[str]

--- a/python/svix/models/operational_webhook_endpoint_in.py
+++ b/python/svix/models/operational_webhook_endpoint_in.py
@@ -1,21 +1,19 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class OperationalWebhookEndpointIn(SvixBaseModel):
+class OperationalWebhookEndpointIn(BaseModel):
     description: t.Optional[str] = None
 
     disabled: t.Optional[bool] = None
 
-    filter_types: t.Optional[t.List[str]] = Field(default=None, alias="filterTypes")
+    filter_types: t.Optional[t.List[str]] = None
 
     metadata: t.Optional[t.Dict[str, str]] = None
 
-    rate_limit: t.Optional[int] = Field(default=None, alias="rateLimit")
+    rate_limit: t.Optional[int] = None
 
     secret: t.Optional[str] = None
     """The endpoint's verification secret.

--- a/python/svix/models/operational_webhook_endpoint_out.py
+++ b/python/svix/models/operational_webhook_endpoint_out.py
@@ -2,31 +2,29 @@
 import typing as t
 from datetime import datetime
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class OperationalWebhookEndpointOut(SvixBaseModel):
-    created_at: datetime = Field(alias="createdAt")
+class OperationalWebhookEndpointOut(BaseModel):
+    created_at: datetime
 
     description: str
     """An example endpoint name."""
 
     disabled: t.Optional[bool] = None
 
-    filter_types: t.Optional[t.List[str]] = Field(default=None, alias="filterTypes")
+    filter_types: t.Optional[t.List[str]] = None
 
     id: str
     """The ep's ID"""
 
     metadata: t.Dict[str, str]
 
-    rate_limit: t.Optional[int] = Field(default=None, alias="rateLimit")
+    rate_limit: t.Optional[int] = None
 
     uid: t.Optional[str] = None
     """Optional unique identifier for the endpoint."""
 
-    updated_at: datetime = Field(alias="updatedAt")
+    updated_at: datetime
 
     url: str

--- a/python/svix/models/operational_webhook_endpoint_secret_in.py
+++ b/python/svix/models/operational_webhook_endpoint_secret_in.py
@@ -1,10 +1,10 @@
 # this file is @generated
 import typing as t
 
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class OperationalWebhookEndpointSecretIn(SvixBaseModel):
+class OperationalWebhookEndpointSecretIn(BaseModel):
     key: t.Optional[str] = None
     """The endpoint's verification secret.
 

--- a/python/svix/models/operational_webhook_endpoint_secret_out.py
+++ b/python/svix/models/operational_webhook_endpoint_secret_out.py
@@ -1,9 +1,9 @@
 # this file is @generated
 
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class OperationalWebhookEndpointSecretOut(SvixBaseModel):
+class OperationalWebhookEndpointSecretOut(BaseModel):
     key: str
     """The endpoint's verification secret.
 

--- a/python/svix/models/operational_webhook_endpoint_update.py
+++ b/python/svix/models/operational_webhook_endpoint_update.py
@@ -1,21 +1,19 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class OperationalWebhookEndpointUpdate(SvixBaseModel):
+class OperationalWebhookEndpointUpdate(BaseModel):
     description: t.Optional[str] = None
 
     disabled: t.Optional[bool] = None
 
-    filter_types: t.Optional[t.List[str]] = Field(default=None, alias="filterTypes")
+    filter_types: t.Optional[t.List[str]] = None
 
     metadata: t.Optional[t.Dict[str, str]] = None
 
-    rate_limit: t.Optional[int] = Field(default=None, alias="rateLimit")
+    rate_limit: t.Optional[int] = None
 
     uid: t.Optional[str] = None
     """Optional unique identifier for the endpoint."""

--- a/python/svix/models/recover_in.py
+++ b/python/svix/models/recover_in.py
@@ -2,10 +2,10 @@
 import typing as t
 from datetime import datetime
 
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class RecoverIn(SvixBaseModel):
+class RecoverIn(BaseModel):
     since: datetime
 
     until: t.Optional[datetime] = None

--- a/python/svix/models/recover_out.py
+++ b/python/svix/models/recover_out.py
@@ -2,10 +2,10 @@
 
 from .background_task_status import BackgroundTaskStatus
 from .background_task_type import BackgroundTaskType
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class RecoverOut(SvixBaseModel):
+class RecoverOut(BaseModel):
     id: str
 
     status: BackgroundTaskStatus

--- a/python/svix/models/replay_in.py
+++ b/python/svix/models/replay_in.py
@@ -2,10 +2,10 @@
 import typing as t
 from datetime import datetime
 
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class ReplayIn(SvixBaseModel):
+class ReplayIn(BaseModel):
     since: datetime
 
     until: t.Optional[datetime] = None

--- a/python/svix/models/replay_out.py
+++ b/python/svix/models/replay_out.py
@@ -2,10 +2,10 @@
 
 from .background_task_status import BackgroundTaskStatus
 from .background_task_type import BackgroundTaskType
-from .common import SvixBaseModel
+from .common import BaseModel
 
 
-class ReplayOut(SvixBaseModel):
+class ReplayOut(BaseModel):
     id: str
 
     status: BackgroundTaskStatus

--- a/python/svix/models/template_in.py
+++ b/python/svix/models/template_in.py
@@ -1,22 +1,20 @@
 # this file is @generated
 import typing as t
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 from .transformation_template_kind import TransformationTemplateKind
 
 
-class TemplateIn(SvixBaseModel):
+class TemplateIn(BaseModel):
     description: t.Optional[str] = None
 
-    feature_flag: t.Optional[str] = Field(default=None, alias="featureFlag")
+    feature_flag: t.Optional[str] = None
 
-    filter_types: t.Optional[t.List[str]] = Field(default=None, alias="filterTypes")
+    filter_types: t.Optional[t.List[str]] = None
 
     instructions: t.Optional[str] = None
 
-    instructions_link: t.Optional[str] = Field(default=None, alias="instructionsLink")
+    instructions_link: t.Optional[str] = None
 
     kind: t.Optional[TransformationTemplateKind] = None
 

--- a/python/svix/models/template_out.py
+++ b/python/svix/models/template_out.py
@@ -2,26 +2,24 @@
 import typing as t
 from datetime import datetime
 
-from pydantic import Field
-
-from .common import SvixBaseModel
+from .common import BaseModel
 from .transformation_template_kind import TransformationTemplateKind
 
 
-class TemplateOut(SvixBaseModel):
-    created_at: datetime = Field(alias="createdAt")
+class TemplateOut(BaseModel):
+    created_at: datetime
 
     description: str
 
-    feature_flag: t.Optional[str] = Field(default=None, alias="featureFlag")
+    feature_flag: t.Optional[str] = None
 
-    filter_types: t.Optional[t.List[str]] = Field(default=None, alias="filterTypes")
+    filter_types: t.Optional[t.List[str]] = None
 
     id: str
 
     instructions: str
 
-    instructions_link: t.Optional[str] = Field(default=None, alias="instructionsLink")
+    instructions_link: t.Optional[str] = None
 
     kind: TransformationTemplateKind
 
@@ -29,8 +27,8 @@ class TemplateOut(SvixBaseModel):
 
     name: str
 
-    org_id: str = Field(alias="orgId")
+    org_id: str
 
     transformation: str
 
-    updated_at: datetime = Field(alias="updatedAt")
+    updated_at: datetime


### PR DESCRIPTION
```json
{
  "file-generated-at": "2025-01-30T21:03:44.929377827+00:00",
  "git-rev": "f56cc1dced773360bae301cac14d84029ac0f2e7",
  "openapi-codegen-version": "0.1.0",
  "openapi.json-sha256": "27c305c4c890291e9dd2506cebe18422317faea9963f3d9abf89a405731e3206"
}
```

Note, the field `to_modify` on [this](https://github.com/svix/svix-webhooks-private/blob/dec537950635d73531734c2980811163191c4d32/rust/src/models/event_type_import_open_api_out_data.rs#L7) model does not follow camelCasing 

