### PR TITLE
ci: Upgrade typos

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -13,4 +13,4 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: crate-ci/typos@v1.28.0
+      - uses: crate-ci/typos@v1.30.1

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,16 +1,8 @@
-[default]
-extend-ignore-re = [
-    # Mock token
-    ";iuani;ansd;ifgjbnai;sdjfgb",
-    "jakarta\\.ws\\.rs",
-]
+[default.extend-words]
+typ = "typ" # since type is a keyword in Rust
 
 [files]
 extend-exclude = [
-    # Typo "achived" is a breaking change to fix
-    "kotlin/lib/src/main/kotlin/EventType.kt",
-    "kotlin/lib/src/main/kotlin/EventTypeListOptions.kt",
-
     # False positives in randomly-generated strings
     "server/svix-server/migrations/20230505222507_operational_webhook_event-types.up.sql",
     "server/svix-server/migrations/20230505222507_operational_webhook_event-types.down.sql",


### PR DESCRIPTION
cc @svix-mman re #1794 I think you should make `ser` an allowed word the same way as `typ` here.