### PR TITLE
Make homebrew action run under release environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,6 +277,7 @@ jobs:
           gh release edit "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --draft=false
 
   publish-homebrew-formula:
+    environment: "release"
     needs:
       - plan
       - host

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -24,9 +24,10 @@ tap = "svix/homebrew-svix"
 # Publish jobs to run in CI
 publish-jobs = ["homebrew"]
 
+allow-dirty = ["ci"]
+
 [dist.github-custom-runners]
 x86_64-unknown-linux-musl = "ubuntu-22.04"
 x86_64-unknown-linux-gnu = "ubuntu-22.04"
 aarch64-unknown-linux-gnu = "ubuntu-22.04"
 global = "ubuntu-22.04"
-


### PR DESCRIPTION
Sadly I have `allow-dirty = ["ci"]` or else dist will complain
