### PR TITLE
go: Retract versions with silent error handling breakage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,19 @@ module github.com/svix/svix-webhooks
 go 1.20
 
 retract (
+	// versions with a bug that silently broke downstream error handling code
+	v1.61.0
+	v1.60.1
+	v1.60.0
+	v1.59.2
+	v1.59.1
+	v1.59.0
+	v1.58.2
+	v1.58.1
+	v1.58.0
+	v1.57.0
+
+	// accidentally-published test versions
 	v1.55.0
 	v1.54.0
 	// v1.53.0 was never published


### PR DESCRIPTION
This bug was introduced in https://github.com/svix/svix-webhooks/commit/b8c5b8cf8a685bd8546b3bc28c948781e1e6fbc2 (v1.57.0) and fixed in https://github.com/svix/svix-webhooks/commit/58f9f543fad3dffb8ac3e555220ff346b4cbd779 (v1.61.1).