### PR TITLE
rust: Fix ListResponseXXXOut models

### DIFF
--- a/rust/src/models/aggregate_event_types_out.rs
+++ b/rust/src/models/aggregate_event_types_out.rs
@@ -7,6 +7,7 @@ use super::{
 
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
 pub struct AggregateEventTypesOut {
+    /// The QueueBackgroundTask's ID.
     pub id: String,
 
     pub status: BackgroundTaskStatus,

--- a/rust/src/models/app_usage_stats_out.rs
+++ b/rust/src/models/app_usage_stats_out.rs
@@ -7,6 +7,7 @@ use super::{
 
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
 pub struct AppUsageStatsOut {
+    /// The QueueBackgroundTask's ID.
     pub id: String,
 
     pub status: BackgroundTaskStatus,

--- a/rust/src/models/application_out.rs
+++ b/rust/src/models/application_out.rs
@@ -6,7 +6,7 @@ pub struct ApplicationOut {
     #[serde(rename = "createdAt")]
     pub created_at: String,
 
-    /// The app's ID
+    /// The Application's ID.
     pub id: String,
 
     pub metadata: std::collections::HashMap<String, String>,
@@ -17,7 +17,7 @@ pub struct ApplicationOut {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rate_limit: Option<u16>,
 
-    /// The app's UID
+    /// The Application's UID.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uid: Option<String>,
 

--- a/rust/src/models/application_patch.rs
+++ b/rust/src/models/application_patch.rs
@@ -14,7 +14,7 @@ pub struct ApplicationPatch {
     #[serde(default, skip_serializing_if = "JsOption::is_undefined")]
     pub rate_limit: JsOption<u16>,
 
-    /// The app's UID
+    /// The Application's UID.
     #[serde(default, skip_serializing_if = "JsOption::is_undefined")]
     pub uid: JsOption<String>,
 }

--- a/rust/src/models/background_task_out.rs
+++ b/rust/src/models/background_task_out.rs
@@ -9,6 +9,7 @@ use super::{
 pub struct BackgroundTaskOut {
     pub data: serde_json::Value,
 
+    /// The QueueBackgroundTask's ID.
     pub id: String,
 
     pub status: BackgroundTaskStatus,

--- a/rust/src/models/background_task_type.rs
+++ b/rust/src/models/background_task_type.rs
@@ -20,6 +20,8 @@ pub enum BackgroundTaskType {
     SdkGenerate,
     #[serde(rename = "event-type.aggregate")]
     EventTypeAggregate,
+    #[serde(rename = "application.purge_content")]
+    ApplicationPurgeContent,
 }
 
 impl fmt::Display for BackgroundTaskType {
@@ -31,6 +33,7 @@ impl fmt::Display for BackgroundTaskType {
             Self::MessageBroadcast => "message.broadcast",
             Self::SdkGenerate => "sdk.generate",
             Self::EventTypeAggregate => "event-type.aggregate",
+            Self::ApplicationPurgeContent => "application.purge_content",
         };
         f.write_str(value)
     }

--- a/rust/src/models/codegen.json
+++ b/rust/src/models/codegen.json
@@ -1,6 +1,0 @@
-{
-  "file-generated-at": "2025-01-24T14:05:22.178518244+00:00",
-  "git-rev": "b1e66d27772222a890af823454f6bc44c3d330aa",
-  "openapi-codegen-version": "0.1.0",
-  "openapi.json-sha256": "9fa16f8eb28f617b8495cafc9bd529626145df7af01e5c09acdc2b98e39a4725"
-}

--- a/rust/src/models/endpoint_message_out.rs
+++ b/rust/src/models/endpoint_message_out.rs
@@ -20,7 +20,7 @@ pub struct EndpointMessageOut {
     #[serde(rename = "eventType")]
     pub event_type: String,
 
-    /// The msg's ID
+    /// The Message's ID.
     pub id: String,
 
     #[serde(rename = "nextAttempt")]

--- a/rust/src/models/endpoint_out.rs
+++ b/rust/src/models/endpoint_out.rs
@@ -20,7 +20,7 @@ pub struct EndpointOut {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filter_types: Option<Vec<String>>,
 
-    /// The ep's ID
+    /// The Endpoint's ID.
     pub id: String,
 
     pub metadata: std::collections::HashMap<String, String>,

--- a/rust/src/models/endpoint_patch.rs
+++ b/rust/src/models/endpoint_patch.rs
@@ -32,7 +32,7 @@ pub struct EndpointPatch {
     #[serde(default, skip_serializing_if = "JsOption::is_undefined")]
     pub secret: JsOption<String>,
 
-    /// The ep's UID
+    /// The Endpoint's UID.
     #[serde(default, skip_serializing_if = "JsOption::is_undefined")]
     pub uid: JsOption<String>,
 

--- a/rust/src/models/environment_out.rs
+++ b/rust/src/models/environment_out.rs
@@ -11,7 +11,8 @@ pub struct EnvironmentOut {
     #[serde(rename = "eventTypes")]
     pub event_types: Vec<EventTypeOut>,
 
-    pub settings: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub settings: Option<serde_json::Value>,
 
     #[serde(rename = "transformationTemplates")]
     pub transformation_templates: Vec<TemplateOut>,
@@ -24,13 +25,12 @@ impl EnvironmentOut {
     pub fn new(
         created_at: String,
         event_types: Vec<EventTypeOut>,
-        settings: serde_json::Value,
         transformation_templates: Vec<TemplateOut>,
     ) -> Self {
         Self {
             created_at,
             event_types,
-            settings,
+            settings: None,
             transformation_templates,
             version: None,
         }

--- a/rust/src/models/expung_all_contents_out.rs
+++ b/rust/src/models/expung_all_contents_out.rs
@@ -1,0 +1,22 @@
+// this file is @generated
+use serde::{Deserialize, Serialize};
+
+use super::{
+    background_task_status::BackgroundTaskStatus, background_task_type::BackgroundTaskType,
+};
+
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+pub struct ExpungAllContentsOut {
+    /// The QueueBackgroundTask's ID.
+    pub id: String,
+
+    pub status: BackgroundTaskStatus,
+
+    pub task: BackgroundTaskType,
+}
+
+impl ExpungAllContentsOut {
+    pub fn new(id: String, status: BackgroundTaskStatus, task: BackgroundTaskType) -> Self {
+        Self { id, status, task }
+    }
+}

--- a/rust/src/models/integration_out.rs
+++ b/rust/src/models/integration_out.rs
@@ -11,7 +11,7 @@ pub struct IntegrationOut {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub feature_flags: Option<Vec<String>>,
 
-    /// The integ's ID
+    /// The Integration's ID.
     pub id: String,
 
     pub name: String,

--- a/rust/src/models/list_response_application_out.rs
+++ b/rust/src/models/list_response_application_out.rs
@@ -9,7 +9,8 @@ pub struct ListResponseApplicationOut {
 
     pub done: bool,
 
-    pub iterator: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iterator: Option<String>,
 
     #[serde(rename = "prevIterator")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -17,11 +18,11 @@ pub struct ListResponseApplicationOut {
 }
 
 impl ListResponseApplicationOut {
-    pub fn new(data: Vec<ApplicationOut>, done: bool, iterator: String) -> Self {
+    pub fn new(data: Vec<ApplicationOut>, done: bool) -> Self {
         Self {
             data,
             done,
-            iterator,
+            iterator: None,
             prev_iterator: None,
         }
     }

--- a/rust/src/models/list_response_background_task_out.rs
+++ b/rust/src/models/list_response_background_task_out.rs
@@ -9,7 +9,8 @@ pub struct ListResponseBackgroundTaskOut {
 
     pub done: bool,
 
-    pub iterator: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iterator: Option<String>,
 
     #[serde(rename = "prevIterator")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -17,11 +18,11 @@ pub struct ListResponseBackgroundTaskOut {
 }
 
 impl ListResponseBackgroundTaskOut {
-    pub fn new(data: Vec<BackgroundTaskOut>, done: bool, iterator: String) -> Self {
+    pub fn new(data: Vec<BackgroundTaskOut>, done: bool) -> Self {
         Self {
             data,
             done,
-            iterator,
+            iterator: None,
             prev_iterator: None,
         }
     }

--- a/rust/src/models/list_response_endpoint_message_out.rs
+++ b/rust/src/models/list_response_endpoint_message_out.rs
@@ -9,7 +9,8 @@ pub struct ListResponseEndpointMessageOut {
 
     pub done: bool,
 
-    pub iterator: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iterator: Option<String>,
 
     #[serde(rename = "prevIterator")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -17,11 +18,11 @@ pub struct ListResponseEndpointMessageOut {
 }
 
 impl ListResponseEndpointMessageOut {
-    pub fn new(data: Vec<EndpointMessageOut>, done: bool, iterator: String) -> Self {
+    pub fn new(data: Vec<EndpointMessageOut>, done: bool) -> Self {
         Self {
             data,
             done,
-            iterator,
+            iterator: None,
             prev_iterator: None,
         }
     }

--- a/rust/src/models/list_response_endpoint_out.rs
+++ b/rust/src/models/list_response_endpoint_out.rs
@@ -9,7 +9,8 @@ pub struct ListResponseEndpointOut {
 
     pub done: bool,
 
-    pub iterator: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iterator: Option<String>,
 
     #[serde(rename = "prevIterator")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -17,11 +18,11 @@ pub struct ListResponseEndpointOut {
 }
 
 impl ListResponseEndpointOut {
-    pub fn new(data: Vec<EndpointOut>, done: bool, iterator: String) -> Self {
+    pub fn new(data: Vec<EndpointOut>, done: bool) -> Self {
         Self {
             data,
             done,
-            iterator,
+            iterator: None,
             prev_iterator: None,
         }
     }

--- a/rust/src/models/list_response_event_type_out.rs
+++ b/rust/src/models/list_response_event_type_out.rs
@@ -9,7 +9,8 @@ pub struct ListResponseEventTypeOut {
 
     pub done: bool,
 
-    pub iterator: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iterator: Option<String>,
 
     #[serde(rename = "prevIterator")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -17,11 +18,11 @@ pub struct ListResponseEventTypeOut {
 }
 
 impl ListResponseEventTypeOut {
-    pub fn new(data: Vec<EventTypeOut>, done: bool, iterator: String) -> Self {
+    pub fn new(data: Vec<EventTypeOut>, done: bool) -> Self {
         Self {
             data,
             done,
-            iterator,
+            iterator: None,
             prev_iterator: None,
         }
     }

--- a/rust/src/models/list_response_integration_out.rs
+++ b/rust/src/models/list_response_integration_out.rs
@@ -9,7 +9,8 @@ pub struct ListResponseIntegrationOut {
 
     pub done: bool,
 
-    pub iterator: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iterator: Option<String>,
 
     #[serde(rename = "prevIterator")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -17,11 +18,11 @@ pub struct ListResponseIntegrationOut {
 }
 
 impl ListResponseIntegrationOut {
-    pub fn new(data: Vec<IntegrationOut>, done: bool, iterator: String) -> Self {
+    pub fn new(data: Vec<IntegrationOut>, done: bool) -> Self {
         Self {
             data,
             done,
-            iterator,
+            iterator: None,
             prev_iterator: None,
         }
     }

--- a/rust/src/models/list_response_message_attempt_out.rs
+++ b/rust/src/models/list_response_message_attempt_out.rs
@@ -9,7 +9,8 @@ pub struct ListResponseMessageAttemptOut {
 
     pub done: bool,
 
-    pub iterator: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iterator: Option<String>,
 
     #[serde(rename = "prevIterator")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -17,11 +18,11 @@ pub struct ListResponseMessageAttemptOut {
 }
 
 impl ListResponseMessageAttemptOut {
-    pub fn new(data: Vec<MessageAttemptOut>, done: bool, iterator: String) -> Self {
+    pub fn new(data: Vec<MessageAttemptOut>, done: bool) -> Self {
         Self {
             data,
             done,
-            iterator,
+            iterator: None,
             prev_iterator: None,
         }
     }

--- a/rust/src/models/list_response_message_endpoint_out.rs
+++ b/rust/src/models/list_response_message_endpoint_out.rs
@@ -9,7 +9,8 @@ pub struct ListResponseMessageEndpointOut {
 
     pub done: bool,
 
-    pub iterator: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iterator: Option<String>,
 
     #[serde(rename = "prevIterator")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -17,11 +18,11 @@ pub struct ListResponseMessageEndpointOut {
 }
 
 impl ListResponseMessageEndpointOut {
-    pub fn new(data: Vec<MessageEndpointOut>, done: bool, iterator: String) -> Self {
+    pub fn new(data: Vec<MessageEndpointOut>, done: bool) -> Self {
         Self {
             data,
             done,
-            iterator,
+            iterator: None,
             prev_iterator: None,
         }
     }

--- a/rust/src/models/list_response_message_out.rs
+++ b/rust/src/models/list_response_message_out.rs
@@ -9,7 +9,8 @@ pub struct ListResponseMessageOut {
 
     pub done: bool,
 
-    pub iterator: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iterator: Option<String>,
 
     #[serde(rename = "prevIterator")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -17,11 +18,11 @@ pub struct ListResponseMessageOut {
 }
 
 impl ListResponseMessageOut {
-    pub fn new(data: Vec<MessageOut>, done: bool, iterator: String) -> Self {
+    pub fn new(data: Vec<MessageOut>, done: bool) -> Self {
         Self {
             data,
             done,
-            iterator,
+            iterator: None,
             prev_iterator: None,
         }
     }

--- a/rust/src/models/list_response_operational_webhook_endpoint_out.rs
+++ b/rust/src/models/list_response_operational_webhook_endpoint_out.rs
@@ -9,7 +9,8 @@ pub struct ListResponseOperationalWebhookEndpointOut {
 
     pub done: bool,
 
-    pub iterator: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iterator: Option<String>,
 
     #[serde(rename = "prevIterator")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -17,11 +18,11 @@ pub struct ListResponseOperationalWebhookEndpointOut {
 }
 
 impl ListResponseOperationalWebhookEndpointOut {
-    pub fn new(data: Vec<OperationalWebhookEndpointOut>, done: bool, iterator: String) -> Self {
+    pub fn new(data: Vec<OperationalWebhookEndpointOut>, done: bool) -> Self {
         Self {
             data,
             done,
-            iterator,
+            iterator: None,
             prev_iterator: None,
         }
     }

--- a/rust/src/models/message_attempt_out.rs
+++ b/rust/src/models/message_attempt_out.rs
@@ -8,17 +8,17 @@ use super::{
 
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
 pub struct MessageAttemptOut {
-    /// The ep's ID
+    /// The Endpoint's ID.
     #[serde(rename = "endpointId")]
     pub endpoint_id: String,
 
-    /// The attempt's ID
+    /// The MessageAttempt's ID.
     pub id: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub msg: Option<MessageOut>,
 
-    /// The msg's ID
+    /// The Message's ID.
     #[serde(rename = "msgId")]
     pub msg_id: String,
 

--- a/rust/src/models/message_endpoint_out.rs
+++ b/rust/src/models/message_endpoint_out.rs
@@ -22,7 +22,7 @@ pub struct MessageEndpointOut {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filter_types: Option<Vec<String>>,
 
-    /// The ep's ID
+    /// The Endpoint's ID.
     pub id: String,
 
     #[serde(rename = "nextAttempt")]

--- a/rust/src/models/message_out.rs
+++ b/rust/src/models/message_out.rs
@@ -16,7 +16,7 @@ pub struct MessageOut {
     #[serde(rename = "eventType")]
     pub event_type: String,
 
-    /// The msg's ID
+    /// The Message's ID.
     pub id: String,
 
     pub payload: serde_json::Value,

--- a/rust/src/models/operational_webhook_endpoint_out.rs
+++ b/rust/src/models/operational_webhook_endpoint_out.rs
@@ -16,7 +16,7 @@ pub struct OperationalWebhookEndpointOut {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filter_types: Option<Vec<String>>,
 
-    /// The ep's ID
+    /// The Endpoint's ID.
     pub id: String,
 
     pub metadata: std::collections::HashMap<String, String>,

--- a/rust/src/models/recover_out.rs
+++ b/rust/src/models/recover_out.rs
@@ -7,6 +7,7 @@ use super::{
 
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
 pub struct RecoverOut {
+    /// The QueueBackgroundTask's ID.
     pub id: String,
 
     pub status: BackgroundTaskStatus,

--- a/rust/src/models/replay_out.rs
+++ b/rust/src/models/replay_out.rs
@@ -7,6 +7,7 @@ use super::{
 
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
 pub struct ReplayOut {
+    /// The QueueBackgroundTask's ID.
     pub id: String,
 
     pub status: BackgroundTaskStatus,

--- a/rust/src/models/template_out.rs
+++ b/rust/src/models/template_out.rs
@@ -18,6 +18,7 @@ pub struct TemplateOut {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filter_types: Option<Vec<String>>,
 
+    /// The TransformationTemplate's ID.
     pub id: String,
 
     pub instructions: String,
@@ -32,6 +33,7 @@ pub struct TemplateOut {
 
     pub name: String,
 
+    /// The Organization's ID.
     #[serde(rename = "orgId")]
     pub org_id: String,
 

--- a/rust/tests/it/kitchen_sink.rs
+++ b/rust/tests/it/kitchen_sink.rs
@@ -123,7 +123,13 @@ async fn test_endpoint_crud() {
 
     // Should complete without error if the deserialization handles empty bodies
     // correctly.
-    client.endpoint().delete(app.id, ep.id).await.unwrap();
+    client
+        .endpoint()
+        .delete(app.id.clone(), ep.id)
+        .await
+        .unwrap();
+
+    client.application().delete(app.id).await.unwrap()
 }
 
 #[tokio::test]

--- a/rust/tests/it/main.rs
+++ b/rust/tests/it/main.rs
@@ -1,2 +1,3 @@
 mod kitchen_sink;
 mod utils;
+mod mode_serialization;

--- a/rust/tests/it/main.rs
+++ b/rust/tests/it/main.rs
@@ -1,3 +1,3 @@
 mod kitchen_sink;
-mod utils;
 mod mode_serialization;
+mod utils;

--- a/rust/tests/it/mode_serialization.rs
+++ b/rust/tests/it/mode_serialization.rs
@@ -17,7 +17,7 @@ async fn test_list_response_xxx_out() {
     assert_eq!(expected_model, loaded_json);
 
     // without iterator and prevIterator
-    let json_str = r#"{"data":[],"done":true}"#;
+    let json_str = r#"{"data":[],"done":true,"iterator":null,"prevIterator":null}"#;
     let loaded_json: ListResponseApplicationOut = serde_json::from_str(json_str).unwrap();
 
     let expected_model = ListResponseApplicationOut {

--- a/rust/tests/it/mode_serialization.rs
+++ b/rust/tests/it/mode_serialization.rs
@@ -5,7 +5,7 @@ async fn test_list_response_xxx_out() {
     // first test with iterator and prevIterator
     let json_str =
         r#"{"data":[],"done":true,"iterator":"iterator-str","prevIterator":"prevIterator-str"}"#;
-    let loaded_json: ListResponseApplicationOut = serde_json::from_str(&json_str).unwrap();
+    let loaded_json: ListResponseApplicationOut = serde_json::from_str(json_str).unwrap();
 
     let expected_model = ListResponseApplicationOut {
         data: vec![],
@@ -18,7 +18,7 @@ async fn test_list_response_xxx_out() {
 
     // without iterator and prevIterator
     let json_str = r#"{"data":[],"done":true}"#;
-    let loaded_json: ListResponseApplicationOut = serde_json::from_str(&json_str).unwrap();
+    let loaded_json: ListResponseApplicationOut = serde_json::from_str(json_str).unwrap();
 
     let expected_model = ListResponseApplicationOut {
         data: vec![],

--- a/rust/tests/it/mode_serialization.rs
+++ b/rust/tests/it/mode_serialization.rs
@@ -1,0 +1,30 @@
+use svix::api::ListResponseApplicationOut;
+
+#[tokio::test]
+async fn test_list_response_xxx_out() {
+    // first test with iterator and prevIterator
+    let json_str =
+        r#"{"data":[],"done":true,"iterator":"iterator-str","prevIterator":"prevIterator-str"}"#;
+    let loaded_json: ListResponseApplicationOut = serde_json::from_str(&json_str).unwrap();
+
+    let expected_model = ListResponseApplicationOut {
+        data: vec![],
+        done: true,
+        iterator: Some("iterator-str".to_string()),
+        prev_iterator: Some("prevIterator-str".to_string()),
+    };
+
+    assert_eq!(expected_model, loaded_json);
+
+    // without iterator and prevIterator
+    let json_str = r#"{"data":[],"done":true}"#;
+    let loaded_json: ListResponseApplicationOut = serde_json::from_str(&json_str).unwrap();
+
+    let expected_model = ListResponseApplicationOut {
+        data: vec![],
+        done: true,
+        ..Default::default()
+    };
+
+    assert_eq!(expected_model, loaded_json);
+}


### PR DESCRIPTION
ref: https://github.com/svix/svix-webhooks/issues/1721

- Pull in new updates from `lib-openapi.json`
    - Doc comments
    - New models

Breaking changes: 
	- For all `ListResponse*Out` structs, the `iterator` field is now `Option<String>,` instead of `String`
	- `EnvironmentOut.settings` is now a `Option<serde_json::Value>` instead of `serde_json::Value`

