### PR TITLE
js: Send content type on request

### DIFF
--- a/javascript/src/mockttp.test.ts
+++ b/javascript/src/mockttp.test.ts
@@ -349,4 +349,28 @@ describe("mockttp tests", () => {
     expect(requests.length).toBe(1);
     expect(requests[0].url.endsWith("api/v1/app/app1/msg?tag=test%23test")).toBe(true);
   });
+
+  test("content-type application/json is sent on request with body", async () => {
+    const endpointMock = await mockServer
+      .forPost(/\/api\/v1\/app.*/)
+      .thenReply(200, ApplicationOut);
+    const svx = new Svix("token", { serverUrl: mockServer.url });
+
+    await svx.application.create({ name: "test" });
+    const requests = await endpointMock.getSeenRequests();
+    expect(requests.length).toBe(1);
+    expect(requests[0].headers["content-type"]).toBe("application/json");
+  });
+
+  test("content type not sent on request without body", async () => {
+    const endpointMock = await mockServer
+      .forGet("/api/v1/app")
+      .thenReply(200, ListResponseApplicationOut);
+    const svx = new Svix("token", { serverUrl: mockServer.url });
+
+    await svx.application.list();
+    const requests = await endpointMock.getSeenRequests();
+    expect(requests.length).toBe(1);
+    expect(requests[0].headers["content-type"]).toBeUndefined();
+  });
 });

--- a/javascript/src/request.ts
+++ b/javascript/src/request.ts
@@ -115,6 +115,9 @@ export class SvixRequest {
 
     const randomId = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
 
+    if (this.body != null) {
+      this.headerParams["content-type"] = "application/json";
+    }
     // Cloudflare Workers fail if the credentials option is used in a fetch call.
     // This work around that. Source:
     // https://github.com/cloudflare/workers-sdk/issues/2514#issuecomment-2178070014


### PR DESCRIPTION
For some reason on we were not sending the correct content-type in our js lib
The server then responds with
```
Expected request with `Content-Type: application/json`
```
Then json parsing of the returned error fails, and we crash at runtime.


Other endpoints like `v1.application.create` and `v1.message.create`, do not return this error when they receive a request without a content-type (or with an incorrect content-type)


fixes: https://github.com/svix/svix-webhooks/issues/1799