### PR TITLE
Fix Javascript release workflow

### DIFF
--- a/.github/workflows/javascript-release.yml
+++ b/.github/workflows/javascript-release.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Publish (pre-release)
         if: github.ref_type == 'branch'
         run: |
-          git config user.name "${{ github.event.pusher.name }}"
-          git config user.email "${{ github.event.pusher.email }}"
+          git config user.name "${{ github.event.pusher.name || 'svix-bot' }}"
+          git config user.email "${{ github.event.pusher.email || 'svix-bot@svix.com' }}"
           cd javascript
           yarn version --prerelease --preid next-${{ github.sha }}
           yarn publish --tag next


### PR DESCRIPTION
When this workflow is triggered by the [Mega Releaser](https://github.com/svix/svix-webhooks/actions/workflows/mega-releaser.yml), `github.event.pusher` is empty (see https://github.com/svix/svix-webhooks/actions/runs/13396336811/job/37416216605). This adds a fallback value so it doesn't fail. 

The value doesn't really matter because it's only needed to run `yarn version`, not actually used to publish the package. 