### PR TITLE
csharp: Update codegen templates to support struct enums

### DIFF
--- a/codegen.toml
+++ b/codegen.toml
@@ -73,17 +73,17 @@ output_dir = "rust/src/models"
 #output_dir = "ruby/lib/svix/models"
 #
 #
-#[csharp]
-#template_dir = "csharp/templates"
-#extra_shell_commands = [
-#    "rm csharp/Svix/{IngestEndpoint,Ingest,OperationalWebhook}.cs",
-#]
-#[[csharp.task]]
-#template = "csharp/templates/api_resource.cs.jinja"
-#output_dir = "csharp/Svix"
-#[[csharp.task]]
-#template = "csharp/templates/component_type.cs.jinja"
-#output_dir = "csharp/Svix/Models"
+[csharp]
+template_dir = "csharp/templates"
+extra_shell_commands = [
+   "rm csharp/Svix/{IngestEndpoint,Ingest,OperationalWebhook}.cs",
+]
+[[csharp.task]]
+template = "csharp/templates/api_resource.cs.jinja"
+output_dir = "csharp/Svix"
+[[csharp.task]]
+template = "csharp/templates/component_type.cs.jinja"
+output_dir = "csharp/Svix/Models"
 
 
 [java]
@@ -100,8 +100,8 @@ output_dir = "java/lib/src/main/java/com/svix/api"
 [[java.task]]
 template = "java/templates/component_type.java.jinja"
 output_dir = "java/lib/src/main/java/com/svix/models"
-
-
+#
+#
 #[go]
 #template_dir = "openapi-templates/go"
 #extra_shell_commands = [

--- a/csharp/Svix.Tests/WiremockTests.cs
+++ b/csharp/Svix.Tests/WiremockTests.cs
@@ -303,5 +303,16 @@ namespace Svix.Tests
             Assert.Equal(sourceIn.Uid, loadedFromJson.Uid);
             Assert.Equal(sourceIn.Config.GetContent(), loadedFromJson.Config.GetContent());
         }
+
+        [Fact]
+        public void ReadStructEnumField()
+        {
+            var jsonString =
+                """{"name":"me","uid":"test","type":"cron","config":{"payload":"asd","schedule":"* * * * *"}}""";
+            var loadedFromJson = JsonConvert.DeserializeObject<IngestSourceIn>(jsonString);
+            Assert.True(loadedFromJson.Config.GetContent().GetType() == typeof(CronConfig));
+            Assert.Equal("asd", ((CronConfig)loadedFromJson.Config.GetContent()).Payload);
+            Assert.Equal("* * * * *", ((CronConfig)loadedFromJson.Config.GetContent()).Schedule);
+        }
     }
 }

--- a/csharp/Svix/IngestSource.cs
+++ b/csharp/Svix/IngestSource.cs
@@ -1,0 +1,383 @@
+// this file is @generated
+#nullable enable
+using Microsoft.Extensions.Logging;
+using Svix.Models;
+
+namespace Svix
+{
+    public class IngestSourceListOptions : SvixOptionsBase
+    {
+        public ulong? Limit { get; set; }
+        public string? Iterator { get; set; }
+        public Ordering? Order { get; set; }
+
+        public new Dictionary<string, string> QueryParams()
+        {
+            return SerializeParams(
+                new Dictionary<string, object?>
+                {
+                    { "limit", Limit },
+                    { "iterator", Iterator },
+                    { "order", Order },
+                }
+            );
+        }
+    }
+
+    public class IngestSourceCreateOptions : SvixOptionsBase
+    {
+        public string? IdempotencyKey { get; set; }
+
+        public new Dictionary<string, string> HeaderParams()
+        {
+            return SerializeParams(
+                new Dictionary<string, object?> { { "idempotency-key", IdempotencyKey } }
+            );
+        }
+    }
+
+    public class IngestSourceRotateTokenOptions : SvixOptionsBase
+    {
+        public string? IdempotencyKey { get; set; }
+
+        public new Dictionary<string, string> HeaderParams()
+        {
+            return SerializeParams(
+                new Dictionary<string, object?> { { "idempotency-key", IdempotencyKey } }
+            );
+        }
+    }
+
+    public class IngestSource(SvixClient client)
+    {
+        readonly SvixClient _client = client;
+
+        /// <summary>
+        /// List of all the organization's Ingest Sources.
+        /// </summary>
+        public async Task<ListResponseIngestSourceOut> ListAsync(
+            IngestSourceListOptions? options = null,
+            CancellationToken cancellationToken = default
+        )
+        {
+            try
+            {
+                var response =
+                    await _client.SvixHttpClient.SendRequestAsync<ListResponseIngestSourceOut>(
+                        method: HttpMethod.Get,
+                        path: "/ingest/api/v1/source",
+                        queryParams: options?.QueryParams(),
+                        headerParams: options?.HeaderParams(),
+                        cancellationToken: cancellationToken
+                    );
+                return response.Data;
+            }
+            catch (ApiException e)
+            {
+                _client.Logger?.LogError(e, $"{nameof(ListAsync)} failed");
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// List of all the organization's Ingest Sources.
+        /// </summary>
+        public ListResponseIngestSourceOut List(IngestSourceListOptions? options = null)
+        {
+            try
+            {
+                var response = _client.SvixHttpClient.SendRequest<ListResponseIngestSourceOut>(
+                    method: HttpMethod.Get,
+                    path: "/ingest/api/v1/source",
+                    queryParams: options?.QueryParams(),
+                    headerParams: options?.HeaderParams()
+                );
+                return response.Data;
+            }
+            catch (ApiException e)
+            {
+                _client.Logger?.LogError(e, $"{nameof(List)} failed");
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Create Ingest Source.
+        /// </summary>
+        public async Task<IngestSourceOut> CreateAsync(
+            IngestSourceIn ingestSourceIn,
+            IngestSourceCreateOptions? options = null,
+            CancellationToken cancellationToken = default
+        )
+        {
+            ingestSourceIn =
+                ingestSourceIn ?? throw new ArgumentNullException(nameof(ingestSourceIn));
+            try
+            {
+                var response = await _client.SvixHttpClient.SendRequestAsync<IngestSourceOut>(
+                    method: HttpMethod.Post,
+                    path: "/ingest/api/v1/source",
+                    queryParams: options?.QueryParams(),
+                    headerParams: options?.HeaderParams(),
+                    content: ingestSourceIn,
+                    cancellationToken: cancellationToken
+                );
+                return response.Data;
+            }
+            catch (ApiException e)
+            {
+                _client.Logger?.LogError(e, $"{nameof(CreateAsync)} failed");
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Create Ingest Source.
+        /// </summary>
+        public IngestSourceOut Create(
+            IngestSourceIn ingestSourceIn,
+            IngestSourceCreateOptions? options = null
+        )
+        {
+            ingestSourceIn =
+                ingestSourceIn ?? throw new ArgumentNullException(nameof(ingestSourceIn));
+            try
+            {
+                var response = _client.SvixHttpClient.SendRequest<IngestSourceOut>(
+                    method: HttpMethod.Post,
+                    path: "/ingest/api/v1/source",
+                    queryParams: options?.QueryParams(),
+                    headerParams: options?.HeaderParams(),
+                    content: ingestSourceIn
+                );
+                return response.Data;
+            }
+            catch (ApiException e)
+            {
+                _client.Logger?.LogError(e, $"{nameof(Create)} failed");
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Get an Ingest Source by id or uid.
+        /// </summary>
+        public async Task<IngestSourceOut> GetAsync(
+            string sourceId,
+            CancellationToken cancellationToken = default
+        )
+        {
+            try
+            {
+                var response = await _client.SvixHttpClient.SendRequestAsync<IngestSourceOut>(
+                    method: HttpMethod.Get,
+                    path: "/ingest/api/v1/source/{source_id}",
+                    pathParams: new Dictionary<string, string> { { "source_id", sourceId } },
+                    cancellationToken: cancellationToken
+                );
+                return response.Data;
+            }
+            catch (ApiException e)
+            {
+                _client.Logger?.LogError(e, $"{nameof(GetAsync)} failed");
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Get an Ingest Source by id or uid.
+        /// </summary>
+        public IngestSourceOut Get(string sourceId)
+        {
+            try
+            {
+                var response = _client.SvixHttpClient.SendRequest<IngestSourceOut>(
+                    method: HttpMethod.Get,
+                    path: "/ingest/api/v1/source/{source_id}",
+                    pathParams: new Dictionary<string, string> { { "source_id", sourceId } }
+                );
+                return response.Data;
+            }
+            catch (ApiException e)
+            {
+                _client.Logger?.LogError(e, $"{nameof(Get)} failed");
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Update an Ingest Source.
+        /// </summary>
+        public async Task<IngestSourceOut> UpdateAsync(
+            string sourceId,
+            IngestSourceIn ingestSourceIn,
+            CancellationToken cancellationToken = default
+        )
+        {
+            ingestSourceIn =
+                ingestSourceIn ?? throw new ArgumentNullException(nameof(ingestSourceIn));
+            try
+            {
+                var response = await _client.SvixHttpClient.SendRequestAsync<IngestSourceOut>(
+                    method: HttpMethod.Put,
+                    path: "/ingest/api/v1/source/{source_id}",
+                    pathParams: new Dictionary<string, string> { { "source_id", sourceId } },
+                    content: ingestSourceIn,
+                    cancellationToken: cancellationToken
+                );
+                return response.Data;
+            }
+            catch (ApiException e)
+            {
+                _client.Logger?.LogError(e, $"{nameof(UpdateAsync)} failed");
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Update an Ingest Source.
+        /// </summary>
+        public IngestSourceOut Update(string sourceId, IngestSourceIn ingestSourceIn)
+        {
+            ingestSourceIn =
+                ingestSourceIn ?? throw new ArgumentNullException(nameof(ingestSourceIn));
+            try
+            {
+                var response = _client.SvixHttpClient.SendRequest<IngestSourceOut>(
+                    method: HttpMethod.Put,
+                    path: "/ingest/api/v1/source/{source_id}",
+                    pathParams: new Dictionary<string, string> { { "source_id", sourceId } },
+                    content: ingestSourceIn
+                );
+                return response.Data;
+            }
+            catch (ApiException e)
+            {
+                _client.Logger?.LogError(e, $"{nameof(Update)} failed");
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Delete an Ingest Source.
+        /// </summary>
+        public async Task<bool> DeleteAsync(
+            string sourceId,
+            CancellationToken cancellationToken = default
+        )
+        {
+            try
+            {
+                var response = await _client.SvixHttpClient.SendRequestAsync<bool>(
+                    method: HttpMethod.Delete,
+                    path: "/ingest/api/v1/source/{source_id}",
+                    pathParams: new Dictionary<string, string> { { "source_id", sourceId } },
+                    cancellationToken: cancellationToken
+                );
+                return response.Data;
+            }
+            catch (ApiException e)
+            {
+                _client.Logger?.LogError(e, $"{nameof(DeleteAsync)} failed");
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Delete an Ingest Source.
+        /// </summary>
+        public bool Delete(string sourceId)
+        {
+            try
+            {
+                var response = _client.SvixHttpClient.SendRequest<bool>(
+                    method: HttpMethod.Delete,
+                    path: "/ingest/api/v1/source/{source_id}",
+                    pathParams: new Dictionary<string, string> { { "source_id", sourceId } }
+                );
+                return response.Data;
+            }
+            catch (ApiException e)
+            {
+                _client.Logger?.LogError(e, $"{nameof(Delete)} failed");
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Rotate the Ingest Source's Url Token.
+        ///
+        /// This will rotate the ingest source's token, which is used to
+        /// construct the unique `ingestUrl` for the source. Previous tokens
+        /// will remain valid for 48 hours after rotation. The token can be
+        /// rotated a maximum of three times within the 48-hour period.
+        /// </summary>
+        public async Task<RotateTokenOut> RotateTokenAsync(
+            string sourceId,
+            IngestSourceRotateTokenOptions? options = null,
+            CancellationToken cancellationToken = default
+        )
+        {
+            try
+            {
+                var response = await _client.SvixHttpClient.SendRequestAsync<RotateTokenOut>(
+                    method: HttpMethod.Post,
+                    path: "/ingest/api/v1/source/{source_id}/token/rotate",
+                    pathParams: new Dictionary<string, string> { { "source_id", sourceId } },
+                    queryParams: options?.QueryParams(),
+                    headerParams: options?.HeaderParams(),
+                    cancellationToken: cancellationToken
+                );
+                return response.Data;
+            }
+            catch (ApiException e)
+            {
+                _client.Logger?.LogError(e, $"{nameof(RotateTokenAsync)} failed");
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Rotate the Ingest Source's Url Token.
+        ///
+        /// This will rotate the ingest source's token, which is used to
+        /// construct the unique `ingestUrl` for the source. Previous tokens
+        /// will remain valid for 48 hours after rotation. The token can be
+        /// rotated a maximum of three times within the 48-hour period.
+        /// </summary>
+        public RotateTokenOut RotateToken(
+            string sourceId,
+            IngestSourceRotateTokenOptions? options = null
+        )
+        {
+            try
+            {
+                var response = _client.SvixHttpClient.SendRequest<RotateTokenOut>(
+                    method: HttpMethod.Post,
+                    path: "/ingest/api/v1/source/{source_id}/token/rotate",
+                    pathParams: new Dictionary<string, string> { { "source_id", sourceId } },
+                    queryParams: options?.QueryParams(),
+                    headerParams: options?.HeaderParams()
+                );
+                return response.Data;
+            }
+            catch (ApiException e)
+            {
+                _client.Logger?.LogError(e, $"{nameof(RotateToken)} failed");
+
+                throw;
+            }
+        }
+    }
+}

--- a/csharp/Svix/Models/AdobeSignConfig.cs
+++ b/csharp/Svix/Models/AdobeSignConfig.cs
@@ -1,0 +1,22 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class AdobeSignConfig
+    {
+        [JsonProperty("clientId", Required = Required.Always)]
+        public required string ClientId { get; set; }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class AdobeSignConfig {\n");
+            sb.Append("  ClientId: ").Append(ClientId).Append('\n');
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/Svix/Models/AdobeSignConfigOut.cs
+++ b/csharp/Svix/Models/AdobeSignConfigOut.cs
@@ -1,0 +1,18 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class AdobeSignConfigOut
+    {
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class AdobeSignConfigOut {\n");
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/Svix/Models/ConnectorOut.cs
+++ b/csharp/Svix/Models/ConnectorOut.cs
@@ -1,0 +1,70 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class ConnectorOut
+    {
+        [JsonProperty("createdAt", Required = Required.Always)]
+        public required DateTime CreatedAt { get; set; }
+
+        [JsonProperty("description", Required = Required.Always)]
+        public required string Description { get; set; }
+
+        [JsonProperty("featureFlag")]
+        public string? FeatureFlag { get; set; } = null;
+
+        [JsonProperty("filterTypes")]
+        public List<string>? FilterTypes { get; set; } = null;
+
+        [JsonProperty("id", Required = Required.Always)]
+        public required string Id { get; set; }
+
+        [JsonProperty("instructions", Required = Required.Always)]
+        public required string Instructions { get; set; }
+
+        [JsonProperty("instructionsLink")]
+        public string? InstructionsLink { get; set; } = null;
+
+        [JsonProperty("kind", Required = Required.Always)]
+        public required ConnectorKind Kind { get; set; }
+
+        [JsonProperty("logo", Required = Required.Always)]
+        public required string Logo { get; set; }
+
+        [JsonProperty("name", Required = Required.Always)]
+        public required string Name { get; set; }
+
+        [JsonProperty("orgId", Required = Required.Always)]
+        public required string OrgId { get; set; }
+
+        [JsonProperty("transformation", Required = Required.Always)]
+        public required string Transformation { get; set; }
+
+        [JsonProperty("updatedAt", Required = Required.Always)]
+        public required DateTime UpdatedAt { get; set; }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class ConnectorOut {\n");
+            sb.Append("  CreatedAt: ").Append(CreatedAt).Append('\n');
+            sb.Append("  Description: ").Append(Description).Append('\n');
+            sb.Append("  FeatureFlag: ").Append(FeatureFlag).Append('\n');
+            sb.Append("  FilterTypes: ").Append(FilterTypes).Append('\n');
+            sb.Append("  Id: ").Append(Id).Append('\n');
+            sb.Append("  Instructions: ").Append(Instructions).Append('\n');
+            sb.Append("  InstructionsLink: ").Append(InstructionsLink).Append('\n');
+            sb.Append("  Kind: ").Append(Kind).Append('\n');
+            sb.Append("  Logo: ").Append(Logo).Append('\n');
+            sb.Append("  Name: ").Append(Name).Append('\n');
+            sb.Append("  OrgId: ").Append(OrgId).Append('\n');
+            sb.Append("  Transformation: ").Append(Transformation).Append('\n');
+            sb.Append("  UpdatedAt: ").Append(UpdatedAt).Append('\n');
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/Svix/Models/CronConfig.cs
+++ b/csharp/Svix/Models/CronConfig.cs
@@ -1,0 +1,30 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class CronConfig
+    {
+        [JsonProperty("contentType")]
+        public string? ContentType { get; set; } = null;
+
+        [JsonProperty("payload", Required = Required.Always)]
+        public required string Payload { get; set; }
+
+        [JsonProperty("schedule", Required = Required.Always)]
+        public required string Schedule { get; set; }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class CronConfig {\n");
+            sb.Append("  ContentType: ").Append(ContentType).Append('\n');
+            sb.Append("  Payload: ").Append(Payload).Append('\n');
+            sb.Append("  Schedule: ").Append(Schedule).Append('\n');
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/Svix/Models/DocusignConfig.cs
+++ b/csharp/Svix/Models/DocusignConfig.cs
@@ -1,0 +1,22 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class DocusignConfig
+    {
+        [JsonProperty("secret")]
+        public string? Secret { get; set; } = null;
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class DocusignConfig {\n");
+            sb.Append("  Secret: ").Append(Secret).Append('\n');
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/Svix/Models/DocusignConfigOut.cs
+++ b/csharp/Svix/Models/DocusignConfigOut.cs
@@ -1,0 +1,18 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class DocusignConfigOut
+    {
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class DocusignConfigOut {\n");
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/Svix/Models/EnvironmentOut.cs
+++ b/csharp/Svix/Models/EnvironmentOut.cs
@@ -16,7 +16,7 @@ namespace Svix.Models
         public Object? Settings { get; set; } = null;
 
         [JsonProperty("transformationTemplates", Required = Required.Always)]
-        public required List<TemplateOut> TransformationTemplates { get; set; }
+        public required List<ConnectorOut> TransformationTemplates { get; set; }
 
         [JsonProperty("version")]
         public long? Version { get; set; } = null;

--- a/csharp/Svix/Models/GithubConfig.cs
+++ b/csharp/Svix/Models/GithubConfig.cs
@@ -1,0 +1,22 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class GithubConfig
+    {
+        [JsonProperty("secret")]
+        public string? Secret { get; set; } = null;
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class GithubConfig {\n");
+            sb.Append("  Secret: ").Append(Secret).Append('\n');
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/Svix/Models/GithubConfigOut.cs
+++ b/csharp/Svix/Models/GithubConfigOut.cs
@@ -1,0 +1,18 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class GithubConfigOut
+    {
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class GithubConfigOut {\n");
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/Svix/Models/HubspotConfig.cs
+++ b/csharp/Svix/Models/HubspotConfig.cs
@@ -1,0 +1,22 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class HubspotConfig
+    {
+        [JsonProperty("secret")]
+        public string? Secret { get; set; } = null;
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class HubspotConfig {\n");
+            sb.Append("  Secret: ").Append(Secret).Append('\n');
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/Svix/Models/HubspotConfigOut.cs
+++ b/csharp/Svix/Models/HubspotConfigOut.cs
@@ -1,0 +1,18 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class HubspotConfigOut
+    {
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class HubspotConfigOut {\n");
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/Svix/Models/IngestSourceConsumerPortalAccessIn.cs
+++ b/csharp/Svix/Models/IngestSourceConsumerPortalAccessIn.cs
@@ -1,0 +1,26 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class IngestSourceConsumerPortalAccessIn
+    {
+        [JsonProperty("expiry")]
+        public ulong? Expiry { get; set; } = null;
+
+        [JsonProperty("readOnly")]
+        public bool? ReadOnly { get; set; } = null;
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class IngestSourceConsumerPortalAccessIn {\n");
+            sb.Append("  Expiry: ").Append(Expiry).Append('\n');
+            sb.Append("  ReadOnly: ").Append(ReadOnly).Append('\n');
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/Svix/Models/IngestSourceIn.cs
+++ b/csharp/Svix/Models/IngestSourceIn.cs
@@ -1,0 +1,507 @@
+// this file is @generated
+using System.Runtime.Serialization;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Svix.Models
+{
+    [JsonConverter(typeof(IngestSourceInConverter))]
+    public class IngestSourceIn
+    {
+        [JsonProperty("name", Required = Required.Always)]
+        public required string Name { get; set; }
+
+        [JsonProperty("uid")]
+        public string? Uid { get; set; } = null;
+
+        [JsonIgnore]
+        public required IngestSourceInConfig Config { get; set; }
+
+        [JsonProperty("type")]
+        private string Type => Config.GetDiscriminator();
+
+        [JsonProperty("config")]
+        private object realConfig
+        {
+            get => Config.GetContent();
+            set => Config.SetContent(value);
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class IngestSourceIn {\n");
+            sb.Append("  Name: ").Append(Name).Append('\n');
+            sb.Append("  Uid: ").Append(Uid).Append('\n');
+            sb.Append("  Config: ").Append(Config).Append('\n');
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+
+    public class IngestSourceInConfig
+    {
+        private object _value;
+        private readonly ConfigType _type;
+
+        internal string GetDiscriminator()
+        {
+            var memberInfo = typeof(ConfigType).GetMember(_type.ToString());
+            var enumMember = memberInfo[0]
+                .GetCustomAttributes(false)
+                .OfType<EnumMemberAttribute>()
+                .FirstOrDefault();
+            return enumMember?.Value ?? _type.ToString().ToLower();
+        }
+
+        internal void SetContent(object value)
+        {
+            _value = value;
+        }
+
+        public object GetContent()
+        {
+            return _value;
+        }
+
+        private IngestSourceInConfig(object value, ConfigType type)
+        {
+            _value = value;
+            _type = type;
+        }
+
+        public static IngestSourceInConfig GenericWebhook() =>
+            new(new Dictionary<string, string>(), ConfigType.GenericWebhook);
+
+        public static IngestSourceInConfig Cron(CronConfig cronConfig) =>
+            new(cronConfig, ConfigType.Cron);
+
+        public static IngestSourceInConfig AdobeSign(AdobeSignConfig adobeSignConfig) =>
+            new(adobeSignConfig, ConfigType.AdobeSign);
+
+        public static IngestSourceInConfig Beehiiv(SvixConfig svixConfig) =>
+            new(svixConfig, ConfigType.Beehiiv);
+
+        public static IngestSourceInConfig Brex(SvixConfig svixConfig) =>
+            new(svixConfig, ConfigType.Brex);
+
+        public static IngestSourceInConfig Clerk(SvixConfig svixConfig) =>
+            new(svixConfig, ConfigType.Clerk);
+
+        public static IngestSourceInConfig Docusign(DocusignConfig docusignConfig) =>
+            new(docusignConfig, ConfigType.Docusign);
+
+        public static IngestSourceInConfig Github(GithubConfig githubConfig) =>
+            new(githubConfig, ConfigType.Github);
+
+        public static IngestSourceInConfig Guesty(SvixConfig svixConfig) =>
+            new(svixConfig, ConfigType.Guesty);
+
+        public static IngestSourceInConfig Hubspot(HubspotConfig hubspotConfig) =>
+            new(hubspotConfig, ConfigType.Hubspot);
+
+        public static IngestSourceInConfig IncidentIo(SvixConfig svixConfig) =>
+            new(svixConfig, ConfigType.IncidentIo);
+
+        public static IngestSourceInConfig Lithic(SvixConfig svixConfig) =>
+            new(svixConfig, ConfigType.Lithic);
+
+        public static IngestSourceInConfig Nash(SvixConfig svixConfig) =>
+            new(svixConfig, ConfigType.Nash);
+
+        public static IngestSourceInConfig Pleo(SvixConfig svixConfig) =>
+            new(svixConfig, ConfigType.Pleo);
+
+        public static IngestSourceInConfig Replicate(SvixConfig svixConfig) =>
+            new(svixConfig, ConfigType.Replicate);
+
+        public static IngestSourceInConfig Resend(SvixConfig svixConfig) =>
+            new(svixConfig, ConfigType.Resend);
+
+        public static IngestSourceInConfig Safebase(SvixConfig svixConfig) =>
+            new(svixConfig, ConfigType.Safebase);
+
+        public static IngestSourceInConfig Sardine(SvixConfig svixConfig) =>
+            new(svixConfig, ConfigType.Sardine);
+
+        public static IngestSourceInConfig Segment(SegmentConfig segmentConfig) =>
+            new(segmentConfig, ConfigType.Segment);
+
+        public static IngestSourceInConfig Shopify(ShopifyConfig shopifyConfig) =>
+            new(shopifyConfig, ConfigType.Shopify);
+
+        public static IngestSourceInConfig Slack(SlackConfig slackConfig) =>
+            new(slackConfig, ConfigType.Slack);
+
+        public static IngestSourceInConfig Stripe(StripeConfig stripeConfig) =>
+            new(stripeConfig, ConfigType.Stripe);
+
+        public static IngestSourceInConfig Stych(SvixConfig svixConfig) =>
+            new(svixConfig, ConfigType.Stych);
+
+        public static IngestSourceInConfig Svix(SvixConfig svixConfig) =>
+            new(svixConfig, ConfigType.Svix);
+
+        public static IngestSourceInConfig Zoom(ZoomConfig zoomConfig) =>
+            new(zoomConfig, ConfigType.Zoom);
+
+        private enum ConfigType
+        {
+            [EnumMember(Value = "generic-webhook")]
+            GenericWebhook,
+
+            [EnumMember(Value = "cron")]
+            Cron,
+
+            [EnumMember(Value = "adobe-sign")]
+            AdobeSign,
+
+            [EnumMember(Value = "beehiiv")]
+            Beehiiv,
+
+            [EnumMember(Value = "brex")]
+            Brex,
+
+            [EnumMember(Value = "clerk")]
+            Clerk,
+
+            [EnumMember(Value = "docusign")]
+            Docusign,
+
+            [EnumMember(Value = "github")]
+            Github,
+
+            [EnumMember(Value = "guesty")]
+            Guesty,
+
+            [EnumMember(Value = "hubspot")]
+            Hubspot,
+
+            [EnumMember(Value = "incident-io")]
+            IncidentIo,
+
+            [EnumMember(Value = "lithic")]
+            Lithic,
+
+            [EnumMember(Value = "nash")]
+            Nash,
+
+            [EnumMember(Value = "pleo")]
+            Pleo,
+
+            [EnumMember(Value = "replicate")]
+            Replicate,
+
+            [EnumMember(Value = "resend")]
+            Resend,
+
+            [EnumMember(Value = "safebase")]
+            Safebase,
+
+            [EnumMember(Value = "sardine")]
+            Sardine,
+
+            [EnumMember(Value = "segment")]
+            Segment,
+
+            [EnumMember(Value = "shopify")]
+            Shopify,
+
+            [EnumMember(Value = "slack")]
+            Slack,
+
+            [EnumMember(Value = "stripe")]
+            Stripe,
+
+            [EnumMember(Value = "stych")]
+            Stych,
+
+            [EnumMember(Value = "svix")]
+            Svix,
+
+            [EnumMember(Value = "zoom")]
+            Zoom,
+        }
+
+        public TResult Match<TResult>(
+            Func<TResult> onGenericWebhook,
+            Func<CronConfig, TResult> onCron,
+            Func<AdobeSignConfig, TResult> onAdobeSign,
+            Func<SvixConfig, TResult> onBeehiiv,
+            Func<SvixConfig, TResult> onBrex,
+            Func<SvixConfig, TResult> onClerk,
+            Func<DocusignConfig, TResult> onDocusign,
+            Func<GithubConfig, TResult> onGithub,
+            Func<SvixConfig, TResult> onGuesty,
+            Func<HubspotConfig, TResult> onHubspot,
+            Func<SvixConfig, TResult> onIncidentIo,
+            Func<SvixConfig, TResult> onLithic,
+            Func<SvixConfig, TResult> onNash,
+            Func<SvixConfig, TResult> onPleo,
+            Func<SvixConfig, TResult> onReplicate,
+            Func<SvixConfig, TResult> onResend,
+            Func<SvixConfig, TResult> onSafebase,
+            Func<SvixConfig, TResult> onSardine,
+            Func<SegmentConfig, TResult> onSegment,
+            Func<ShopifyConfig, TResult> onShopify,
+            Func<SlackConfig, TResult> onSlack,
+            Func<StripeConfig, TResult> onStripe,
+            Func<SvixConfig, TResult> onStych,
+            Func<SvixConfig, TResult> onSvix,
+            Func<ZoomConfig, TResult> onZoom
+        )
+        {
+            return _type switch
+            {
+                ConfigType.GenericWebhook => onGenericWebhook(),
+                ConfigType.Cron => onCron((CronConfig)_value),
+                ConfigType.AdobeSign => onAdobeSign((AdobeSignConfig)_value),
+                ConfigType.Beehiiv => onBeehiiv((SvixConfig)_value),
+                ConfigType.Brex => onBrex((SvixConfig)_value),
+                ConfigType.Clerk => onClerk((SvixConfig)_value),
+                ConfigType.Docusign => onDocusign((DocusignConfig)_value),
+                ConfigType.Github => onGithub((GithubConfig)_value),
+                ConfigType.Guesty => onGuesty((SvixConfig)_value),
+                ConfigType.Hubspot => onHubspot((HubspotConfig)_value),
+                ConfigType.IncidentIo => onIncidentIo((SvixConfig)_value),
+                ConfigType.Lithic => onLithic((SvixConfig)_value),
+                ConfigType.Nash => onNash((SvixConfig)_value),
+                ConfigType.Pleo => onPleo((SvixConfig)_value),
+                ConfigType.Replicate => onReplicate((SvixConfig)_value),
+                ConfigType.Resend => onResend((SvixConfig)_value),
+                ConfigType.Safebase => onSafebase((SvixConfig)_value),
+                ConfigType.Sardine => onSardine((SvixConfig)_value),
+                ConfigType.Segment => onSegment((SegmentConfig)_value),
+                ConfigType.Shopify => onShopify((ShopifyConfig)_value),
+                ConfigType.Slack => onSlack((SlackConfig)_value),
+                ConfigType.Stripe => onStripe((StripeConfig)_value),
+                ConfigType.Stych => onStych((SvixConfig)_value),
+                ConfigType.Svix => onSvix((SvixConfig)_value),
+                ConfigType.Zoom => onZoom((ZoomConfig)_value),
+                // unreachable
+                _ => throw new InvalidOperationException("Unknown config type"),
+            };
+        }
+
+        public void Switch(
+            Action onGenericWebhook,
+            Action<CronConfig> onCron,
+            Action<AdobeSignConfig> onAdobeSign,
+            Action<SvixConfig> onBeehiiv,
+            Action<SvixConfig> onBrex,
+            Action<SvixConfig> onClerk,
+            Action<DocusignConfig> onDocusign,
+            Action<GithubConfig> onGithub,
+            Action<SvixConfig> onGuesty,
+            Action<HubspotConfig> onHubspot,
+            Action<SvixConfig> onIncidentIo,
+            Action<SvixConfig> onLithic,
+            Action<SvixConfig> onNash,
+            Action<SvixConfig> onPleo,
+            Action<SvixConfig> onReplicate,
+            Action<SvixConfig> onResend,
+            Action<SvixConfig> onSafebase,
+            Action<SvixConfig> onSardine,
+            Action<SegmentConfig> onSegment,
+            Action<ShopifyConfig> onShopify,
+            Action<SlackConfig> onSlack,
+            Action<StripeConfig> onStripe,
+            Action<SvixConfig> onStych,
+            Action<SvixConfig> onSvix,
+            Action<ZoomConfig> onZoom
+        )
+        {
+            switch (_type)
+            {
+                case ConfigType.GenericWebhook:
+                    onGenericWebhook();
+                    break;
+                case ConfigType.Cron:
+                    onCron((CronConfig)_value);
+                    break;
+                case ConfigType.AdobeSign:
+                    onAdobeSign((AdobeSignConfig)_value);
+                    break;
+                case ConfigType.Beehiiv:
+                    onBeehiiv((SvixConfig)_value);
+                    break;
+                case ConfigType.Brex:
+                    onBrex((SvixConfig)_value);
+                    break;
+                case ConfigType.Clerk:
+                    onClerk((SvixConfig)_value);
+                    break;
+                case ConfigType.Docusign:
+                    onDocusign((DocusignConfig)_value);
+                    break;
+                case ConfigType.Github:
+                    onGithub((GithubConfig)_value);
+                    break;
+                case ConfigType.Guesty:
+                    onGuesty((SvixConfig)_value);
+                    break;
+                case ConfigType.Hubspot:
+                    onHubspot((HubspotConfig)_value);
+                    break;
+                case ConfigType.IncidentIo:
+                    onIncidentIo((SvixConfig)_value);
+                    break;
+                case ConfigType.Lithic:
+                    onLithic((SvixConfig)_value);
+                    break;
+                case ConfigType.Nash:
+                    onNash((SvixConfig)_value);
+                    break;
+                case ConfigType.Pleo:
+                    onPleo((SvixConfig)_value);
+                    break;
+                case ConfigType.Replicate:
+                    onReplicate((SvixConfig)_value);
+                    break;
+                case ConfigType.Resend:
+                    onResend((SvixConfig)_value);
+                    break;
+                case ConfigType.Safebase:
+                    onSafebase((SvixConfig)_value);
+                    break;
+                case ConfigType.Sardine:
+                    onSardine((SvixConfig)_value);
+                    break;
+                case ConfigType.Segment:
+                    onSegment((SegmentConfig)_value);
+                    break;
+                case ConfigType.Shopify:
+                    onShopify((ShopifyConfig)_value);
+                    break;
+                case ConfigType.Slack:
+                    onSlack((SlackConfig)_value);
+                    break;
+                case ConfigType.Stripe:
+                    onStripe((StripeConfig)_value);
+                    break;
+                case ConfigType.Stych:
+                    onStych((SvixConfig)_value);
+                    break;
+                case ConfigType.Svix:
+                    onSvix((SvixConfig)_value);
+                    break;
+                case ConfigType.Zoom:
+                    onZoom((ZoomConfig)_value);
+                    break;
+                default:
+                    // unreachable
+                    throw new InvalidOperationException("Unknown config type");
+            }
+        }
+    }
+
+    internal class IngestSourceInSurrogate
+    {
+        [JsonProperty("name", Required = Required.Always)]
+        public required string Name { get; set; }
+
+        [JsonProperty("uid")]
+        public string? Uid { get; set; } = null;
+
+        [JsonProperty("type", Required = Required.Always)]
+        public required string Type { get; set; }
+
+        [JsonProperty("config", Required = Required.Always)]
+        public required JObject Config { get; set; }
+    }
+
+    public class IngestSourceInConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(IngestSourceIn);
+        }
+
+        public override bool CanWrite
+        {
+            get { return false; }
+        }
+
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+        {
+            // unreachable: CanWrite tells Newtonsoft not to call this method
+            throw new NotImplementedException();
+        }
+
+        public override object ReadJson(
+            JsonReader reader,
+            Type objectType,
+            object? existingValue,
+            JsonSerializer serializer
+        )
+        {
+            var surrogate =
+                serializer.Deserialize<IngestSourceInSurrogate>(reader)
+                ?? throw new JsonSerializationException(
+                    "Failed to deserialize JSON to IngestSourceInSurrogate"
+                );
+            if (
+                !typeMap.TryGetValue(
+                    surrogate.Type,
+                    out Func<(JObject, string), IngestSourceInConfig>? func
+                )
+            )
+            {
+                throw new JsonSerializationException(
+                    $"Unexpected type {surrogate.Type} for IngestSourceInConfig.config"
+                );
+            }
+
+            IngestSourceInConfig config = func((surrogate.Config, surrogate.Type));
+
+            return new IngestSourceIn
+            {
+                Name = surrogate.Name,
+                Uid = surrogate.Uid,
+                Config = config,
+            };
+        }
+
+        private static T ToObj<T>((JObject, string) args)
+        {
+            var loadedObj =
+                args.Item1.ToObject<T>()
+                ?? throw new JsonSerializationException(
+                    $"Failed to deserialize {args.Item2} config"
+                );
+            return loadedObj;
+        }
+
+        private readonly Dictionary<string, Func<(JObject, string), IngestSourceInConfig>> typeMap =
+            new()
+            {
+                ["generic-webhook"] = c => IngestSourceInConfig.GenericWebhook(),
+                ["cron"] = c => IngestSourceInConfig.Cron(ToObj<CronConfig>(c)),
+                ["adobe-sign"] = c => IngestSourceInConfig.AdobeSign(ToObj<AdobeSignConfig>(c)),
+                ["beehiiv"] = c => IngestSourceInConfig.Beehiiv(ToObj<SvixConfig>(c)),
+                ["brex"] = c => IngestSourceInConfig.Brex(ToObj<SvixConfig>(c)),
+                ["clerk"] = c => IngestSourceInConfig.Clerk(ToObj<SvixConfig>(c)),
+                ["docusign"] = c => IngestSourceInConfig.Docusign(ToObj<DocusignConfig>(c)),
+                ["github"] = c => IngestSourceInConfig.Github(ToObj<GithubConfig>(c)),
+                ["guesty"] = c => IngestSourceInConfig.Guesty(ToObj<SvixConfig>(c)),
+                ["hubspot"] = c => IngestSourceInConfig.Hubspot(ToObj<HubspotConfig>(c)),
+                ["incident-io"] = c => IngestSourceInConfig.IncidentIo(ToObj<SvixConfig>(c)),
+                ["lithic"] = c => IngestSourceInConfig.Lithic(ToObj<SvixConfig>(c)),
+                ["nash"] = c => IngestSourceInConfig.Nash(ToObj<SvixConfig>(c)),
+                ["pleo"] = c => IngestSourceInConfig.Pleo(ToObj<SvixConfig>(c)),
+                ["replicate"] = c => IngestSourceInConfig.Replicate(ToObj<SvixConfig>(c)),
+                ["resend"] = c => IngestSourceInConfig.Resend(ToObj<SvixConfig>(c)),
+                ["safebase"] = c => IngestSourceInConfig.Safebase(ToObj<SvixConfig>(c)),
+                ["sardine"] = c => IngestSourceInConfig.Sardine(ToObj<SvixConfig>(c)),
+                ["segment"] = c => IngestSourceInConfig.Segment(ToObj<SegmentConfig>(c)),
+                ["shopify"] = c => IngestSourceInConfig.Shopify(ToObj<ShopifyConfig>(c)),
+                ["slack"] = c => IngestSourceInConfig.Slack(ToObj<SlackConfig>(c)),
+                ["stripe"] = c => IngestSourceInConfig.Stripe(ToObj<StripeConfig>(c)),
+                ["stych"] = c => IngestSourceInConfig.Stych(ToObj<SvixConfig>(c)),
+                ["svix"] = c => IngestSourceInConfig.Svix(ToObj<SvixConfig>(c)),
+                ["zoom"] = c => IngestSourceInConfig.Zoom(ToObj<ZoomConfig>(c)),
+            };
+    }
+}

--- a/csharp/Svix/Models/IngestSourceOut.cs
+++ b/csharp/Svix/Models/IngestSourceOut.cs
@@ -1,0 +1,541 @@
+// this file is @generated
+using System.Runtime.Serialization;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Svix.Models
+{
+    [JsonConverter(typeof(IngestSourceOutConverter))]
+    public class IngestSourceOut
+    {
+        [JsonProperty("createdAt", Required = Required.Always)]
+        public required DateTime CreatedAt { get; set; }
+
+        [JsonProperty("id", Required = Required.Always)]
+        public required string Id { get; set; }
+
+        [JsonProperty("ingestUrl")]
+        public string? IngestUrl { get; set; } = null;
+
+        [JsonProperty("name", Required = Required.Always)]
+        public required string Name { get; set; }
+
+        [JsonProperty("uid")]
+        public string? Uid { get; set; } = null;
+
+        [JsonProperty("updatedAt", Required = Required.Always)]
+        public required DateTime UpdatedAt { get; set; }
+
+        [JsonIgnore]
+        public required IngestSourceOutConfig Config { get; set; }
+
+        [JsonProperty("type")]
+        private string Type => Config.GetDiscriminator();
+
+        [JsonProperty("config")]
+        private object realConfig
+        {
+            get => Config.GetContent();
+            set => Config.SetContent(value);
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class IngestSourceOut {\n");
+            sb.Append("  CreatedAt: ").Append(CreatedAt).Append('\n');
+            sb.Append("  Id: ").Append(Id).Append('\n');
+            sb.Append("  IngestUrl: ").Append(IngestUrl).Append('\n');
+            sb.Append("  Name: ").Append(Name).Append('\n');
+            sb.Append("  Uid: ").Append(Uid).Append('\n');
+            sb.Append("  UpdatedAt: ").Append(UpdatedAt).Append('\n');
+            sb.Append("  Config: ").Append(Config).Append('\n');
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+
+    public class IngestSourceOutConfig
+    {
+        private object _value;
+        private readonly ConfigType _type;
+
+        internal string GetDiscriminator()
+        {
+            var memberInfo = typeof(ConfigType).GetMember(_type.ToString());
+            var enumMember = memberInfo[0]
+                .GetCustomAttributes(false)
+                .OfType<EnumMemberAttribute>()
+                .FirstOrDefault();
+            return enumMember?.Value ?? _type.ToString().ToLower();
+        }
+
+        internal void SetContent(object value)
+        {
+            _value = value;
+        }
+
+        public object GetContent()
+        {
+            return _value;
+        }
+
+        private IngestSourceOutConfig(object value, ConfigType type)
+        {
+            _value = value;
+            _type = type;
+        }
+
+        public static IngestSourceOutConfig GenericWebhook() =>
+            new(new Dictionary<string, string>(), ConfigType.GenericWebhook);
+
+        public static IngestSourceOutConfig Cron(CronConfig cronConfig) =>
+            new(cronConfig, ConfigType.Cron);
+
+        public static IngestSourceOutConfig AdobeSign(AdobeSignConfigOut adobeSignConfigOut) =>
+            new(adobeSignConfigOut, ConfigType.AdobeSign);
+
+        public static IngestSourceOutConfig Beehiiv(SvixConfigOut svixConfigOut) =>
+            new(svixConfigOut, ConfigType.Beehiiv);
+
+        public static IngestSourceOutConfig Brex(SvixConfigOut svixConfigOut) =>
+            new(svixConfigOut, ConfigType.Brex);
+
+        public static IngestSourceOutConfig Clerk(SvixConfigOut svixConfigOut) =>
+            new(svixConfigOut, ConfigType.Clerk);
+
+        public static IngestSourceOutConfig Docusign(DocusignConfigOut docusignConfigOut) =>
+            new(docusignConfigOut, ConfigType.Docusign);
+
+        public static IngestSourceOutConfig Github(GithubConfigOut githubConfigOut) =>
+            new(githubConfigOut, ConfigType.Github);
+
+        public static IngestSourceOutConfig Guesty(SvixConfigOut svixConfigOut) =>
+            new(svixConfigOut, ConfigType.Guesty);
+
+        public static IngestSourceOutConfig Hubspot(HubspotConfigOut hubspotConfigOut) =>
+            new(hubspotConfigOut, ConfigType.Hubspot);
+
+        public static IngestSourceOutConfig IncidentIo(SvixConfigOut svixConfigOut) =>
+            new(svixConfigOut, ConfigType.IncidentIo);
+
+        public static IngestSourceOutConfig Lithic(SvixConfigOut svixConfigOut) =>
+            new(svixConfigOut, ConfigType.Lithic);
+
+        public static IngestSourceOutConfig Nash(SvixConfigOut svixConfigOut) =>
+            new(svixConfigOut, ConfigType.Nash);
+
+        public static IngestSourceOutConfig Pleo(SvixConfigOut svixConfigOut) =>
+            new(svixConfigOut, ConfigType.Pleo);
+
+        public static IngestSourceOutConfig Replicate(SvixConfigOut svixConfigOut) =>
+            new(svixConfigOut, ConfigType.Replicate);
+
+        public static IngestSourceOutConfig Resend(SvixConfigOut svixConfigOut) =>
+            new(svixConfigOut, ConfigType.Resend);
+
+        public static IngestSourceOutConfig Safebase(SvixConfigOut svixConfigOut) =>
+            new(svixConfigOut, ConfigType.Safebase);
+
+        public static IngestSourceOutConfig Sardine(SvixConfigOut svixConfigOut) =>
+            new(svixConfigOut, ConfigType.Sardine);
+
+        public static IngestSourceOutConfig Segment(SegmentConfigOut segmentConfigOut) =>
+            new(segmentConfigOut, ConfigType.Segment);
+
+        public static IngestSourceOutConfig Shopify(ShopifyConfigOut shopifyConfigOut) =>
+            new(shopifyConfigOut, ConfigType.Shopify);
+
+        public static IngestSourceOutConfig Slack(SlackConfigOut slackConfigOut) =>
+            new(slackConfigOut, ConfigType.Slack);
+
+        public static IngestSourceOutConfig Stripe(StripeConfigOut stripeConfigOut) =>
+            new(stripeConfigOut, ConfigType.Stripe);
+
+        public static IngestSourceOutConfig Stych(SvixConfigOut svixConfigOut) =>
+            new(svixConfigOut, ConfigType.Stych);
+
+        public static IngestSourceOutConfig Svix(SvixConfigOut svixConfigOut) =>
+            new(svixConfigOut, ConfigType.Svix);
+
+        public static IngestSourceOutConfig Zoom(ZoomConfigOut zoomConfigOut) =>
+            new(zoomConfigOut, ConfigType.Zoom);
+
+        private enum ConfigType
+        {
+            [EnumMember(Value = "generic-webhook")]
+            GenericWebhook,
+
+            [EnumMember(Value = "cron")]
+            Cron,
+
+            [EnumMember(Value = "adobe-sign")]
+            AdobeSign,
+
+            [EnumMember(Value = "beehiiv")]
+            Beehiiv,
+
+            [EnumMember(Value = "brex")]
+            Brex,
+
+            [EnumMember(Value = "clerk")]
+            Clerk,
+
+            [EnumMember(Value = "docusign")]
+            Docusign,
+
+            [EnumMember(Value = "github")]
+            Github,
+
+            [EnumMember(Value = "guesty")]
+            Guesty,
+
+            [EnumMember(Value = "hubspot")]
+            Hubspot,
+
+            [EnumMember(Value = "incident-io")]
+            IncidentIo,
+
+            [EnumMember(Value = "lithic")]
+            Lithic,
+
+            [EnumMember(Value = "nash")]
+            Nash,
+
+            [EnumMember(Value = "pleo")]
+            Pleo,
+
+            [EnumMember(Value = "replicate")]
+            Replicate,
+
+            [EnumMember(Value = "resend")]
+            Resend,
+
+            [EnumMember(Value = "safebase")]
+            Safebase,
+
+            [EnumMember(Value = "sardine")]
+            Sardine,
+
+            [EnumMember(Value = "segment")]
+            Segment,
+
+            [EnumMember(Value = "shopify")]
+            Shopify,
+
+            [EnumMember(Value = "slack")]
+            Slack,
+
+            [EnumMember(Value = "stripe")]
+            Stripe,
+
+            [EnumMember(Value = "stych")]
+            Stych,
+
+            [EnumMember(Value = "svix")]
+            Svix,
+
+            [EnumMember(Value = "zoom")]
+            Zoom,
+        }
+
+        public TResult Match<TResult>(
+            Func<TResult> onGenericWebhook,
+            Func<CronConfig, TResult> onCron,
+            Func<AdobeSignConfigOut, TResult> onAdobeSign,
+            Func<SvixConfigOut, TResult> onBeehiiv,
+            Func<SvixConfigOut, TResult> onBrex,
+            Func<SvixConfigOut, TResult> onClerk,
+            Func<DocusignConfigOut, TResult> onDocusign,
+            Func<GithubConfigOut, TResult> onGithub,
+            Func<SvixConfigOut, TResult> onGuesty,
+            Func<HubspotConfigOut, TResult> onHubspot,
+            Func<SvixConfigOut, TResult> onIncidentIo,
+            Func<SvixConfigOut, TResult> onLithic,
+            Func<SvixConfigOut, TResult> onNash,
+            Func<SvixConfigOut, TResult> onPleo,
+            Func<SvixConfigOut, TResult> onReplicate,
+            Func<SvixConfigOut, TResult> onResend,
+            Func<SvixConfigOut, TResult> onSafebase,
+            Func<SvixConfigOut, TResult> onSardine,
+            Func<SegmentConfigOut, TResult> onSegment,
+            Func<ShopifyConfigOut, TResult> onShopify,
+            Func<SlackConfigOut, TResult> onSlack,
+            Func<StripeConfigOut, TResult> onStripe,
+            Func<SvixConfigOut, TResult> onStych,
+            Func<SvixConfigOut, TResult> onSvix,
+            Func<ZoomConfigOut, TResult> onZoom
+        )
+        {
+            return _type switch
+            {
+                ConfigType.GenericWebhook => onGenericWebhook(),
+                ConfigType.Cron => onCron((CronConfig)_value),
+                ConfigType.AdobeSign => onAdobeSign((AdobeSignConfigOut)_value),
+                ConfigType.Beehiiv => onBeehiiv((SvixConfigOut)_value),
+                ConfigType.Brex => onBrex((SvixConfigOut)_value),
+                ConfigType.Clerk => onClerk((SvixConfigOut)_value),
+                ConfigType.Docusign => onDocusign((DocusignConfigOut)_value),
+                ConfigType.Github => onGithub((GithubConfigOut)_value),
+                ConfigType.Guesty => onGuesty((SvixConfigOut)_value),
+                ConfigType.Hubspot => onHubspot((HubspotConfigOut)_value),
+                ConfigType.IncidentIo => onIncidentIo((SvixConfigOut)_value),
+                ConfigType.Lithic => onLithic((SvixConfigOut)_value),
+                ConfigType.Nash => onNash((SvixConfigOut)_value),
+                ConfigType.Pleo => onPleo((SvixConfigOut)_value),
+                ConfigType.Replicate => onReplicate((SvixConfigOut)_value),
+                ConfigType.Resend => onResend((SvixConfigOut)_value),
+                ConfigType.Safebase => onSafebase((SvixConfigOut)_value),
+                ConfigType.Sardine => onSardine((SvixConfigOut)_value),
+                ConfigType.Segment => onSegment((SegmentConfigOut)_value),
+                ConfigType.Shopify => onShopify((ShopifyConfigOut)_value),
+                ConfigType.Slack => onSlack((SlackConfigOut)_value),
+                ConfigType.Stripe => onStripe((StripeConfigOut)_value),
+                ConfigType.Stych => onStych((SvixConfigOut)_value),
+                ConfigType.Svix => onSvix((SvixConfigOut)_value),
+                ConfigType.Zoom => onZoom((ZoomConfigOut)_value),
+                // unreachable
+                _ => throw new InvalidOperationException("Unknown config type"),
+            };
+        }
+
+        public void Switch(
+            Action onGenericWebhook,
+            Action<CronConfig> onCron,
+            Action<AdobeSignConfigOut> onAdobeSign,
+            Action<SvixConfigOut> onBeehiiv,
+            Action<SvixConfigOut> onBrex,
+            Action<SvixConfigOut> onClerk,
+            Action<DocusignConfigOut> onDocusign,
+            Action<GithubConfigOut> onGithub,
+            Action<SvixConfigOut> onGuesty,
+            Action<HubspotConfigOut> onHubspot,
+            Action<SvixConfigOut> onIncidentIo,
+            Action<SvixConfigOut> onLithic,
+            Action<SvixConfigOut> onNash,
+            Action<SvixConfigOut> onPleo,
+            Action<SvixConfigOut> onReplicate,
+            Action<SvixConfigOut> onResend,
+            Action<SvixConfigOut> onSafebase,
+            Action<SvixConfigOut> onSardine,
+            Action<SegmentConfigOut> onSegment,
+            Action<ShopifyConfigOut> onShopify,
+            Action<SlackConfigOut> onSlack,
+            Action<StripeConfigOut> onStripe,
+            Action<SvixConfigOut> onStych,
+            Action<SvixConfigOut> onSvix,
+            Action<ZoomConfigOut> onZoom
+        )
+        {
+            switch (_type)
+            {
+                case ConfigType.GenericWebhook:
+                    onGenericWebhook();
+                    break;
+                case ConfigType.Cron:
+                    onCron((CronConfig)_value);
+                    break;
+                case ConfigType.AdobeSign:
+                    onAdobeSign((AdobeSignConfigOut)_value);
+                    break;
+                case ConfigType.Beehiiv:
+                    onBeehiiv((SvixConfigOut)_value);
+                    break;
+                case ConfigType.Brex:
+                    onBrex((SvixConfigOut)_value);
+                    break;
+                case ConfigType.Clerk:
+                    onClerk((SvixConfigOut)_value);
+                    break;
+                case ConfigType.Docusign:
+                    onDocusign((DocusignConfigOut)_value);
+                    break;
+                case ConfigType.Github:
+                    onGithub((GithubConfigOut)_value);
+                    break;
+                case ConfigType.Guesty:
+                    onGuesty((SvixConfigOut)_value);
+                    break;
+                case ConfigType.Hubspot:
+                    onHubspot((HubspotConfigOut)_value);
+                    break;
+                case ConfigType.IncidentIo:
+                    onIncidentIo((SvixConfigOut)_value);
+                    break;
+                case ConfigType.Lithic:
+                    onLithic((SvixConfigOut)_value);
+                    break;
+                case ConfigType.Nash:
+                    onNash((SvixConfigOut)_value);
+                    break;
+                case ConfigType.Pleo:
+                    onPleo((SvixConfigOut)_value);
+                    break;
+                case ConfigType.Replicate:
+                    onReplicate((SvixConfigOut)_value);
+                    break;
+                case ConfigType.Resend:
+                    onResend((SvixConfigOut)_value);
+                    break;
+                case ConfigType.Safebase:
+                    onSafebase((SvixConfigOut)_value);
+                    break;
+                case ConfigType.Sardine:
+                    onSardine((SvixConfigOut)_value);
+                    break;
+                case ConfigType.Segment:
+                    onSegment((SegmentConfigOut)_value);
+                    break;
+                case ConfigType.Shopify:
+                    onShopify((ShopifyConfigOut)_value);
+                    break;
+                case ConfigType.Slack:
+                    onSlack((SlackConfigOut)_value);
+                    break;
+                case ConfigType.Stripe:
+                    onStripe((StripeConfigOut)_value);
+                    break;
+                case ConfigType.Stych:
+                    onStych((SvixConfigOut)_value);
+                    break;
+                case ConfigType.Svix:
+                    onSvix((SvixConfigOut)_value);
+                    break;
+                case ConfigType.Zoom:
+                    onZoom((ZoomConfigOut)_value);
+                    break;
+                default:
+                    // unreachable
+                    throw new InvalidOperationException("Unknown config type");
+            }
+        }
+    }
+
+    internal class IngestSourceOutSurrogate
+    {
+        [JsonProperty("createdAt", Required = Required.Always)]
+        public required DateTime CreatedAt { get; set; }
+
+        [JsonProperty("id", Required = Required.Always)]
+        public required string Id { get; set; }
+
+        [JsonProperty("ingestUrl")]
+        public string? IngestUrl { get; set; } = null;
+
+        [JsonProperty("name", Required = Required.Always)]
+        public required string Name { get; set; }
+
+        [JsonProperty("uid")]
+        public string? Uid { get; set; } = null;
+
+        [JsonProperty("updatedAt", Required = Required.Always)]
+        public required DateTime UpdatedAt { get; set; }
+
+        [JsonProperty("type", Required = Required.Always)]
+        public required string Type { get; set; }
+
+        [JsonProperty("config", Required = Required.Always)]
+        public required JObject Config { get; set; }
+    }
+
+    public class IngestSourceOutConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(IngestSourceOut);
+        }
+
+        public override bool CanWrite
+        {
+            get { return false; }
+        }
+
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+        {
+            // unreachable: CanWrite tells Newtonsoft not to call this method
+            throw new NotImplementedException();
+        }
+
+        public override object ReadJson(
+            JsonReader reader,
+            Type objectType,
+            object? existingValue,
+            JsonSerializer serializer
+        )
+        {
+            var surrogate =
+                serializer.Deserialize<IngestSourceOutSurrogate>(reader)
+                ?? throw new JsonSerializationException(
+                    "Failed to deserialize JSON to IngestSourceOutSurrogate"
+                );
+            if (
+                !typeMap.TryGetValue(
+                    surrogate.Type,
+                    out Func<(JObject, string), IngestSourceOutConfig>? func
+                )
+            )
+            {
+                throw new JsonSerializationException(
+                    $"Unexpected type {surrogate.Type} for IngestSourceOutConfig.config"
+                );
+            }
+
+            IngestSourceOutConfig config = func((surrogate.Config, surrogate.Type));
+
+            return new IngestSourceOut
+            {
+                CreatedAt = surrogate.CreatedAt,
+                Id = surrogate.Id,
+                IngestUrl = surrogate.IngestUrl,
+                Name = surrogate.Name,
+                Uid = surrogate.Uid,
+                UpdatedAt = surrogate.UpdatedAt,
+                Config = config,
+            };
+        }
+
+        private static T ToObj<T>((JObject, string) args)
+        {
+            var loadedObj =
+                args.Item1.ToObject<T>()
+                ?? throw new JsonSerializationException(
+                    $"Failed to deserialize {args.Item2} config"
+                );
+            return loadedObj;
+        }
+
+        private readonly Dictionary<
+            string,
+            Func<(JObject, string), IngestSourceOutConfig>
+        > typeMap = new()
+        {
+            ["generic-webhook"] = c => IngestSourceOutConfig.GenericWebhook(),
+            ["cron"] = c => IngestSourceOutConfig.Cron(ToObj<CronConfig>(c)),
+            ["adobe-sign"] = c => IngestSourceOutConfig.AdobeSign(ToObj<AdobeSignConfigOut>(c)),
+            ["beehiiv"] = c => IngestSourceOutConfig.Beehiiv(ToObj<SvixConfigOut>(c)),
+            ["brex"] = c => IngestSourceOutConfig.Brex(ToObj<SvixConfigOut>(c)),
+            ["clerk"] = c => IngestSourceOutConfig.Clerk(ToObj<SvixConfigOut>(c)),
+            ["docusign"] = c => IngestSourceOutConfig.Docusign(ToObj<DocusignConfigOut>(c)),
+            ["github"] = c => IngestSourceOutConfig.Github(ToObj<GithubConfigOut>(c)),
+            ["guesty"] = c => IngestSourceOutConfig.Guesty(ToObj<SvixConfigOut>(c)),
+            ["hubspot"] = c => IngestSourceOutConfig.Hubspot(ToObj<HubspotConfigOut>(c)),
+            ["incident-io"] = c => IngestSourceOutConfig.IncidentIo(ToObj<SvixConfigOut>(c)),
+            ["lithic"] = c => IngestSourceOutConfig.Lithic(ToObj<SvixConfigOut>(c)),
+            ["nash"] = c => IngestSourceOutConfig.Nash(ToObj<SvixConfigOut>(c)),
+            ["pleo"] = c => IngestSourceOutConfig.Pleo(ToObj<SvixConfigOut>(c)),
+            ["replicate"] = c => IngestSourceOutConfig.Replicate(ToObj<SvixConfigOut>(c)),
+            ["resend"] = c => IngestSourceOutConfig.Resend(ToObj<SvixConfigOut>(c)),
+            ["safebase"] = c => IngestSourceOutConfig.Safebase(ToObj<SvixConfigOut>(c)),
+            ["sardine"] = c => IngestSourceOutConfig.Sardine(ToObj<SvixConfigOut>(c)),
+            ["segment"] = c => IngestSourceOutConfig.Segment(ToObj<SegmentConfigOut>(c)),
+            ["shopify"] = c => IngestSourceOutConfig.Shopify(ToObj<ShopifyConfigOut>(c)),
+            ["slack"] = c => IngestSourceOutConfig.Slack(ToObj<SlackConfigOut>(c)),
+            ["stripe"] = c => IngestSourceOutConfig.Stripe(ToObj<StripeConfigOut>(c)),
+            ["stych"] = c => IngestSourceOutConfig.Stych(ToObj<SvixConfigOut>(c)),
+            ["svix"] = c => IngestSourceOutConfig.Svix(ToObj<SvixConfigOut>(c)),
+            ["zoom"] = c => IngestSourceOutConfig.Zoom(ToObj<ZoomConfigOut>(c)),
+        };
+    }
+}

--- a/csharp/Svix/Models/ListResponseIngestSourceOut.cs
+++ b/csharp/Svix/Models/ListResponseIngestSourceOut.cs
@@ -1,0 +1,34 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class ListResponseIngestSourceOut
+    {
+        [JsonProperty("data", Required = Required.Always)]
+        public required List<IngestSourceOut> Data { get; set; }
+
+        [JsonProperty("done", Required = Required.Always)]
+        public required bool Done { get; set; }
+
+        [JsonProperty("iterator")]
+        public string? Iterator { get; set; } = null;
+
+        [JsonProperty("prevIterator")]
+        public string? PrevIterator { get; set; } = null;
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class ListResponseIngestSourceOut {\n");
+            sb.Append("  Data: ").Append(Data).Append('\n');
+            sb.Append("  Done: ").Append(Done).Append('\n');
+            sb.Append("  Iterator: ").Append(Iterator).Append('\n');
+            sb.Append("  PrevIterator: ").Append(PrevIterator).Append('\n');
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/Svix/Models/RotateTokenOut.cs
+++ b/csharp/Svix/Models/RotateTokenOut.cs
@@ -1,0 +1,22 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class RotateTokenOut
+    {
+        [JsonProperty("ingestUrl", Required = Required.Always)]
+        public required string IngestUrl { get; set; }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class RotateTokenOut {\n");
+            sb.Append("  IngestUrl: ").Append(IngestUrl).Append('\n');
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/Svix/Models/SegmentConfig.cs
+++ b/csharp/Svix/Models/SegmentConfig.cs
@@ -1,0 +1,22 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class SegmentConfig
+    {
+        [JsonProperty("secret")]
+        public string? Secret { get; set; } = null;
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class SegmentConfig {\n");
+            sb.Append("  Secret: ").Append(Secret).Append('\n');
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/Svix/Models/SegmentConfigOut.cs
+++ b/csharp/Svix/Models/SegmentConfigOut.cs
@@ -1,0 +1,18 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class SegmentConfigOut
+    {
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class SegmentConfigOut {\n");
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/Svix/Models/ShopifyConfig.cs
+++ b/csharp/Svix/Models/ShopifyConfig.cs
@@ -1,0 +1,22 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class ShopifyConfig
+    {
+        [JsonProperty("secret", Required = Required.Always)]
+        public required string Secret { get; set; }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class ShopifyConfig {\n");
+            sb.Append("  Secret: ").Append(Secret).Append('\n');
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/Svix/Models/ShopifyConfigOut.cs
+++ b/csharp/Svix/Models/ShopifyConfigOut.cs
@@ -1,0 +1,18 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class ShopifyConfigOut
+    {
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class ShopifyConfigOut {\n");
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/Svix/Models/SlackConfig.cs
+++ b/csharp/Svix/Models/SlackConfig.cs
@@ -1,0 +1,22 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class SlackConfig
+    {
+        [JsonProperty("secret", Required = Required.Always)]
+        public required string Secret { get; set; }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class SlackConfig {\n");
+            sb.Append("  Secret: ").Append(Secret).Append('\n');
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/Svix/Models/SlackConfigOut.cs
+++ b/csharp/Svix/Models/SlackConfigOut.cs
@@ -1,0 +1,18 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class SlackConfigOut
+    {
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class SlackConfigOut {\n");
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/Svix/Models/StripeConfig.cs
+++ b/csharp/Svix/Models/StripeConfig.cs
@@ -1,0 +1,22 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class StripeConfig
+    {
+        [JsonProperty("secret", Required = Required.Always)]
+        public required string Secret { get; set; }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class StripeConfig {\n");
+            sb.Append("  Secret: ").Append(Secret).Append('\n');
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/Svix/Models/StripeConfigOut.cs
+++ b/csharp/Svix/Models/StripeConfigOut.cs
@@ -1,0 +1,18 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class StripeConfigOut
+    {
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class StripeConfigOut {\n");
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/Svix/Models/SvixConfig.cs
+++ b/csharp/Svix/Models/SvixConfig.cs
@@ -1,0 +1,22 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class SvixConfig
+    {
+        [JsonProperty("secret", Required = Required.Always)]
+        public required string Secret { get; set; }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class SvixConfig {\n");
+            sb.Append("  Secret: ").Append(Secret).Append('\n');
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/Svix/Models/SvixConfigOut.cs
+++ b/csharp/Svix/Models/SvixConfigOut.cs
@@ -1,0 +1,18 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class SvixConfigOut
+    {
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class SvixConfigOut {\n");
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/Svix/Models/ZoomConfig.cs
+++ b/csharp/Svix/Models/ZoomConfig.cs
@@ -1,0 +1,22 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class ZoomConfig
+    {
+        [JsonProperty("secret", Required = Required.Always)]
+        public required string Secret { get; set; }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class ZoomConfig {\n");
+            sb.Append("  Secret: ").Append(Secret).Append('\n');
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/Svix/Models/ZoomConfigOut.cs
+++ b/csharp/Svix/Models/ZoomConfigOut.cs
@@ -1,0 +1,18 @@
+// this file is @generated
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Svix.Models
+{
+    public class ZoomConfigOut
+    {
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class ZoomConfigOut {\n");
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/csharp/templates/component_type.cs.jinja
+++ b/csharp/templates/component_type.cs.jinja
@@ -4,4 +4,6 @@
     {% include "types/string_enum.cs.jinja" %}
 {%- elif type.kind == "integer_enum" -%}
     {%- include "types/integer_enum.cs.jinja" -%}
+{%- elif type.kind == "struct_enum" -%}
+    {%- include "types/struct_enum.cs.jinja" -%}
 {%- endif %}

--- a/csharp/templates/types/struct.cs.jinja
+++ b/csharp/templates/types/struct.cs.jinja
@@ -10,31 +10,7 @@ namespace Svix.Models {
     {% endif %}
     public class {{ type.name | to_upper_camel_case }}
     {
-        {%- for field in type.fields %}
-        {%- set is_patch = type.name is endingwith "Patch" %}
-        [JsonProperty("{{ field.name }}"{% if field.required and not field.nullable %},Required = Required.Always{% endif %})]
-        {%- set f_ty = field.type.to_csharp() %}
-        {%- set modifier = "public"%}
-        {%- if field.nullable or not field.required %}
-            {%- set f_ty %}{{ f_ty }}?{% endset %}
-            {%- set f_val = "= null;" %}
-        {%- else %}
-            {%- set modifier %}{{ modifier }} required{% endset %}
-            {%- set f_val = "" %}
-        {%- endif %}
-        {%- if is_patch and field.nullable %}
-            {%- set f_ty %}MaybeUnset<{{ f_ty }}>{% endset %}
-            {%- set f_val %}= {{ f_ty }}.Unset();{% endset %}
-        {% endif %}
-        {{ modifier }} {{ f_ty }} {{ field.name | to_upper_camel_case }} { get; set; } {{ f_val }}
-        {%- if is_patch and field.nullable %}
-        public bool ShouldSerialize{{ field.name | to_upper_camel_case }}() => !{{ field.name | to_upper_camel_case }}.IsUnset;
-        {%- elif is_patch and not field.nullable %}
-        public bool ShouldSerialize{{ field.name | to_upper_camel_case }}() => {{ field.name | to_upper_camel_case }} != null;
-        {%- endif %}
-        {%- endfor %}
-
-
+        {% include "types/struct_fields.cs.jinja" %}
         public override string ToString(){
             StringBuilder sb = new StringBuilder();
 

--- a/csharp/templates/types/struct_enum.cs.jinja
+++ b/csharp/templates/types/struct_enum.cs.jinja
@@ -1,0 +1,224 @@
+{% set type_name = type.name | to_upper_camel_case -%}
+{% set enum_type_name %}{{ type_name }}Config{% endset -%}
+{% set discriminator_field_name = type.discriminator_field | to_upper_camel_case -%}
+{% set content_field_name = type.content_field | to_upper_camel_case -%}
+// this file is @generated
+using System.Runtime.Serialization;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Svix.Models {
+    {%- if type.description is defined %}
+    /// <summary>
+    {{ type.description | to_doc_comment(style="csharp") | indent(4) }}
+    /// <summary>
+    {% endif %}
+    [JsonConverter(typeof({{ type_name }}Converter))]
+    public class {{ type_name }}
+    {
+        {% include "types/struct_fields.cs.jinja" %}
+        [JsonIgnore]
+        public required {{ enum_type_name }} {{ content_field_name }} { get; set; }
+
+        [JsonProperty("{{ type.discriminator_field }}")]
+        private string {{ discriminator_field_name }} => Config.GetDiscriminator();
+
+        [JsonProperty("{{ type.content_field  }}")]
+        private object real{{ content_field_name }} { get => Config.GetContent(); set => Config.SetContent(value); }
+
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append("class {{ type_name }} {\n");
+            {% for f in type.fields -%}
+            sb.Append("  {{ f.name | to_upper_camel_case }}: ").Append({{ f.name | to_upper_camel_case }}).Append('\n');
+            {% endfor -%}
+            sb.Append("  {{ content_field_name }}: ").Append({{ content_field_name }}).Append('\n');
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+
+    }
+
+
+
+
+    public class {{ enum_type_name }}
+    {
+        private object _value;
+        private readonly {{ content_field_name }}Type _type;
+
+        internal string GetDiscriminator()
+        {
+            var memberInfo = typeof({{ content_field_name }}Type).GetMember(_type.ToString());
+            var enumMember = memberInfo[0].GetCustomAttributes(false)
+                .OfType<EnumMemberAttribute>()
+                .FirstOrDefault();
+            return enumMember?.Value ?? _type.ToString().ToLower();
+        }
+
+        internal void SetContent(object value)
+        {
+            _value = value;
+        }
+
+        public object GetContent()
+        {
+            return _value;
+        }
+
+        private {{ enum_type_name }}(object value, {{ content_field_name }}Type type)
+        {
+            _value = value;
+            _type = type;
+        }
+
+        {% for v in type.variants -%}
+        public static {{ enum_type_name }} {{ v.name | to_upper_camel_case }}(
+            {%- if v.schema_ref is defined -%}
+                {{ v.schema_ref | to_upper_camel_case }} {{ v.schema_ref | to_lower_camel_case }}
+            {%- endif -%}
+        ) =>
+            new(
+                {% if v.schema_ref is defined -%}
+                {{ v.schema_ref | to_lower_camel_case }},
+                {% else -%}
+                new Dictionary<string, string>(),
+                {% endif -%}
+                {{ content_field_name }}Type.{{ v.name | to_upper_camel_case }}
+            );
+        {% endfor -%}
+
+        private enum {{ content_field_name }}Type
+        {
+            {% for v in type.variants -%}
+            [EnumMember(Value = "{{ v.name }}")]
+            {{ v.name | to_upper_camel_case }},
+            {% endfor -%}
+        }
+
+        public TResult Match<TResult>(
+            {% set func_args -%}
+                {%- for v in type.variants -%}
+                    {%- if v.schema_ref is defined -%}
+                    Func<{{ v.schema_ref | to_upper_camel_case }},TResult> on{{ v.name | to_upper_camel_case }},
+                    {%- else -%}
+                    Func<TResult> on{{ v.name | to_upper_camel_case }},
+                    {%- endif -%}
+                {%- endfor -%}
+            {% endset -%}
+            {{ func_args | strip_trailing_comma }}
+        )
+        {
+            return _type switch
+            {
+                {% for v in type.variants -%}
+                    {{ content_field_name }}Type.{{ v.name | to_upper_camel_case }} => on{{ v.name | to_upper_camel_case }}(
+                        {%- if v.schema_ref is defined -%}
+                        ({{ v.schema_ref | to_upper_camel_case }})_value
+                        {%- endif -%}
+                    ),
+                {% endfor -%}
+                // unreachable
+                _ => throw new InvalidOperationException("Unknown config type")
+            };
+
+        }
+        public void Switch(
+            {% set func_args -%}
+                {%- for v in type.variants -%}
+                    {%- if v.schema_ref is defined -%}
+                    Action<{{ v.schema_ref | to_upper_camel_case }}> on{{ v.name | to_upper_camel_case }},
+                    {%- else -%}
+                    Action on{{ v.name | to_upper_camel_case }},
+                    {%- endif -%}
+                {%- endfor -%}
+            {% endset -%}
+            {{ func_args | strip_trailing_comma }}
+        )
+        {
+            switch (_type)
+            {
+                {% for v in type.variants -%}
+                case {{ content_field_name }}Type.{{ v.name | to_upper_camel_case }}:
+                    on{{ v.name | to_upper_camel_case }}(
+                        {%- if v.schema_ref is defined -%}
+                        ({{ v.schema_ref | to_upper_camel_case }})_value
+                        {%- endif -%}
+                    );
+                    break;
+                {% endfor -%}
+                default:
+                    // unreachable
+                    throw new InvalidOperationException("Unknown config type");
+            }
+
+        }
+
+    }
+
+    internal class {{ type_name }}Surrogate
+    {
+        {% include "types/struct_fields.cs.jinja" %}
+        [JsonProperty("{{ type.discriminator_field }}", Required = Required.Always)]
+        public required string {{ discriminator_field_name }} { get; set; }
+
+        [JsonProperty("{{ type.content_field }}", Required = Required.Always)]
+        public required JObject {{ content_field_name }} { get; set; }
+
+    }
+
+    public class {{ type_name }}Converter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof({{ type_name }});
+        }
+        public override bool CanWrite { get { return false; } }
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+        {
+            // unreachable: CanWrite tells Newtonsoft not to call this method
+            throw new NotImplementedException();
+        }
+
+
+        public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+        {
+
+            var surrogate = serializer.Deserialize<{{ type_name }}Surrogate>(reader) ?? throw new JsonSerializationException("Failed to deserialize JSON to {{ type_name }}Surrogate");
+            if (!typeMap.TryGetValue(surrogate.Type, out Func<(JObject, string), {{ enum_type_name }}>? func))
+            {
+                throw new JsonSerializationException($"Unexpected type {surrogate.Type} for {{ enum_type_name }}.config");
+            }
+
+            {{ enum_type_name }} config = func((surrogate.Config,surrogate.Type));
+
+            return new {{ type_name }}
+            {
+                {% for f in type.fields -%}
+                {{ f.name | to_upper_camel_case }} = surrogate.{{ f.name | to_upper_camel_case }},
+                {% endfor -%}
+                Config = config
+            };
+        }
+
+        static private T ToObj<T>((JObject, string) args)
+        {
+            var loadedObj = args.Item1.ToObject<T>() ?? throw new JsonSerializationException($"Failed to deserialize {args.Item2} config");
+            return loadedObj;
+        }
+        private readonly Dictionary<string, Func<(JObject, string), {{ enum_type_name }}>> typeMap = new()
+        {
+            {% for v in type.variants -%}
+            ["{{ v.name }}"] = c => {{ enum_type_name }}.{{ v.name | to_upper_camel_case }}(
+                {%- if v.schema_ref is defined -%}
+                ToObj<{{ v.schema_ref | to_upper_camel_case }}>(c)
+                {%- endif -%}
+            ),
+            {% endfor -%}
+        };
+    }
+}

--- a/csharp/templates/types/struct_fields.cs.jinja
+++ b/csharp/templates/types/struct_fields.cs.jinja
@@ -1,0 +1,23 @@
+{% for field in type.fields -%}
+    {% set is_patch = type.name is endingwith "Patch" -%}
+    [JsonProperty("{{ field.name }}"{% if field.required and not field.nullable %},Required = Required.Always{% endif %})]
+    {% set f_ty = field.type.to_csharp() -%}
+    {% set modifier = "public"-%}
+    {% if field.nullable or not field.required -%}
+        {% set f_ty %}{{ f_ty }}?{% endset -%}
+        {% set f_val = "= null;" -%}
+    {% else -%}
+        {% set modifier %}{{ modifier }} required{% endset -%}
+        {% set f_val = "" -%}
+    {% endif -%}
+    {% if is_patch and field.nullable -%}
+        {% set f_ty %}MaybeUnset<{{ f_ty }}>{% endset -%}
+        {% set f_val %}= {{ f_ty }}.Unset();{% endset -%}
+    {% endif -%}
+    {{ modifier }} {{ f_ty }} {{ field.name | to_upper_camel_case }} { get; set; } {{ f_val }}
+    {% if is_patch and field.nullable -%}
+    public bool ShouldSerialize{{ field.name | to_upper_camel_case }}() => !{{ field.name | to_upper_camel_case }}.IsUnset;
+    {% elif is_patch and not field.nullable -%}
+    public bool ShouldSerialize{{ field.name | to_upper_camel_case }}() => {{ field.name | to_upper_camel_case }} != null;
+    {% endif -%}
+{% endfor -%}


### PR DESCRIPTION
API looks like this
```csharp
var sourceIn = new IngestSourceIn
{
    Name = "me",
    Uid = "test",
    Config = IngestSourceInConfig.Cron(
        new CronConfig { Payload = "asd", Schedule = "asd" }
    ),
};

// without any fields
var sourceIn = new IngestSourceIn
{
    Name = "me",
    Uid = "test",
    Config = IngestSourceInConfig.GenericWebhook(),
};

// read a field
if (sourceIn.Config.GetContent().GetType() == typeof(CronConfig)){
    Console.WriteLine((CronConfig)loadedFromJson.Config.GetContent()).Schedule);
}
```