### PR TITLE
ci: Fix issue with svix next package publishing

### DIFF
--- a/.github/workflows/javascript-release.yml
+++ b/.github/workflows/javascript-release.yml
@@ -34,7 +34,7 @@ jobs:
           yarn
 
       - name: Publish (pre-release)
-        if: github.ref_type == 'branch'
+        if: ${{ github.ref_type == 'branch' && !startsWith(github.event.workflow_run.head_branch,'v') }}
         run: |
           git config user.name "${{ github.event.pusher.name || 'svix-bot' }}"
           git config user.email "${{ github.event.pusher.email || 'svix-bot@svix.com' }}"
@@ -45,7 +45,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish
-        if: github.ref_type == 'tag'
+        if: ${{ github.ref_type == 'tag' || startsWith(github.event.workflow_run.head_branch,'v') }}
         run: |
           cd javascript
           yarn publish


### PR DESCRIPTION
Context: We use `ref_type` to check if we are running on a branch or a tag If we are running on a branch (main) we will publish a pre-release version of the js lib If we running on a tag we publish the new "real" version

The problem happens when a workflow gets triggered using workflow_run, the `github.ref_type` is not preserved, And even if the Mega releaser had a  ref_type = 'tag' the js release workflow sees ref_type = 'branch' (https://github.com/orgs/community/discussions/27124)

To fix this, I check if `github.event.workflow_run.head_branch` starts with 'v' (v1.58.0), this tells me if this workflow was triggered workflow_run
