### PR TITLE
Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/bridge-release.yml
+++ b/.github/workflows/bridge-release.yml
@@ -39,7 +39,7 @@ jobs:
         run: cargo build --release --manifest-path bridge/svix-bridge/Cargo.toml
 
       - name: Release
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: svix-bridge-x86_64-unknown-linux-gnu
           path: bridge/target/release/svix-bridge

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -27,7 +27,7 @@ jobs:
         run: cargo build --release --manifest-path server/svix-server/Cargo.toml
 
       - name: Release
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: svix-server-x86_64-unknown-linux-gnu
           path: server/target/release/svix-server


### PR DESCRIPTION
Breaking changes in v4: https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes

I think that shouldn't affect us
