### PR TITLE
rust: Add OperationalWebhook resource

### DIFF
--- a/rust/src/api/mod.rs
+++ b/rust/src/api/mod.rs
@@ -15,6 +15,7 @@ mod ingest_endpoint;
 mod integration;
 mod message;
 mod message_attempt;
+mod operational_webhook;
 mod operational_webhook_endpoint;
 mod statistics;
 
@@ -53,6 +54,7 @@ pub use self::{
         MessageAttemptListAttemptedMessagesOptions, MessageAttemptListByEndpointOptions,
         MessageAttemptListByMsgOptions, MessageAttemptResendOptions,
     },
+    operational_webhook::OperationalWebhook,
     operational_webhook_endpoint::{
         OperationalWebhookEndpoint, OperationalWebhookEndpointCreateOptions,
         OperationalWebhookEndpointListOptions,
@@ -104,6 +106,10 @@ impl Svix {
 
     pub fn message_attempt(&self) -> MessageAttempt<'_> {
         MessageAttempt::new(&self.cfg)
+    }
+
+    pub fn operational_webhook(&self) -> OperationalWebhook<'_> {
+        OperationalWebhook::new(&self.cfg)
     }
 
     pub fn operational_webhook_endpoint(&self) -> OperationalWebhookEndpoint<'_> {

--- a/rust/src/api/operational_webhook.rs
+++ b/rust/src/api/operational_webhook.rs
@@ -1,0 +1,16 @@
+use super::OperationalWebhookEndpoint;
+use crate::Configuration;
+
+pub struct OperationalWebhook<'a> {
+    cfg: &'a Configuration,
+}
+
+impl<'a> OperationalWebhook<'a> {
+    pub(super) fn new(cfg: &'a Configuration) -> Self {
+        Self { cfg }
+    }
+
+    pub fn endpoint(&self) -> OperationalWebhookEndpoint<'a> {
+        OperationalWebhookEndpoint::new(self.cfg)
+    }
+}

--- a/rust/templates/api_resource.rs.jinja
+++ b/rust/templates/api_resource.rs.jinja
@@ -1,9 +1,16 @@
 {% set resource_type_name = resource.name | to_upper_camel_case -%}
 
 use crate::{
+{%- if resource.operations | length > 0 %}
     error::Result,
     models::*,
+{%- endif %}
     Configuration,
+};
+use super::{
+    {% for _, sub in resource.subresources | items -%}
+        {{ sub.name | to_upper_camel_case }} ,
+    {%- endfor %}
 };
 
 {% for op in resource.operations -%}
@@ -50,6 +57,14 @@ impl<'a> {{ resource_type_name }}<'a> {
     pub(super) fn new(cfg: &'a Configuration) -> Self {
         Self { cfg }
     }
+
+    {% for name, sub in resource.subresources | items -%}
+    {% set sub_type_name = sub.name | to_upper_camel_case -%}
+    pub fn {{ name | to_snake_case }}(&self) -> {{ sub_type_name }}<'a> {
+        {{ sub_type_name }}::new(self.cfg)
+    }
+
+    {% endfor -%}
 
     {% for op in resource.operations %}
     {% set has_params = op | has_query_or_header_params -%}


### PR DESCRIPTION
We are going to deprecate the `svix.operational_webhook_endpoint()` accessor in favor of `svix.operational_webhook().endpoint()` down the line.

The new file was generated using https://github.com/svix/openapi-codegen/pull/86. I'm not updating the git rev in this PR though because that PR is not yet merged, and because the other templates we use in CI have not yet been updated. Luckily we don't currently error when there are unused left-over files, though maybe we should do so down the line.