### PR TITLE
Add rust lib regeneration to regen_openapi.sh

### DIFF
--- a/.github/workflows/cli-lint.yml
+++ b/.github/workflows/cli-lint.yml
@@ -49,6 +49,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    # the codegen uses `rustfmt +nightly`
+    - uses: dtolnay/rust-toolchain@nightly
+      with:
+        components: rustfmt
+
     - name: Regen openapi libs
       run: |
         yarn

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -47,6 +47,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    # the codegen uses `rustfmt +nightly`
+    - uses: dtolnay/rust-toolchain@nightly
+      with:
+        components: rustfmt
+
     - name: Regen openapi libs
       run: |
         yarn

--- a/rust/src/api/message.rs
+++ b/rust/src/api/message.rs
@@ -40,6 +40,11 @@ pub struct MessageCreateOptions {
 }
 
 #[derive(Default)]
+pub struct MessageExpungeAllContentsOptions {
+    pub idempotency_key: Option<String>,
+}
+
+#[derive(Default)]
 pub struct MessageGetOptions {
     /// When `true` message payloads are included in the response.
     pub with_content: Option<bool>,
@@ -132,6 +137,26 @@ impl<'a> Message<'a> {
             .with_body_param(message_in)
             .execute(self.cfg)
             .await
+    }
+
+    /// Purge all message content for the application.
+    ///
+    /// Delete all message payloads for the application.
+    pub async fn expunge_all_contents(
+        &self,
+        app_id: String,
+        options: Option<MessageExpungeAllContentsOptions>,
+    ) -> Result<ExpungAllContentsOut> {
+        let MessageExpungeAllContentsOptions { idempotency_key } = options.unwrap_or_default();
+
+        crate::request::Request::new(
+            http1::Method::POST,
+            "/api/v1/app/{app_id}/msg/expunge-all-contents",
+        )
+        .with_path_param("app_id", app_id)
+        .with_optional_header_param("idempotency-key", idempotency_key)
+        .execute(self.cfg)
+        .await
     }
 
     /// Get a message by its ID or eventID.

--- a/rust/src/models/mod.rs
+++ b/rust/src/models/mod.rs
@@ -39,6 +39,7 @@ pub mod event_type_in;
 pub mod event_type_out;
 pub mod event_type_patch;
 pub mod event_type_update;
+pub mod expung_all_contents_out;
 pub mod http_error_out;
 pub mod http_validation_error;
 pub mod integration_in;
@@ -121,6 +122,7 @@ pub use self::{
     event_type_out::EventTypeOut,
     event_type_patch::EventTypePatch,
     event_type_update::EventTypeUpdate,
+    expung_all_contents_out::ExpungAllContentsOut,
     http_error_out::HttpErrorOut,
     http_validation_error::HttpValidationError,
     integration_in::IntegrationIn,

--- a/rust/templates/api_extra/application_create.rs
+++ b/rust/templates/api_extra/application_create.rs
@@ -1,0 +1,16 @@
+/// Create the application with the given ID, or create a new one if it
+/// doesn't exist yet.
+pub async fn get_or_create(
+    &self,
+    application_in: ApplicationIn,
+    options: Option<ApplicationCreateOptions>,
+) -> Result<ApplicationOut> {
+    let ApplicationCreateOptions { idempotency_key } = options.unwrap_or_default();
+
+    crate::request::Request::new(http1::Method::POST, "/api/v1/app")
+        .with_query_param("get_if_exists", "true".to_owned())
+        .with_optional_header_param("idempotency-key", idempotency_key)
+        .with_body_param(application_in)
+        .execute(self.cfg)
+        .await
+}

--- a/rust/templates/api_extra/message.rs
+++ b/rust/templates/api_extra/message.rs
@@ -1,0 +1,33 @@
+#[cfg(feature = "svix_beta")]
+#[derive(Clone, Debug)]
+pub struct V1MessageEventsParams {
+    /// The app's ID or UID
+    pub app_id: String,
+    /// Limit the number of returned items
+    pub limit: Option<i32>,
+    /// The iterator returned from a prior invocation
+    pub iterator: Option<String>,
+    /// Filter response based on the event type
+    pub event_types: Option<Vec<String>>,
+    /// Filter response based on the event type.
+    pub channels: Option<Vec<String>>,
+    pub after: Option<String>,
+}
+
+#[cfg(feature = "svix_beta")]
+#[derive(Clone, Debug)]
+pub struct V1MessageEventsSubscriptionParams {
+    /// The app's ID or UID
+    pub app_id: String,
+    /// The esub's ID or UID
+    pub subscription_id: String,
+    /// Limit the number of returned items
+    pub limit: Option<i32>,
+    /// The iterator returned from a prior invocation
+    pub iterator: Option<String>,
+    /// Filter response based on the event type
+    pub event_types: Option<Vec<String>>,
+    /// Filter response based on the event type.
+    pub channels: Option<Vec<String>>,
+    pub after: Option<String>,
+}

--- a/rust/templates/api_extra/message_attempt_list_attempted_messages.rs
+++ b/rust/templates/api_extra/message_attempt_list_attempted_messages.rs
@@ -1,0 +1,40 @@
+#[deprecated = "Use `list_by_msg` instead, setting the `endpoint_id` in `options`."]
+pub async fn list_attempts_for_endpoint(
+    &self,
+    app_id: String,
+    msg_id: String,
+    endpoint_id: String,
+    options: Option<MessageAttemptListByMsgOptions>,
+) -> Result<ListResponseMessageAttemptEndpointOut> {
+    let MessageAttemptListByMsgOptions {
+        iterator,
+        limit,
+        event_types,
+        before,
+        after,
+        channel,
+        tag,
+        status,
+        status_code_class: _,
+        endpoint_id: _,
+        with_content: _,
+    } = options.unwrap_or_default();
+
+    crate::request::Request::new(
+        http1::Method::GET,
+        "/api/v1/app/{app_id}/msg/{msg_id}/endpoint/{endpoint_id}/attempt",
+    )
+    .with_optional_query_param("limit", limit)
+    .with_optional_query_param("iterator", iterator)
+    .with_optional_query_param("channel", channel)
+    .with_optional_query_param("tag", tag)
+    .with_optional_query_param("status", status)
+    .with_optional_query_param("before", before)
+    .with_optional_query_param("after", after)
+    .with_optional_query_param("event_types", event_types)
+    .with_path_param("app_id", app_id.to_string())
+    .with_path_param("msg_id", msg_id.to_string())
+    .with_path_param("endpoint_id", endpoint_id.to_string())
+    .execute(self.cfg)
+    .await
+}

--- a/rust/templates/api_extra/message_expunge_content.rs
+++ b/rust/templates/api_extra/message_expunge_content.rs
@@ -1,0 +1,54 @@
+#[cfg(feature = "svix_beta")]
+pub async fn events(
+    &self,
+    params: V1MessageEventsParams,
+) -> Result<crate::models::MessageEventsOut> {
+    let V1MessageEventsParams {
+        app_id,
+        limit,
+        iterator,
+        event_types,
+        channels,
+        after,
+    } = params;
+
+    crate::request::Request::new(http1::Method::GET, "/api/v1/app/{app_id}/events")
+        .with_path_param("app_id", app_id)
+        .with_optional_query_param("limit", limit)
+        .with_optional_query_param("iterator", iterator)
+        .with_optional_query_param("event_types", event_types)
+        .with_optional_query_param("channels", channels)
+        .with_optional_query_param("after", after)
+        .execute(self.cfg)
+        .await
+}
+
+#[cfg(feature = "svix_beta")]
+pub async fn events_subscription(
+    &self,
+    params: V1MessageEventsSubscriptionParams,
+) -> Result<crate::models::MessageEventsOut> {
+    let V1MessageEventsSubscriptionParams {
+        app_id,
+        subscription_id,
+        limit,
+        iterator,
+        event_types,
+        channels,
+        after,
+    } = params;
+
+    crate::request::Request::new(
+        http1::Method::GET,
+        "/api/v1/app/{app_id}/events/subscription/{subscription_id}",
+    )
+    .with_path_param("app_id", app_id.to_string())
+    .with_path_param("subscription_id", subscription_id.to_string())
+    .with_optional_query_param("limit", limit)
+    .with_optional_query_param("iterator", iterator)
+    .with_optional_query_param("event_types", event_types)
+    .with_optional_query_param("channels", channels)
+    .with_optional_query_param("after", after)
+    .execute(self.cfg)
+    .await
+}

--- a/rust/templates/api_resource.rs.jinja
+++ b/rust/templates/api_resource.rs.jinja
@@ -1,0 +1,145 @@
+{% set resource_type_name = resource.name | to_upper_camel_case -%}
+
+use crate::{
+    error::Result,
+    models::*,
+    Configuration,
+};
+
+{% for op in resource.operations -%}
+    {% if op | has_query_or_header_params %}
+    {% if not op | has_required_query_or_header_params -%}
+        #[derive(Default)]
+    {% endif -%}
+    pub struct {{ resource_type_name }}{{ op.name | to_upper_camel_case }}Options {
+        {% for p in op.query_params -%}
+            {% if p.type.is_datetime() -%}
+                {% set ty = "String" -%}
+            {% else -%}
+                {% set ty = p.type.to_rust() -%}
+            {% endif -%}
+            {% if not p.required %}{% set ty %}Option<{{ ty }}>{% endset %}{% endif %}
+            {% if p.description is defined -%}
+                {{ p.description | to_doc_comment(style="rust") }}
+                {# we currently use String for date-time params, for backwards compat -#}
+                {# document the format so it's not _that_ awkward -#}
+                {% if p.type.is_datetime() -%}
+                ///
+                /// RFC3339 date string.
+                {% endif -%}
+            {% endif -%}
+            pub {{ p.name | to_snake_case }}: {{ ty }},
+        {% endfor -%}
+        {% for p in op.header_params -%}
+            {% set ty = "String" -%}
+            {% if not p.required %}{% set ty %}Option<{{ ty }}>{% endset %}{% endif %}
+            {% if p.description is defined -%}
+                {{ p.description | to_doc_comment(style="rust") }}
+            {% endif -%}
+            pub {{ p.name | to_snake_case }}: {{ ty }},
+        {% endfor -%}
+    }
+    {% endif %}
+{% endfor -%}
+
+pub struct {{ resource_type_name }}<'a> {
+    cfg: &'a Configuration,
+}
+
+impl<'a> {{ resource_type_name }}<'a> {
+    pub(super) fn new(cfg: &'a Configuration) -> Self {
+        Self { cfg }
+    }
+
+    {% for op in resource.operations %}
+    {% set has_params = op | has_query_or_header_params -%}
+    {% if op.description is defined -%}
+        {{ op.description | to_doc_comment(style="rust") }}
+    {% endif -%}
+    {% if op.deprecated -%}
+        #[deprecated]
+    {% endif -%}
+    pub async fn {{ op.name | to_snake_case }}(
+        &self,
+
+        {#- path parameters -#}
+        {% for p in op.path_params -%}
+            {{ p }}: String,
+        {% endfor -%}
+
+        {# body parameter struct -#}
+        {% if op.request_body_schema_name is defined -%}
+            {{ op.request_body_schema_name | to_snake_case }}: {{ op.request_body_schema_name }},
+        {% endif -%}
+
+        {# query / header parameter struct -#}
+        {% if has_params -%}
+            {% set param_struct_name -%}
+                {{ resource_type_name }}{{ op.name | to_upper_camel_case }}Options
+            {%- endset -%}
+            {% set has_required_params = op | has_required_query_or_header_params -%}
+            {%- if has_required_params -%}
+                options: {{ param_struct_name }},
+            {%- else -%}
+                options: Option<{{ param_struct_name }}>,
+            {%- endif -%}
+        {% endif -%}
+    ) -> Result<{{ op.response_body_schema_name | default("()") | replace("_", "") }}> {
+        {% if has_params -%}
+            {# unpack query / header parameter struct -#}
+            let {{ param_struct_name }} {
+                {% for p in op.query_params %}{{ p.name | to_snake_case }},{% endfor %}
+                {% for p in op.header_params %}{{ p.name | to_snake_case }},{% endfor %}
+            } = options
+            {%- if not has_required_params %}.unwrap_or_default(){% endif -%}
+            ;
+        {% endif -%}
+
+        {% if has_header_params -%}
+            {# unpack PostOptions -#}
+            let PostOptions { idempotency_key } = options.unwrap_or_default();
+        {% endif -%}
+
+        {# make the request #}
+        crate::request::Request::new(http1::Method::{{ op.method | upper }}, "{{ op.path }}")
+
+        {% for p in op.path_params -%}
+            .with_path_param("{{ p }}", {{ p }})
+        {% endfor -%}
+
+        {% for p in op.query_params -%}
+            {% if p.required -%}
+                .with_query_param
+            {%- else -%}
+                .with_optional_query_param
+            {%- endif -%}
+            ("{{ p.name }}", {{ p.name | to_snake_case }})
+        {% endfor -%}
+
+        {% for p in op.header_params -%}
+            .with_optional_header_param("{{ p.name }}", {{ p.name | to_snake_case }})
+        {% endfor -%}
+
+        {% if op.request_body_schema_name is defined -%}
+            .with_body_param({{ op.request_body_schema_name | to_snake_case }})
+        {% endif -%}
+
+        {% if op.response_body_schema_name is undefined -%}
+            .returns_nothing()
+        {% endif -%}
+
+            .execute(self.cfg)
+            .await
+    }
+
+    {% set extra_path -%}
+        api_extra/{{ resource.name | to_snake_case }}_{{ op.name | to_snake_case }}.rs
+    {%- endset -%}
+    {% include extra_path ignore missing %}
+    {% endfor %}
+}
+
+{% set extra_path -%}
+    api_extra/{{ resource.name | to_snake_case }}.rs
+{%- endset -%}
+{% include extra_path ignore missing %}

--- a/rust/templates/api_summary.rs.jinja
+++ b/rust/templates/api_summary.rs.jinja
@@ -1,0 +1,17 @@
+{% for resource in api.resources -%}
+    mod {{ resource.name | to_snake_case }};
+{% endfor %}
+
+pub use self::{
+    {% for resource in api.resources -%}
+        {% set resource_type_name = resource.name | to_upper_camel_case -%}
+        {{ resource.name | to_snake_case }}::{
+            {{ resource_type_name }},
+            {% for op in resource.operations -%}
+                {% if op.query_params | length > 0 -%}
+                    {{ resource_type_name }}{{ op.name | to_upper_camel_case }}Options,
+                {% endif -%}
+            {% endfor -%}
+        },
+    {% endfor -%}
+};

--- a/rust/templates/component_type.rs.jinja
+++ b/rust/templates/component_type.rs.jinja
@@ -1,0 +1,14 @@
+// this file is @generated
+{% if type.description is defined -%}
+{% set doc_comment = type.description | to_doc_comment(style="rust") -%}
+{% endif -%}
+
+{% if type.kind == "struct" -%}
+    {% include "types/struct.rs.jinja" -%}
+{% elif type.kind == "string_enum" -%}
+    {% include "types/string_enum.rs.jinja" -%}
+{% elif type.kind == "integer_enum" -%}
+    {% include "types/integer_enum.rs.jinja" -%}
+{% else -%}
+    compile_error!("{{ type.kind }} types are not supported by this codegen template");
+{% endif %}

--- a/rust/templates/types/integer_enum.rs.jinja
+++ b/rust/templates/types/integer_enum.rs.jinja
@@ -1,0 +1,33 @@
+use std::fmt;
+
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+{{ doc_comment }}
+#[repr(i64)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize_repr,
+    Deserialize_repr,
+)]
+pub enum {{ type.name | to_upper_camel_case }} {
+    {% for name, value in type.variants -%}
+        {% if loop.first -%}
+            #[default]
+        {% endif -%}
+        {{ name | to_upper_camel_case }} = {{ value }},
+    {% endfor -%}
+}
+
+impl fmt::Display for {{ type.name | to_upper_camel_case }} {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", *self as i64)
+    }
+}

--- a/rust/templates/types/string_enum.rs.jinja
+++ b/rust/templates/types/string_enum.rs.jinja
@@ -1,0 +1,28 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+{{ doc_comment }}
+#[derive(
+    Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize,
+)]
+pub enum {{ type.name | to_upper_camel_case }} {
+    {% for value in type.values -%}
+        {% if loop.first -%}
+            #[default]
+        {% endif -%}
+        #[serde(rename = "{{ value }}")]
+        {{ value | to_upper_camel_case }},
+    {% endfor -%}
+}
+
+impl fmt::Display for {{ type.name | to_upper_camel_case }} {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let value = match self {
+            {% for value in type.values -%}
+                Self::{{ value | to_upper_camel_case }} => "{{ value }}",
+            {% endfor -%}
+        };
+        f.write_str(value)
+    }
+}

--- a/rust/templates/types/struct.rs.jinja
+++ b/rust/templates/types/struct.rs.jinja
@@ -1,0 +1,92 @@
+{% if type.name is endingwith "Patch" -%}
+    use js_option::JsOption;
+{% endif -%}
+use serde::{Deserialize, Serialize};
+
+use super::{
+    {% for c in referenced_components -%}
+        {{ c | to_snake_case }}::{{ c | to_upper_camel_case }},
+    {% endfor -%}
+};
+
+{{ doc_comment }}
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+pub struct {{ type.name | to_upper_camel_case }} {
+    {% for field in type.fields %}
+        {% if field.description is defined -%}
+            {{ field.description | to_doc_comment(style="rust") }}
+            {# we currently use String for date-time params, for backwards compat -#}
+            {# document the format so it's not _that_ awkward -#}
+            {% if field.type.is_datetime() -%}
+            ///
+            /// RFC3339 date string.
+            {% endif -%}
+        {% endif -%}
+
+        {% if field.deprecated -%}
+            #[deprecated]
+        {% endif -%}
+
+        {% if field.name != field.name | to_snake_case -%}
+            #[serde(rename = "{{ field.name }}")]
+        {% endif -%}
+
+        {#
+            we only have defaults on optional fields now, and the old codegen
+            was not doing anything with them, so leave them alone here as well,
+            at least for now
+        -#}
+        {# {% if field.default is defined and field.default is not none -%}
+        #[serde(default = "{{ field.name | to_snake_case }}_default")]
+        {% endif -%} -#}
+        {% if field.type.is_datetime() -%}
+            {% set field_ty = "String" -%}
+        {% else -%}
+            {% set field_ty = field.type.to_rust() -%}
+        {% endif -%}
+
+        {% if not field.required or field.nullable -%}
+            {# only for patch requests, if the field is both non-required
+               and nullable, use JsOption -#}
+            {% if type.name is endingwith "Patch" and field.nullable -%}
+                {% set field_ty %}JsOption<{{ field_ty }}>{% endset -%}
+                #[serde(default, skip_serializing_if = "JsOption::is_undefined")]
+            {% else -%}
+                {% set field_ty %}Option<{{ field_ty }}>{% endset -%}
+                #[serde(skip_serializing_if = "Option::is_none")]
+            {% endif -%}
+        {% endif -%}
+
+        pub {{ field.name | to_snake_case }}: {{ field_ty }},
+    {% endfor %}
+}
+
+impl {{ type.name | to_upper_camel_case }} {
+    pub fn new(
+        {% for field in type.fields -%}
+            {% if field.type.is_datetime() -%}
+                {% set field_ty = "String" -%}
+            {% else -%}
+                {% set field_ty = field.type.to_rust() -%}
+            {% endif -%}
+            {% if field.required and not field.nullable -%}
+                {{ field.name | to_snake_case }}: {{ field_ty }},
+            {% endif -%}
+        {% endfor -%}
+    ) -> Self {
+        {% if type.fields | selectattr("deprecated") | length > 0 -%}
+            #[allow(deprecated)]
+        {% endif -%}
+        Self {
+            {% for field in type.fields -%}
+                {% if field.required and not field.nullable -%}
+                    {{ field.name | to_snake_case }},
+                {% elif type.name is endingwith "Patch" and field.nullable -%}
+                    {{ field.name | to_snake_case }}: JsOption::Undefined,
+                {% else -%}
+                    {{ field.name | to_snake_case }}: None,
+                {% endif -%}
+            {% endfor -%}
+        }
+    }
+}


### PR DESCRIPTION
I'm not back from vacation yet, but I had a free minute and wanted to get this branch that I had ready locally into a PR.

The first commit includes a typo that's carried over from the OpenAPI spec: `ExpungAllContentsOut` should be `ExpungeAllContentsOut`. Should be fixed separately.