### PR TITLE
kotlin: Update codegen templates to support struct enums

### DIFF
--- a/codegen.toml
+++ b/codegen.toml
@@ -118,15 +118,15 @@ output_dir = "rust/src/models"
 #output_dir = "go/models"
 #
 #
-#[kotlin]
-#extra_shell_commands = [
-#    "rm kotlin/lib/src/main/kotlin/{Ingest,OperationalWebhook}.kt",
-#]
-#template_dir = "kotlin/templates"
-#[[kotlin.task]]
-#template = "kotlin/templates/component_type.kt.jinja"
-#output_dir = "kotlin/lib/src/main/kotlin/models"
-#
-#[[kotlin.task]]
-#template = "kotlin/templates/api_resource.kt.jinja"
-#output_dir = "kotlin/lib/src/main/kotlin"
+[kotlin]
+extra_shell_commands = [
+   "rm kotlin/lib/src/main/kotlin/{Ingest,OperationalWebhook}.kt",
+]
+template_dir = "kotlin/templates"
+[[kotlin.task]]
+template = "kotlin/templates/component_type.kt.jinja"
+output_dir = "kotlin/lib/src/main/kotlin/models"
+
+[[kotlin.task]]
+template = "kotlin/templates/api_resource.kt.jinja"
+output_dir = "kotlin/lib/src/main/kotlin"

--- a/kotlin/lib/src/main/kotlin/IngestSource.kt
+++ b/kotlin/lib/src/main/kotlin/IngestSource.kt
@@ -1,0 +1,96 @@
+// this file is @generated
+package com.svix.kotlin
+
+import com.svix.kotlin.models.IngestSourceIn
+import com.svix.kotlin.models.IngestSourceOut
+import com.svix.kotlin.models.ListResponseIngestSourceOut
+import com.svix.kotlin.models.Ordering
+import com.svix.kotlin.models.RotateTokenOut
+import okhttp3.Headers
+
+data class IngestSourceListOptions(
+    /** Limit the number of returned items */
+    val limit: ULong? = null,
+    /** The iterator returned from a prior invocation */
+    val iterator: String? = null,
+    /** The sorting order of the returned items */
+    val order: Ordering? = null,
+)
+
+data class IngestSourceCreateOptions(val idempotencyKey: String? = null)
+
+data class IngestSourceRotateTokenOptions(val idempotencyKey: String? = null)
+
+class IngestSource(private val client: SvixHttpClient) {
+    /** List of all the organization's Ingest Sources. */
+    suspend fun list(
+        options: IngestSourceListOptions = IngestSourceListOptions()
+    ): ListResponseIngestSourceOut {
+        val url = client.newUrlBuilder().encodedPath("/ingest/api/v1/source")
+        options.limit?.let { url.addQueryParameter("limit", serializeQueryParam(it)) }
+        options.iterator?.let { url.addQueryParameter("iterator", it) }
+        options.order?.let { url.addQueryParameter("order", serializeQueryParam(it)) }
+        return client.executeRequest<Any, ListResponseIngestSourceOut>("GET", url.build())
+    }
+
+    /** Create Ingest Source. */
+    suspend fun create(
+        ingestSourceIn: IngestSourceIn,
+        options: IngestSourceCreateOptions = IngestSourceCreateOptions(),
+    ): IngestSourceOut {
+        val url = client.newUrlBuilder().encodedPath("/ingest/api/v1/source")
+        val headers = Headers.Builder()
+        options.idempotencyKey?.let { headers.add("idempotency-key", it) }
+
+        return client.executeRequest<IngestSourceIn, IngestSourceOut>(
+            "POST",
+            url.build(),
+            headers = headers.build(),
+            reqBody = ingestSourceIn,
+        )
+    }
+
+    /** Get an Ingest Source by id or uid. */
+    suspend fun get(sourceId: String): IngestSourceOut {
+        val url = client.newUrlBuilder().encodedPath("/ingest/api/v1/source/$sourceId")
+        return client.executeRequest<Any, IngestSourceOut>("GET", url.build())
+    }
+
+    /** Update an Ingest Source. */
+    suspend fun update(sourceId: String, ingestSourceIn: IngestSourceIn): IngestSourceOut {
+        val url = client.newUrlBuilder().encodedPath("/ingest/api/v1/source/$sourceId")
+
+        return client.executeRequest<IngestSourceIn, IngestSourceOut>(
+            "PUT",
+            url.build(),
+            reqBody = ingestSourceIn,
+        )
+    }
+
+    /** Delete an Ingest Source. */
+    suspend fun delete(sourceId: String) {
+        val url = client.newUrlBuilder().encodedPath("/ingest/api/v1/source/$sourceId")
+        client.executeRequest<Any, Boolean>("DELETE", url.build())
+    }
+
+    /**
+     * Rotate the Ingest Source's Url Token.
+     *
+     * This will rotate the ingest source's token, which is used to construct the unique `ingestUrl`
+     * for the source. Previous tokens will remain valid for 48 hours after rotation. The token can
+     * be rotated a maximum of three times within the 48-hour period.
+     */
+    suspend fun rotateToken(
+        sourceId: String,
+        options: IngestSourceRotateTokenOptions = IngestSourceRotateTokenOptions(),
+    ): RotateTokenOut {
+        val url = client.newUrlBuilder().encodedPath("/ingest/api/v1/source/$sourceId/token/rotate")
+        val headers = Headers.Builder()
+        options.idempotencyKey?.let { headers.add("idempotency-key", it) }
+        return client.executeRequest<Any, RotateTokenOut>(
+            "POST",
+            url.build(),
+            headers = headers.build(),
+        )
+    }
+}

--- a/kotlin/lib/src/main/kotlin/models/AdobeSignConfig.kt
+++ b/kotlin/lib/src/main/kotlin/models/AdobeSignConfig.kt
@@ -1,0 +1,6 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable data class AdobeSignConfig(val clientId: String)

--- a/kotlin/lib/src/main/kotlin/models/AdobeSignConfigOut.kt
+++ b/kotlin/lib/src/main/kotlin/models/AdobeSignConfigOut.kt
@@ -1,0 +1,6 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable data object AdobeSignConfigOut

--- a/kotlin/lib/src/main/kotlin/models/ConnectorOut.kt
+++ b/kotlin/lib/src/main/kotlin/models/ConnectorOut.kt
@@ -1,0 +1,22 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ConnectorOut(
+    val createdAt: Instant,
+    val description: String,
+    val featureFlag: String? = null,
+    val filterTypes: Set<String>? = null,
+    val id: String,
+    val instructions: String,
+    val instructionsLink: String? = null,
+    val kind: ConnectorKind,
+    val logo: String,
+    val name: String,
+    val orgId: String,
+    val transformation: String,
+    val updatedAt: Instant,
+)

--- a/kotlin/lib/src/main/kotlin/models/CronConfig.kt
+++ b/kotlin/lib/src/main/kotlin/models/CronConfig.kt
@@ -1,0 +1,7 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CronConfig(val contentType: String? = null, val payload: String, val schedule: String)

--- a/kotlin/lib/src/main/kotlin/models/DocusignConfig.kt
+++ b/kotlin/lib/src/main/kotlin/models/DocusignConfig.kt
@@ -1,0 +1,6 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable data class DocusignConfig(val secret: String? = null)

--- a/kotlin/lib/src/main/kotlin/models/DocusignConfigOut.kt
+++ b/kotlin/lib/src/main/kotlin/models/DocusignConfigOut.kt
@@ -1,0 +1,6 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable data object DocusignConfigOut

--- a/kotlin/lib/src/main/kotlin/models/EnvironmentOut.kt
+++ b/kotlin/lib/src/main/kotlin/models/EnvironmentOut.kt
@@ -10,6 +10,6 @@ data class EnvironmentOut(
     val createdAt: Instant,
     val eventTypes: List<EventTypeOut>,
     @Serializable(with = StringAnyMapSerializer::class) val settings: Map<String, Any>? = null,
-    val transformationTemplates: List<TemplateOut>,
+    val transformationTemplates: List<ConnectorOut>,
     val version: Long? = null,
 )

--- a/kotlin/lib/src/main/kotlin/models/GithubConfig.kt
+++ b/kotlin/lib/src/main/kotlin/models/GithubConfig.kt
@@ -1,0 +1,6 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable data class GithubConfig(val secret: String? = null)

--- a/kotlin/lib/src/main/kotlin/models/GithubConfigOut.kt
+++ b/kotlin/lib/src/main/kotlin/models/GithubConfigOut.kt
@@ -1,0 +1,6 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable data object GithubConfigOut

--- a/kotlin/lib/src/main/kotlin/models/HubspotConfig.kt
+++ b/kotlin/lib/src/main/kotlin/models/HubspotConfig.kt
@@ -1,0 +1,6 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable data class HubspotConfig(val secret: String? = null)

--- a/kotlin/lib/src/main/kotlin/models/HubspotConfigOut.kt
+++ b/kotlin/lib/src/main/kotlin/models/HubspotConfigOut.kt
@@ -1,0 +1,6 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable data object HubspotConfigOut

--- a/kotlin/lib/src/main/kotlin/models/IngestSourceConsumerPortalAccessIn.kt
+++ b/kotlin/lib/src/main/kotlin/models/IngestSourceConsumerPortalAccessIn.kt
@@ -1,0 +1,10 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class IngestSourceConsumerPortalAccessIn(
+    val expiry: ULong? = null,
+    val readOnly: Boolean? = null,
+)

--- a/kotlin/lib/src/main/kotlin/models/IngestSourceIn.kt
+++ b/kotlin/lib/src/main/kotlin/models/IngestSourceIn.kt
@@ -1,0 +1,294 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.buildJsonObject
+
+@Serializable(with = IngestSourceInSerializer::class)
+data class IngestSourceIn(
+    val name: String,
+    val uid: String? = null,
+    val config: IngestSourceInConfig,
+)
+
+@Serializable
+sealed class IngestSourceInConfig {
+    val variantName: String
+        get() = this::class.annotations.filterIsInstance<VariantName>().first().name
+
+    abstract fun toJsonElement(): JsonElement
+
+    @VariantName("generic-webhook")
+    data object GenericWebhook : IngestSourceInConfig() {
+        override fun toJsonElement() = buildJsonObject {}
+    }
+
+    @VariantName("cron")
+    data class Cron(val cron: CronConfig) : IngestSourceInConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(CronConfig.serializer(), cron)
+    }
+
+    @VariantName("adobe-sign")
+    data class AdobeSign(val adobeSign: AdobeSignConfig) : IngestSourceInConfig() {
+        override fun toJsonElement() =
+            Json.encodeToJsonElement(AdobeSignConfig.serializer(), adobeSign)
+    }
+
+    @VariantName("beehiiv")
+    data class Beehiiv(val beehiiv: SvixConfig) : IngestSourceInConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfig.serializer(), beehiiv)
+    }
+
+    @VariantName("brex")
+    data class Brex(val brex: SvixConfig) : IngestSourceInConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfig.serializer(), brex)
+    }
+
+    @VariantName("clerk")
+    data class Clerk(val clerk: SvixConfig) : IngestSourceInConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfig.serializer(), clerk)
+    }
+
+    @VariantName("docusign")
+    data class Docusign(val docusign: DocusignConfig) : IngestSourceInConfig() {
+        override fun toJsonElement() =
+            Json.encodeToJsonElement(DocusignConfig.serializer(), docusign)
+    }
+
+    @VariantName("github")
+    data class Github(val github: GithubConfig) : IngestSourceInConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(GithubConfig.serializer(), github)
+    }
+
+    @VariantName("guesty")
+    data class Guesty(val guesty: SvixConfig) : IngestSourceInConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfig.serializer(), guesty)
+    }
+
+    @VariantName("hubspot")
+    data class Hubspot(val hubspot: HubspotConfig) : IngestSourceInConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(HubspotConfig.serializer(), hubspot)
+    }
+
+    @VariantName("incident-io")
+    data class IncidentIo(val incidentIo: SvixConfig) : IngestSourceInConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfig.serializer(), incidentIo)
+    }
+
+    @VariantName("lithic")
+    data class Lithic(val lithic: SvixConfig) : IngestSourceInConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfig.serializer(), lithic)
+    }
+
+    @VariantName("nash")
+    data class Nash(val nash: SvixConfig) : IngestSourceInConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfig.serializer(), nash)
+    }
+
+    @VariantName("pleo")
+    data class Pleo(val pleo: SvixConfig) : IngestSourceInConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfig.serializer(), pleo)
+    }
+
+    @VariantName("replicate")
+    data class Replicate(val replicate: SvixConfig) : IngestSourceInConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfig.serializer(), replicate)
+    }
+
+    @VariantName("resend")
+    data class Resend(val resend: SvixConfig) : IngestSourceInConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfig.serializer(), resend)
+    }
+
+    @VariantName("safebase")
+    data class Safebase(val safebase: SvixConfig) : IngestSourceInConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfig.serializer(), safebase)
+    }
+
+    @VariantName("sardine")
+    data class Sardine(val sardine: SvixConfig) : IngestSourceInConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfig.serializer(), sardine)
+    }
+
+    @VariantName("segment")
+    data class Segment(val segment: SegmentConfig) : IngestSourceInConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SegmentConfig.serializer(), segment)
+    }
+
+    @VariantName("shopify")
+    data class Shopify(val shopify: ShopifyConfig) : IngestSourceInConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(ShopifyConfig.serializer(), shopify)
+    }
+
+    @VariantName("slack")
+    data class Slack(val slack: SlackConfig) : IngestSourceInConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SlackConfig.serializer(), slack)
+    }
+
+    @VariantName("stripe")
+    data class Stripe(val stripe: StripeConfig) : IngestSourceInConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(StripeConfig.serializer(), stripe)
+    }
+
+    @VariantName("stych")
+    data class Stych(val stych: SvixConfig) : IngestSourceInConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfig.serializer(), stych)
+    }
+
+    @VariantName("svix")
+    data class Svix(val svix: SvixConfig) : IngestSourceInConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfig.serializer(), svix)
+    }
+
+    @VariantName("zoom")
+    data class Zoom(val zoom: ZoomConfig) : IngestSourceInConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(ZoomConfig.serializer(), zoom)
+    }
+
+    companion object {
+        private val typeMap =
+            mapOf<String, (JsonElement) -> IngestSourceInConfig>(
+                "generic-webhook" to { _ -> GenericWebhook },
+                "cron" to
+                    { config ->
+                        Cron(Json.decodeFromJsonElement(CronConfig.serializer(), config))
+                    },
+                "adobe-sign" to
+                    { config ->
+                        AdobeSign(Json.decodeFromJsonElement(AdobeSignConfig.serializer(), config))
+                    },
+                "beehiiv" to
+                    { config ->
+                        Beehiiv(Json.decodeFromJsonElement(SvixConfig.serializer(), config))
+                    },
+                "brex" to
+                    { config ->
+                        Brex(Json.decodeFromJsonElement(SvixConfig.serializer(), config))
+                    },
+                "clerk" to
+                    { config ->
+                        Clerk(Json.decodeFromJsonElement(SvixConfig.serializer(), config))
+                    },
+                "docusign" to
+                    { config ->
+                        Docusign(Json.decodeFromJsonElement(DocusignConfig.serializer(), config))
+                    },
+                "github" to
+                    { config ->
+                        Github(Json.decodeFromJsonElement(GithubConfig.serializer(), config))
+                    },
+                "guesty" to
+                    { config ->
+                        Guesty(Json.decodeFromJsonElement(SvixConfig.serializer(), config))
+                    },
+                "hubspot" to
+                    { config ->
+                        Hubspot(Json.decodeFromJsonElement(HubspotConfig.serializer(), config))
+                    },
+                "incident-io" to
+                    { config ->
+                        IncidentIo(Json.decodeFromJsonElement(SvixConfig.serializer(), config))
+                    },
+                "lithic" to
+                    { config ->
+                        Lithic(Json.decodeFromJsonElement(SvixConfig.serializer(), config))
+                    },
+                "nash" to
+                    { config ->
+                        Nash(Json.decodeFromJsonElement(SvixConfig.serializer(), config))
+                    },
+                "pleo" to
+                    { config ->
+                        Pleo(Json.decodeFromJsonElement(SvixConfig.serializer(), config))
+                    },
+                "replicate" to
+                    { config ->
+                        Replicate(Json.decodeFromJsonElement(SvixConfig.serializer(), config))
+                    },
+                "resend" to
+                    { config ->
+                        Resend(Json.decodeFromJsonElement(SvixConfig.serializer(), config))
+                    },
+                "safebase" to
+                    { config ->
+                        Safebase(Json.decodeFromJsonElement(SvixConfig.serializer(), config))
+                    },
+                "sardine" to
+                    { config ->
+                        Sardine(Json.decodeFromJsonElement(SvixConfig.serializer(), config))
+                    },
+                "segment" to
+                    { config ->
+                        Segment(Json.decodeFromJsonElement(SegmentConfig.serializer(), config))
+                    },
+                "shopify" to
+                    { config ->
+                        Shopify(Json.decodeFromJsonElement(ShopifyConfig.serializer(), config))
+                    },
+                "slack" to
+                    { config ->
+                        Slack(Json.decodeFromJsonElement(SlackConfig.serializer(), config))
+                    },
+                "stripe" to
+                    { config ->
+                        Stripe(Json.decodeFromJsonElement(StripeConfig.serializer(), config))
+                    },
+                "stych" to
+                    { config ->
+                        Stych(Json.decodeFromJsonElement(SvixConfig.serializer(), config))
+                    },
+                "svix" to
+                    { config ->
+                        Svix(Json.decodeFromJsonElement(SvixConfig.serializer(), config))
+                    },
+                "zoom" to
+                    { config ->
+                        Zoom(Json.decodeFromJsonElement(ZoomConfig.serializer(), config))
+                    },
+            )
+
+        fun fromTypeAndConfig(type: String, config: JsonElement): IngestSourceInConfig {
+            return typeMap[type]?.invoke(config)
+                ?: throw SerializationException("Unknown type: $type")
+        }
+    }
+}
+
+class IngestSourceInSerializer : KSerializer<IngestSourceIn> {
+    @Serializable
+    private data class IngestSourceInSurrogate(
+        val name: String,
+        val uid: String? = null,
+        val type: String,
+        val config: JsonElement,
+    )
+
+    override val descriptor: SerialDescriptor = IngestSourceInSurrogate.serializer().descriptor
+
+    override fun serialize(encoder: Encoder, value: IngestSourceIn) {
+        val surrogate =
+            IngestSourceInSurrogate(
+                name = value.name,
+                uid = value.uid,
+                type = value.config.variantName,
+                config = value.config.toJsonElement(),
+            )
+        encoder.encodeSerializableValue(IngestSourceInSurrogate.serializer(), surrogate)
+    }
+
+    override fun deserialize(decoder: Decoder): IngestSourceIn {
+        val surrogate = decoder.decodeSerializableValue(IngestSourceInSurrogate.serializer())
+        return IngestSourceIn(
+            name = surrogate.name,
+            uid = surrogate.uid,
+            config = IngestSourceInConfig.fromTypeAndConfig(surrogate.type, surrogate.config),
+        )
+    }
+}

--- a/kotlin/lib/src/main/kotlin/models/IngestSourceOut.kt
+++ b/kotlin/lib/src/main/kotlin/models/IngestSourceOut.kt
@@ -1,0 +1,321 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.buildJsonObject
+
+@Serializable(with = IngestSourceOutSerializer::class)
+data class IngestSourceOut(
+    val createdAt: Instant,
+    val id: String,
+    val ingestUrl: String? = null,
+    val name: String,
+    val uid: String? = null,
+    val updatedAt: Instant,
+    val config: IngestSourceOutConfig,
+)
+
+@Serializable
+sealed class IngestSourceOutConfig {
+    val variantName: String
+        get() = this::class.annotations.filterIsInstance<VariantName>().first().name
+
+    abstract fun toJsonElement(): JsonElement
+
+    @VariantName("generic-webhook")
+    data object GenericWebhook : IngestSourceOutConfig() {
+        override fun toJsonElement() = buildJsonObject {}
+    }
+
+    @VariantName("cron")
+    data class Cron(val cron: CronConfig) : IngestSourceOutConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(CronConfig.serializer(), cron)
+    }
+
+    @VariantName("adobe-sign")
+    data class AdobeSign(val adobeSign: AdobeSignConfigOut) : IngestSourceOutConfig() {
+        override fun toJsonElement() =
+            Json.encodeToJsonElement(AdobeSignConfigOut.serializer(), adobeSign)
+    }
+
+    @VariantName("beehiiv")
+    data class Beehiiv(val beehiiv: SvixConfigOut) : IngestSourceOutConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfigOut.serializer(), beehiiv)
+    }
+
+    @VariantName("brex")
+    data class Brex(val brex: SvixConfigOut) : IngestSourceOutConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfigOut.serializer(), brex)
+    }
+
+    @VariantName("clerk")
+    data class Clerk(val clerk: SvixConfigOut) : IngestSourceOutConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfigOut.serializer(), clerk)
+    }
+
+    @VariantName("docusign")
+    data class Docusign(val docusign: DocusignConfigOut) : IngestSourceOutConfig() {
+        override fun toJsonElement() =
+            Json.encodeToJsonElement(DocusignConfigOut.serializer(), docusign)
+    }
+
+    @VariantName("github")
+    data class Github(val github: GithubConfigOut) : IngestSourceOutConfig() {
+        override fun toJsonElement() =
+            Json.encodeToJsonElement(GithubConfigOut.serializer(), github)
+    }
+
+    @VariantName("guesty")
+    data class Guesty(val guesty: SvixConfigOut) : IngestSourceOutConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfigOut.serializer(), guesty)
+    }
+
+    @VariantName("hubspot")
+    data class Hubspot(val hubspot: HubspotConfigOut) : IngestSourceOutConfig() {
+        override fun toJsonElement() =
+            Json.encodeToJsonElement(HubspotConfigOut.serializer(), hubspot)
+    }
+
+    @VariantName("incident-io")
+    data class IncidentIo(val incidentIo: SvixConfigOut) : IngestSourceOutConfig() {
+        override fun toJsonElement() =
+            Json.encodeToJsonElement(SvixConfigOut.serializer(), incidentIo)
+    }
+
+    @VariantName("lithic")
+    data class Lithic(val lithic: SvixConfigOut) : IngestSourceOutConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfigOut.serializer(), lithic)
+    }
+
+    @VariantName("nash")
+    data class Nash(val nash: SvixConfigOut) : IngestSourceOutConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfigOut.serializer(), nash)
+    }
+
+    @VariantName("pleo")
+    data class Pleo(val pleo: SvixConfigOut) : IngestSourceOutConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfigOut.serializer(), pleo)
+    }
+
+    @VariantName("replicate")
+    data class Replicate(val replicate: SvixConfigOut) : IngestSourceOutConfig() {
+        override fun toJsonElement() =
+            Json.encodeToJsonElement(SvixConfigOut.serializer(), replicate)
+    }
+
+    @VariantName("resend")
+    data class Resend(val resend: SvixConfigOut) : IngestSourceOutConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfigOut.serializer(), resend)
+    }
+
+    @VariantName("safebase")
+    data class Safebase(val safebase: SvixConfigOut) : IngestSourceOutConfig() {
+        override fun toJsonElement() =
+            Json.encodeToJsonElement(SvixConfigOut.serializer(), safebase)
+    }
+
+    @VariantName("sardine")
+    data class Sardine(val sardine: SvixConfigOut) : IngestSourceOutConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfigOut.serializer(), sardine)
+    }
+
+    @VariantName("segment")
+    data class Segment(val segment: SegmentConfigOut) : IngestSourceOutConfig() {
+        override fun toJsonElement() =
+            Json.encodeToJsonElement(SegmentConfigOut.serializer(), segment)
+    }
+
+    @VariantName("shopify")
+    data class Shopify(val shopify: ShopifyConfigOut) : IngestSourceOutConfig() {
+        override fun toJsonElement() =
+            Json.encodeToJsonElement(ShopifyConfigOut.serializer(), shopify)
+    }
+
+    @VariantName("slack")
+    data class Slack(val slack: SlackConfigOut) : IngestSourceOutConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SlackConfigOut.serializer(), slack)
+    }
+
+    @VariantName("stripe")
+    data class Stripe(val stripe: StripeConfigOut) : IngestSourceOutConfig() {
+        override fun toJsonElement() =
+            Json.encodeToJsonElement(StripeConfigOut.serializer(), stripe)
+    }
+
+    @VariantName("stych")
+    data class Stych(val stych: SvixConfigOut) : IngestSourceOutConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfigOut.serializer(), stych)
+    }
+
+    @VariantName("svix")
+    data class Svix(val svix: SvixConfigOut) : IngestSourceOutConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(SvixConfigOut.serializer(), svix)
+    }
+
+    @VariantName("zoom")
+    data class Zoom(val zoom: ZoomConfigOut) : IngestSourceOutConfig() {
+        override fun toJsonElement() = Json.encodeToJsonElement(ZoomConfigOut.serializer(), zoom)
+    }
+
+    companion object {
+        private val typeMap =
+            mapOf<String, (JsonElement) -> IngestSourceOutConfig>(
+                "generic-webhook" to { _ -> GenericWebhook },
+                "cron" to
+                    { config ->
+                        Cron(Json.decodeFromJsonElement(CronConfig.serializer(), config))
+                    },
+                "adobe-sign" to
+                    { config ->
+                        AdobeSign(
+                            Json.decodeFromJsonElement(AdobeSignConfigOut.serializer(), config)
+                        )
+                    },
+                "beehiiv" to
+                    { config ->
+                        Beehiiv(Json.decodeFromJsonElement(SvixConfigOut.serializer(), config))
+                    },
+                "brex" to
+                    { config ->
+                        Brex(Json.decodeFromJsonElement(SvixConfigOut.serializer(), config))
+                    },
+                "clerk" to
+                    { config ->
+                        Clerk(Json.decodeFromJsonElement(SvixConfigOut.serializer(), config))
+                    },
+                "docusign" to
+                    { config ->
+                        Docusign(Json.decodeFromJsonElement(DocusignConfigOut.serializer(), config))
+                    },
+                "github" to
+                    { config ->
+                        Github(Json.decodeFromJsonElement(GithubConfigOut.serializer(), config))
+                    },
+                "guesty" to
+                    { config ->
+                        Guesty(Json.decodeFromJsonElement(SvixConfigOut.serializer(), config))
+                    },
+                "hubspot" to
+                    { config ->
+                        Hubspot(Json.decodeFromJsonElement(HubspotConfigOut.serializer(), config))
+                    },
+                "incident-io" to
+                    { config ->
+                        IncidentIo(Json.decodeFromJsonElement(SvixConfigOut.serializer(), config))
+                    },
+                "lithic" to
+                    { config ->
+                        Lithic(Json.decodeFromJsonElement(SvixConfigOut.serializer(), config))
+                    },
+                "nash" to
+                    { config ->
+                        Nash(Json.decodeFromJsonElement(SvixConfigOut.serializer(), config))
+                    },
+                "pleo" to
+                    { config ->
+                        Pleo(Json.decodeFromJsonElement(SvixConfigOut.serializer(), config))
+                    },
+                "replicate" to
+                    { config ->
+                        Replicate(Json.decodeFromJsonElement(SvixConfigOut.serializer(), config))
+                    },
+                "resend" to
+                    { config ->
+                        Resend(Json.decodeFromJsonElement(SvixConfigOut.serializer(), config))
+                    },
+                "safebase" to
+                    { config ->
+                        Safebase(Json.decodeFromJsonElement(SvixConfigOut.serializer(), config))
+                    },
+                "sardine" to
+                    { config ->
+                        Sardine(Json.decodeFromJsonElement(SvixConfigOut.serializer(), config))
+                    },
+                "segment" to
+                    { config ->
+                        Segment(Json.decodeFromJsonElement(SegmentConfigOut.serializer(), config))
+                    },
+                "shopify" to
+                    { config ->
+                        Shopify(Json.decodeFromJsonElement(ShopifyConfigOut.serializer(), config))
+                    },
+                "slack" to
+                    { config ->
+                        Slack(Json.decodeFromJsonElement(SlackConfigOut.serializer(), config))
+                    },
+                "stripe" to
+                    { config ->
+                        Stripe(Json.decodeFromJsonElement(StripeConfigOut.serializer(), config))
+                    },
+                "stych" to
+                    { config ->
+                        Stych(Json.decodeFromJsonElement(SvixConfigOut.serializer(), config))
+                    },
+                "svix" to
+                    { config ->
+                        Svix(Json.decodeFromJsonElement(SvixConfigOut.serializer(), config))
+                    },
+                "zoom" to
+                    { config ->
+                        Zoom(Json.decodeFromJsonElement(ZoomConfigOut.serializer(), config))
+                    },
+            )
+
+        fun fromTypeAndConfig(type: String, config: JsonElement): IngestSourceOutConfig {
+            return typeMap[type]?.invoke(config)
+                ?: throw SerializationException("Unknown type: $type")
+        }
+    }
+}
+
+class IngestSourceOutSerializer : KSerializer<IngestSourceOut> {
+    @Serializable
+    private data class IngestSourceOutSurrogate(
+        val createdAt: Instant,
+        val id: String,
+        val ingestUrl: String? = null,
+        val name: String,
+        val uid: String? = null,
+        val updatedAt: Instant,
+        val type: String,
+        val config: JsonElement,
+    )
+
+    override val descriptor: SerialDescriptor = IngestSourceOutSurrogate.serializer().descriptor
+
+    override fun serialize(encoder: Encoder, value: IngestSourceOut) {
+        val surrogate =
+            IngestSourceOutSurrogate(
+                createdAt = value.createdAt,
+                id = value.id,
+                ingestUrl = value.ingestUrl,
+                name = value.name,
+                uid = value.uid,
+                updatedAt = value.updatedAt,
+                type = value.config.variantName,
+                config = value.config.toJsonElement(),
+            )
+        encoder.encodeSerializableValue(IngestSourceOutSurrogate.serializer(), surrogate)
+    }
+
+    override fun deserialize(decoder: Decoder): IngestSourceOut {
+        val surrogate = decoder.decodeSerializableValue(IngestSourceOutSurrogate.serializer())
+        return IngestSourceOut(
+            createdAt = surrogate.createdAt,
+            id = surrogate.id,
+            ingestUrl = surrogate.ingestUrl,
+            name = surrogate.name,
+            uid = surrogate.uid,
+            updatedAt = surrogate.updatedAt,
+            config = IngestSourceOutConfig.fromTypeAndConfig(surrogate.type, surrogate.config),
+        )
+    }
+}

--- a/kotlin/lib/src/main/kotlin/models/ListResponseIngestSourceOut.kt
+++ b/kotlin/lib/src/main/kotlin/models/ListResponseIngestSourceOut.kt
@@ -1,0 +1,12 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ListResponseIngestSourceOut(
+    val data: List<IngestSourceOut>,
+    val done: Boolean,
+    val iterator: String? = null,
+    val prevIterator: String? = null,
+)

--- a/kotlin/lib/src/main/kotlin/models/RotateTokenOut.kt
+++ b/kotlin/lib/src/main/kotlin/models/RotateTokenOut.kt
@@ -1,0 +1,6 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable data class RotateTokenOut(val ingestUrl: String)

--- a/kotlin/lib/src/main/kotlin/models/SegmentConfig.kt
+++ b/kotlin/lib/src/main/kotlin/models/SegmentConfig.kt
@@ -1,0 +1,6 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable data class SegmentConfig(val secret: String? = null)

--- a/kotlin/lib/src/main/kotlin/models/SegmentConfigOut.kt
+++ b/kotlin/lib/src/main/kotlin/models/SegmentConfigOut.kt
@@ -1,0 +1,6 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable data object SegmentConfigOut

--- a/kotlin/lib/src/main/kotlin/models/ShopifyConfig.kt
+++ b/kotlin/lib/src/main/kotlin/models/ShopifyConfig.kt
@@ -1,0 +1,6 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable data class ShopifyConfig(val secret: String)

--- a/kotlin/lib/src/main/kotlin/models/ShopifyConfigOut.kt
+++ b/kotlin/lib/src/main/kotlin/models/ShopifyConfigOut.kt
@@ -1,0 +1,6 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable data object ShopifyConfigOut

--- a/kotlin/lib/src/main/kotlin/models/SlackConfig.kt
+++ b/kotlin/lib/src/main/kotlin/models/SlackConfig.kt
@@ -1,0 +1,6 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable data class SlackConfig(val secret: String)

--- a/kotlin/lib/src/main/kotlin/models/SlackConfigOut.kt
+++ b/kotlin/lib/src/main/kotlin/models/SlackConfigOut.kt
@@ -1,0 +1,6 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable data object SlackConfigOut

--- a/kotlin/lib/src/main/kotlin/models/StripeConfig.kt
+++ b/kotlin/lib/src/main/kotlin/models/StripeConfig.kt
@@ -1,0 +1,6 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable data class StripeConfig(val secret: String)

--- a/kotlin/lib/src/main/kotlin/models/StripeConfigOut.kt
+++ b/kotlin/lib/src/main/kotlin/models/StripeConfigOut.kt
@@ -1,0 +1,6 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable data object StripeConfigOut

--- a/kotlin/lib/src/main/kotlin/models/SvixConfig.kt
+++ b/kotlin/lib/src/main/kotlin/models/SvixConfig.kt
@@ -1,0 +1,6 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable data class SvixConfig(val secret: String)

--- a/kotlin/lib/src/main/kotlin/models/SvixConfigOut.kt
+++ b/kotlin/lib/src/main/kotlin/models/SvixConfigOut.kt
@@ -1,0 +1,6 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable data object SvixConfigOut

--- a/kotlin/lib/src/main/kotlin/models/VariantName.kt
+++ b/kotlin/lib/src/main/kotlin/models/VariantName.kt
@@ -1,0 +1,5 @@
+// this file was written by hand
+package com.svix.kotlin.models
+
+@Target(AnnotationTarget.CLASS)
+annotation class VariantName(val name: String)

--- a/kotlin/lib/src/main/kotlin/models/ZoomConfig.kt
+++ b/kotlin/lib/src/main/kotlin/models/ZoomConfig.kt
@@ -1,0 +1,6 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable data class ZoomConfig(val secret: String)

--- a/kotlin/lib/src/main/kotlin/models/ZoomConfigOut.kt
+++ b/kotlin/lib/src/main/kotlin/models/ZoomConfigOut.kt
@@ -1,0 +1,6 @@
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable data object ZoomConfigOut

--- a/kotlin/lib/src/test/com/svix/kotlin/SerializationTests.kt
+++ b/kotlin/lib/src/test/com/svix/kotlin/SerializationTests.kt
@@ -1,0 +1,59 @@
+package com.svix.kotlin
+
+import com.svix.kotlin.models.CronConfig
+import com.svix.kotlin.models.IngestSourceIn
+import com.svix.kotlin.models.IngestSourceInConfig
+import com.svix.kotlin.models.IngestSourceInConfig.Cron
+import kotlin.test.assertEquals
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+import kotlin.test.assertIs
+
+class SerializationTests {
+    @Test
+    fun structEnumWithFields() {
+        val jsonSource =
+            """{"name":"name","uid":"uuiidd","type":"cron","config":{"contentType":"web-app/json","payload":"totally json fr fr","schedule":"* * * * *"}}"""
+        val sourceIn =
+            IngestSourceIn(
+                name = "name",
+                uid = "uuiidd",
+                config = Cron(
+                    CronConfig(
+                        contentType = "web-app/json",
+                        payload = "totally json fr fr",
+                        schedule = "* * * * *",
+                    )
+                ),
+            )
+        // de/serialization works both ways
+        assertEquals(jsonSource, Json.encodeToString(sourceIn))
+        assertEquals(sourceIn, Json.decodeFromString(jsonSource))
+    }
+
+    @Test
+    fun structEnumWithNoExtraFields() {
+        val jsonSource =
+            """{"name":"mendy is","uid":"very unique","type":"generic-webhook","config":{}}"""
+        val sourceIn =
+            IngestSourceIn(
+                name = "mendy is",
+                uid = "very unique",
+                config = IngestSourceInConfig.GenericWebhook,
+            )
+        // de/serialization works both ways
+        assertEquals(jsonSource, Json.encodeToString(sourceIn))
+        assertEquals(sourceIn, Json.decodeFromString(jsonSource))
+    }
+
+    @Test
+    fun readStructEnumField() {
+        val jsonSource =
+            """{"name":"name","uid":"uuiidd","type":"cron","config":{"contentType":"web-app/json","payload":"totally json fr fr","schedule":"* * * * *"}}"""
+        val sourceIn = Json.decodeFromString(IngestSourceIn.serializer(), jsonSource)
+
+        assertIs<IngestSourceInConfig.Cron>(sourceIn.config)
+        // the assertIs smart casted for us
+        assertEquals("* * * * *", sourceIn.config.cron.schedule)
+    }
+}

--- a/kotlin/templates/component_type.kt.jinja
+++ b/kotlin/templates/component_type.kt.jinja
@@ -4,4 +4,6 @@
     {% include "types/string_enum.kt.jinja" -%}
 {%- elif type.kind == "integer_enum" -%}
     {%- include "types/integer_enum.kt.jinja" -%}
+{% elif type.kind == "struct_enum" -%}
+    {% include "types/struct_enum.kt.jinja" -%}
 {%- endif %}

--- a/kotlin/templates/types/struct.kt.jinja
+++ b/kotlin/templates/types/struct.kt.jinja
@@ -12,34 +12,10 @@ import com.svix.kotlin.MaybeUnsetStringAnyMapSerializer
 
 
 @Serializable
+{% if type.fields | length > 0 -%}
 data class {{ type.name | to_upper_camel_case }}(
-{% for field in type.fields -%}
-    {% set f_name = field.name | to_lower_camel_case -%}
-    {% set f_type = field.type.to_kotlin() -%}
-    {% set f_val = "" -%}
-    {% set use_nullable = type.name is endingwith "Patch" and field.nullable -%}
-    {% if use_nullable -%}
-        {% set f_type %}MaybeUnset<{{ f_type }}>{% endset -%}
-        {% set f_val = "= MaybeUnset.Unset" -%}
-    {% endif -%}
-    {% if (not field.required or field.nullable) and not use_nullable -%}
-        {% set f_type %}{{ f_type }}?{% endset -%}
-        {% set f_val = "= null" -%}
-    {% endif -%}
-
-    {% if type.name == "MessageIn" and field.name == "payload" -%}
-        var payload: String,
-    {% else -%}
-        {% if field.name | to_lower_camel_case != field.name -%}
-        @SerialName("{{ field.name }}")
-        {% endif -%}
-        {% if field.type.is_json_object() and not use_nullable -%}
-        @Serializable(with = StringAnyMapSerializer::class)
-        {% elif field.type.is_json_object() and use_nullable -%}
-        @Serializable(with = MaybeUnsetStringAnyMapSerializer::class)
-        {% endif -%}
-        {% if type.name == "MessageIn" and field.name == "transformationsParams" -%}var {% else %}val {% endif -%}
-        {{ field.name | to_lower_camel_case }}: {{ f_type }} {{ f_val }},
-    {% endif -%}
-{% endfor %}
+{% include "types/struct_fields.kt.jinja" %}
 )
+{% else -%}
+data object {{ type.name | to_upper_camel_case }}
+{% endif -%}

--- a/kotlin/templates/types/struct_enum.kt.jinja
+++ b/kotlin/templates/types/struct_enum.kt.jinja
@@ -1,0 +1,97 @@
+{% set type_name = type.name | to_upper_camel_case -%}
+{% set enum_type_name %}{{ type_name }}Config{% endset -%}
+{% set discriminator_field_name = type.discriminator_field | to_lower_camel_case -%}
+{% set content_field_name = type.content_field | to_lower_camel_case -%}
+// This file is @generated
+package com.svix.kotlin.models
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.datetime.Instant
+
+
+@Serializable(with = {{ type_name }}Serializer::class)
+data class {{ type_name }}(
+    {% include "types/struct_fields.kt.jinja" %}
+    val {{ content_field_name }}: {{ enum_type_name }}
+)
+
+
+@Serializable
+sealed  class {{ enum_type_name }} {
+    val variantName: String get() = this::class.annotations.filterIsInstance<VariantName>().first().name
+    abstract fun toJsonElement(): JsonElement
+
+{% for variant in type.variants %} 
+    {% set val_name %}{{ variant.name | to_lower_camel_case }}{% endset -%}
+    @VariantName("{{ variant.name }}")
+    {% if variant.schema_ref is defined -%}
+    data class {{ variant.name | to_upper_camel_case }}(val {{ val_name }}: {{ variant.schema_ref }}) : {{ enum_type_name }}() {
+        override fun toJsonElement() =
+            Json.encodeToJsonElement({{ variant.schema_ref }}.serializer(), {{ val_name }})
+    }
+    {% else -%}
+    data object {{ variant.name | to_upper_camel_case }} : {{ enum_type_name }}(){
+        override fun toJsonElement() = buildJsonObject { }
+    }
+    {% endif -%}
+{% endfor %}
+    companion object {
+        private val typeMap = mapOf<String, (JsonElement) -> {{ enum_type_name }}>(
+            {% for variant in type.variants -%}
+                {% if variant.schema_ref is defined -%}
+                "{{ variant.name }}" to { config -> {{ variant.name | to_upper_camel_case }}(Json.decodeFromJsonElement({{ variant.schema_ref }}.serializer(), config)) },
+                {% else -%}
+                "{{ variant.name }}" to { _ -> {{ variant.name | to_upper_camel_case }}},
+
+                {% endif -%}
+            {% endfor -%}
+        )
+
+        fun fromTypeAndConfig(type: String, config: JsonElement): {{ enum_type_name }} {
+            return typeMap[type]?.invoke(config)
+                ?: throw SerializationException("Unknown type: $type")
+        }
+    }
+
+}
+
+
+class {{ type_name }}Serializer : KSerializer<{{ type_name }}> {
+    @Serializable
+    private data class {{ type_name }}Surrogate(
+        {% include "types/struct_fields.kt.jinja" %}
+        val {{ discriminator_field_name }}: String,
+        val {{ content_field_name }}: JsonElement,
+    )
+
+    override val descriptor: SerialDescriptor = {{ type_name }}Surrogate.serializer().descriptor
+
+    override fun serialize(encoder: Encoder, value: {{ type_name }}) {
+        val surrogate = {{ type_name }}Surrogate(
+            {% for f in type.fields -%}
+            {{ f.name | to_lower_camel_case }} = value.{{ f.name | to_lower_camel_case }},
+            {% endfor -%}
+            {{ discriminator_field_name}} = value.{{ content_field_name}}.variantName,
+            {{ content_field_name }} = value.{{ content_field_name }}.toJsonElement()
+        )
+        encoder.encodeSerializableValue({{ type_name }}Surrogate.serializer(), surrogate)
+    }
+
+    override fun deserialize(decoder: Decoder): {{ type_name }} {
+        val surrogate = decoder.decodeSerializableValue({{ type_name }}Surrogate.serializer())
+        return {{ type_name }}(
+            {% for f in type.fields -%}
+            {{ f.name | to_lower_camel_case }} = surrogate.{{ f.name | to_lower_camel_case }},
+            {% endfor -%}
+            {{ content_field_name }} = {{ enum_type_name }}.fromTypeAndConfig(surrogate.type, surrogate.config)
+        )
+    }
+}

--- a/kotlin/templates/types/struct_fields.kt.jinja
+++ b/kotlin/templates/types/struct_fields.kt.jinja
@@ -1,0 +1,29 @@
+{% for field in type.fields -%}
+    {% set f_name = field.name | to_lower_camel_case -%}
+    {% set f_type = field.type.to_kotlin() -%}
+    {% set f_val = "" -%}
+    {% set use_nullable = type.name is endingwith "Patch" and field.nullable -%}
+    {% if use_nullable -%}
+        {% set f_type %}MaybeUnset<{{ f_type }}>{% endset -%}
+        {% set f_val = "= MaybeUnset.Unset" -%}
+    {% endif -%}
+    {% if (not field.required or field.nullable) and not use_nullable -%}
+        {% set f_type %}{{ f_type }}?{% endset -%}
+        {% set f_val = "= null" -%}
+    {% endif -%}
+
+    {% if type.name == "MessageIn" and field.name == "payload" -%}
+        var payload: String,
+    {% else -%}
+        {% if field.name | to_lower_camel_case != field.name -%}
+        @SerialName("{{ field.name }}")
+        {% endif -%}
+        {% if field.type.is_json_object() and not use_nullable -%}
+        @Serializable(with = StringAnyMapSerializer::class)
+        {% elif field.type.is_json_object() and use_nullable -%}
+        @Serializable(with = MaybeUnsetStringAnyMapSerializer::class)
+        {% endif -%}
+        {% if type.name == "MessageIn" and field.name == "transformationsParams" -%}var {% else %}val {% endif -%}
+        {{ field.name | to_lower_camel_case }}: {{ f_type }} {{ f_val }},
+    {% endif -%}
+{% endfor %}


### PR DESCRIPTION
The API looks like this
```kotlin
val sourceIn = IngestSourceIn(
    name = "name",
    uid = "uuiidd",
    config = IngestSourceInConfig.Cron(
        CronConfig(
            contentType = "ads123",
            payload = "payload",
            schedule = "* * * * *",
        )
    ),
)
// read the payload field
if (sourceIn.config is Cron) {
    // smart cast
    println(sourceIn.config.cron.payload)
}

// without any enum fields
val sourceIn = IngestSourceIn(
    name = "name",
    uid = "uuiidd",
    config = IngestSourceInConfig.Genericwebhook,
)
```