### PR TITLE
Remove accidentally-committed early exit from regen_openapi.sh

### DIFF
--- a/regen_openapi.sh
+++ b/regen_openapi.sh
@@ -62,8 +62,6 @@ fi
     rm python/svix/api/{environment,health}.py
 )
 
-exit 0
-
 cd $(dirname "$0")
 mkdir -p .codegen-tmp
 # OpenAPI version has to be overwritten to avoid broken codegen paths in OpenAPI generator.


### PR DESCRIPTION
Accidentally included in #1756. Since the ruby lint workflow didn't trigger, we didn't catch the breakage.