### PR TITLE
go: Pull in change from latest codegen

### DIFF
--- a/go/application.go
+++ b/go/application.go
@@ -40,7 +40,6 @@ func (application *Application) List(
 			return nil, err
 		}
 	}
-
 	return executeRequest[any, models.ListResponseApplicationOut](
 		ctx,
 		application.client,
@@ -51,7 +50,6 @@ func (application *Application) List(
 		nil,
 		nil,
 	)
-
 }
 
 // Create a new application.
@@ -71,7 +69,6 @@ func (application *Application) Create(
 			return nil, err
 		}
 	}
-
 	return executeRequest[models.ApplicationIn, models.ApplicationOut](
 		ctx,
 		application.client,
@@ -82,7 +79,6 @@ func (application *Application) Create(
 		headerMap,
 		&applicationIn,
 	)
-
 }
 
 // Get or create a new application.
@@ -124,7 +120,6 @@ func (application *Application) Get(
 	pathMap := map[string]string{
 		"app_id": appId,
 	}
-
 	return executeRequest[any, models.ApplicationOut](
 		ctx,
 		application.client,
@@ -135,7 +130,6 @@ func (application *Application) Get(
 		nil,
 		nil,
 	)
-
 }
 
 // Update an application.
@@ -147,7 +141,6 @@ func (application *Application) Update(
 	pathMap := map[string]string{
 		"app_id": appId,
 	}
-
 	return executeRequest[models.ApplicationIn, models.ApplicationOut](
 		ctx,
 		application.client,
@@ -158,7 +151,6 @@ func (application *Application) Update(
 		nil,
 		&applicationIn,
 	)
-
 }
 
 // Delete an application.
@@ -169,7 +161,6 @@ func (application *Application) Delete(
 	pathMap := map[string]string{
 		"app_id": appId,
 	}
-
 	_, err := executeRequest[any, any](
 		ctx,
 		application.client,
@@ -181,7 +172,6 @@ func (application *Application) Delete(
 		nil,
 	)
 	return err
-
 }
 
 // Partially update an application.
@@ -193,7 +183,6 @@ func (application *Application) Patch(
 	pathMap := map[string]string{
 		"app_id": appId,
 	}
-
 	return executeRequest[models.ApplicationPatch, models.ApplicationOut](
 		ctx,
 		application.client,
@@ -204,5 +193,4 @@ func (application *Application) Patch(
 		nil,
 		&applicationPatch,
 	)
-
 }

--- a/go/authentication.go
+++ b/go/authentication.go
@@ -45,7 +45,6 @@ func (authentication *Authentication) AppPortalAccess(
 			return nil, err
 		}
 	}
-
 	return executeRequest[models.AppPortalAccessIn, models.AppPortalAccessOut](
 		ctx,
 		authentication.client,
@@ -56,7 +55,6 @@ func (authentication *Authentication) AppPortalAccess(
 		headerMap,
 		&appPortalAccessIn,
 	)
-
 }
 
 // Expire all of the tokens associated with a specific application.
@@ -77,7 +75,6 @@ func (authentication *Authentication) ExpireAll(
 			return err
 		}
 	}
-
 	_, err = executeRequest[models.ApplicationTokenExpireIn, any](
 		ctx,
 		authentication.client,
@@ -89,7 +86,6 @@ func (authentication *Authentication) ExpireAll(
 		&applicationTokenExpireIn,
 	)
 	return err
-
 }
 
 // DEPRECATED: Please use `app-portal-access` instead.
@@ -111,7 +107,6 @@ func (authentication *Authentication) DashboardAccess(
 			return nil, err
 		}
 	}
-
 	return executeRequest[any, models.DashboardAccessOut](
 		ctx,
 		authentication.client,
@@ -122,7 +117,6 @@ func (authentication *Authentication) DashboardAccess(
 		headerMap,
 		nil,
 	)
-
 }
 
 // Logout an app token.
@@ -140,7 +134,6 @@ func (authentication *Authentication) Logout(
 			return err
 		}
 	}
-
 	_, err = executeRequest[any, any](
 		ctx,
 		authentication.client,
@@ -152,5 +145,4 @@ func (authentication *Authentication) Logout(
 		nil,
 	)
 	return err
-
 }

--- a/go/background_task.go
+++ b/go/background_task.go
@@ -44,7 +44,6 @@ func (backgroundTask *BackgroundTask) List(
 			return nil, err
 		}
 	}
-
 	return executeRequest[any, models.ListResponseBackgroundTaskOut](
 		ctx,
 		backgroundTask.client,
@@ -55,7 +54,6 @@ func (backgroundTask *BackgroundTask) List(
 		nil,
 		nil,
 	)
-
 }
 
 // Get a background task by ID.
@@ -66,7 +64,6 @@ func (backgroundTask *BackgroundTask) Get(
 	pathMap := map[string]string{
 		"task_id": taskId,
 	}
-
 	return executeRequest[any, models.BackgroundTaskOut](
 		ctx,
 		backgroundTask.client,
@@ -77,5 +74,4 @@ func (backgroundTask *BackgroundTask) Get(
 		nil,
 		nil,
 	)
-
 }

--- a/go/endpoint.go
+++ b/go/endpoint.go
@@ -68,7 +68,6 @@ func (endpoint *Endpoint) List(
 			return nil, err
 		}
 	}
-
 	return executeRequest[any, models.ListResponseEndpointOut](
 		ctx,
 		endpoint.client,
@@ -79,7 +78,6 @@ func (endpoint *Endpoint) List(
 		nil,
 		nil,
 	)
-
 }
 
 // Create a new endpoint for the application.
@@ -102,7 +100,6 @@ func (endpoint *Endpoint) Create(
 			return nil, err
 		}
 	}
-
 	return executeRequest[models.EndpointIn, models.EndpointOut](
 		ctx,
 		endpoint.client,
@@ -113,7 +110,6 @@ func (endpoint *Endpoint) Create(
 		headerMap,
 		&endpointIn,
 	)
-
 }
 
 // Get an endpoint.
@@ -126,7 +122,6 @@ func (endpoint *Endpoint) Get(
 		"app_id":      appId,
 		"endpoint_id": endpointId,
 	}
-
 	return executeRequest[any, models.EndpointOut](
 		ctx,
 		endpoint.client,
@@ -137,7 +132,6 @@ func (endpoint *Endpoint) Get(
 		nil,
 		nil,
 	)
-
 }
 
 // Update an endpoint.
@@ -151,7 +145,6 @@ func (endpoint *Endpoint) Update(
 		"app_id":      appId,
 		"endpoint_id": endpointId,
 	}
-
 	return executeRequest[models.EndpointUpdate, models.EndpointOut](
 		ctx,
 		endpoint.client,
@@ -162,7 +155,6 @@ func (endpoint *Endpoint) Update(
 		nil,
 		&endpointUpdate,
 	)
-
 }
 
 // Delete an endpoint.
@@ -175,7 +167,6 @@ func (endpoint *Endpoint) Delete(
 		"app_id":      appId,
 		"endpoint_id": endpointId,
 	}
-
 	_, err := executeRequest[any, any](
 		ctx,
 		endpoint.client,
@@ -187,7 +178,6 @@ func (endpoint *Endpoint) Delete(
 		nil,
 	)
 	return err
-
 }
 
 // Partially update an endpoint.
@@ -201,7 +191,6 @@ func (endpoint *Endpoint) Patch(
 		"app_id":      appId,
 		"endpoint_id": endpointId,
 	}
-
 	return executeRequest[models.EndpointPatch, models.EndpointOut](
 		ctx,
 		endpoint.client,
@@ -212,7 +201,6 @@ func (endpoint *Endpoint) Patch(
 		nil,
 		&endpointPatch,
 	)
-
 }
 
 // Get the additional headers to be sent with the webhook.
@@ -225,7 +213,6 @@ func (endpoint *Endpoint) GetHeaders(
 		"app_id":      appId,
 		"endpoint_id": endpointId,
 	}
-
 	return executeRequest[any, models.EndpointHeadersOut](
 		ctx,
 		endpoint.client,
@@ -236,7 +223,6 @@ func (endpoint *Endpoint) GetHeaders(
 		nil,
 		nil,
 	)
-
 }
 
 // Set the additional headers to be sent with the webhook.
@@ -250,7 +236,6 @@ func (endpoint *Endpoint) UpdateHeaders(
 		"app_id":      appId,
 		"endpoint_id": endpointId,
 	}
-
 	_, err := executeRequest[models.EndpointHeadersIn, any](
 		ctx,
 		endpoint.client,
@@ -262,7 +247,6 @@ func (endpoint *Endpoint) UpdateHeaders(
 		&endpointHeadersIn,
 	)
 	return err
-
 }
 
 // Partially set the additional headers to be sent with the webhook.
@@ -276,7 +260,6 @@ func (endpoint *Endpoint) PatchHeaders(
 		"app_id":      appId,
 		"endpoint_id": endpointId,
 	}
-
 	_, err := executeRequest[models.EndpointHeadersPatchIn, any](
 		ctx,
 		endpoint.client,
@@ -288,7 +271,6 @@ func (endpoint *Endpoint) PatchHeaders(
 		&endpointHeadersPatchIn,
 	)
 	return err
-
 }
 
 // Resend all failed messages since a given time.
@@ -313,7 +295,6 @@ func (endpoint *Endpoint) Recover(
 			return nil, err
 		}
 	}
-
 	return executeRequest[models.RecoverIn, models.RecoverOut](
 		ctx,
 		endpoint.client,
@@ -324,7 +305,6 @@ func (endpoint *Endpoint) Recover(
 		headerMap,
 		&recoverIn,
 	)
-
 }
 
 // Replays messages to the endpoint.
@@ -350,7 +330,6 @@ func (endpoint *Endpoint) ReplayMissing(
 			return nil, err
 		}
 	}
-
 	return executeRequest[models.ReplayIn, models.ReplayOut](
 		ctx,
 		endpoint.client,
@@ -361,7 +340,6 @@ func (endpoint *Endpoint) ReplayMissing(
 		headerMap,
 		&replayIn,
 	)
-
 }
 
 // Get the endpoint's signing secret.
@@ -377,7 +355,6 @@ func (endpoint *Endpoint) GetSecret(
 		"app_id":      appId,
 		"endpoint_id": endpointId,
 	}
-
 	return executeRequest[any, models.EndpointSecretOut](
 		ctx,
 		endpoint.client,
@@ -388,7 +365,6 @@ func (endpoint *Endpoint) GetSecret(
 		nil,
 		nil,
 	)
-
 }
 
 // Rotates the endpoint's signing secret.
@@ -413,7 +389,6 @@ func (endpoint *Endpoint) RotateSecret(
 			return err
 		}
 	}
-
 	_, err = executeRequest[models.EndpointSecretRotateIn, any](
 		ctx,
 		endpoint.client,
@@ -425,7 +400,6 @@ func (endpoint *Endpoint) RotateSecret(
 		&endpointSecretRotateIn,
 	)
 	return err
-
 }
 
 // Send an example message for an event.
@@ -448,7 +422,6 @@ func (endpoint *Endpoint) SendExample(
 			return nil, err
 		}
 	}
-
 	return executeRequest[models.EventExampleIn, models.MessageOut](
 		ctx,
 		endpoint.client,
@@ -459,7 +432,6 @@ func (endpoint *Endpoint) SendExample(
 		headerMap,
 		&eventExampleIn,
 	)
-
 }
 
 // Get basic statistics for the endpoint.
@@ -482,7 +454,6 @@ func (endpoint *Endpoint) GetStats(
 			return nil, err
 		}
 	}
-
 	return executeRequest[any, models.EndpointStats](
 		ctx,
 		endpoint.client,
@@ -493,7 +464,6 @@ func (endpoint *Endpoint) GetStats(
 		nil,
 		nil,
 	)
-
 }
 
 // Get the transformation code associated with this endpoint.
@@ -506,7 +476,6 @@ func (endpoint *Endpoint) TransformationGet(
 		"app_id":      appId,
 		"endpoint_id": endpointId,
 	}
-
 	return executeRequest[any, models.EndpointTransformationOut](
 		ctx,
 		endpoint.client,
@@ -517,7 +486,6 @@ func (endpoint *Endpoint) TransformationGet(
 		nil,
 		nil,
 	)
-
 }
 
 // Set or unset the transformation code associated with this endpoint.
@@ -531,7 +499,6 @@ func (endpoint *Endpoint) TransformationPartialUpdate(
 		"app_id":      appId,
 		"endpoint_id": endpointId,
 	}
-
 	_, err := executeRequest[models.EndpointTransformationIn, any](
 		ctx,
 		endpoint.client,
@@ -543,5 +510,4 @@ func (endpoint *Endpoint) TransformationPartialUpdate(
 		&endpointTransformationIn,
 	)
 	return err
-
 }

--- a/go/event_type.go
+++ b/go/event_type.go
@@ -55,7 +55,6 @@ func (eventType *EventType) List(
 			return nil, err
 		}
 	}
-
 	return executeRequest[any, models.ListResponseEventTypeOut](
 		ctx,
 		eventType.client,
@@ -66,7 +65,6 @@ func (eventType *EventType) List(
 		nil,
 		nil,
 	)
-
 }
 
 // Create new or unarchive existing event type.
@@ -87,7 +85,6 @@ func (eventType *EventType) Create(
 			return nil, err
 		}
 	}
-
 	return executeRequest[models.EventTypeIn, models.EventTypeOut](
 		ctx,
 		eventType.client,
@@ -98,7 +95,6 @@ func (eventType *EventType) Create(
 		headerMap,
 		&eventTypeIn,
 	)
-
 }
 
 // Given an OpenAPI spec, create new or update existing event types.
@@ -119,7 +115,6 @@ func (eventType *EventType) ImportOpenapi(
 			return nil, err
 		}
 	}
-
 	return executeRequest[models.EventTypeImportOpenApiIn, models.EventTypeImportOpenApiOut](
 		ctx,
 		eventType.client,
@@ -130,7 +125,6 @@ func (eventType *EventType) ImportOpenapi(
 		headerMap,
 		&eventTypeImportOpenApiIn,
 	)
-
 }
 
 // Get an event type.
@@ -141,7 +135,6 @@ func (eventType *EventType) Get(
 	pathMap := map[string]string{
 		"event_type_name": eventTypeName,
 	}
-
 	return executeRequest[any, models.EventTypeOut](
 		ctx,
 		eventType.client,
@@ -152,7 +145,6 @@ func (eventType *EventType) Get(
 		nil,
 		nil,
 	)
-
 }
 
 // Update an event type.
@@ -164,7 +156,6 @@ func (eventType *EventType) Update(
 	pathMap := map[string]string{
 		"event_type_name": eventTypeName,
 	}
-
 	return executeRequest[models.EventTypeUpdate, models.EventTypeOut](
 		ctx,
 		eventType.client,
@@ -175,7 +166,6 @@ func (eventType *EventType) Update(
 		nil,
 		&eventTypeUpdate,
 	)
-
 }
 
 // Archive an event type.
@@ -200,7 +190,6 @@ func (eventType *EventType) Delete(
 			return err
 		}
 	}
-
 	_, err = executeRequest[any, any](
 		ctx,
 		eventType.client,
@@ -212,7 +201,6 @@ func (eventType *EventType) Delete(
 		nil,
 	)
 	return err
-
 }
 
 // Partially update an event type.
@@ -224,7 +212,6 @@ func (eventType *EventType) Patch(
 	pathMap := map[string]string{
 		"event_type_name": eventTypeName,
 	}
-
 	return executeRequest[models.EventTypePatch, models.EventTypeOut](
 		ctx,
 		eventType.client,
@@ -235,5 +222,4 @@ func (eventType *EventType) Patch(
 		nil,
 		&eventTypePatch,
 	)
-
 }

--- a/go/integration.go
+++ b/go/integration.go
@@ -48,7 +48,6 @@ func (integration *Integration) List(
 			return nil, err
 		}
 	}
-
 	return executeRequest[any, models.ListResponseIntegrationOut](
 		ctx,
 		integration.client,
@@ -59,7 +58,6 @@ func (integration *Integration) List(
 		nil,
 		nil,
 	)
-
 }
 
 // Create an integration.
@@ -80,7 +78,6 @@ func (integration *Integration) Create(
 			return nil, err
 		}
 	}
-
 	return executeRequest[models.IntegrationIn, models.IntegrationOut](
 		ctx,
 		integration.client,
@@ -91,7 +88,6 @@ func (integration *Integration) Create(
 		headerMap,
 		&integrationIn,
 	)
-
 }
 
 // Get an integration.
@@ -104,7 +100,6 @@ func (integration *Integration) Get(
 		"app_id":   appId,
 		"integ_id": integId,
 	}
-
 	return executeRequest[any, models.IntegrationOut](
 		ctx,
 		integration.client,
@@ -115,7 +110,6 @@ func (integration *Integration) Get(
 		nil,
 		nil,
 	)
-
 }
 
 // Update an integration.
@@ -129,7 +123,6 @@ func (integration *Integration) Update(
 		"app_id":   appId,
 		"integ_id": integId,
 	}
-
 	return executeRequest[models.IntegrationUpdate, models.IntegrationOut](
 		ctx,
 		integration.client,
@@ -140,7 +133,6 @@ func (integration *Integration) Update(
 		nil,
 		&integrationUpdate,
 	)
-
 }
 
 // Delete an integration.
@@ -153,7 +145,6 @@ func (integration *Integration) Delete(
 		"app_id":   appId,
 		"integ_id": integId,
 	}
-
 	_, err := executeRequest[any, any](
 		ctx,
 		integration.client,
@@ -165,7 +156,6 @@ func (integration *Integration) Delete(
 		nil,
 	)
 	return err
-
 }
 
 // Get an integration's key.
@@ -180,7 +170,6 @@ func (integration *Integration) GetKey(
 		"app_id":   appId,
 		"integ_id": integId,
 	}
-
 	return executeRequest[any, models.IntegrationKeyOut](
 		ctx,
 		integration.client,
@@ -191,7 +180,6 @@ func (integration *Integration) GetKey(
 		nil,
 		nil,
 	)
-
 }
 
 // Rotate the integration's key. The previous key will be immediately revoked.
@@ -213,7 +201,6 @@ func (integration *Integration) RotateKey(
 			return nil, err
 		}
 	}
-
 	return executeRequest[any, models.IntegrationKeyOut](
 		ctx,
 		integration.client,
@@ -224,5 +211,4 @@ func (integration *Integration) RotateKey(
 		headerMap,
 		nil,
 	)
-
 }

--- a/go/message.go
+++ b/go/message.go
@@ -78,7 +78,6 @@ func (message *Message) List(
 			return nil, err
 		}
 	}
-
 	return executeRequest[any, models.ListResponseMessageOut](
 		ctx,
 		message.client,
@@ -89,7 +88,6 @@ func (message *Message) List(
 		nil,
 		nil,
 	)
-
 }
 
 // Creates a new message and dispatches it to all of the application's endpoints.
@@ -120,7 +118,6 @@ func (message *Message) Create(
 			return nil, err
 		}
 	}
-
 	return executeRequest[models.MessageIn, models.MessageOut](
 		ctx,
 		message.client,
@@ -131,7 +128,6 @@ func (message *Message) Create(
 		headerMap,
 		&messageIn,
 	)
-
 }
 
 // Purge all message content for the application.
@@ -153,7 +149,6 @@ func (message *Message) ExpungeAllContents(
 			return nil, err
 		}
 	}
-
 	return executeRequest[any, models.ExpungeAllContentsOut](
 		ctx,
 		message.client,
@@ -164,7 +159,6 @@ func (message *Message) ExpungeAllContents(
 		headerMap,
 		nil,
 	)
-
 }
 
 // Get a message by its ID or eventID.
@@ -186,7 +180,6 @@ func (message *Message) Get(
 			return nil, err
 		}
 	}
-
 	return executeRequest[any, models.MessageOut](
 		ctx,
 		message.client,
@@ -197,7 +190,6 @@ func (message *Message) Get(
 		nil,
 		nil,
 	)
-
 }
 
 // Delete the given message's payload.
@@ -213,7 +205,6 @@ func (message *Message) ExpungeContent(
 		"app_id": appId,
 		"msg_id": msgId,
 	}
-
 	_, err := executeRequest[any, any](
 		ctx,
 		message.client,
@@ -225,5 +216,4 @@ func (message *Message) ExpungeContent(
 		nil,
 	)
 	return err
-
 }

--- a/go/message.go
+++ b/go/message.go
@@ -141,7 +141,7 @@ func (message *Message) ExpungeAllContents(
 	ctx context.Context,
 	appId string,
 	o *MessageExpungeAllContentsOptions,
-) (*models.ExpungAllContentsOut, error) {
+) (*models.ExpungeAllContentsOut, error) {
 	pathMap := map[string]string{
 		"app_id": appId,
 	}
@@ -154,7 +154,7 @@ func (message *Message) ExpungeAllContents(
 		}
 	}
 
-	return executeRequest[any, models.ExpungAllContentsOut](
+	return executeRequest[any, models.ExpungeAllContentsOut](
 		ctx,
 		message.client,
 		"POST",

--- a/go/message_attempt.go
+++ b/go/message_attempt.go
@@ -133,7 +133,6 @@ func (messageAttempt *MessageAttempt) ListByEndpoint(
 			return nil, err
 		}
 	}
-
 	return executeRequest[any, models.ListResponseMessageAttemptOut](
 		ctx,
 		messageAttempt.client,
@@ -144,7 +143,6 @@ func (messageAttempt *MessageAttempt) ListByEndpoint(
 		nil,
 		nil,
 	)
-
 }
 
 // List attempts by message ID.
@@ -181,7 +179,6 @@ func (messageAttempt *MessageAttempt) ListByMsg(
 			return nil, err
 		}
 	}
-
 	return executeRequest[any, models.ListResponseMessageAttemptOut](
 		ctx,
 		messageAttempt.client,
@@ -192,7 +189,6 @@ func (messageAttempt *MessageAttempt) ListByMsg(
 		nil,
 		nil,
 	)
-
 }
 
 // List messages for a particular endpoint. Additionally includes metadata about the latest message attempt.
@@ -229,7 +225,6 @@ func (messageAttempt *MessageAttempt) ListAttemptedMessages(
 			return nil, err
 		}
 	}
-
 	return executeRequest[any, models.ListResponseEndpointMessageOut](
 		ctx,
 		messageAttempt.client,
@@ -240,7 +235,6 @@ func (messageAttempt *MessageAttempt) ListAttemptedMessages(
 		nil,
 		nil,
 	)
-
 }
 
 // `msg_id`: Use a message id or a message `eventId`
@@ -255,7 +249,6 @@ func (messageAttempt *MessageAttempt) Get(
 		"msg_id":     msgId,
 		"attempt_id": attemptId,
 	}
-
 	return executeRequest[any, models.MessageAttemptOut](
 		ctx,
 		messageAttempt.client,
@@ -266,7 +259,6 @@ func (messageAttempt *MessageAttempt) Get(
 		nil,
 		nil,
 	)
-
 }
 
 // Deletes the given attempt's response body.
@@ -284,7 +276,6 @@ func (messageAttempt *MessageAttempt) ExpungeContent(
 		"msg_id":     msgId,
 		"attempt_id": attemptId,
 	}
-
 	_, err := executeRequest[any, any](
 		ctx,
 		messageAttempt.client,
@@ -296,7 +287,6 @@ func (messageAttempt *MessageAttempt) ExpungeContent(
 		nil,
 	)
 	return err
-
 }
 
 // List endpoints attempted by a given message.
@@ -322,7 +312,6 @@ func (messageAttempt *MessageAttempt) ListAttemptedDestinations(
 			return nil, err
 		}
 	}
-
 	return executeRequest[any, models.ListResponseMessageEndpointOut](
 		ctx,
 		messageAttempt.client,
@@ -333,7 +322,6 @@ func (messageAttempt *MessageAttempt) ListAttemptedDestinations(
 		nil,
 		nil,
 	)
-
 }
 
 // Resend a message to the specified endpoint.
@@ -357,7 +345,6 @@ func (messageAttempt *MessageAttempt) Resend(
 			return err
 		}
 	}
-
 	_, err = executeRequest[any, any](
 		ctx,
 		messageAttempt.client,
@@ -369,5 +356,4 @@ func (messageAttempt *MessageAttempt) Resend(
 		nil,
 	)
 	return err
-
 }

--- a/go/models.go
+++ b/go/models.go
@@ -43,7 +43,14 @@ type (
 	EventTypeOut                              = models.EventTypeOut
 	EventTypePatch                            = models.EventTypePatch
 	EventTypeUpdate                           = models.EventTypeUpdate
-	ExpungAllContentsOut                      = models.ExpungAllContentsOut
+	ExpungeAllContentsOut                     = models.ExpungeAllContentsOut
+	IngestEndpointHeadersIn                   = models.IngestEndpointHeadersIn
+	IngestEndpointHeadersOut                  = models.IngestEndpointHeadersOut
+	IngestEndpointIn                          = models.IngestEndpointIn
+	IngestEndpointOut                         = models.IngestEndpointOut
+	IngestEndpointSecretIn                    = models.IngestEndpointSecretIn
+	IngestEndpointSecretOut                   = models.IngestEndpointSecretOut
+	IngestEndpointUpdate                      = models.IngestEndpointUpdate
 	IntegrationIn                             = models.IntegrationIn
 	IntegrationKeyOut                         = models.IntegrationKeyOut
 	IntegrationOut                            = models.IntegrationOut
@@ -53,6 +60,7 @@ type (
 	ListResponseEndpointMessageOut            = models.ListResponseEndpointMessageOut
 	ListResponseEndpointOut                   = models.ListResponseEndpointOut
 	ListResponseEventTypeOut                  = models.ListResponseEventTypeOut
+	ListResponseIngestEndpointOut             = models.ListResponseIngestEndpointOut
 	ListResponseIntegrationOut                = models.ListResponseIntegrationOut
 	ListResponseMessageAttemptOut             = models.ListResponseMessageAttemptOut
 	ListResponseMessageEndpointOut            = models.ListResponseMessageEndpointOut

--- a/go/models/expunge_all_contents_out.go
+++ b/go/models/expunge_all_contents_out.go
@@ -1,0 +1,8 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type ExpungeAllContentsOut struct {
+	Id     string               `json:"id"` // The QueueBackgroundTask's ID.
+	Status BackgroundTaskStatus `json:"status"`
+	Task   BackgroundTaskType   `json:"task"`
+}

--- a/go/models/ingest_endpoint_headers_in.go
+++ b/go/models/ingest_endpoint_headers_in.go
@@ -1,0 +1,6 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type IngestEndpointHeadersIn struct {
+	Headers map[string]string `json:"headers"`
+}

--- a/go/models/ingest_endpoint_headers_out.go
+++ b/go/models/ingest_endpoint_headers_out.go
@@ -1,0 +1,7 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type IngestEndpointHeadersOut struct {
+	Headers   map[string]string `json:"headers"`
+	Sensitive []string          `json:"sensitive"`
+}

--- a/go/models/ingest_endpoint_in.go
+++ b/go/models/ingest_endpoint_in.go
@@ -1,20 +1,16 @@
 // Package svix this file is @generated DO NOT EDIT
 package models
 
-type EndpointIn struct {
-	Channels    []string           `json:"channels,omitempty"` // List of message channels this endpoint listens to (omit for all).
+type IngestEndpointIn struct {
 	Description *string            `json:"description,omitempty"`
 	Disabled    *bool              `json:"disabled,omitempty"`
-	FilterTypes []string           `json:"filterTypes,omitempty"`
-	Headers     *map[string]string `json:"headers,omitempty"`
 	Metadata    *map[string]string `json:"metadata,omitempty"`
 	RateLimit   *uint16            `json:"rateLimit,omitempty"`
 	// The endpoint's verification secret.
 	//
 	// Format: `base64` encoded random bytes optionally prefixed with `whsec_`.
 	// It is recommended to not set this and let the server generate the secret.
-	Secret  *string `json:"secret,omitempty"`
-	Uid     *string `json:"uid,omitempty"` // Optional unique identifier for the endpoint.
-	Url     string  `json:"url"`
-	Version *uint16 `json:"version,omitempty"`
+	Secret *string `json:"secret,omitempty"`
+	Uid    *string `json:"uid,omitempty"` // Optional unique identifier for the endpoint.
+	Url    string  `json:"url"`
 }

--- a/go/models/ingest_endpoint_out.go
+++ b/go/models/ingest_endpoint_out.go
@@ -1,0 +1,16 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+import "time"
+
+type IngestEndpointOut struct {
+	CreatedAt   time.Time         `json:"createdAt"`
+	Description string            `json:"description"` // An example endpoint name.
+	Disabled    *bool             `json:"disabled,omitempty"`
+	Id          string            `json:"id"` // The Endpoint's ID.
+	Metadata    map[string]string `json:"metadata"`
+	RateLimit   *uint16           `json:"rateLimit,omitempty"`
+	Uid         *string           `json:"uid,omitempty"` // Optional unique identifier for the endpoint.
+	UpdatedAt   time.Time         `json:"updatedAt"`
+	Url         string            `json:"url"`
+}

--- a/go/models/ingest_endpoint_secret_in.go
+++ b/go/models/ingest_endpoint_secret_in.go
@@ -1,0 +1,10 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type IngestEndpointSecretIn struct {
+	// The endpoint's verification secret.
+	//
+	// Format: `base64` encoded random bytes optionally prefixed with `whsec_`.
+	// It is recommended to not set this and let the server generate the secret.
+	Key *string `json:"key,omitempty"`
+}

--- a/go/models/ingest_endpoint_secret_out.go
+++ b/go/models/ingest_endpoint_secret_out.go
@@ -1,0 +1,10 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type IngestEndpointSecretOut struct {
+	// The endpoint's verification secret.
+	//
+	// Format: `base64` encoded random bytes optionally prefixed with `whsec_`.
+	// It is recommended to not set this and let the server generate the secret.
+	Key string `json:"key"`
+}

--- a/go/models/ingest_endpoint_update.go
+++ b/go/models/ingest_endpoint_update.go
@@ -1,0 +1,11 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type IngestEndpointUpdate struct {
+	Description *string            `json:"description,omitempty"`
+	Disabled    *bool              `json:"disabled,omitempty"`
+	Metadata    *map[string]string `json:"metadata,omitempty"`
+	RateLimit   *uint16            `json:"rateLimit,omitempty"`
+	Uid         *string            `json:"uid,omitempty"` // Optional unique identifier for the endpoint.
+	Url         string             `json:"url"`
+}

--- a/go/models/list_response_ingest_endpoint_out.go
+++ b/go/models/list_response_ingest_endpoint_out.go
@@ -1,0 +1,9 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type ListResponseIngestEndpointOut struct {
+	Data         []IngestEndpointOut `json:"data"`
+	Done         bool                `json:"done"`
+	Iterator     *string             `json:"iterator,omitempty"`
+	PrevIterator *string             `json:"prevIterator,omitempty"`
+}

--- a/go/operational_webhook_endpoint.go
+++ b/go/operational_webhook_endpoint.go
@@ -44,7 +44,6 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) List(
 			return nil, err
 		}
 	}
-
 	return executeRequest[any, models.ListResponseOperationalWebhookEndpointOut](
 		ctx,
 		operationalWebhookEndpoint.client,
@@ -55,7 +54,6 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) List(
 		nil,
 		nil,
 	)
-
 }
 
 // Create an operational webhook endpoint.
@@ -72,7 +70,6 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) Create(
 			return nil, err
 		}
 	}
-
 	return executeRequest[models.OperationalWebhookEndpointIn, models.OperationalWebhookEndpointOut](
 		ctx,
 		operationalWebhookEndpoint.client,
@@ -83,7 +80,6 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) Create(
 		headerMap,
 		&operationalWebhookEndpointIn,
 	)
-
 }
 
 // Get an operational webhook endpoint.
@@ -94,7 +90,6 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) Get(
 	pathMap := map[string]string{
 		"endpoint_id": endpointId,
 	}
-
 	return executeRequest[any, models.OperationalWebhookEndpointOut](
 		ctx,
 		operationalWebhookEndpoint.client,
@@ -105,7 +100,6 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) Get(
 		nil,
 		nil,
 	)
-
 }
 
 // Update an operational webhook endpoint.
@@ -117,7 +111,6 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) Update(
 	pathMap := map[string]string{
 		"endpoint_id": endpointId,
 	}
-
 	return executeRequest[models.OperationalWebhookEndpointUpdate, models.OperationalWebhookEndpointOut](
 		ctx,
 		operationalWebhookEndpoint.client,
@@ -128,7 +121,6 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) Update(
 		nil,
 		&operationalWebhookEndpointUpdate,
 	)
-
 }
 
 // Delete an operational webhook endpoint.
@@ -139,7 +131,6 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) Delete(
 	pathMap := map[string]string{
 		"endpoint_id": endpointId,
 	}
-
 	_, err := executeRequest[any, any](
 		ctx,
 		operationalWebhookEndpoint.client,
@@ -151,7 +142,6 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) Delete(
 		nil,
 	)
 	return err
-
 }
 
 // Get the additional headers to be sent with the operational webhook.
@@ -162,7 +152,6 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) GetHeaders(
 	pathMap := map[string]string{
 		"endpoint_id": endpointId,
 	}
-
 	return executeRequest[any, models.OperationalWebhookEndpointHeadersOut](
 		ctx,
 		operationalWebhookEndpoint.client,
@@ -173,7 +162,6 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) GetHeaders(
 		nil,
 		nil,
 	)
-
 }
 
 // Set the additional headers to be sent with the operational webhook.
@@ -185,7 +173,6 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) UpdateHeaders(
 	pathMap := map[string]string{
 		"endpoint_id": endpointId,
 	}
-
 	_, err := executeRequest[models.OperationalWebhookEndpointHeadersIn, any](
 		ctx,
 		operationalWebhookEndpoint.client,
@@ -197,7 +184,6 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) UpdateHeaders(
 		&operationalWebhookEndpointHeadersIn,
 	)
 	return err
-
 }
 
 // Get an operational webhook endpoint's signing secret.
@@ -211,7 +197,6 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) GetSecret(
 	pathMap := map[string]string{
 		"endpoint_id": endpointId,
 	}
-
 	return executeRequest[any, models.OperationalWebhookEndpointSecretOut](
 		ctx,
 		operationalWebhookEndpoint.client,
@@ -222,7 +207,6 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) GetSecret(
 		nil,
 		nil,
 	)
-
 }
 
 // Rotates an operational webhook endpoint's signing secret.
@@ -245,7 +229,6 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) RotateSecret(
 			return err
 		}
 	}
-
 	_, err = executeRequest[models.OperationalWebhookEndpointSecretIn, any](
 		ctx,
 		operationalWebhookEndpoint.client,
@@ -257,5 +240,4 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) RotateSecret(
 		&operationalWebhookEndpointSecretIn,
 	)
 	return err
-
 }

--- a/go/statistics.go
+++ b/go/statistics.go
@@ -32,7 +32,6 @@ func (statistics *Statistics) AggregateAppStats(
 			return nil, err
 		}
 	}
-
 	return executeRequest[models.AppUsageStatsIn, models.AppUsageStatsOut](
 		ctx,
 		statistics.client,
@@ -43,7 +42,6 @@ func (statistics *Statistics) AggregateAppStats(
 		headerMap,
 		&appUsageStatsIn,
 	)
-
 }
 
 // Creates a background task to calculate the listed event types for all apps in the organization.
@@ -53,7 +51,6 @@ func (statistics *Statistics) AggregateAppStats(
 func (statistics *Statistics) AggregateEventTypes(
 	ctx context.Context,
 ) (*models.AggregateEventTypesOut, error) {
-
 	return executeRequest[any, models.AggregateEventTypesOut](
 		ctx,
 		statistics.client,
@@ -64,5 +61,4 @@ func (statistics *Statistics) AggregateEventTypes(
 		nil,
 		nil,
 	)
-
 }

--- a/openapi-templates/go/api_extra/application_create.go
+++ b/openapi-templates/go/api_extra/application_create.go
@@ -1,0 +1,30 @@
+// Get or create a new application.
+func (application *Application) GetOrCreate(
+	ctx context.Context,
+	applicationIn models.ApplicationIn,
+	o *ApplicationCreateOptions,
+) (*models.ApplicationOut, error) {
+	queryMap := map[string]string{
+		"get_if_exists": "true",
+	}
+	headerMap := map[string]string{}
+
+	var err error
+	if o != nil {
+		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return executeRequest[models.ApplicationIn, models.ApplicationOut](
+		ctx,
+		application.client,
+		"POST",
+		"/api/v1/app",
+		nil,
+		queryMap,
+		headerMap,
+		&applicationIn,
+	)
+}

--- a/openapi-templates/go/api_resource.go.jinja
+++ b/openapi-templates/go/api_resource.go.jinja
@@ -1,0 +1,196 @@
+{% set resource_type_name = resource.name | to_upper_camel_case -%}
+{% set resource_self_name = resource.name | to_lower_camel_case -%}
+// Package svix this file is @generated DO NOT EDIT
+package svix
+
+import (
+	"fmt"
+	"time"
+	"context"
+	"encoding/json"
+
+	"github.com/svix/svix-webhooks/go/models"
+)
+
+
+type {{ resource_type_name }} struct {
+	client *SvixHttpClient
+}
+
+
+{% for op in resource.operations -%}
+    {% if op | has_query_or_header_params -%}
+	{% set opt_struct_name %}{{ resource_type_name }}{{ op.name | to_upper_camel_case }}Options{% endset %}
+type {{ opt_struct_name }} struct{
+        {% for p in op.query_params -%}
+			{% set p_ty = p.type.to_go() -%}
+			{% if p.type.is_schema_ref() -%}
+				{% set p_ty %}models.{{ p.type.to_go() }}{% endset %}
+			{% endif -%}
+            {% if p.description is defined -%}
+    {{ p.description | to_doc_comment(style="go") }}
+            {% endif -%}
+	{# all types in *Options structs are optional -#}
+    {{ p.name | to_upper_camel_case }} *{{ p_ty }}
+        {% endfor -%}
+		{% for p in op.header_params -%}
+	{{ p.name | to_upper_camel_case }} *string
+		{% endfor -%}
+
+}
+	{% endif -%}
+{% endfor -%}
+
+{% for op in resource.operations %}
+	{% if op.request_body_schema_name is defined -%}
+		{% set request_body_param = op.request_body_schema_name | to_lower_camel_case -%}
+	{% endif -%}
+
+	{# return type -#}
+	{% set has_return = false -%}
+	{% if op.response_body_schema_name is defined -%}
+		{% set has_return = true -%}
+		{% set ret_type %}models.{{ op.response_body_schema_name | to_upper_camel_case }}{% endset -%}
+		{% set func_ret_type %}(*{{ ret_type }}, error){% endset -%}
+	{% else -%}
+		{% set ret_type = "any" -%}
+		{% set func_ret_type %}error{% endset -%}
+	{% endif -%}
+
+	{% if op.description is defined -%}
+	{{ op.description | to_doc_comment(style="go") }}
+	{% endif -%}
+	{% if op.deprecated and "deprecated" not in op.description | lower -%}
+	{% if op.description is defined -%}
+//
+	{% endif -%}
+// Deprecated: {{ op.name | to_upper_camel_case }} is deprecated.
+	{% endif -%}
+func ({{ resource_self_name }} *{{ resource_type_name }}) {{ op.name | to_upper_camel_case }}(
+	ctx context.Context,
+
+	{#- path parameters #}
+	{% for p in op.path_params -%}
+		{{ p | to_lower_camel_case }} string,
+	{% endfor -%}
+
+	{# body parameter interface -#}
+	{% if op.request_body_schema_name is defined -%}
+		{{ request_body_param }} models.{{ op.request_body_schema_name }},
+	{% endif -%}
+
+	{% if op | has_query_or_header_params -%}
+		o *{{ resource_type_name }}{{ op.name | to_upper_camel_case }}Options,
+	{% endif -%}
+
+) {{ func_ret_type }} {
+	{% set used_err = false -%}
+
+	{# path params -#}
+	{% if op.path_params | length > 0 -%}
+	pathMap := map[string]string{
+		{% for p in op.path_params -%}
+		"{{ p }}" : {{ p | to_lower_camel_case }},
+		{% endfor -%}
+	}
+	{% endif -%}
+
+	{% if op.id == "v1.application.create" -%}
+	queryMap := map[string]string{
+		"get_if_exists": "false",
+	}
+	{% elif op.query_params | length > 0 -%}
+	queryMap := map[string]string{}
+	{% endif -%}
+
+	{% if op.header_params | length >0 -%}
+	headerMap := map[string]string{}
+	{% endif -%}
+
+	{% if op | has_query_or_header_params -%}
+	{% set used_err = true -%}
+	var err error
+	if o != nil {
+		{# header params -#}
+		{% if op.header_params | length > 0 -%}
+			{% for p in op.header_params -%}
+		serializeParamToMap("{{ p.name }}", o.{{ p.name | to_upper_camel_case }}, headerMap, &err)
+			{% endfor -%}
+		{% endif -%}
+
+		{# query params -#}
+		{% if op.query_params | length >0 -%}
+			{% for p in op.query_params -%}
+		serializeParamToMap("{{ p.name }}", o.{{ p.name | to_upper_camel_case }}, queryMap, &err)
+			{% endfor -%}
+		{% endif -%}
+
+		if err != nil {
+			return {% if has_return %}nil,{% endif %} err
+		}
+	}
+	{% endif -%}
+
+	{# make template ugly, but generated code nice -#}
+	{% set generic_ret_type = ret_type -%}
+	{% if op.request_body_schema_name is defined -%}
+		{% set generic_ret_type -%}models.{{ op.request_body_schema_name }},{{ ret_type }}{% endset -%}
+	{% else -%}
+		{% set generic_ret_type -%}any,{{ ret_type }}{% endset -%}
+	{% endif -%}
+	{# 	{% if has_return %}ret{% else %}_{% endif %}, err {% if not used_err or has_return %}:={% else %}={% endif %} #}
+	{% if has_return %}return {% else %} _,err {% if not used_err%}:{% endif%}= {% endif %}executeRequest[{{ generic_ret_type }}](
+		ctx,
+		{{ resource_self_name }}.client,
+		"{{ op.method | upper }}",
+		"{{ op.path }}",
+		{# path params -#}
+		{% if op.path_params | length > 0 -%}
+		pathMap,
+		{% else -%}
+		nil,
+		{% endif -%}
+
+		{#- query params -#}
+		{% if op.query_params | length > 0 or op.id == "v1.application.create"  -%}
+		queryMap,
+		{% else -%}
+		nil,
+		{% endif -%}
+
+		{#- header params -#}
+		{% if op.header_params | length >0 -%}
+		headerMap,
+		{% else -%}
+		nil,
+		{% endif -%}
+
+		{% if op.request_body_schema_name is defined -%}
+		&{{ request_body_param }},
+		{% else -%}
+		nil,
+		{% endif -%}
+	)
+	{% if not has_return -%}
+	return err
+	{% endif -%}
+	{# if err != nil {
+		return {% if has_return %}nil,{% endif %} err
+	}
+	{% if has_return -%}
+		return ret, nil
+	{% else -%}
+		return nil
+	{% endif -%} #}
+
+
+
+}
+	{% set extra_path -%}
+		api_extra/{{ resource.name | to_snake_case }}_{{ op.name | to_snake_case }}.go
+	{%- endset -%}
+	{% include extra_path ignore missing %}
+
+
+{% endfor %}
+

--- a/openapi-templates/go/api_resource.go.jinja
+++ b/openapi-templates/go/api_resource.go.jinja
@@ -19,20 +19,20 @@ type {{ resource_type_name }} struct {
 
 
 {% for op in resource.operations -%}
-    {% if op | has_query_or_header_params -%}
+	{% if op | has_query_or_header_params -%}
 	{% set opt_struct_name %}{{ resource_type_name }}{{ op.name | to_upper_camel_case }}Options{% endset %}
 type {{ opt_struct_name }} struct{
-        {% for p in op.query_params -%}
+		{% for p in op.query_params -%}
 			{% set p_ty = p.type.to_go() -%}
 			{% if p.type.is_schema_ref() -%}
 				{% set p_ty %}models.{{ p.type.to_go() }}{% endset %}
 			{% endif -%}
-            {% if p.description is defined -%}
-    {{ p.description | to_doc_comment(style="go") }}
-            {% endif -%}
+			{% if p.description is defined -%}
+	{{ p.description | to_doc_comment(style="go") }}
+			{% endif -%}
 	{# all types in *Options structs are optional -#}
-    {{ p.name | to_upper_camel_case }} *{{ p_ty }}
-        {% endfor -%}
+	{{ p.name | to_upper_camel_case }} *{{ p_ty }}
+		{% endfor -%}
 		{% for p in op.header_params -%}
 	{{ p.name | to_upper_camel_case }} *string
 		{% endfor -%}
@@ -138,7 +138,6 @@ func ({{ resource_self_name }} *{{ resource_type_name }}) {{ op.name | to_upper_
 	{% else -%}
 		{% set generic_ret_type -%}any,{{ ret_type }}{% endset -%}
 	{% endif -%}
-	{# 	{% if has_return %}ret{% else %}_{% endif %}, err {% if not used_err or has_return %}:={% else %}={% endif %} #}
 	{% if has_return %}return {% else %} _,err {% if not used_err%}:{% endif%}= {% endif %}executeRequest[{{ generic_ret_type }}](
 		ctx,
 		{{ resource_self_name }}.client,
@@ -174,23 +173,9 @@ func ({{ resource_self_name }} *{{ resource_type_name }}) {{ op.name | to_upper_
 	{% if not has_return -%}
 	return err
 	{% endif -%}
-	{# if err != nil {
-		return {% if has_return %}nil,{% endif %} err
-	}
-	{% if has_return -%}
-		return ret, nil
-	{% else -%}
-		return nil
-	{% endif -%} #}
-
-
-
 }
 	{% set extra_path -%}
 		api_extra/{{ resource.name | to_snake_case }}_{{ op.name | to_snake_case }}.go
 	{%- endset -%}
 	{% include extra_path ignore missing %}
-
-
 {% endfor %}
-

--- a/openapi-templates/go/component_type.go.jinja
+++ b/openapi-templates/go/component_type.go.jinja
@@ -1,0 +1,7 @@
+{% if type.kind == "struct" -%}
+    {% include "types/struct.go.jinja" ignore missing -%}
+{% elif type.kind == "string_enum" -%}
+    {% include "types/string_enum.go.jinja" ignore missing -%}
+{% elif type.kind == "integer_enum" -%}
+{% include "types/integer_enum.go.jinja" ignore missing -%}
+{% endif -%}

--- a/openapi-templates/go/component_type.go.jinja
+++ b/openapi-templates/go/component_type.go.jinja
@@ -1,7 +1,7 @@
 {% if type.kind == "struct" -%}
-    {% include "types/struct.go.jinja" ignore missing -%}
+	{% include "types/struct.go.jinja" ignore missing -%}
 {% elif type.kind == "string_enum" -%}
-    {% include "types/string_enum.go.jinja" ignore missing -%}
+	{% include "types/string_enum.go.jinja" ignore missing -%}
 {% elif type.kind == "integer_enum" -%}
-{% include "types/integer_enum.go.jinja" ignore missing -%}
+	{% include "types/integer_enum.go.jinja" ignore missing -%}
 {% endif -%}

--- a/openapi-templates/go/component_type_summary.go.jinja
+++ b/openapi-templates/go/component_type_summary.go.jinja
@@ -1,0 +1,10 @@
+// Package svix this file is @generated DO NOT EDIT
+package svix
+
+import "github.com/svix/svix-webhooks/go/models"
+
+type (
+{% for type in types -%}
+    {{ type | to_upper_camel_case }} =  models.{{ type | to_upper_camel_case }}
+{% endfor %}
+)

--- a/openapi-templates/go/component_type_summary.go.jinja
+++ b/openapi-templates/go/component_type_summary.go.jinja
@@ -5,6 +5,6 @@ import "github.com/svix/svix-webhooks/go/models"
 
 type (
 {% for type in types -%}
-    {{ type | to_upper_camel_case }} =  models.{{ type | to_upper_camel_case }}
+	{{ type | to_upper_camel_case }} =  models.{{ type | to_upper_camel_case }}
 {% endfor %}
 )

--- a/openapi-templates/go/types/integer_enum.go.jinja
+++ b/openapi-templates/go/types/integer_enum.go.jinja
@@ -1,0 +1,42 @@
+{% set ty_name =  type.name | to_upper_camel_case -%}
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+)
+
+{% if type.description is defined -%}
+{{ type.description | to_doc_comment(style="go") }}
+{% endif -%}
+type {{ ty_name }} int64
+
+const (
+{% for varname, val in type.variants -%}
+    {{ type.name |  to_upper_snake_case | replace("_", "") }}_{{ varname | to_upper_snake_case }}  {{ ty_name }} = {{ val }}
+{% endfor -%}
+)
+
+var allowed{{ ty_name }} = []{{ ty_name }}{
+	{% for _, val in type.variants -%}
+	{{ val }},
+	{% endfor -%}
+}
+
+
+func (v *{{ ty_name }}) UnmarshalJSON(src []byte) error {
+	var value int64
+	err := json.Unmarshal(src, &value)
+	if err != nil {
+		return err
+	}
+	enumVal := {{ ty_name }}(value)
+	if slices.Contains(allowed{{ ty_name }}, enumVal) {
+		*v = enumVal
+		return nil
+	}
+	return fmt.Errorf("`%+v` is not a valid {{ ty_name }}", value)
+
+}

--- a/openapi-templates/go/types/integer_enum.go.jinja
+++ b/openapi-templates/go/types/integer_enum.go.jinja
@@ -15,7 +15,7 @@ type {{ ty_name }} int64
 
 const (
 {% for varname, val in type.variants -%}
-    {{ type.name |  to_upper_snake_case | replace("_", "") }}_{{ varname | to_upper_snake_case }}  {{ ty_name }} = {{ val }}
+	{{ type.name |  to_upper_snake_case | replace("_", "") }}_{{ varname | to_upper_snake_case }}  {{ ty_name }} = {{ val }}
 {% endfor -%}
 )
 

--- a/openapi-templates/go/types/string_enum.go.jinja
+++ b/openapi-templates/go/types/string_enum.go.jinja
@@ -1,0 +1,42 @@
+{% set ty_name =  type.name | to_upper_camel_case -%}
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+)
+
+{% if type.description is defined -%}
+{{ type.description | to_doc_comment(style="go") }}
+{% endif -%}
+type {{ ty_name }} string
+
+const (
+{% for value in type.values -%}
+    {{ type.name |  to_upper_snake_case | replace("_", "") }}_{{ value | to_upper_snake_case }} {{ ty_name }} = "{{ value }}"
+{% endfor -%}
+)
+
+var allowed{{ ty_name }} = []{{ ty_name }}{
+	{% for v in type.values -%}
+	"{{ v }}",
+	{% endfor -%}
+}
+
+
+func (v *{{ ty_name }}) UnmarshalJSON(src []byte) error {
+	var value string
+	err := json.Unmarshal(src, &value)
+	if err != nil {
+		return err
+	}
+	enumVal := {{ ty_name }}(value)
+	if slices.Contains(allowed{{ ty_name }}, enumVal) {
+		*v = enumVal
+		return nil
+	}
+	return fmt.Errorf("`%+v` is not a valid {{ ty_name }}", value)
+
+}

--- a/openapi-templates/go/types/string_enum.go.jinja
+++ b/openapi-templates/go/types/string_enum.go.jinja
@@ -15,7 +15,7 @@ type {{ ty_name }} string
 
 const (
 {% for value in type.values -%}
-    {{ type.name |  to_upper_snake_case | replace("_", "") }}_{{ value | to_upper_snake_case }} {{ ty_name }} = "{{ value }}"
+	{{ type.name |  to_upper_snake_case | replace("_", "") }}_{{ value | to_upper_snake_case }} {{ ty_name }} = "{{ value }}"
 {% endfor -%}
 )
 

--- a/openapi-templates/go/types/struct.go.jinja
+++ b/openapi-templates/go/types/struct.go.jinja
@@ -6,43 +6,43 @@ import "github.com/svix/svix-webhooks/go/utils"
 {{ type.description | to_doc_comment(style="go")}}
 {% endif -%}
 type {{ type.name | to_upper_camel_case }} struct {
-    {% for field in type.fields -%}
-        {% set f_name = field.name | to_upper_camel_case -%}
-        {% set f_type = field.type.to_go() -%}
-        {% set use_nullable = type.name is endingwith "Patch" and field.nullable -%}
-        {% set json_annotation = "" -%}
-        {% if use_nullable -%}
-            {% set f_type %}utils.Nullable[{{ f_type }}]{% endset -%}
-        {% endif -%}
-        {% if (not field.required or field.nullable) and not use_nullable -%}
-            {% set json_annotation = ",omitempty" -%}
-            {% if not field.type.is_set() and not field.type.is_list() -%}
-                {% set f_type %}*{{ f_type }}{% endset -%}
-            {% endif -%}
-        {% endif -%}
-        {% if field.description is defined and "\n" in field.description -%}
-    {{ field.description | to_doc_comment(style="go") | indent(4) }}
-        {% endif -%}
-    {{ f_name }} {{ f_type }} `json:"{{ field.name }}{{ json_annotation }}"`
-        {%- if field.description is defined and "\n" not in field.description -%}
-        {{ field.description | to_doc_comment(style="go") }}
-        {%- endif %}
-    {% endfor -%}
+	{% for field in type.fields -%}
+		{% set f_name = field.name | to_upper_camel_case -%}
+		{% set f_type = field.type.to_go() -%}
+		{% set use_nullable = type.name is endingwith "Patch" and field.nullable -%}
+		{% set json_annotation = "" -%}
+		{% if use_nullable -%}
+			{% set f_type %}utils.Nullable[{{ f_type }}]{% endset -%}
+		{% endif -%}
+		{% if (not field.required or field.nullable) and not use_nullable -%}
+			{% set json_annotation = ",omitempty" -%}
+			{% if not field.type.is_set() and not field.type.is_list() -%}
+				{% set f_type %}*{{ f_type }}{% endset -%}
+			{% endif -%}
+		{% endif -%}
+		{% if field.description is defined and "\n" in field.description -%}
+	{{ field.description | to_doc_comment(style="go") | indent(4) }}
+		{% endif -%}
+	{{ f_name }} {{ f_type }} `json:"{{ field.name }}{{ json_annotation }}"`
+		{%- if field.description is defined and "\n" not in field.description -%}
+		{{ field.description | to_doc_comment(style="go") }}
+		{%- endif %}
+	{% endfor -%}
 }
 {% if type.name is endingwith "Patch" -%}
 func (o {{ type.name | to_upper_camel_case }}) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
-    {% for field in type.fields -%}
-        {% if field.nullable -%}
+	{% for field in type.fields -%}
+		{% if field.nullable -%}
 	if o.{{ field.name | to_upper_camel_case }}.IsSet() {
 		toSerialize["{{ field.name }}"] = o.{{ field.name | to_upper_camel_case }}
 	}
-        {% else -%}
+		{% else -%}
 	if o.{{ field.name | to_upper_camel_case }} != nil {
 		toSerialize["{{ field.name }}"] = o.{{ field.name | to_upper_camel_case }}
 	}
-        {% endif -%}
-    {% endfor -%}
+		{% endif -%}
+	{% endfor -%}
 	return json.Marshal(toSerialize)
 }
 {% endif -%}

--- a/openapi-templates/go/types/struct.go.jinja
+++ b/openapi-templates/go/types/struct.go.jinja
@@ -1,0 +1,48 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+import "github.com/svix/svix-webhooks/go/utils"
+
+{% if type.description is defined -%}
+{{ type.description | to_doc_comment(style="go")}}
+{% endif -%}
+type {{ type.name | to_upper_camel_case }} struct {
+    {% for field in type.fields -%}
+        {% set f_name = field.name | to_upper_camel_case -%}
+        {% set f_type = field.type.to_go() -%}
+        {% set use_nullable = type.name is endingwith "Patch" and field.nullable -%}
+        {% set json_annotation = "" -%}
+        {% if use_nullable -%}
+            {% set f_type %}utils.Nullable[{{ f_type }}]{% endset -%}
+        {% endif -%}
+        {% if (not field.required or field.nullable) and not use_nullable -%}
+            {% set json_annotation = ",omitempty" -%}
+            {% if not field.type.is_set() and not field.type.is_list() -%}
+                {% set f_type %}*{{ f_type }}{% endset -%}
+            {% endif -%}
+        {% endif -%}
+        {% if field.description is defined and "\n" in field.description -%}
+    {{ field.description | to_doc_comment(style="go") | indent(4) }}
+        {% endif -%}
+    {{ f_name }} {{ f_type }} `json:"{{ field.name }}{{ json_annotation }}"`
+        {%- if field.description is defined and "\n" not in field.description -%}
+        {{ field.description | to_doc_comment(style="go") }}
+        {%- endif %}
+    {% endfor -%}
+}
+{% if type.name is endingwith "Patch" -%}
+func (o {{ type.name | to_upper_camel_case }}) MarshalJSON() ([]byte, error) {
+	toSerialize := map[string]interface{}{}
+    {% for field in type.fields -%}
+        {% if field.nullable -%}
+	if o.{{ field.name | to_upper_camel_case }}.IsSet() {
+		toSerialize["{{ field.name }}"] = o.{{ field.name | to_upper_camel_case }}
+	}
+        {% else -%}
+	if o.{{ field.name | to_upper_camel_case }} != nil {
+		toSerialize["{{ field.name }}"] = o.{{ field.name | to_upper_camel_case }}
+	}
+        {% endif -%}
+    {% endfor -%}
+	return json.Marshal(toSerialize)
+}
+{% endif -%}

--- a/regen_openapi.sh
+++ b/regen_openapi.sh
@@ -23,19 +23,19 @@ set -x
 
 # === Go ===
 if [[ -z "$CI" ]]; then
-openapi-codegen generate \
-    --template openapi-templates/go/api_resource.go.jinja \
-    --input-file lib-openapi.json \
-    --output-dir go
-openapi-codegen generate \
-    --template openapi-templates/go/component_type_summary.go.jinja \
-    --input-file lib-openapi.json \
-    --output-dir go
-openapi-codegen generate \
-    --template openapi-templates/go/component_type.go.jinja \
-    --input-file lib-openapi.json \
-    --output-dir go/models
-rm go/{environment,health,ingest_endpoint}.go
+    openapi-codegen generate \
+        --template openapi-templates/go/api_resource.go.jinja \
+        --input-file lib-openapi.json \
+        --output-dir go
+    openapi-codegen generate \
+        --template openapi-templates/go/component_type_summary.go.jinja \
+        --input-file lib-openapi.json \
+        --output-dir go
+    openapi-codegen generate \
+        --template openapi-templates/go/component_type.go.jinja \
+        --input-file lib-openapi.json \
+        --output-dir go/models
+    rm go/{environment,health,ingest_endpoint}.go
 fi
 
 

--- a/regen_openapi.sh
+++ b/regen_openapi.sh
@@ -21,6 +21,23 @@ fi
 # Print commands we run from here on
 set -x
 
+# === Go ===
+if [[ -z "$CI" ]]; then
+openapi-codegen generate \
+    --template openapi-templates/go/api_resource.go.jinja \
+    --input-file lib-openapi.json \
+    --output-dir go
+openapi-codegen generate \
+    --template openapi-templates/go/component_type_summary.go.jinja \
+    --input-file lib-openapi.json \
+    --output-dir go
+openapi-codegen generate \
+    --template openapi-templates/go/component_type.go.jinja \
+    --input-file lib-openapi.json \
+    --output-dir go/models
+rm go/{environment,health,ingest_endpoint}.go
+fi
+
 
 # === Ruby ===
 if [[ -z "$CI" ]]; then


### PR DESCRIPTION
Pull in Go templates from the `openapi-codegen` repo
Also pull in latest changes from `lib-openapi.json`

For now `regen_openapi.sh` for Go is disabled in CI

If I leave the templates in the `go` folder, `go build` will try to compile the `api_extra` files
So I am placing the templates in `openapi-templates/go`.
Once merged I will go around the other libs and move their templates to the `openapi-templates` dir