### PR TITLE
kotlin: Revert swaping these function args

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,7 +25,6 @@
 * Libs/Kotlin **(Breaking)**: Update `MessageAttempt` list methods to each have its own type for
   list options, since they don't all support the exact same set of parameters and some of the
   parameters that could be set before would just get ignored
-* Libs/Kotlin: Fix the parameter names of `Endpoint.get` - `appId` and `endpointId` were swapped
 * Libs/Kotlin: Fix a bug in `EventType.list` where `options.order` was not getting honored
 * Libs/Rust **(Breaking)**: Add optional `EventTypeDeleteOptions` parameter to `EventType::delete`
 * Libs/Rust **(Breaking)**: Add optional `options` parameters to `Endpoint::recover`,

--- a/kotlin/lib/src/main/kotlin/Endpoint.kt
+++ b/kotlin/lib/src/main/kotlin/Endpoint.kt
@@ -91,7 +91,7 @@ class Endpoint internal constructor(token: String, options: SvixOptions) {
     }
 
     /** Get an endpoint. */
-    suspend fun get(endpointId: String, appId: String): EndpointOut {
+    suspend fun get(appId: String, endpointId: String): EndpointOut {
         try {
             return api.v1EndpointGet(appId, endpointId)
         } catch (e: Exception) {


### PR DESCRIPTION
Revert this change, Would have broken some customers at runtime