### PR TITLE
Enable codegen for svix-cli

### DIFF
--- a/codegen.toml
+++ b/codegen.toml
@@ -30,17 +30,17 @@ output_dir = "rust/src/models"
 #output_dir = "javascript/src/models"
 #
 #
-#[cli]
-#template_dir = "svix-cli/templates"
-#extra_mounts = { "svix-cli/.rustfmt.toml" = "/app/.rustfmt.toml" }
-#extra_shell_commands = [
-#    "cargo fix --manifest-path svix-cli/Cargo.toml --allow-dirty",
-#    "cargo fmt --manifest-path svix-cli/Cargo.toml",
-#    "rm svix-cli/src/cmds/api/{ingest,operational_webhook,background_task,environment,health,operational_webhook_endpoint,statistics}.rs",
-#]
-#[[cli.task]]
-#template = "svix-cli/templates/api_resource.rs.jinja"
-#output_dir = "svix-cli/src/cmds/api"
+[cli]
+template_dir = "svix-cli/templates"
+extra_mounts = { "svix-cli/.rustfmt.toml" = "/app/.rustfmt.toml" }
+extra_shell_commands = [
+   "cargo fix --manifest-path svix-cli/Cargo.toml --allow-dirty",
+   "cargo fmt --manifest-path svix-cli/Cargo.toml",
+   "rm svix-cli/src/cmds/api/{ingest,ingest_source,operational_webhook,background_task,environment,health,operational_webhook_endpoint,statistics}.rs",
+]
+[[cli.task]]
+template = "svix-cli/templates/api_resource.rs.jinja"
+output_dir = "svix-cli/src/cmds/api"
 #
 #
 #[python]


### PR DESCRIPTION
Does not affect anything
https://github.com/svix/monorepo-private/issues/10071 will add the endpoints that are currently excluded 