### PR TITLE
js: Ignore eslint.config.mjs

### DIFF
--- a/javascript/tsconfig.json
+++ b/javascript/tsconfig.json
@@ -25,6 +25,7 @@
     "node_modules",
     "jest.config.js",
     "src/**/*.test.ts",
+    "eslint.config.mjs"
   ],
   "filesGlob": ["./src/**/*.ts"]
 }


### PR DESCRIPTION
Without this tsc will create a `src` subdir in our packages
