### PR TITLE
go: Return a pointer to an error

### DIFF
--- a/go/svix_http_client.go
+++ b/go/svix_http_client.go
@@ -92,7 +92,7 @@ func executeRequest[ReqBody any, ResBody any](
 
 		return &ret, nil
 	}
-	return nil, Error{
+	return nil, &Error{
 		status: res.StatusCode,
 		body:   body,
 		error:  fmt.Sprintf("status code %s", res.Status),


### PR DESCRIPTION
Fixes a regression with our new Go lib, we used to return a `*svix.Error`.
