### PR TITLE
ci: Remove regen_openapi.sh from kotlin release

### DIFF
--- a/.github/workflows/kotlin-release.yml
+++ b/.github/workflows/kotlin-release.yml
@@ -23,11 +23,6 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
-      - name: Regen openapi libs
-        run: |
-          yarn
-          ./regen_openapi.sh
-
       - name: Restore gradle.properties
         run: |
           mkdir -p ~/.gradle/


### PR DESCRIPTION
The `regen_openapi.sh` does not generate our kotlin lib anymore