### PR TITLE
js: Add authorization header for requests

### DIFF
--- a/javascript/src/request.ts
+++ b/javascript/src/request.ts
@@ -114,6 +114,7 @@ export class SvixRequest {
       body: this.body,
       headers: {
         accept: "application/json, */*;q=0.8",
+        authorization: `Bearer ${ctx.token}`,
         "user-agent": USER_AGENT,
         "svix-req-id": randomId.toString(),
         ...this.headerParams,


### PR DESCRIPTION
Missed / forgot this when carrying over request-making logic from the internal openapi library.