### PR TITLE
Add tests for ListResponseApplicationOut

### DIFF
--- a/csharp/Svix.Tests/SvixClientTests.cs
+++ b/csharp/Svix.Tests/SvixClientTests.cs
@@ -112,5 +112,8 @@ public class SvixClientTests
             new ApplicationIn { Name = "same app", Uid = "test-app-get-or-create-csharp-tests" }
         );
         Assert.Equal(app3.Id, app4.Id);
+        client.Application.Delete(app.Id);
+        client.Application.Delete(app2.Id);
+        client.Application.Delete(app3.Id);
     }
 }

--- a/csharp/Svix.Tests/WiremockTests.cs
+++ b/csharp/Svix.Tests/WiremockTests.cs
@@ -6,6 +6,7 @@ using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
 using WireMock.Settings;
+using Wmhelp.XPath2.AST;
 using Xunit;
 
 namespace Svix.Tests
@@ -229,6 +230,19 @@ namespace Svix.Tests
             await Assert.ThrowsAsync<ArgumentNullException>(
                 () => client.Application.CreateAsync(null, null, default)
             );
+        }
+
+        [Fact]
+        public void ListResponseApplicationOutWorksCorrectly()
+        {
+            stub.Given(Request.Create().WithPath("/api/v1/app"))
+                .RespondWith(
+                    Response
+                        .Create()
+                        .WithStatusCode(200)
+                        .WithBody("""{"data":[],"iterator":null,"prevIterator":null,"done":true}""")
+                );
+            client.Application.List();
         }
     }
 }


### PR DESCRIPTION
This is not currently a problem here. But in some other libs, if `iterator` is null this code will panic.
Add tests to me catch any regression