### PR TITLE
python: Support field-less object types

### DIFF
--- a/python/templates/types/struct_fields.py.jinja
+++ b/python/templates/types/struct_fields.py.jinja
@@ -1,3 +1,4 @@
+{% if type.fields | length == 0 %}    pass{% endif -%}
 {% for field in type.fields %}
     {%- if field.required and not field.nullable %}
         {%- if field.name | to_lower_camel_case != field.name %}


### PR DESCRIPTION
We've got some field-less object types in the next version of our API spec.