### PR TITLE
js: Add new codegen templates

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -25,6 +25,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    # JS codegen uses biome
+    - name: Setup Biome
+      uses: biomejs/setup-biome@v2
+      with:
+        version: "1.9.4"
+
     # Rust codegen uses `rustfmt +nightly`
     - uses: dtolnay/rust-toolchain@nightly
       with:

--- a/javascript/templates/api_extra/application_create.ts
+++ b/javascript/templates/api_extra/application_create.ts
@@ -1,0 +1,13 @@
+/** Get the application with the UID from `applicationIn`, or create it if it doesn't exist yet. */
+public getOrCreate(
+  applicationIn: ApplicationIn,
+  options?: ApplicationCreateOptions
+): Promise<ApplicationOut> {
+  const request = new SvixRequest(HttpMethod.POST, "/api/v1/app");
+
+  request.setQueryParam("get_if_exists", true);
+  request.setHeaderParam("idempotency-key", options?.idempotencyKey);
+  request.setBody(ApplicationInSerializer._toJsonObject(applicationIn));
+
+  return request.send(this.requestCtx, ApplicationOutSerializer._fromJsonObject);
+}

--- a/javascript/templates/api_extra/background_task_list.ts
+++ b/javascript/templates/api_extra/background_task_list.ts
@@ -1,0 +1,10 @@
+/**
+ * List background tasks executed in the past 90 days.
+ *
+ * @deprecated Use list instead.
+ * */
+public listByEndpoint(
+  options?: BackgroundTaskListOptions
+): Promise<ListResponseBackgroundTaskOut> {
+  return this.list(options);
+}

--- a/javascript/templates/api_extra/endpoint_patch_headers.ts
+++ b/javascript/templates/api_extra/endpoint_patch_headers.ts
@@ -1,0 +1,7 @@
+public headersPatch(
+  appId: string,
+  endpointId: string,
+  endpointHeadersPatchIn: EndpointHeadersPatchIn
+): Promise<void> {
+  return this.patchHeaders(appId, endpointId, endpointHeadersPatchIn);
+}

--- a/javascript/templates/api_extra/endpoint_update_headers.ts
+++ b/javascript/templates/api_extra/endpoint_update_headers.ts
@@ -1,0 +1,7 @@
+public headersUpdate(
+  appId: string,
+  endpointId: string,
+  endpointHeadersIn: EndpointHeadersIn
+): Promise<void> {
+  return this.updateHeaders(appId, endpointId, endpointHeadersIn);
+}

--- a/javascript/templates/api_extra/message.ts
+++ b/javascript/templates/api_extra/message.ts
@@ -1,0 +1,30 @@
+/**
+ * Creates a `MessageIn` with a raw string payload.
+ *
+ * The payload is not normalized on the server. Normally, payloads are
+ * required to be JSON, and Svix will minify the payload before sending the
+ * webhooks (for example, by removing extraneous whitespace or unnecessarily
+ * escaped characters in strings). With this function, the payload will be
+ * sent "as is", without any minification or other processing.
+ *
+ * @param payload Serialized message payload
+ * @param contentType The value to use for the Content-Type header of the webhook sent by Svix, overwriting the default of `application/json` if specified
+ *
+ * See the class documentation for details about the other parameters.
+ */
+export function messageInRaw(
+  eventType: string,
+  payload: string,
+  contentType?: string
+): MessageIn {
+  const headers = contentType ? { "content-type": contentType } : undefined;
+
+  return {
+    eventType,
+    payload: {},
+    transformationsParams: {
+      rawPayload: payload,
+      headers,
+    },
+  };
+}

--- a/javascript/templates/api_resource.ts.jinja
+++ b/javascript/templates/api_resource.ts.jinja
@@ -1,0 +1,110 @@
+// this file is @generated
+{% set resource_type_name = resource.name | to_upper_camel_case -%}
+
+{% for c in referenced_components -%}
+import {
+    {{ c | to_upper_camel_case }},
+    {{ c | to_upper_camel_case }}Serializer,
+} from '../models/{{ c | to_lower_camel_case }}';
+{% endfor -%}
+import { HttpMethod, SvixRequest, SvixRequestContext } from "../request";
+
+{% for op in resource.operations -%}
+    {% if op | has_query_or_header_params -%}
+    export interface {{ resource_type_name }}{{ op.name | to_upper_camel_case }}Options {
+        {% for p in op.query_params -%}
+            {% if p.description is defined -%}
+                {{ p.description | to_doc_comment(style="js") }}
+            {% endif -%}
+            {% set field_ty = p.type.to_js() -%}
+            {% if p.name == "iterator" %}{% set field_ty = "string | null" %}{% endif -%}
+            {% if p.type.is_datetime() %}{% set field_ty = "Date | null"%}{% endif -%}
+            {{ p.name | to_lower_camel_case }}{% if not p.required %}?{% endif %}: {{ field_ty }};
+        {% endfor -%}
+        {% for p in op.header_params -%}
+            {% if p.description is defined -%}
+                {{ p.description | to_doc_comment(style="js") }}
+            {% endif -%}
+            {% set field_ty = "string" -%}
+            {{ p.name | to_lower_camel_case }}{% if not p.required %}?{% endif %}: {{ field_ty }};
+        {% endfor -%}
+    }
+
+    {% endif -%}
+{% endfor -%}
+
+export class {{ resource_type_name }} {
+    public constructor(private readonly requestCtx: SvixRequestContext) {}
+
+    {% for op in resource.operations -%}
+        {% set response_type =
+            op.response_body_schema_name | default("void") | replace("_", "") -%}
+        {{ op.description | with_javadoc_deprecation(op.deprecated) | to_doc_comment(style="js") }}
+        public {{ op.name | to_lower_camel_case }}(
+            {# path parameters -#}
+            {% for p in op.path_params -%}
+                {{ p | to_lower_camel_case }}: string,
+            {% endfor -%}
+
+            {# body parameter interface -#}
+            {% if op.request_body_schema_name is defined -%}
+                {% set field_name = op.request_body_schema_name | to_lower_camel_case -%}
+                {{ field_name }}: {{ op.request_body_schema_name }},
+            {% endif -%}
+
+            {# query parameters -#}
+            {% if op | has_query_or_header_params -%}
+                {% set field_ty -%}
+                    {{ resource_type_name }}{{ op.name | to_upper_camel_case }}Options
+                {%- endset -%}
+                options{% if not op | has_required_query_or_header_params %}?{% endif %}: {{ field_ty }},
+            {% endif -%}
+        ): Promise<{{ response_type }}> {
+            const request = new SvixRequest(HttpMethod.{{ op.method | upper }}, "{{ op.path }}");
+
+            {# path parameters -#}
+            {% for p in op.path_params -%}
+                request.setPathParam("{{ p }}", {{ p | to_lower_camel_case }});
+            {% endfor -%}
+
+            {# query parameters -#}
+            {% for p in op.query_params -%}
+                request.setQueryParam("{{ p.name }}", options{% if not p.required %}?{% endif %}.{{ p.name | to_lower_camel_case }});
+            {% endfor -%}
+
+            {# header parameters -#}
+            {% for p in op.header_params -%}
+                request.setHeaderParam("{{ p.name }}", options?.{{ p.name | to_lower_camel_case }});
+            {% endfor -%}
+
+            {# body parameter -#}
+            {% if op.request_body_schema_name is defined -%}
+                request.setBody(
+                    {{ op.request_body_schema_name | to_upper_camel_case }}Serializer._toJsonObject(
+                        {{ op.request_body_schema_name | to_lower_camel_case }},
+                    )
+                );
+            {% endif -%}
+
+            {% if op.response_body_schema_name is defined %}
+                return request.send(
+                    this.requestCtx,
+                    {{ op.response_body_schema_name | to_upper_camel_case }}Serializer._fromJsonObject,
+                );
+            {% else %}
+                return request.sendNoResponseBody(this.requestCtx);
+            {% endif -%}
+        }
+
+        {% set extra_path -%}
+            api_extra/{{ resource.name | to_snake_case }}_{{ op.name | to_snake_case }}.ts
+        {%- endset -%}
+        {% include extra_path ignore missing %}
+
+    {% endfor -%}
+}
+
+{% set extra_path -%}
+    api_extra/{{ resource.name | to_snake_case }}.ts
+{%- endset -%}
+{% include extra_path ignore missing %}

--- a/javascript/templates/component_type.ts.jinja
+++ b/javascript/templates/component_type.ts.jinja
@@ -1,0 +1,13 @@
+// this file is @generated
+/* eslint @typescript-eslint/no-explicit-any: 0 */
+{% if type.description is defined -%}
+{% set doc_comment = type.description | to_doc_comment(style="js") -%}
+{% endif -%}
+
+{% if type.kind == "struct" -%}
+    {% include "types/struct.ts.jinja" -%}
+{% elif type.kind == "string_enum" -%}
+    {% include "types/string_enum.ts.jinja" -%}
+{% elif type.kind == "integer_enum" -%}
+    {% include "types/integer_enum.ts.jinja" -%}
+{% endif %}

--- a/javascript/templates/component_type_summary.ts.jinja
+++ b/javascript/templates/component_type_summary.ts.jinja
@@ -1,0 +1,4 @@
+// this file is @generated
+{% for type in types -%}
+export { {{ type | to_upper_camel_case }} } from "./{{ type | to_lower_camel_case }}";
+{% endfor %}

--- a/javascript/templates/types/integer_enum.ts.jinja
+++ b/javascript/templates/types/integer_enum.ts.jinja
@@ -1,0 +1,16 @@
+{{ doc_comment }}
+export enum {{ type.name | to_upper_camel_case }} {
+    {% for name, value in type.variants -%}
+    {{ name | to_upper_camel_case }} = {{ value }},
+    {% endfor -%}
+}
+
+export const {{ type.name | to_upper_camel_case }}Serializer = {
+    _fromJsonObject(object: any): {{ type.name | to_upper_camel_case }} {
+        return object;
+    },
+
+    _toJsonObject(self: {{ type.name | to_upper_camel_case }}): any {
+        return self;
+    }
+}

--- a/javascript/templates/types/string_enum.ts.jinja
+++ b/javascript/templates/types/string_enum.ts.jinja
@@ -1,0 +1,16 @@
+{{ doc_comment }}
+export enum {{ type.name | to_upper_camel_case }} {
+    {% for value in type.values -%}
+    {{ value | to_upper_camel_case }} = '{{ value }}',
+    {% endfor -%}
+}
+
+export const {{ type.name | to_upper_camel_case }}Serializer = {
+    _fromJsonObject(object: any): {{ type.name | to_upper_camel_case }} {
+        return object;
+    },
+
+    _toJsonObject(self: {{ type.name | to_upper_camel_case }}): any {
+        return self;
+    }
+}

--- a/javascript/templates/types/struct.ts.jinja
+++ b/javascript/templates/types/struct.ts.jinja
@@ -1,0 +1,111 @@
+{% for c in referenced_components -%}
+import {
+    {{ c | to_upper_camel_case }},
+    {{ c | to_upper_camel_case }}Serializer,
+} from './{{ c | to_lower_camel_case }}';
+{% endfor -%}
+
+{% macro field_from_json(field_expr, type, field_required) %}
+    {%- if type.is_datetime() -%}
+        new Date({{ field_expr }})
+    {%- elif type.is_schema_ref() -%}
+        {%- if not field_required -%}
+            {{ field_expr }} ? {{ type.to_js() }}Serializer._fromJsonObject({{ field_expr }}): undefined
+        {%- else -%}
+            {{ type.to_js() }}Serializer._fromJsonObject({{ field_expr }})
+        {%- endif %}
+    {%- elif type.is_list() or type.is_set() -%}
+        {{ field_expr }}
+        {%- set inner_t = type.inner_type() -%}
+        {%- if inner_t.is_datetime()
+            or inner_t.is_schema_ref()
+            or inner_t.is_list()
+            or inner_t.is_set()
+            or inner_t.is_map() -%}
+            .map((item: {{ inner_t.to_js() }}) => {{ field_from_json("item", inner_t, true) }})
+        {%- endif -%}
+    {%- elif type.is_map() -%}
+        {%- set value_t = type.value_type() -%}
+        {%- if value_t.is_datetime()
+            or value_t.is_schema_ref()
+            or value_t.is_list()
+            or value_t.is_set()
+            or value_t.is_map() -%}
+            Object.fromEntries(Object.entries({{ field_expr }}).map(
+                (item : {{ inner_t.to_js() }}) => [item[0], {{ field_from_json("item[1]", value_t, true) }}]
+            ))
+        {%- else -%}
+            {{ field_expr }}
+        {%- endif -%}
+    {%- else -%}
+        {{ field_expr }}
+    {%- endif -%}
+{% endmacro -%}
+
+{% macro field_to_json(field_expr, type, field_required) %}
+    {%- if type.is_schema_ref() -%}
+        {%- if not field_required -%}
+        {{ field_expr }} ? {{ type.to_js() }}Serializer._toJsonObject({{ field_expr }}) : undefined
+        {%- else -%}
+        {{ type.to_js() }}Serializer._toJsonObject({{ field_expr }})
+        {%- endif -%}
+    {%- elif type.is_list() or type.is_set() -%}
+        {{ field_expr }}
+        {%- set inner_t = type.inner_type() -%}
+        {%- if inner_t.is_schema_ref()
+            or inner_t.is_list()
+            or inner_t.is_set()
+            or inner_t.is_map() -%}
+            {%- if not field_required -%}?{% endif -%}
+            .map((item) => {{ field_to_json("item", inner_t, true) }})
+        {%- endif -%}
+    {%- elif type.is_map() -%}
+        {%- set value_t = type.value_type() -%}
+        {%- if value_t.is_schema_ref()
+            or value_t.is_list()
+            or value_t.is_set()
+            or value_t.is_map() -%}
+            Object.fromEntries(Object.entries({{ field_expr }}).map(
+                (item) => [item[0], {{ field_to_json("item[1]", value_t, true) }}]
+            ))
+        {%- else -%}
+            {{ field_expr }}
+        {%- endif -%}
+    {%- else -%}
+        {{ field_expr }}
+    {%- endif -%}
+{% endmacro -%}
+
+{{ doc_comment }}
+export interface {{ type.name | to_upper_camel_case }} {
+    {% for field in type.fields -%}
+        {% if field.description is defined -%}
+            {{ field.description | with_javadoc_deprecation(field.deprecated) | to_doc_comment(style="js") }}
+        {% endif -%}
+        {% set field_lhs = field.name | to_lower_camel_case -%}
+        {% if not field.required %}{% set field_lhs %}{{ field_lhs }}?{% endset %}{% endif -%}
+        {% set ty = field.type.to_js() -%}
+        {% if field.nullable %}{% set ty %}{{ ty }} | null{% endset %}{% endif -%}
+        {{ field_lhs }}: {{ ty }};
+    {% endfor -%}
+}
+
+export const {{ type.name | to_upper_camel_case }}Serializer = {
+    _fromJsonObject(object: any): {{ type.name | to_upper_camel_case }} {
+        return {
+            {% for field in type.fields -%}
+                {% set field_expr %}object['{{ field.name }}']{% endset -%}
+                {{ field.name | to_lower_camel_case }}: {{ field_from_json(field_expr, field.type, field.required) }},
+            {% endfor -%}
+        };
+    },
+
+    _toJsonObject(self: {{ type.name | to_upper_camel_case }}): any {
+        return {
+            {% for field in type.fields -%}
+                {% set field_expr %}self.{{ field.name | to_lower_camel_case }}{% endset -%}
+                '{{ field.name }}': {{ field_to_json(field_expr, field.type, field.required) }},
+            {% endfor -%}
+        };
+    }
+}

--- a/javascript/tsconfig.json
+++ b/javascript/tsconfig.json
@@ -23,6 +23,7 @@
   "exclude": [
     "dist",
     "node_modules",
+    "templates",
     "jest.config.js",
     "src/**/*.test.ts",
     "eslint.config.mjs"

--- a/regen_openapi.sh
+++ b/regen_openapi.sh
@@ -18,6 +18,25 @@ if ! command -v openapi-codegen >/dev/null; then
     fi
 fi
 
+# JavaScript
+(
+    # Print commands we run
+    set -x
+
+    openapi-codegen generate \
+        --template javascript/templates/api_resource.ts.jinja \
+        --input-file lib-openapi.json \
+        --output-dir javascript/src/api
+    openapi-codegen generate \
+        --template javascript/templates/component_type_summary.ts.jinja \
+        --input-file lib-openapi.json \
+        --output-dir javascript/src/models
+    openapi-codegen generate \
+        --template javascript/templates/component_type.ts.jinja \
+        --input-file lib-openapi.json \
+        --output-dir javascript/src/models
+)
+
 # Rust
 (
     # Print commands we run


### PR DESCRIPTION
One tiny change from the templates currently in https://github.com/svix/openapi-codegen: `DateTime` query parameters  are hardcoded to accept `null` (they were broken since a recent PR correctly changed `Date | null` => `Date` in JS type translation).