### PR TITLE
java/kotlin: Switch the type of `MessageIn.payload` to a string

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Version 1.61.1
+* Libs/Java **(Breaking)**: The type of `MessageIn.transformationsParams` changed from `Object` to  `Map<String,Object>`.
 * Libs/Java and Libs/Kotlin **(Breaking)**: Due to an internal change in the underlining JSON de/serialization library, some JSON objects may not be serialized correctly. To address this `MessageIn.payload` now accepts a JSON encoded string instead of an `Object` (for Java) or `Map<String, Any>` (for Kotlin)
 
 ## Version 1.61.0

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 1.61.1
+* Libs/Java and Libs/Kotlin **(Breaking)**: Due to an internal change in the underlining JSON de/serialization library, some JSON objects may not be serialized correctly. To address this `MessageIn.payload` now accepts a JSON encoded string instead of an `Object` (for Java) or `Map<String, Any>` (for Kotlin)
+
 ## Version 1.61.0
 * Libs/Ruby **(Breaking)**: Ruby version changed from `2.7` to `3.4.2`
 * Libs/Ruby **(Breaking)**: Deprecated methods `MessageAttempt.list` and `MessageAttempt.list_attempts_for_endpoint` are removed

--- a/java/lib/src/main/java/com/svix/api/Message.java
+++ b/java/lib/src/main/java/com/svix/api/Message.java
@@ -135,6 +135,20 @@ public class Message {
         if (options.idempotencyKey != null) {
             headers.put("idempotency-key", options.idempotencyKey);
         }
+        if (messageIn.getTransformationsParams() != null) {
+            if (messageIn.getTransformationsParams().get("rawPayload") == null) {
+                // transformationsParams may be immutable
+                HashMap<String, Object> trParams =
+                        new HashMap<>(messageIn.getTransformationsParams());
+                trParams.put("rawPayload", messageIn.getPayload());
+                messageIn.setTransformationsParams(trParams);
+            }
+        } else {
+            HashMap<String, Object> trParam = new HashMap<>();
+            trParam.put("rawPayload", messageIn.getPayload());
+            messageIn.setTransformationsParams(trParam);
+        }
+        messageIn.setPayload("");
         return this.client.executeRequest(
                 "POST", url.build(), Headers.of(headers), messageIn, MessageOut.class);
     }
@@ -215,7 +229,7 @@ public class Message {
      */
     public static MessageIn messageInRaw(final String payload) {
         MessageIn msg = new MessageIn();
-        msg.setPayload(new HashMap<>());
+        msg.setPayload("");
         msg.setTransformationsParams(Collections.singletonMap("rawPayload", payload));
         return msg;
     }
@@ -233,7 +247,7 @@ public class Message {
         trParam.put("rawPayload", payload);
         trParam.put("headers", Collections.singletonMap("content-type", contentType));
         MessageIn msg = new MessageIn();
-        msg.setPayload(new HashMap<>());
+        msg.setPayload("");
         msg.setTransformationsParams(trParam);
         return msg;
     }

--- a/java/lib/src/main/java/com/svix/models/MessageIn.java
+++ b/java/lib/src/main/java/com/svix/models/MessageIn.java
@@ -12,6 +12,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 
 @ToString
@@ -23,11 +24,11 @@ public class MessageIn {
     @JsonProperty private Set<String> channels;
     @JsonProperty private String eventId;
     @JsonProperty private String eventType;
-    @JsonProperty private Object payload;
+    @JsonProperty private String payload;
     @JsonProperty private Long payloadRetentionHours;
     @JsonProperty private Long payloadRetentionPeriod;
     @JsonProperty private Set<String> tags;
-    @JsonProperty private Object transformationsParams;
+    @JsonProperty private Map<String, Object> transformationsParams;
 
     public MessageIn() {}
 
@@ -119,7 +120,7 @@ public class MessageIn {
         this.eventType = eventType;
     }
 
-    public MessageIn payload(Object payload) {
+    public MessageIn payload(String payload) {
         this.payload = payload;
         return this;
     }
@@ -132,11 +133,11 @@ public class MessageIn {
      * @return payload
      */
     @javax.annotation.Nonnull
-    public Object getPayload() {
+    public String getPayload() {
         return payload;
     }
 
-    public void setPayload(Object payload) {
+    public void setPayload(String payload) {
         this.payload = payload;
     }
 
@@ -208,7 +209,7 @@ public class MessageIn {
         this.tags = tags;
     }
 
-    public MessageIn transformationsParams(Object transformationsParams) {
+    public MessageIn transformationsParams(Map<String, Object> transformationsParams) {
         this.transformationsParams = transformationsParams;
         return this;
     }
@@ -219,11 +220,11 @@ public class MessageIn {
      * @return transformationsParams
      */
     @javax.annotation.Nullable
-    public Object getTransformationsParams() {
+    public Map<String, Object> getTransformationsParams() {
         return transformationsParams;
     }
 
-    public void setTransformationsParams(Object transformationsParams) {
+    public void setTransformationsParams(Map<String, Object> transformationsParams) {
         this.transformationsParams = transformationsParams;
     }
 

--- a/java/lib/src/test/resources/__files/ExpectedMsgCreateBody.json
+++ b/java/lib/src/test/resources/__files/ExpectedMsgCreateBody.json
@@ -1,0 +1,1 @@
+{"payload":"","transformationsParams":{"rawPayload":"{\"key1\":\"val\",\"key2\":\"val\",\"key\":\"val\"}"}}

--- a/java/lib/src/test/resources/__files/ExpectedMsgCreateBody2.json
+++ b/java/lib/src/test/resources/__files/ExpectedMsgCreateBody2.json
@@ -1,0 +1,1 @@
+{"eventType":"event.type","payload":"","transformationsParams":{"rawPayload":"{\"key\":\"val\",\"key1\":[\"list\"]}"}}

--- a/java/lib/src/test/resources/__files/ExpectedMsgCreateBodyWithHeaders.json
+++ b/java/lib/src/test/resources/__files/ExpectedMsgCreateBodyWithHeaders.json
@@ -1,0 +1,1 @@
+{"eventType":"event.type","payload":"","transformationsParams":{"rawPayload":"{\"key\":\"val\",\"key1\":[\"list\"]}","headers":{"header-key":"header-val"}}}

--- a/java/templates/api_extra/message.java
+++ b/java/templates/api_extra/message.java
@@ -10,7 +10,7 @@
  */
 public static MessageIn messageInRaw(final String payload) {
     MessageIn msg = new MessageIn();
-    msg.setPayload(new HashMap<>());
+    msg.setPayload("");
     msg.setTransformationsParams(Collections.singletonMap("rawPayload", payload));
     return msg;
 }
@@ -28,7 +28,7 @@ public static MessageIn messageInRaw(final String payload, final String contentT
     trParam.put("rawPayload", payload);
     trParam.put("headers", Collections.singletonMap("content-type", contentType));
     MessageIn msg = new MessageIn();
-    msg.setPayload(new HashMap<>());
+    msg.setPayload("");
     msg.setTransformationsParams(trParam);
     return msg;
 }

--- a/java/templates/api_extra/message_create_body.java
+++ b/java/templates/api_extra/message_create_body.java
@@ -1,0 +1,13 @@
+if (messageIn.getTransformationsParams() != null) {
+    if (messageIn.getTransformationsParams().get("rawPayload") == null) {
+        // transformationsParams may be immutable
+        HashMap<String, Object> trParams = new HashMap<>(messageIn.getTransformationsParams());
+        trParams.put("rawPayload",messageIn.getPayload());
+        messageIn.setTransformationsParams(trParams);
+    }
+} else {
+    HashMap<String, Object> trParam = new HashMap<>();
+    trParam.put("rawPayload", messageIn.getPayload());
+    messageIn.setTransformationsParams(trParam);
+}
+messageIn.setPayload("");

--- a/java/templates/api_resource.java.jinja
+++ b/java/templates/api_resource.java.jinja
@@ -126,6 +126,10 @@ public class {{ resource_type_name }} {
             {% endfor -%}
         {% endif -%}
 
+        {% if op.id == "v1.message.create" -%}
+            {% include "api_extra/message_create_body.java" -%}
+        {% endif -%}
+
         {% if res_type != "void" %}return{% endif %}  this.client.executeRequest(
             "{{ op.method | upper }}",
             url.build(),

--- a/java/templates/types/struct.java.jinja
+++ b/java/templates/types/struct.java.jinja
@@ -47,6 +47,11 @@ public class {{ type.name | to_upper_camel_case }} {
     {% if type.name is endingwith "Patch" and field.nullable -%}
         {% set field_ty %}MaybeUnset<{{ field_ty }}>{% endset -%}
     {% endif -%}
+    {% if type.name == "MessageIn" and field.name == "payload" -%}
+        {% set field_ty = "String" -%}
+    {% elif type.name == "MessageIn" and field.name == "transformationsParams" -%}
+        {% set field_ty = "Map<String,Object>" -%}
+    {% endif -%}
     {{ field_annotation}} private {{ field_ty }} {{ field.name | to_lower_camel_case }};
 {% endfor -%}
 
@@ -55,6 +60,11 @@ public class {{ type.name | to_upper_camel_case }} {
 
 {% for field in type.fields -%}
     {% set f_ty = field.type.to_java() -%}
+    {% if type.name == "MessageIn" and field.name == "payload" -%}
+        {% set f_ty = "String" -%}
+    {% elif type.name == "MessageIn" and field.name == "transformationsParams" -%}
+        {% set f_ty = "Map<String,Object>" -%}
+    {% endif -%}
     {% set f_varname = field.name | to_lower_camel_case -%}
     {% set f_deprecated = "" -%}
     {% if field.deprecated -%}

--- a/kotlin/lib/src/main/kotlin/models/MessageIn.kt
+++ b/kotlin/lib/src/main/kotlin/models/MessageIn.kt
@@ -10,10 +10,10 @@ data class MessageIn(
     val channels: Set<String>? = null,
     val eventId: String? = null,
     val eventType: String,
-    @Serializable(with = StringAnyMapSerializer::class) val payload: Map<String, Any>,
+    var payload: String,
     val payloadRetentionHours: Long? = null,
     val payloadRetentionPeriod: Long? = null,
     val tags: Set<String>? = null,
     @Serializable(with = StringAnyMapSerializer::class)
-    val transformationsParams: Map<String, Any>? = null,
+    var transformationsParams: Map<String, Any>? = null,
 )

--- a/kotlin/lib/src/test/com/svix/kotlin/BasicTest.kt
+++ b/kotlin/lib/src/test/com/svix/kotlin/BasicTest.kt
@@ -10,6 +10,7 @@ import com.svix.kotlin.models.MessageIn
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.encodeToString
 
 class BasicTest {
     companion object {
@@ -36,12 +37,13 @@ class BasicTest {
                 applicationOut.id,
                 MessageIn(
                     eventType = "invoice.paid",
-                    payload =
+                    payload = kotlinx.serialization.json.Json.encodeToString(
                         mapOf<String, Any>(
                             "id" to "invoice_WF7WtCLFFtd8ubcTgboSFNql",
                             "status" to "paid",
                             "attempt" to 2,
-                        ),
+                        )
+                    ),
                 ),
             )
             svix.application.delete(applicationOut.id)

--- a/kotlin/templates/api_extra/message.kt
+++ b/kotlin/templates/api_extra/message.kt
@@ -33,7 +33,7 @@ fun messageInRaw(
 
     return MessageIn(
         eventType = eventType,
-        payload = JsonObject(mapOf()),
+        payload = "",
         application = application,
         channels = channels,
         eventId = eventId,

--- a/kotlin/templates/api_extra/message_create_body.kt
+++ b/kotlin/templates/api_extra/message_create_body.kt
@@ -1,0 +1,12 @@
+if (messageIn.transformationsParams != null) {
+    // only set rawPayload if not already set
+    if (messageIn.transformationsParams!!["rawPayload"] == null) {
+        var trParams = (messageIn.transformationsParams as Map<String, Any>).toMutableMap();
+        trParams["rawPayload"] = messageIn.payload
+        messageIn.transformationsParams = trParams.toMap()
+    }
+} else {
+    val trParams = mapOf("rawPayload" to messageIn.payload)
+    messageIn.transformationsParams = trParams
+}
+messageIn.payload = ""

--- a/kotlin/templates/api_resource.kt.jinja
+++ b/kotlin/templates/api_resource.kt.jinja
@@ -103,7 +103,9 @@ suspend fun {{ op.name | to_lower_camel_case }}(
     options.{{ p.name | to_lower_camel_case }}?.let { headers.add("{{ p.name }}",it) }
     {% endfor -%}
     {% endif -%}
-
+    {% if op.id == "v1.message.create" -%}
+        {% include "api_extra/message_create_body.kt" -%}
+    {% endif -%}
     {% set generic_res_type = res_type -%}
     {% if not op.response_body_schema_name is defined -%}
         {% set generic_res_type = "Boolean" -%}

--- a/kotlin/templates/types/struct.kt.jinja
+++ b/kotlin/templates/types/struct.kt.jinja
@@ -27,14 +27,19 @@ data class {{ type.name | to_upper_camel_case }}(
         {% set f_val = "= null" -%}
     {% endif -%}
 
-    {% if field.name | to_lower_camel_case != field.name -%}
-    @SerialName("{{ field.name }}")
+    {% if type.name == "MessageIn" and field.name == "payload" -%}
+        var payload: String,
+    {% else -%}
+        {% if field.name | to_lower_camel_case != field.name -%}
+        @SerialName("{{ field.name }}")
+        {% endif -%}
+        {% if field.type.is_json_object() and not use_nullable -%}
+        @Serializable(with = StringAnyMapSerializer::class)
+        {% elif field.type.is_json_object() and use_nullable -%}
+        @Serializable(with = MaybeUnsetStringAnyMapSerializer::class)
+        {% endif -%}
+        {% if type.name == "MessageIn" and field.name == "transformationsParams" -%}var {% else %}val {% endif -%}
+        {{ field.name | to_lower_camel_case }}: {{ f_type }} {{ f_val }},
     {% endif -%}
-    {% if field.type.is_json_object() and not use_nullable -%}
-    @Serializable(with = StringAnyMapSerializer::class)
-    {% elif field.type.is_json_object() and use_nullable -%}
-    @Serializable(with = MaybeUnsetStringAnyMapSerializer::class)
-    {% endif -%}
-    val {{ field.name | to_lower_camel_case }}: {{ f_type }} {{ f_val }},
 {% endfor %}
 )


### PR DESCRIPTION
Switch to type of `MessageIn.payload` to a string, this allows customers to send pre-serialized json string

fixes: https://github.com/svix/svix-webhooks/issues/1779