### PR TITLE
Fix bug in bump_version.js script

### DIFF
--- a/tools/bump_version.js
+++ b/tools/bump_version.js
@@ -36,8 +36,6 @@ const filesPaths = [
     // Ruby
     "ruby/Gemfile.lock",
     "ruby/lib/svix/version.rb",
-    // OpenAPI spec
-    "server/openapi.json",
     // Cloud OpenAPI spec - not necessary but any other time of updating seems weirder
     "lib-openapi.json",
 ];
@@ -63,6 +61,10 @@ filesPaths.forEach((relativePath) => {
     const filePath = join(rootDir, relativePath);
     const content = readFileSync(filePath, 'utf8');
     const updated_content = content.replace(replaceRegExp, newVersion);
+    if (content === updated_content) {
+        console.error("New version was not written to " + filePath)
+        process.exit(1);
+    }
     writeFileSync(filePath, updated_content);
 })
 


### PR DESCRIPTION
The script reads the `.version` file to get the `<old_version>` It then uses the `<new_version>` from `argv[2]` to replace `<old_version>` with `<new_version>` for all of the files in `filesPaths`

There is a bug if for whatever reason the `<old_version>` in the target file does not match the `<old_version>` in `.version`

I added a quick check to see if the file was modified, if it was not exit with status 1
