### PR TITLE
python: Add special case where the server does not send a camelCase field

### DIFF
--- a/python/svix/models/event_type_import_open_api_out_data.py
+++ b/python/svix/models/event_type_import_open_api_out_data.py
@@ -1,5 +1,6 @@
-# this file is @generated
 import typing as t
+
+from pydantic import Field
 
 from .common import BaseModel
 from .event_type_from_open_api import EventTypeFromOpenApi
@@ -8,4 +9,6 @@ from .event_type_from_open_api import EventTypeFromOpenApi
 class EventTypeImportOpenApiOutData(BaseModel):
     modified: t.List[str]
 
-    to_modify: t.Optional[t.List[EventTypeFromOpenApi]] = None
+    to_modify: t.Optional[t.List[EventTypeFromOpenApi]] = Field(
+        default=None, alias="to_modify"
+    )


### PR DESCRIPTION
@svix-jplatte [here](https://github.com/svix/svix-webhooks-private/blob/dec537950635d73531734c2980811163191c4d32/server/svix-server/src/v1/endpoints/event_type/mod.rs#L720) is where this field is defined