### PR TITLE
go: Switch to `math/rand` from `math/rand/v2` #1745

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -12,13 +12,15 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
-
+    strategy:
+      matrix:
+        version: ["1.23.x", "1.21.x"]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23.x"
+          go-version: ${{ matrix.version }}
           cache-dependency-path: ./go.sum
       - name: Display Go version
         run: go version

--- a/go/svix_http_client.go
+++ b/go/svix_http_client.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math/rand/v2"
+	"math/rand"
 	"net/http"
 	"net/http/httputil"
 	"net/url"

--- a/go/svix_test.go
+++ b/go/svix_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"math/rand/v2"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"os"


### PR DESCRIPTION
`math/rand/v2` was introduced in go 1.22.
Since we are not using any v2 specific features, there is no need to use v2

Also add go1.21 as a target in CI

ref: https://github.com/svix/svix-webhooks/issues/1745