### PR TITLE
 java: Update codegen templates to support struct enums 

### DIFF
--- a/java/lib/src/test/com/svix/test/ModelTests.java
+++ b/java/lib/src/test/com/svix/test/ModelTests.java
@@ -1,9 +1,13 @@
+// FIXME: re-enable tests when new lib-openapi.json merges
+// same story as kotlin, before the new lib-openapi.json is merged this test wont compile
 package com.svix.test;
 
 import static org.junit.Assert.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+//  import com.svix.models.CronConfig;
 import com.svix.models.DashboardAccessOut;
+//  import com.svix.models.IngestSourceIn;
 
 import org.junit.Test;
 
@@ -20,4 +24,37 @@ public class ModelTests {
         DashboardAccessOut model = DashboardAccessOut.fromJson("{\"token\":\"asd\"}");
         assertEquals(expectedModel, model);
     }
+
+    //  @Test
+    //  public void structEnumWithNoExtraFields() throws JsonProcessingException {
+    //      String jsonString =
+    //              "{\"name\":\"mendy\",\"uid\":\"very"
+    //                      + " unique\",\"type\":\"generic-webhook\",\"config\":{}}";
+    //      IngestSourceIn sourceIn =
+    //              new IngestSourceIn(
+    //                      "mendy",
+    //                      "very unique",
+    //                      new IngestSourceIn.IngestSourceInType.GenericWebhook());
+
+    //      assertEquals(jsonString, sourceIn.toJson());
+    //      assertEquals(IngestSourceIn.fromJson(jsonString), sourceIn);
+    //  }
+
+    //  @Test
+    //  public void structEnumWithFields() throws JsonProcessingException {
+    //      String jsonString =
+    //              "{\"name\":\"name\",\"uid\":\"uuiidd\",\"type\":\"cron\",\"config\":{\"contentType\":\"asd\",\"payload\":\"cool\",\"schedule\":\"*"
+    //                  + " * * * *\"}}";
+    //      IngestSourceIn sourceIn =
+    //              new IngestSourceIn(
+    //                      "name",
+    //                      "uuiidd",
+    //                      new IngestSourceIn.IngestSourceInType.Cron(
+    //                              new CronConfig()
+    //                                      .contentType("asd")
+    //                                      .payload("cool")
+    //                                      .schedule("* * * * *")));
+    //      assertEquals(jsonString, sourceIn.toJson());
+    //      assertEquals(IngestSourceIn.fromJson(jsonString), sourceIn);
+    //  }
 }

--- a/java/templates/component_type.java.jinja
+++ b/java/templates/component_type.java.jinja
@@ -4,4 +4,6 @@
     {% include "types/string_enum.java.jinja" -%}
 {%- elif type.kind == "integer_enum" -%}
     {%- include "types/integer_enum.java.jinja" -%}
+{% elif type.kind == "struct_enum" -%}
+    {% include "types/struct_enum.java.jinja" -%}
 {%- endif %}

--- a/java/templates/types/struct_enum.java.jinja
+++ b/java/templates/types/struct_enum.java.jinja
@@ -1,0 +1,181 @@
+{% set type_name = type.name | to_upper_camel_case -%}
+{% set enum_type_name %}{{ type_name }}Type{% endset -%}
+{% set discriminator_field_name = type.discriminator_field | to_lower_camel_case -%}
+{% set content_field_name = type.content_field | to_lower_camel_case -%}
+// This file is @generated
+package com.svix.models;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.svix.Utils;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.EqualsAndHashCode;
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+
+@Setter
+@Getter
+@ToString
+@EqualsAndHashCode
+@JsonSerialize(using = {{ type_name }}Serializer.class)
+@JsonDeserialize(using = {{ type_name }}Deserializer.class)
+public class {{ type_name }} {
+    {% for f in type.fields -%}
+    private {{ f.type.to_java() }} {{ f.name | to_lower_camel_case }};
+    {% endfor -%}
+    private {{ enum_type_name }} {{ discriminator_field_name }};
+
+    @JsonCreator
+    public {{ type_name }}(
+        {% for f in type.fields -%}
+        @JsonProperty("{{ f.name }}") {{ f.type.to_java() }} {{ f.name | to_lower_camel_case }},
+        {% endfor -%}
+        @JsonProperty("{{ type.discriminator_field }}") {{ enum_type_name }} {{ discriminator_field_name }}) {
+        {% for f in type.fields -%}
+        this.{{ f.name | to_lower_camel_case }} = {{ f.name | to_lower_camel_case  }};
+        {% endfor -%}
+        this.{{ discriminator_field_name }} = {{ discriminator_field_name }};
+    }
+
+    public String toJson() throws JsonProcessingException {
+        return Utils.getObjectMapper().writeValueAsString(this);
+    }
+
+    public static {{ type_name }} fromJson(String jsonString) throws JsonProcessingException {
+        return Utils.getObjectMapper().readValue(jsonString, {{ type_name }}.class);
+    }
+
+    @ToString
+    @EqualsAndHashCode
+    public static abstract class {{ enum_type_name }} {
+        @JsonIgnore
+        public String getVariantName() {
+            VariantName annotation = this.getClass().getAnnotation(VariantName.class);
+            return annotation != null ? annotation.value() : null;
+        }
+
+        public abstract JsonNode toJsonNode();
+
+        {% for variant in type.variants -%}
+        @ToString
+        @EqualsAndHashCode(callSuper = false)
+        @VariantName("{{ variant.name }}")
+        public static class {{ variant.name | to_upper_camel_case }} extends {{ enum_type_name }} {
+            {% if variant.schema_ref is defined -%}
+            private final {{ variant.schema_ref | to_upper_camel_case }} config;
+            public {{ variant.name | to_upper_camel_case }}({{ variant.schema_ref | to_upper_camel_case }} config) {
+                this.config = config;
+            }
+            {% endif -%}
+            @Override public JsonNode toJsonNode() {
+                {% if variant.schema_ref is defined -%}
+                return Utils.getObjectMapper().valueToTree(config);
+                {% else -%}
+                return Utils.getObjectMapper().createObjectNode();
+                {% endif -%}
+            }
+        }
+        {% endfor -%}
+
+        @FunctionalInterface
+        private interface TypeFactory {
+            {{ enum_type_name }} create(JsonNode config);
+        }
+        private static final Map<String, TypeFactory> TY_M = new HashMap<>();
+        private static final ObjectMapper m = Utils.getObjectMapper();
+        static {
+            {% for variant in type.variants -%}
+                {% if variant.schema_ref is defined -%}
+            TY_M.put("{{ variant.name }}", c -> new {{ variant.name | to_upper_camel_case }}(m.convertValue(c, {{ variant.schema_ref | to_upper_camel_case }}.class)));
+                {% else -%}
+            TY_M.put("{{ variant.name }}", c -> new {{ variant.name | to_upper_camel_case }}());
+                {% endif -%}
+            {% endfor -%}
+        }
+
+        public static {{ enum_type_name }} fromTypeAndConfig(String type, JsonNode config) {
+            TypeFactory factory = TY_M.get(type);
+            if (factory == null) {
+                throw new IllegalArgumentException("Unknown type: " + type);
+            }
+            return factory.create(config);
+        }
+
+    }
+}
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@interface VariantName {
+    String value();
+}
+
+class {{ type_name }}Serializer extends StdSerializer<{{ type_name }}> {
+    public {{ type_name }}Serializer() {
+        this(null);
+    }
+
+    public {{ type_name }}Serializer(Class<{{ type_name }}> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize({{ type_name }} value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeStartObject();
+        {% for f in type.fields -%}
+            if (value.get{{ f.name | to_upper_camel_case }}() != null) {
+                gen.writeStringField("{{ f.name }}", value.get{{ f.name | to_upper_camel_case }}());
+            }
+        {% endfor -%}
+        gen.writeStringField("{{ type.discriminator_field }}", value.getType().getVariantName());
+        gen.writeFieldName("{{ type.content_field }}");
+        gen.writeRawValue(value.getType().toJsonNode().toString());
+        gen.writeEndObject();
+    }
+}
+
+
+class {{ type_name }}Deserializer extends StdDeserializer<{{ type_name }}> {
+    public {{ type_name }}Deserializer() {
+        this(null);
+    }
+
+    public {{ type_name }}Deserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public {{ type_name }} deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        JsonNode node = p.getCodec().readTree(p);
+
+        // FIXME: we are not currently handling non-string fields
+        {% for f in type.fields -%}
+            {{ f.type.to_java() }} {{ f.name | to_lower_camel_case }} = node.has("{{ f.name }}") ? node.get("{{ f.name }}").asText() : null;
+        {% endfor -%}
+        String {{ discriminator_field_name }} = node.get("{{ type.discriminator_field }}").asText();
+        JsonNode {{ content_field_name }} = node.get("{{ type.content_field }}");
+        {{ type_name }}.{{ enum_type_name }} sourceType = {{ type_name }}.{{ enum_type_name }}.fromTypeAndConfig({{ discriminator_field_name }}, {{ content_field_name }});
+        return new {{ type_name }}(name, uid, sourceType);
+    }
+}

--- a/regen_openapi.py
+++ b/regen_openapi.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import argparse
 import json
 import os
 import pathlib
@@ -158,8 +159,6 @@ def execute_codegen_task(task):
         ENDC,
     )
 
-    prefix_print(prefix, "Starting codegen task")
-
     container_name = docker_container_create(prefix, task).strip()
     dbg(prefix, f"Container id {container_name}")
 
@@ -182,7 +181,7 @@ def execute_codegen_task(task):
 
     docker_container_rm(prefix, container_name)
 
-    prefix_print(prefix, "Codegen task completed")
+    print(f"{GREEN}#{ENDC}", flush=True, end="")
 
 
 def run_codegen_for_language(language, language_config):
@@ -204,13 +203,15 @@ def run_codegen_for_language(language, language_config):
         )
 
 
-def parse_config():
+def parse_config(args):
     with open(REPO_ROOT.joinpath("codegen.toml"), "rb") as f:
         data = tomllib.load(f)
     openapi = data.pop("global")["openapi"]
     config = {}
     for language, language_config in data.items():
-        config[language] = {"tasks": []}
+        if args.task_group is not None and args.task_group != language:
+            continue
+        config[language] = {"tasks": [], "tasks_count": len(language_config["task"])}
         for language_task_index, task in enumerate(language_config["task"]):
             config[language]["extra_shell_commands"] = language_config.get(
                 "extra_shell_commands", []
@@ -251,6 +252,7 @@ def pull_image():
     )
     # if it does not exist, pull image
     if check.returncode != 0:
+        print("Pulling docker image", flush=True)
         pull = subprocess.run(
             [get_docker_binary(), "image", "pull", OPENAPI_CODEGEN_IMAGE]
         )
@@ -260,8 +262,14 @@ def pull_image():
 
 def main():
     pull_image()
-    config = parse_config()
-    print("Pulling docker image", flush=True)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-t", "--task-group")
+    args = parser.parse_args()
+
+    config = parse_config(args)
+    all_tasks = sum([i["tasks_count"] for i in config.values()])
+    print(f"Running {all_tasks} codegen tasks")
 
     threads = []
     for language, language_config in config.items():
@@ -271,6 +279,9 @@ def main():
 
     for th in threads:
         th.join()
+
+    # final newline
+    print()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The API will look like this
```java
IngestSourceIn sourceIn = new IngestSourceIn(
    "mendy",
    "very unique",
    new IngestSourceIn.IngestSourceInType.GenericWebhook()
);
// with fields
IngestSourceIn sourceIn =new IngestSourceIn(
    "name",
    "uuiidd",
    new IngestSourceIn.IngestSourceInType.Cron(
        new CronConfig()
        .contentType("asd")
        .payload("cool")
        .schedule("* * * * *")
    )
);
```
TODO
- [ ] Add [accessors](https://projectlombok.org/features/experimental/Accessors) style getter/setter (we have this for all other types)
- [ ] Generate `IngestSourceInType` in a separate file so we don't need to `IngestSourceIn.IngestSourceInType` (requires changes on the codegen side)
- [ ] deserialization assumes that all fields on `IngestSourceIn` are strings. fix this !

Generated code looks foul, but :shrug: I don't see a better way to do this

```java
// This file is @generated
package com.svix.models;

import com.fasterxml.jackson.annotation.JsonCreator;
import com.fasterxml.jackson.annotation.JsonIgnore;
import com.fasterxml.jackson.annotation.JsonProperty;
import com.fasterxml.jackson.core.JsonGenerator;
import com.fasterxml.jackson.core.JsonParser;
import com.fasterxml.jackson.core.JsonProcessingException;
import com.fasterxml.jackson.databind.DeserializationContext;
import com.fasterxml.jackson.databind.JsonNode;
import com.fasterxml.jackson.databind.ObjectMapper;
import com.fasterxml.jackson.databind.SerializerProvider;
import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
import com.fasterxml.jackson.databind.annotation.JsonSerialize;
import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
import com.fasterxml.jackson.databind.ser.std.StdSerializer;
import com.svix.Utils;

import lombok.EqualsAndHashCode;
import lombok.Getter;
import lombok.Setter;
import lombok.ToString;

import java.io.IOException;
import java.lang.annotation.ElementType;
import java.lang.annotation.Retention;
import java.lang.annotation.RetentionPolicy;
import java.lang.annotation.Target;
import java.util.HashMap;
import java.util.Map;

@Setter
@Getter
@ToString
@EqualsAndHashCode
@JsonSerialize(using = IngestSourceInSerializer.class)
@JsonDeserialize(using = IngestSourceInDeserializer.class)
public class IngestSourceIn {
    private String name;
    private String uid;
    private IngestSourceInType type;

    @JsonCreator
    public IngestSourceIn(
            @JsonProperty("name") String name,
            @JsonProperty("uid") String uid,
            @JsonProperty("type") IngestSourceInType type) {
        this.name = name;
        this.uid = uid;
        this.type = type;
    }

    public String toJson() throws JsonProcessingException {
        return Utils.getObjectMapper().writeValueAsString(this);
    }

    public static IngestSourceIn fromJson(String jsonString) throws JsonProcessingException {
        return Utils.getObjectMapper().readValue(jsonString, IngestSourceIn.class);
    }

    @ToString
    @EqualsAndHashCode
    public abstract static class IngestSourceInType {
        @JsonIgnore
        public String getVariantName() {
            VariantName annotation = this.getClass().getAnnotation(VariantName.class);
            return annotation != null ? annotation.value() : null;
        }

        public abstract JsonNode toJsonNode();

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("generic-webhook")
        public static class GenericWebhook extends IngestSourceInType {
            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().createObjectNode();
            }
        }

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("cron")
        public static class Cron extends IngestSourceInType {
            private final CronConfig config;

            public Cron(CronConfig config) {
                this.config = config;
            }

            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().valueToTree(config);
            }
        }

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("adobe-sign")
        public static class AdobeSign extends IngestSourceInType {
            private final AdobeSignConfig config;

            public AdobeSign(AdobeSignConfig config) {
                this.config = config;
            }

            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().valueToTree(config);
            }
        }

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("beehiiv")
        public static class Beehiiv extends IngestSourceInType {
            private final SvixConfig config;

            public Beehiiv(SvixConfig config) {
                this.config = config;
            }

            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().valueToTree(config);
            }
        }

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("brex")
        public static class Brex extends IngestSourceInType {
            private final SvixConfig config;

            public Brex(SvixConfig config) {
                this.config = config;
            }

            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().valueToTree(config);
            }
        }

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("clerk")
        public static class Clerk extends IngestSourceInType {
            private final SvixConfig config;

            public Clerk(SvixConfig config) {
                this.config = config;
            }

            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().valueToTree(config);
            }
        }

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("docusign")
        public static class Docusign extends IngestSourceInType {
            private final DocusignConfig config;

            public Docusign(DocusignConfig config) {
                this.config = config;
            }

            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().valueToTree(config);
            }
        }

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("github")
        public static class Github extends IngestSourceInType {
            private final GithubConfig config;

            public Github(GithubConfig config) {
                this.config = config;
            }

            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().valueToTree(config);
            }
        }

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("guesty")
        public static class Guesty extends IngestSourceInType {
            private final SvixConfig config;

            public Guesty(SvixConfig config) {
                this.config = config;
            }

            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().valueToTree(config);
            }
        }

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("hubspot")
        public static class Hubspot extends IngestSourceInType {
            private final HubspotConfig config;

            public Hubspot(HubspotConfig config) {
                this.config = config;
            }

            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().valueToTree(config);
            }
        }

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("incident-io")
        public static class IncidentIo extends IngestSourceInType {
            private final SvixConfig config;

            public IncidentIo(SvixConfig config) {
                this.config = config;
            }

            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().valueToTree(config);
            }
        }

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("lithic")
        public static class Lithic extends IngestSourceInType {
            private final SvixConfig config;

            public Lithic(SvixConfig config) {
                this.config = config;
            }

            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().valueToTree(config);
            }
        }

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("nash")
        public static class Nash extends IngestSourceInType {
            private final SvixConfig config;

            public Nash(SvixConfig config) {
                this.config = config;
            }

            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().valueToTree(config);
            }
        }

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("pleo")
        public static class Pleo extends IngestSourceInType {
            private final SvixConfig config;

            public Pleo(SvixConfig config) {
                this.config = config;
            }

            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().valueToTree(config);
            }
        }

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("replicate")
        public static class Replicate extends IngestSourceInType {
            private final SvixConfig config;

            public Replicate(SvixConfig config) {
                this.config = config;
            }

            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().valueToTree(config);
            }
        }

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("resend")
        public static class Resend extends IngestSourceInType {
            private final SvixConfig config;

            public Resend(SvixConfig config) {
                this.config = config;
            }

            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().valueToTree(config);
            }
        }

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("safebase")
        public static class Safebase extends IngestSourceInType {
            private final SvixConfig config;

            public Safebase(SvixConfig config) {
                this.config = config;
            }

            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().valueToTree(config);
            }
        }

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("sardine")
        public static class Sardine extends IngestSourceInType {
            private final SvixConfig config;

            public Sardine(SvixConfig config) {
                this.config = config;
            }

            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().valueToTree(config);
            }
        }

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("segment")
        public static class Segment extends IngestSourceInType {
            private final SegmentConfig config;

            public Segment(SegmentConfig config) {
                this.config = config;
            }

            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().valueToTree(config);
            }
        }

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("shopify")
        public static class Shopify extends IngestSourceInType {
            private final ShopifyConfig config;

            public Shopify(ShopifyConfig config) {
                this.config = config;
            }

            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().valueToTree(config);
            }
        }

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("slack")
        public static class Slack extends IngestSourceInType {
            private final SlackConfig config;

            public Slack(SlackConfig config) {
                this.config = config;
            }

            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().valueToTree(config);
            }
        }

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("stripe")
        public static class Stripe extends IngestSourceInType {
            private final StripeConfig config;

            public Stripe(StripeConfig config) {
                this.config = config;
            }

            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().valueToTree(config);
            }
        }

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("stych")
        public static class Stych extends IngestSourceInType {
            private final SvixConfig config;

            public Stych(SvixConfig config) {
                this.config = config;
            }

            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().valueToTree(config);
            }
        }

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("svix")
        public static class Svix extends IngestSourceInType {
            private final SvixConfig config;

            public Svix(SvixConfig config) {
                this.config = config;
            }

            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().valueToTree(config);
            }
        }

        @ToString
        @EqualsAndHashCode(callSuper = false)
        @VariantName("zoom")
        public static class Zoom extends IngestSourceInType {
            private final ZoomConfig config;

            public Zoom(ZoomConfig config) {
                this.config = config;
            }

            @Override
            public JsonNode toJsonNode() {
                return Utils.getObjectMapper().valueToTree(config);
            }
        }

        @FunctionalInterface
        private interface TypeFactory {
            IngestSourceInType create(JsonNode config);
        }

        private static final Map<String, TypeFactory> TY_M = new HashMap<>();
        private static final ObjectMapper m = Utils.getObjectMapper();

        static {
            TY_M.put("generic-webhook", c -> new GenericWebhook());
            TY_M.put("cron", c -> new Cron(m.convertValue(c, CronConfig.class)));
            TY_M.put("adobe-sign", c -> new AdobeSign(m.convertValue(c, AdobeSignConfig.class)));
            TY_M.put("beehiiv", c -> new Beehiiv(m.convertValue(c, SvixConfig.class)));
            TY_M.put("brex", c -> new Brex(m.convertValue(c, SvixConfig.class)));
            TY_M.put("clerk", c -> new Clerk(m.convertValue(c, SvixConfig.class)));
            TY_M.put("docusign", c -> new Docusign(m.convertValue(c, DocusignConfig.class)));
            TY_M.put("github", c -> new Github(m.convertValue(c, GithubConfig.class)));
            TY_M.put("guesty", c -> new Guesty(m.convertValue(c, SvixConfig.class)));
            TY_M.put("hubspot", c -> new Hubspot(m.convertValue(c, HubspotConfig.class)));
            TY_M.put("incident-io", c -> new IncidentIo(m.convertValue(c, SvixConfig.class)));
            TY_M.put("lithic", c -> new Lithic(m.convertValue(c, SvixConfig.class)));
            TY_M.put("nash", c -> new Nash(m.convertValue(c, SvixConfig.class)));
            TY_M.put("pleo", c -> new Pleo(m.convertValue(c, SvixConfig.class)));
            TY_M.put("replicate", c -> new Replicate(m.convertValue(c, SvixConfig.class)));
            TY_M.put("resend", c -> new Resend(m.convertValue(c, SvixConfig.class)));
            TY_M.put("safebase", c -> new Safebase(m.convertValue(c, SvixConfig.class)));
            TY_M.put("sardine", c -> new Sardine(m.convertValue(c, SvixConfig.class)));
            TY_M.put("segment", c -> new Segment(m.convertValue(c, SegmentConfig.class)));
            TY_M.put("shopify", c -> new Shopify(m.convertValue(c, ShopifyConfig.class)));
            TY_M.put("slack", c -> new Slack(m.convertValue(c, SlackConfig.class)));
            TY_M.put("stripe", c -> new Stripe(m.convertValue(c, StripeConfig.class)));
            TY_M.put("stych", c -> new Stych(m.convertValue(c, SvixConfig.class)));
            TY_M.put("svix", c -> new Svix(m.convertValue(c, SvixConfig.class)));
            TY_M.put("zoom", c -> new Zoom(m.convertValue(c, ZoomConfig.class)));
        }

        public static IngestSourceInType fromTypeAndConfig(String type, JsonNode config) {
            TypeFactory factory = TY_M.get(type);
            if (factory == null) {
                throw new IllegalArgumentException("Unknown type: " + type);
            }
            return factory.create(config);
        }
    }
}

@Target(ElementType.TYPE)
@Retention(RetentionPolicy.RUNTIME)
@interface VariantName {
    String value();
}

class IngestSourceInSerializer extends StdSerializer<IngestSourceIn> {
    public IngestSourceInSerializer() {
        this(null);
    }

    public IngestSourceInSerializer(Class<IngestSourceIn> t) {
        super(t);
    }

    @Override
    public void serialize(IngestSourceIn value, JsonGenerator gen, SerializerProvider provider)
            throws IOException {
        gen.writeStartObject();
        if (value.getName() != null) {
            gen.writeStringField("name", value.getName());
        }
        if (value.getUid() != null) {
            gen.writeStringField("uid", value.getUid());
        }
        gen.writeStringField("type", value.getType().getVariantName());
        gen.writeFieldName("config");
        gen.writeRawValue(value.getType().toJsonNode().toString());
        gen.writeEndObject();
    }
}

class IngestSourceInDeserializer extends StdDeserializer<IngestSourceIn> {
    public IngestSourceInDeserializer() {
        this(null);
    }

    public IngestSourceInDeserializer(Class<?> vc) {
        super(vc);
    }

    @Override
    public IngestSourceIn deserialize(JsonParser p, DeserializationContext ctxt)
            throws IOException {
        JsonNode node = p.getCodec().readTree(p);

        // FIXME: we are not currently handling non-string fields
        String name = node.has("name") ? node.get("name").asText() : null;
        String uid = node.has("uid") ? node.get("uid").asText() : null;
        String type = node.get("type").asText();
        JsonNode config = node.get("config");
        IngestSourceIn.IngestSourceInType sourceType =
                IngestSourceIn.IngestSourceInType.fromTypeAndConfig(type, config);
        return new IngestSourceIn(name, uid, sourceType);
    }
}

```