### PR TITLE
js: Fix issues causing `_fromJsonObject` to panic at runtime

### DIFF
--- a/javascript/src/mockttp.test.ts
+++ b/javascript/src/mockttp.test.ts
@@ -304,4 +304,36 @@ describe("mockttp tests", () => {
     expect(requests[0].headers["authorization"]).toBe("Bearer token.eu");
     expect(requests[0].headers["user-agent"]).toBe(`svix-libs/${LIB_VERSION}/javascript`);
   });
+
+  test("MessageAttemptOut without msg", async () => {
+    const RES = `{
+      "data": [
+        {
+          "url": "https://example.com/webhook/",
+          "response": "{}",
+          "responseStatusCode": 200,
+          "responseDurationMs": 0,
+          "status": 0,
+          "triggerType": 0,
+          "msgId": "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2",
+          "endpointId": "ep_1srOrx2ZWZBpBUvZwXKQmoEYga2",
+          "id": "atmpt_1srOrx2ZWZBpBUvZwXKQmoEYga2",
+          "timestamp": "2019-08-24T14:15:22Z"
+        }
+      ],
+      "iterator": "iterator",
+      "prevIterator": "-iterator",
+      "done": true
+    }`;
+    const endpointMock = await mockServer
+      .forGet("/api/v1/app/app/attempt/endpoint/edp")
+      .thenReply(200, RES);
+
+    const svx = new Svix("token.eu", { serverUrl: mockServer.url });
+
+    await svx.messageAttempt.listByEndpoint("app", "edp");
+
+    const requests = await endpointMock.getSeenRequests();
+    expect(requests.length).toBe(1);
+  });
 });

--- a/javascript/src/models/appPortalAccessIn.ts
+++ b/javascript/src/models/appPortalAccessIn.ts
@@ -24,7 +24,9 @@ export interface AppPortalAccessIn {
 export const AppPortalAccessInSerializer = {
   _fromJsonObject(object: any): AppPortalAccessIn {
     return {
-      application: ApplicationInSerializer._fromJsonObject(object["application"]),
+      application: object["application"]
+        ? ApplicationInSerializer._fromJsonObject(object["application"])
+        : undefined,
       expiry: object["expiry"],
       featureFlags: object["featureFlags"],
       readOnly: object["readOnly"],

--- a/javascript/src/models/connectorIn.ts
+++ b/javascript/src/models/connectorIn.ts
@@ -22,7 +22,9 @@ export const ConnectorInSerializer = {
       filterTypes: object["filterTypes"],
       instructions: object["instructions"],
       instructionsLink: object["instructionsLink"],
-      kind: ConnectorKindSerializer._fromJsonObject(object["kind"]),
+      kind: object["kind"]
+        ? ConnectorKindSerializer._fromJsonObject(object["kind"])
+        : undefined,
       logo: object["logo"],
       name: object["name"],
       transformation: object["transformation"],

--- a/javascript/src/models/messageAttemptOut.ts
+++ b/javascript/src/models/messageAttemptOut.ts
@@ -30,7 +30,9 @@ export const MessageAttemptOutSerializer = {
     return {
       endpointId: object["endpointId"],
       id: object["id"],
-      msg: MessageOutSerializer._fromJsonObject(object["msg"]),
+      msg: object["msg"]
+        ? MessageOutSerializer._fromJsonObject(object["msg"])
+        : undefined,
       msgId: object["msgId"],
       response: object["response"],
       responseDurationMs: object["responseDurationMs"],

--- a/javascript/src/models/messageIn.ts
+++ b/javascript/src/models/messageIn.ts
@@ -34,7 +34,9 @@ export interface MessageIn {
 export const MessageInSerializer = {
   _fromJsonObject(object: any): MessageIn {
     return {
-      application: ApplicationInSerializer._fromJsonObject(object["application"]),
+      application: object["application"]
+        ? ApplicationInSerializer._fromJsonObject(object["application"])
+        : undefined,
       channels: object["channels"],
       eventId: object["eventId"],
       eventType: object["eventType"],


### PR DESCRIPTION
In the case of `MessageAttemptOut`, If there is no `msg` field then the `_fromJsonObject` is called on `undefined`. This causes a runtime panic.
The solution is to do a quick null check before calling `_fromJsonObject`

Depends on: https://github.com/svix/openapi-codegen/pull/77