### PR TITLE
Add url encoding test for C#,Go,Java,Kotlin and Typescript

### DIFF
--- a/csharp/Svix.Tests/WiremockTests.cs
+++ b/csharp/Svix.Tests/WiremockTests.cs
@@ -244,5 +244,23 @@ namespace Svix.Tests
                 );
             client.Application.List();
         }
+
+        [Fact]
+        public void UrlEncodedOctothorpe()
+        {
+            stub.Given(Request.Create().WithPath("/api/v1/app/app_id/msg"))
+                .RespondWith(
+                    Response
+                        .Create()
+                        .WithStatusCode(200)
+                        .WithBody("""{"data":[],"iterator":null,"prevIterator":null,"done":true}""")
+                );
+            client.Message.List("app_id", new MessageListOptions { Tag = "test#test" });
+            Assert.Equal(1, stub.LogEntries.Count);
+            Assert.EndsWith(
+                "/api/v1/app/app_id/msg?tag=test%23test",
+                stub.LogEntries[0].RequestMessage.Url
+            );
+        }
     }
 }

--- a/go/svix_http_client_test.go
+++ b/go/svix_http_client_test.go
@@ -195,3 +195,27 @@ func TestQueryParamListSerialization(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestOctothorpeUrlParam(t *testing.T) {
+	svx := newMockClient()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("GET", "http://testapi.test/api/v1/app/random_app_id/msg",
+		func(r *http.Request) (*http.Response, error) {
+			if !reflect.DeepEqual(r.URL.RawQuery, "tag=test%23test") {
+				t.Errorf("Unexpected MessageListOptions serialization, got: %v", r.URL.RawQuery)
+			}
+
+			return httpmock.NewStringResponse(200, msgListOut), nil
+		},
+	)
+	tag := "test#test"
+	listOpts := svix.MessageListOptions{
+		Tag: &tag,
+	}
+	_, err := svx.Message.List(context.Background(), "random_app_id", &listOpts)
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/java/lib/src/test/com/svix/test/WiremockTests.java
+++ b/java/lib/src/test/com/svix/test/WiremockTests.java
@@ -435,4 +435,21 @@ public class WiremockTests {
                 postRequestedFor(urlEqualTo("/api/v1/app/app1/msg"))
                         .withRequestBody(equalTo(expectedBody)));
     }
+
+    @Test
+    public void octothorpeInUrlQuery() throws Exception {
+        Svix svx = testClient();
+        wireMockRule.stubFor(
+                WireMock.get(urlEqualTo("/api/v1/app/app1/msg?tag=test%23test"))
+                        .willReturn(WireMock.ok().withBodyFile("ListResponseMessageOut.json")));
+
+        MessageListOptions opts = new MessageListOptions();
+        opts.setTag("test#test");
+        svx.getMessage().list("app1", opts);
+
+        wireMockRule.verify(
+                1,
+                getRequestedFor(urlEqualTo("/api/v1/app/app1/msg?tag=test%23test")));
+    }
+
 }

--- a/javascript/src/mockttp.test.ts
+++ b/javascript/src/mockttp.test.ts
@@ -336,4 +336,17 @@ describe("mockttp tests", () => {
     const requests = await endpointMock.getSeenRequests();
     expect(requests.length).toBe(1);
   });
+
+  test("octothorpe in url query", async () => {
+    const endpointMock = await mockServer
+      .forGet("/api/v1/app/app1/msg")
+      .thenReply(200, ListResponseMessageOut);
+    const svx = new Svix("token.eu", { serverUrl: mockServer.url });
+
+    await svx.message.list("app1", { tag: "test#test" });
+
+    const requests = await endpointMock.getSeenRequests();
+    expect(requests.length).toBe(1);
+    expect(requests[0].url.endsWith("api/v1/app/app1/msg?tag=test%23test")).toBe(true);
+  });
 });

--- a/kotlin/lib/src/test/com/svix/kotlin/WiremockTests.kt
+++ b/kotlin/lib/src/test/com/svix/kotlin/WiremockTests.kt
@@ -16,6 +16,7 @@ import kotlin.test.assertEquals
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Instant
 import org.junit.jupiter.api.*
+import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class WiremockTests {
@@ -381,4 +382,21 @@ class WiremockTests {
         )
         runBlocking { svx.application.list() }
     }
+
+    @Test
+    fun octothorpeInUrlQuery() {
+        val svx = testClient()
+        wireMockServer.stubFor(
+            get(urlEqualTo("/api/v1/app/app1/msg?tag=test%23test"))
+                .willReturn(ok().withBodyFile("ListResponseMessageOut.json"))
+        )
+
+        runBlocking { svx.message.list("app1", MessageListOptions(tag = "test#test")) }
+
+        wireMockServer.verify(
+            1,
+            getRequestedFor(urlEqualTo("/api/v1/app/app1/msg?tag=test%23test"))
+        )
+    }
+
 }


### PR DESCRIPTION
Add test cases for `#` in a url param
Python/Rust will be in a separate PR

ref: https://github.com/svix/monorepo-private/issues/9996