### PR TITLE
js: don't add query param when value is an empty array

### DIFF
--- a/javascript/src/request.ts
+++ b/javascript/src/request.ts
@@ -57,7 +57,9 @@ export class SvixRequest {
     } else if (value instanceof Date) {
       this.queryParams[name] = value.toISOString();
     } else if (value instanceof Array) {
-      this.queryParams[name] = value.join(",");
+      if (value.length > 0) {
+        this.queryParams[name] = value.join(",");
+      }
     } else {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const _assert_unreachable: never = value;


### PR DESCRIPTION
the server doesn't like it