### PR TITLE
server: Replace usage of once_cell with equivalent from std

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -4827,7 +4827,6 @@ dependencies = [
  "lapin",
  "num_enum",
  "omniqueue",
- "once_cell",
  "openssl",
  "opentelemetry",
  "opentelemetry-http",

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -32,7 +32,6 @@ serde_path_to_error = "0.1.7"
 num_enum = "0.7.2"
 enum_dispatch = "0.3.8"
 regex = "1.5.5"
-once_cell = "1.18.0"
 figment = { version = "0.10", features = ["toml", "env", "test"] }
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/server/svix-server/src/core/types/mod.rs
+++ b/server/svix-server/src/core/types/mod.rs
@@ -4,11 +4,11 @@
 use std::{
     collections::{HashMap, HashSet},
     ops::Deref,
+    sync::LazyLock,
 };
 
 use chrono::{DateTime, Utc};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
-use once_cell::sync::Lazy;
 use rand::Rng;
 use regex::Regex;
 use schemars::JsonSchema;
@@ -229,7 +229,7 @@ pub trait BaseId: Deref<Target = String> {
 
 fn validate_limited_str(s: &str) -> Result<(), ValidationErrors> {
     const MAX_LENGTH: usize = 256;
-    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[a-zA-Z0-9\-_.]+$").unwrap());
+    static RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9\-_.]+$").unwrap());
     let mut errors = ValidationErrors::new();
     if s.is_empty() {
         errors.add(

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -6,13 +6,15 @@
 
 use std::{
     borrow::Cow,
-    sync::atomic::{AtomicBool, Ordering},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        LazyLock,
+    },
     time::Duration,
 };
 
 use aide::axum::ApiRouter;
 use cfg::ConfigurationInner;
-use once_cell::sync::Lazy;
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::{metrics::SdkMeterProvider, runtime::Tokio};
 use queue::TaskQueueProducer;
@@ -57,8 +59,8 @@ const CRATE_NAME: &str = env!("CARGO_CRATE_NAME");
 
 pub static SHUTTING_DOWN: AtomicBool = AtomicBool::new(false);
 
-pub static INSTANCE_ID: Lazy<String> =
-    Lazy::new(|| hex::encode(KsuidMs::new(None, None).to_string()));
+pub static INSTANCE_ID: LazyLock<String> =
+    LazyLock::new(|| hex::encode(KsuidMs::new(None, None).to_string()));
 
 async fn graceful_shutdown_handler() {
     let ctrl_c = async {

--- a/server/svix-server/src/v1/utils/mod.rs
+++ b/server/svix-server/src/v1/utils/mod.rs
@@ -6,6 +6,7 @@ use std::{
     collections::HashSet,
     error::Error as StdError,
     ops::Deref,
+    sync::LazyLock,
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -25,7 +26,6 @@ use axum::{
 };
 use chrono::{DateTime, Utc};
 use http::{request::Parts, Request, StatusCode};
-use once_cell::sync::Lazy;
 use regex::Regex;
 use schemars::JsonSchema;
 use sea_orm::{ColumnTrait, QueryFilter, QueryOrder, QuerySelect};
@@ -49,11 +49,13 @@ const fn default_limit() -> PaginationLimit {
 
 const PAGINATION_LIMIT_CAP_HARD: bool = true;
 const PAGINATION_LIMIT_CAP_LIMIT: u64 = 250;
-static PAGINATION_LIMIT_ERROR: Lazy<String> =
-    Lazy::new(|| format!("Given limit must not exceed {PAGINATION_LIMIT_CAP_LIMIT}"));
+static PAGINATION_LIMIT_ERROR: LazyLock<String> =
+    LazyLock::new(|| format!("Given limit must not exceed {PAGINATION_LIMIT_CAP_LIMIT}"));
 
-static FUTURE_QUERY_LIMIT: Lazy<chrono::Duration> = Lazy::new(|| chrono::Duration::hours(1));
-static LIMITED_QUERY_DURATION: Lazy<chrono::Duration> = Lazy::new(|| chrono::Duration::days(90));
+static FUTURE_QUERY_LIMIT: LazyLock<chrono::Duration> =
+    LazyLock::new(|| chrono::Duration::hours(1));
+static LIMITED_QUERY_DURATION: LazyLock<chrono::Duration> =
+    LazyLock::new(|| chrono::Duration::days(90));
 
 #[derive(Debug, Deserialize, Validate, JsonSchema)]
 pub struct PaginationDescending<T: Validate + JsonSchema> {

--- a/server/svix-server/src/worker.rs
+++ b/server/svix-server/src/worker.rs
@@ -5,7 +5,7 @@ use std::{
     collections::HashMap,
     sync::{
         atomic::{AtomicU64, AtomicUsize, Ordering},
-        Arc,
+        Arc, LazyLock,
     },
     time::Duration,
 };
@@ -14,7 +14,6 @@ use axum::body::HttpBody as _;
 use chrono::Utc;
 use futures::future;
 use http::{HeaderValue, StatusCode, Version};
-use once_cell::sync::Lazy;
 use rand::Rng;
 use sea_orm::{
     prelude::DateTimeUtc, ActiveModelBehavior, ActiveModelTrait, ColumnTrait, DatabaseConnection,
@@ -912,7 +911,7 @@ async fn process_queue_task_inner(
     Ok(())
 }
 
-pub static LAST_QUEUE_POLL: Lazy<AtomicU64> = Lazy::new(|| get_unix_timestamp().into());
+pub static LAST_QUEUE_POLL: LazyLock<AtomicU64> = LazyLock::new(|| get_unix_timestamp().into());
 
 async fn update_last_poll_time() {
     LAST_QUEUE_POLL.swap(get_unix_timestamp(), Ordering::Relaxed);


### PR DESCRIPTION
Drop the direct dependency on `once_cell` as equivalent functionality was released in `std` for Rust 1.80 (July 25, 2024). 

## Motivation

Eventually this will hopefully lead to 1 less dependency, however for now `once_cell` still remains as an indirect dependency since it is used widely in the ecosystem.

## Solution

Replace usage of `once_cell::sync::Lazy` with `std::sync::LazyLock`.