### PR TITLE
go: Add support for struct enums

### DIFF
--- a/codegen.toml
+++ b/codegen.toml
@@ -44,8 +44,8 @@ output_dir = "javascript/src/models"
 template = "javascript/templates/component_type.ts.jinja"
 output_dir = "javascript/src/models"
 extra_codegen_args = ["--include-mode=public-and-hidden"]
-#
-#
+
+
 [cli]
 template_dir = "svix-cli/templates"
 extra_mounts = { "svix-cli/.rustfmt.toml" = "/app/.rustfmt.toml" }
@@ -57,8 +57,8 @@ extra_shell_commands = [
 [[cli.task]]
 template = "svix-cli/templates/api_resource.rs.jinja"
 output_dir = "svix-cli/src/cmds/api"
-#
-#
+
+
 [python]
 template_dir = "python/templates"
 extra_shell_commands = [
@@ -76,13 +76,11 @@ output_dir = "python/svix/models"
 [[python.task]]
 template = "python/templates/summary.py.jinja"
 output_dir = "python/svix/api"
-#
-#
+
+
 [ruby]
 template_dir = "ruby/templates"
-extra_shell_commands = [
-   "rm ruby/lib/svix/api/operational_webhook.rb"
-   ]
+extra_shell_commands = ["rm ruby/lib/svix/api/operational_webhook.rb"]
 [[ruby.task]]
 template = "ruby/templates/api_resource.rb.jinja"
 output_dir = "ruby/lib/svix/api"
@@ -92,8 +90,8 @@ output_dir = "ruby/lib"
 [[ruby.task]]
 template = "ruby/templates/component_type.rb.jinja"
 output_dir = "ruby/lib/svix/models"
-#
-#
+
+
 [csharp]
 template_dir = "csharp/templates"
 extra_shell_commands = [
@@ -121,24 +119,24 @@ output_dir = "java/lib/src/main/java/com/svix/api"
 [[java.task]]
 template = "java/templates/component_type.java.jinja"
 output_dir = "java/lib/src/main/java/com/svix/models"
-#
-#
-#[go]
-#template_dir = "openapi-templates/go"
-#extra_shell_commands = [
-#    "rm go/{environment,health,ingest_endpoint,ingest,operational_webhook}.go",
-#]
-#[[go.task]]
-#template = "openapi-templates/go/api_resource.go.jinja"
-#output_dir = "go"
-#[[go.task]]
-#template = "openapi-templates/go/component_type_summary.go.jinja"
-#output_dir = "go"
-#[[go.task]]
-#template = "openapi-templates/go/component_type.go.jinja"
-#output_dir = "go/models"
-#
-#
+
+
+[go]
+template_dir = "openapi-templates/go"
+extra_shell_commands = [
+   "rm go/{environment,health,ingest_endpoint,ingest,ingest_source,operational_webhook}.go",
+]
+[[go.task]]
+template = "openapi-templates/go/api_resource.go.jinja"
+output_dir = "go"
+[[go.task]]
+template = "openapi-templates/go/component_type_summary.go.jinja"
+output_dir = "go"
+[[go.task]]
+template = "openapi-templates/go/component_type.go.jinja"
+output_dir = "go/models"
+
+
 [kotlin]
 extra_shell_commands = [
    "rm kotlin/lib/src/main/kotlin/{Ingest,OperationalWebhook}.kt",

--- a/go/message.go
+++ b/go/message.go
@@ -130,9 +130,9 @@ func (message *Message) Create(
 	)
 }
 
-// Purge all message content for the application.
-//
 // Delete all message payloads for the application.
+//
+// This operation is only available in the <a href="https://svix.com/pricing" target="_blank">Enterprise</a> plan.
 func (message *Message) ExpungeAllContents(
 	ctx context.Context,
 	appId string,

--- a/go/models.go
+++ b/go/models.go
@@ -4,6 +4,8 @@ package svix
 import "github.com/svix/svix-webhooks/go/models"
 
 type (
+	AdobeSignConfig                           = models.AdobeSignConfig
+	AdobeSignConfigOut                        = models.AdobeSignConfigOut
 	AggregateEventTypesOut                    = models.AggregateEventTypesOut
 	AppPortalAccessIn                         = models.AppPortalAccessIn
 	AppPortalAccessOut                        = models.AppPortalAccessOut
@@ -13,12 +15,27 @@ type (
 	ApplicationOut                            = models.ApplicationOut
 	ApplicationPatch                          = models.ApplicationPatch
 	ApplicationTokenExpireIn                  = models.ApplicationTokenExpireIn
+	BackgroundTaskFinishedEvent               = models.BackgroundTaskFinishedEvent
+	BackgroundTaskFinishedEvent2              = models.BackgroundTaskFinishedEvent2
 	BackgroundTaskOut                         = models.BackgroundTaskOut
 	BackgroundTaskStatus                      = models.BackgroundTaskStatus
 	BackgroundTaskType                        = models.BackgroundTaskType
 	ConnectorIn                               = models.ConnectorIn
 	ConnectorKind                             = models.ConnectorKind
+	ConnectorOut                              = models.ConnectorOut
+	CronConfig                                = models.CronConfig
 	DashboardAccessOut                        = models.DashboardAccessOut
+	DocusignConfig                            = models.DocusignConfig
+	DocusignConfigOut                         = models.DocusignConfigOut
+	EndpointCreatedEvent                      = models.EndpointCreatedEvent
+	EndpointCreatedEventData                  = models.EndpointCreatedEventData
+	EndpointDeletedEvent                      = models.EndpointDeletedEvent
+	EndpointDeletedEventData                  = models.EndpointDeletedEventData
+	EndpointDisabledEvent                     = models.EndpointDisabledEvent
+	EndpointDisabledEventData                 = models.EndpointDisabledEventData
+	EndpointDisabledTrigger                   = models.EndpointDisabledTrigger
+	EndpointEnabledEvent                      = models.EndpointEnabledEvent
+	EndpointEnabledEventData                  = models.EndpointEnabledEventData
 	EndpointHeadersIn                         = models.EndpointHeadersIn
 	EndpointHeadersOut                        = models.EndpointHeadersOut
 	EndpointHeadersPatchIn                    = models.EndpointHeadersPatchIn
@@ -32,6 +49,8 @@ type (
 	EndpointTransformationIn                  = models.EndpointTransformationIn
 	EndpointTransformationOut                 = models.EndpointTransformationOut
 	EndpointUpdate                            = models.EndpointUpdate
+	EndpointUpdatedEvent                      = models.EndpointUpdatedEvent
+	EndpointUpdatedEventData                  = models.EndpointUpdatedEventData
 	EnvironmentIn                             = models.EnvironmentIn
 	EnvironmentOut                            = models.EnvironmentOut
 	EventExampleIn                            = models.EventExampleIn
@@ -44,6 +63,10 @@ type (
 	EventTypePatch                            = models.EventTypePatch
 	EventTypeUpdate                           = models.EventTypeUpdate
 	ExpungeAllContentsOut                     = models.ExpungeAllContentsOut
+	GithubConfig                              = models.GithubConfig
+	GithubConfigOut                           = models.GithubConfigOut
+	HubspotConfig                             = models.HubspotConfig
+	HubspotConfigOut                          = models.HubspotConfigOut
 	IngestEndpointHeadersIn                   = models.IngestEndpointHeadersIn
 	IngestEndpointHeadersOut                  = models.IngestEndpointHeadersOut
 	IngestEndpointIn                          = models.IngestEndpointIn
@@ -51,6 +74,9 @@ type (
 	IngestEndpointSecretIn                    = models.IngestEndpointSecretIn
 	IngestEndpointSecretOut                   = models.IngestEndpointSecretOut
 	IngestEndpointUpdate                      = models.IngestEndpointUpdate
+	IngestSourceConsumerPortalAccessIn        = models.IngestSourceConsumerPortalAccessIn
+	IngestSourceIn                            = models.IngestSourceIn
+	IngestSourceOut                           = models.IngestSourceOut
 	IntegrationIn                             = models.IntegrationIn
 	IntegrationKeyOut                         = models.IntegrationKeyOut
 	IntegrationOut                            = models.IntegrationOut
@@ -61,12 +87,20 @@ type (
 	ListResponseEndpointOut                   = models.ListResponseEndpointOut
 	ListResponseEventTypeOut                  = models.ListResponseEventTypeOut
 	ListResponseIngestEndpointOut             = models.ListResponseIngestEndpointOut
+	ListResponseIngestSourceOut               = models.ListResponseIngestSourceOut
 	ListResponseIntegrationOut                = models.ListResponseIntegrationOut
 	ListResponseMessageAttemptOut             = models.ListResponseMessageAttemptOut
 	ListResponseMessageEndpointOut            = models.ListResponseMessageEndpointOut
 	ListResponseMessageOut                    = models.ListResponseMessageOut
 	ListResponseOperationalWebhookEndpointOut = models.ListResponseOperationalWebhookEndpointOut
+	MessageAttemptExhaustedEvent              = models.MessageAttemptExhaustedEvent
+	MessageAttemptExhaustedEventData          = models.MessageAttemptExhaustedEventData
+	MessageAttemptFailedData                  = models.MessageAttemptFailedData
+	MessageAttemptFailingEvent                = models.MessageAttemptFailingEvent
+	MessageAttemptFailingEventData            = models.MessageAttemptFailingEventData
 	MessageAttemptOut                         = models.MessageAttemptOut
+	MessageAttemptRecoveredEvent              = models.MessageAttemptRecoveredEvent
+	MessageAttemptRecoveredEventData          = models.MessageAttemptRecoveredEventData
 	MessageAttemptTriggerType                 = models.MessageAttemptTriggerType
 	MessageEndpointOut                        = models.MessageEndpointOut
 	MessageIn                                 = models.MessageIn
@@ -84,6 +118,18 @@ type (
 	RecoverOut                                = models.RecoverOut
 	ReplayIn                                  = models.ReplayIn
 	ReplayOut                                 = models.ReplayOut
+	RotateTokenOut                            = models.RotateTokenOut
+	SegmentConfig                             = models.SegmentConfig
+	SegmentConfigOut                          = models.SegmentConfigOut
+	ShopifyConfig                             = models.ShopifyConfig
+	ShopifyConfigOut                          = models.ShopifyConfigOut
+	SlackConfig                               = models.SlackConfig
+	SlackConfigOut                            = models.SlackConfigOut
 	StatusCodeClass                           = models.StatusCodeClass
-	TemplateOut                               = models.TemplateOut
+	StripeConfig                              = models.StripeConfig
+	StripeConfigOut                           = models.StripeConfigOut
+	SvixConfig                                = models.SvixConfig
+	SvixConfigOut                             = models.SvixConfigOut
+	ZoomConfig                                = models.ZoomConfig
+	ZoomConfigOut                             = models.ZoomConfigOut
 )

--- a/go/models/adobe_sign_config.go
+++ b/go/models/adobe_sign_config.go
@@ -1,0 +1,6 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type AdobeSignConfig struct {
+	ClientId string `json:"clientId"`
+}

--- a/go/models/adobe_sign_config_out.go
+++ b/go/models/adobe_sign_config_out.go
@@ -1,0 +1,5 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type AdobeSignConfigOut struct {
+}

--- a/go/models/background_task_finished_event.go
+++ b/go/models/background_task_finished_event.go
@@ -1,0 +1,8 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+// Sent when a background task is finished.
+type BackgroundTaskFinishedEvent struct {
+	Data BackgroundTaskFinishedEvent2 `json:"data"`
+	Type string                       `json:"type"`
+}

--- a/go/models/background_task_finished_event2.go
+++ b/go/models/background_task_finished_event2.go
@@ -1,0 +1,9 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type BackgroundTaskFinishedEvent2 struct {
+	Data   map[string]any       `json:"data"`
+	Status BackgroundTaskStatus `json:"status"`
+	Task   BackgroundTaskType   `json:"task"`
+	TaskId string               `json:"taskId"` // The QueueBackgroundTask's ID.
+}

--- a/go/models/connector_out.go
+++ b/go/models/connector_out.go
@@ -1,0 +1,20 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+import "time"
+
+type ConnectorOut struct {
+	CreatedAt        time.Time     `json:"createdAt"`
+	Description      string        `json:"description"`
+	FeatureFlag      *string       `json:"featureFlag,omitempty"`
+	FilterTypes      []string      `json:"filterTypes,omitempty"`
+	Id               string        `json:"id"` // The TransformationTemplate's ID.
+	Instructions     string        `json:"instructions"`
+	InstructionsLink *string       `json:"instructionsLink,omitempty"`
+	Kind             ConnectorKind `json:"kind"`
+	Logo             string        `json:"logo"`
+	Name             string        `json:"name"`
+	OrgId            string        `json:"orgId"` // The Organization's ID.
+	Transformation   string        `json:"transformation"`
+	UpdatedAt        time.Time     `json:"updatedAt"`
+}

--- a/go/models/cron_config.go
+++ b/go/models/cron_config.go
@@ -1,0 +1,11 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type CronConfig struct {
+	// Override the default content-type.
+	//
+	// Recommended if the payload is not JSON.
+	ContentType *string `json:"contentType,omitempty"`
+	Payload     string  `json:"payload"`
+	Schedule    string  `json:"schedule"`
+}

--- a/go/models/docusign_config.go
+++ b/go/models/docusign_config.go
@@ -1,0 +1,6 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type DocusignConfig struct {
+	Secret *string `json:"secret,omitempty"`
+}

--- a/go/models/docusign_config_out.go
+++ b/go/models/docusign_config_out.go
@@ -1,0 +1,5 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type DocusignConfigOut struct {
+}

--- a/go/models/empty_map.go
+++ b/go/models/empty_map.go
@@ -1,0 +1,5 @@
+// Package svix this file was hand written
+package models
+
+// Used to denote an empty map
+type emptyMap struct{}

--- a/go/models/endpoint_created_event.go
+++ b/go/models/endpoint_created_event.go
@@ -1,0 +1,8 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+// Sent when an endpoint is created.
+type EndpointCreatedEvent struct {
+	Data EndpointCreatedEventData `json:"data"`
+	Type string                   `json:"type"`
+}

--- a/go/models/endpoint_created_event_data.go
+++ b/go/models/endpoint_created_event_data.go
@@ -1,0 +1,10 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+// Sent when an endpoint is created, updated, or deleted
+type EndpointCreatedEventData struct {
+	AppId       string  `json:"appId"`                 // The Application's ID.
+	AppUid      *string `json:"appUid,omitempty"`      // The Application's UID.
+	EndpointId  string  `json:"endpointId"`            // The Endpoint's ID.
+	EndpointUid *string `json:"endpointUid,omitempty"` // The Endpoint's UID.
+}

--- a/go/models/endpoint_deleted_event.go
+++ b/go/models/endpoint_deleted_event.go
@@ -1,0 +1,8 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+// Sent when an endpoint is deleted.
+type EndpointDeletedEvent struct {
+	Data EndpointDeletedEventData `json:"data"`
+	Type string                   `json:"type"`
+}

--- a/go/models/endpoint_deleted_event_data.go
+++ b/go/models/endpoint_deleted_event_data.go
@@ -1,0 +1,10 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+// Sent when an endpoint is created, updated, or deleted
+type EndpointDeletedEventData struct {
+	AppId       string  `json:"appId"`                 // The Application's ID.
+	AppUid      *string `json:"appUid,omitempty"`      // The Application's UID.
+	EndpointId  string  `json:"endpointId"`            // The Endpoint's ID.
+	EndpointUid *string `json:"endpointUid,omitempty"` // The Endpoint's UID.
+}

--- a/go/models/endpoint_disabled_event.go
+++ b/go/models/endpoint_disabled_event.go
@@ -1,0 +1,8 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+// Sent when an endpoint has been automatically disabled after continuous failures, or manually via an API call.
+type EndpointDisabledEvent struct {
+	Data EndpointDisabledEventData `json:"data"`
+	Type string                    `json:"type"`
+}

--- a/go/models/endpoint_disabled_event_data.go
+++ b/go/models/endpoint_disabled_event_data.go
@@ -1,0 +1,14 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+import "time"
+
+// Sent when an endpoint has been automatically disabled after continuous failures, or manually via an API call.
+type EndpointDisabledEventData struct {
+	AppId       string                   `json:"appId"`                 // The Application's ID.
+	AppUid      *string                  `json:"appUid,omitempty"`      // The Application's UID.
+	EndpointId  string                   `json:"endpointId"`            // The Endpoint's ID.
+	EndpointUid *string                  `json:"endpointUid,omitempty"` // The Endpoint's UID.
+	FailSince   *time.Time               `json:"failSince,omitempty"`
+	Trigger     *EndpointDisabledTrigger `json:"trigger,omitempty"`
+}

--- a/go/models/endpoint_disabled_trigger.go
+++ b/go/models/endpoint_disabled_trigger.go
@@ -1,0 +1,35 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+)
+
+type EndpointDisabledTrigger string
+
+const (
+	ENDPOINTDISABLEDTRIGGER_MANUAL    EndpointDisabledTrigger = "manual"
+	ENDPOINTDISABLEDTRIGGER_AUTOMATIC EndpointDisabledTrigger = "automatic"
+)
+
+var allowedEndpointDisabledTrigger = []EndpointDisabledTrigger{
+	"manual",
+	"automatic",
+}
+
+func (v *EndpointDisabledTrigger) UnmarshalJSON(src []byte) error {
+	var value string
+	err := json.Unmarshal(src, &value)
+	if err != nil {
+		return err
+	}
+	enumVal := EndpointDisabledTrigger(value)
+	if slices.Contains(allowedEndpointDisabledTrigger, enumVal) {
+		*v = enumVal
+		return nil
+	}
+	return fmt.Errorf("`%+v` is not a valid EndpointDisabledTrigger", value)
+
+}

--- a/go/models/endpoint_enabled_event.go
+++ b/go/models/endpoint_enabled_event.go
@@ -1,0 +1,8 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+// Sent when an endpoint has been enabled.
+type EndpointEnabledEvent struct {
+	Data EndpointEnabledEventData `json:"data"`
+	Type string                   `json:"type"`
+}

--- a/go/models/endpoint_enabled_event_data.go
+++ b/go/models/endpoint_enabled_event_data.go
@@ -1,0 +1,10 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+// Sent when an endpoint has been enabled.
+type EndpointEnabledEventData struct {
+	AppId       string  `json:"appId"`                 // The Application's ID.
+	AppUid      *string `json:"appUid,omitempty"`      // The Application's UID.
+	EndpointId  string  `json:"endpointId"`            // The Endpoint's ID.
+	EndpointUid *string `json:"endpointUid,omitempty"` // The Endpoint's UID.
+}

--- a/go/models/endpoint_updated_event.go
+++ b/go/models/endpoint_updated_event.go
@@ -1,0 +1,8 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+// Sent when an endpoint is updated.
+type EndpointUpdatedEvent struct {
+	Data EndpointUpdatedEventData `json:"data"`
+	Type string                   `json:"type"`
+}

--- a/go/models/endpoint_updated_event_data.go
+++ b/go/models/endpoint_updated_event_data.go
@@ -1,0 +1,10 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+// Sent when an endpoint is created, updated, or deleted
+type EndpointUpdatedEventData struct {
+	AppId       string  `json:"appId"`                 // The Application's ID.
+	AppUid      *string `json:"appUid,omitempty"`      // The Application's UID.
+	EndpointId  string  `json:"endpointId"`            // The Endpoint's ID.
+	EndpointUid *string `json:"endpointUid,omitempty"` // The Endpoint's UID.
+}

--- a/go/models/environment_out.go
+++ b/go/models/environment_out.go
@@ -7,6 +7,6 @@ type EnvironmentOut struct {
 	CreatedAt               time.Time       `json:"createdAt"`
 	EventTypes              []EventTypeOut  `json:"eventTypes"`
 	Settings                *map[string]any `json:"settings,omitempty"`
-	TransformationTemplates []TemplateOut   `json:"transformationTemplates"`
+	TransformationTemplates []ConnectorOut  `json:"transformationTemplates"`
 	Version                 *int64          `json:"version,omitempty"`
 }

--- a/go/models/github_config.go
+++ b/go/models/github_config.go
@@ -1,0 +1,6 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type GithubConfig struct {
+	Secret *string `json:"secret,omitempty"`
+}

--- a/go/models/github_config_out.go
+++ b/go/models/github_config_out.go
@@ -1,0 +1,5 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type GithubConfigOut struct {
+}

--- a/go/models/hubspot_config.go
+++ b/go/models/hubspot_config.go
@@ -1,0 +1,6 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type HubspotConfig struct {
+	Secret *string `json:"secret,omitempty"`
+}

--- a/go/models/hubspot_config_out.go
+++ b/go/models/hubspot_config_out.go
@@ -1,0 +1,5 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type HubspotConfigOut struct {
+}

--- a/go/models/ingest_source_consumer_portal_access_in.go
+++ b/go/models/ingest_source_consumer_portal_access_in.go
@@ -1,0 +1,10 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type IngestSourceConsumerPortalAccessIn struct {
+	// How long the token will be valid for, in seconds.
+	//
+	// Valid values are between 1 hour and 7 days. The default is 7 days.
+	Expiry   *uint64 `json:"expiry,omitempty"`
+	ReadOnly *bool   `json:"readOnly,omitempty"` // Whether the app portal should be in read-only mode.
+}

--- a/go/models/ingest_source_in.go
+++ b/go/models/ingest_source_in.go
@@ -1,0 +1,151 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// When creating an IngestSourceIn, use the appropriate config structure based on the Type:
+//   - "generic-webhook": No config needed (nil or just ignore the config field)
+//   - "adobe-sign": Use AdobeSignConfig
+//   - "cron": Use CronConfig
+//   - "docusign": Use DocusignConfig
+//   - "github": Use GithubConfig
+//   - "hubspot": Use HubspotConfig
+//   - "segment": Use SegmentConfig
+//   - "shopify": Use ShopifyConfig
+//   - "slack": Use SlackConfig
+//   - "stripe": Use StripeConfig
+//   - "beehiiv","brex","clerk","guesty","incident-io","lithic","nash","pleo","replicate","resend","safebase","sardine","stych","svix": Use SvixConfig
+//   - "zoom": Use ZoomConfig
+type IngestSourceIn struct {
+	Name   string               `json:"name"`
+	Uid    *string              `json:"uid,omitempty"` // The Source's UID.
+	Type   IngestSourceInType   `json:"type"`
+	Config IngestSourceInConfig `json:"config"`
+}
+
+type IngestSourceInType string
+
+const (
+	IngestSourceInTypeGenericWebhook IngestSourceInType = "generic-webhook"
+	IngestSourceInTypeCron           IngestSourceInType = "cron"
+	IngestSourceInTypeAdobeSign      IngestSourceInType = "adobe-sign"
+	IngestSourceInTypeBeehiiv        IngestSourceInType = "beehiiv"
+	IngestSourceInTypeBrex           IngestSourceInType = "brex"
+	IngestSourceInTypeClerk          IngestSourceInType = "clerk"
+	IngestSourceInTypeDocusign       IngestSourceInType = "docusign"
+	IngestSourceInTypeGithub         IngestSourceInType = "github"
+	IngestSourceInTypeGuesty         IngestSourceInType = "guesty"
+	IngestSourceInTypeHubspot        IngestSourceInType = "hubspot"
+	IngestSourceInTypeIncidentIo     IngestSourceInType = "incident-io"
+	IngestSourceInTypeLithic         IngestSourceInType = "lithic"
+	IngestSourceInTypeNash           IngestSourceInType = "nash"
+	IngestSourceInTypePleo           IngestSourceInType = "pleo"
+	IngestSourceInTypeReplicate      IngestSourceInType = "replicate"
+	IngestSourceInTypeResend         IngestSourceInType = "resend"
+	IngestSourceInTypeSafebase       IngestSourceInType = "safebase"
+	IngestSourceInTypeSardine        IngestSourceInType = "sardine"
+	IngestSourceInTypeSegment        IngestSourceInType = "segment"
+	IngestSourceInTypeShopify        IngestSourceInType = "shopify"
+	IngestSourceInTypeSlack          IngestSourceInType = "slack"
+	IngestSourceInTypeStripe         IngestSourceInType = "stripe"
+	IngestSourceInTypeStych          IngestSourceInType = "stych"
+	IngestSourceInTypeSvix           IngestSourceInType = "svix"
+	IngestSourceInTypeZoom           IngestSourceInType = "zoom"
+)
+
+type IngestSourceInConfig interface {
+	isIngestSourceInConfig()
+}
+
+func (emptyMap) isIngestSourceInConfig()        {}
+func (CronConfig) isIngestSourceInConfig()      {}
+func (AdobeSignConfig) isIngestSourceInConfig() {}
+func (SvixConfig) isIngestSourceInConfig()      {}
+func (DocusignConfig) isIngestSourceInConfig()  {}
+func (GithubConfig) isIngestSourceInConfig()    {}
+func (HubspotConfig) isIngestSourceInConfig()   {}
+func (SegmentConfig) isIngestSourceInConfig()   {}
+func (ShopifyConfig) isIngestSourceInConfig()   {}
+func (SlackConfig) isIngestSourceInConfig()     {}
+func (StripeConfig) isIngestSourceInConfig()    {}
+func (ZoomConfig) isIngestSourceInConfig()      {}
+
+func (i *IngestSourceIn) UnmarshalJSON(data []byte) error {
+	type Alias IngestSourceIn
+	aux := struct {
+		*Alias
+		Config json.RawMessage `json:"config"`
+	}{Alias: (*Alias)(i)}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	var err error
+	switch i.Type {
+	case "generic-webhook":
+	case "adobe-sign":
+		var c AdobeSignConfig
+		err = json.Unmarshal(aux.Config, &c)
+		i.Config = c
+	case "cron":
+		var c CronConfig
+		err = json.Unmarshal(aux.Config, &c)
+		i.Config = c
+	case "docusign":
+		var c DocusignConfig
+		err = json.Unmarshal(aux.Config, &c)
+		i.Config = c
+	case "github":
+		var c GithubConfig
+		err = json.Unmarshal(aux.Config, &c)
+		i.Config = c
+	case "hubspot":
+		var c HubspotConfig
+		err = json.Unmarshal(aux.Config, &c)
+		i.Config = c
+	case "segment":
+		var c SegmentConfig
+		err = json.Unmarshal(aux.Config, &c)
+		i.Config = c
+	case "shopify":
+		var c ShopifyConfig
+		err = json.Unmarshal(aux.Config, &c)
+		i.Config = c
+	case "slack":
+		var c SlackConfig
+		err = json.Unmarshal(aux.Config, &c)
+		i.Config = c
+	case "stripe":
+		var c StripeConfig
+		err = json.Unmarshal(aux.Config, &c)
+		i.Config = c
+	case "beehiiv", "brex", "clerk", "guesty", "incident-io", "lithic", "nash", "pleo", "replicate", "resend", "safebase", "sardine", "stych", "svix":
+		var c SvixConfig
+		err = json.Unmarshal(aux.Config, &c)
+		i.Config = c
+	case "zoom":
+		var c ZoomConfig
+		err = json.Unmarshal(aux.Config, &c)
+		i.Config = c
+	default:
+		// should be unreachable
+		return fmt.Errorf("unexpected type %s", i.Type)
+	}
+	return err
+}
+
+var IngestSourceInTypeWithNoConfig = map[string]bool{
+	"generic-webhook": true,
+}
+
+func (i IngestSourceIn) MarshalJSON() ([]byte, error) {
+	type Alias IngestSourceIn
+	if _, found := IngestSourceInTypeWithNoConfig[string(i.Type)]; found {
+		i.Config = emptyMap{}
+	}
+	return json.Marshal(&struct{ Alias }{Alias: (Alias)(i)})
+}

--- a/go/models/ingest_source_out.go
+++ b/go/models/ingest_source_out.go
@@ -1,0 +1,156 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// When creating an IngestSourceOut, use the appropriate config structure based on the Type:
+//   - "generic-webhook": No config needed (nil or just ignore the config field)
+//   - "adobe-sign": Use AdobeSignConfigOut
+//   - "cron": Use CronConfig
+//   - "docusign": Use DocusignConfigOut
+//   - "github": Use GithubConfigOut
+//   - "hubspot": Use HubspotConfigOut
+//   - "segment": Use SegmentConfigOut
+//   - "shopify": Use ShopifyConfigOut
+//   - "slack": Use SlackConfigOut
+//   - "stripe": Use StripeConfigOut
+//   - "beehiiv","brex","clerk","guesty","incident-io","lithic","nash","pleo","replicate","resend","safebase","sardine","stych","svix": Use SvixConfigOut
+//   - "zoom": Use ZoomConfigOut
+type IngestSourceOut struct {
+	CreatedAt time.Time             `json:"createdAt"`
+	Id        string                `json:"id"` // The Source's ID.
+	IngestUrl *string               `json:"ingestUrl,omitempty"`
+	Name      string                `json:"name"`
+	Uid       *string               `json:"uid,omitempty"` // The Source's UID.
+	UpdatedAt time.Time             `json:"updatedAt"`
+	Type      IngestSourceOutType   `json:"type"`
+	Config    IngestSourceOutConfig `json:"config"`
+}
+
+type IngestSourceOutType string
+
+const (
+	IngestSourceOutTypeGenericWebhook IngestSourceOutType = "generic-webhook"
+	IngestSourceOutTypeCron           IngestSourceOutType = "cron"
+	IngestSourceOutTypeAdobeSign      IngestSourceOutType = "adobe-sign"
+	IngestSourceOutTypeBeehiiv        IngestSourceOutType = "beehiiv"
+	IngestSourceOutTypeBrex           IngestSourceOutType = "brex"
+	IngestSourceOutTypeClerk          IngestSourceOutType = "clerk"
+	IngestSourceOutTypeDocusign       IngestSourceOutType = "docusign"
+	IngestSourceOutTypeGithub         IngestSourceOutType = "github"
+	IngestSourceOutTypeGuesty         IngestSourceOutType = "guesty"
+	IngestSourceOutTypeHubspot        IngestSourceOutType = "hubspot"
+	IngestSourceOutTypeIncidentIo     IngestSourceOutType = "incident-io"
+	IngestSourceOutTypeLithic         IngestSourceOutType = "lithic"
+	IngestSourceOutTypeNash           IngestSourceOutType = "nash"
+	IngestSourceOutTypePleo           IngestSourceOutType = "pleo"
+	IngestSourceOutTypeReplicate      IngestSourceOutType = "replicate"
+	IngestSourceOutTypeResend         IngestSourceOutType = "resend"
+	IngestSourceOutTypeSafebase       IngestSourceOutType = "safebase"
+	IngestSourceOutTypeSardine        IngestSourceOutType = "sardine"
+	IngestSourceOutTypeSegment        IngestSourceOutType = "segment"
+	IngestSourceOutTypeShopify        IngestSourceOutType = "shopify"
+	IngestSourceOutTypeSlack          IngestSourceOutType = "slack"
+	IngestSourceOutTypeStripe         IngestSourceOutType = "stripe"
+	IngestSourceOutTypeStych          IngestSourceOutType = "stych"
+	IngestSourceOutTypeSvix           IngestSourceOutType = "svix"
+	IngestSourceOutTypeZoom           IngestSourceOutType = "zoom"
+)
+
+type IngestSourceOutConfig interface {
+	isIngestSourceOutConfig()
+}
+
+func (emptyMap) isIngestSourceOutConfig()           {}
+func (CronConfig) isIngestSourceOutConfig()         {}
+func (AdobeSignConfigOut) isIngestSourceOutConfig() {}
+func (SvixConfigOut) isIngestSourceOutConfig()      {}
+func (DocusignConfigOut) isIngestSourceOutConfig()  {}
+func (GithubConfigOut) isIngestSourceOutConfig()    {}
+func (HubspotConfigOut) isIngestSourceOutConfig()   {}
+func (SegmentConfigOut) isIngestSourceOutConfig()   {}
+func (ShopifyConfigOut) isIngestSourceOutConfig()   {}
+func (SlackConfigOut) isIngestSourceOutConfig()     {}
+func (StripeConfigOut) isIngestSourceOutConfig()    {}
+func (ZoomConfigOut) isIngestSourceOutConfig()      {}
+
+func (i *IngestSourceOut) UnmarshalJSON(data []byte) error {
+	type Alias IngestSourceOut
+	aux := struct {
+		*Alias
+		Config json.RawMessage `json:"config"`
+	}{Alias: (*Alias)(i)}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	var err error
+	switch i.Type {
+	case "generic-webhook":
+	case "adobe-sign":
+		var c AdobeSignConfigOut
+		err = json.Unmarshal(aux.Config, &c)
+		i.Config = c
+	case "cron":
+		var c CronConfig
+		err = json.Unmarshal(aux.Config, &c)
+		i.Config = c
+	case "docusign":
+		var c DocusignConfigOut
+		err = json.Unmarshal(aux.Config, &c)
+		i.Config = c
+	case "github":
+		var c GithubConfigOut
+		err = json.Unmarshal(aux.Config, &c)
+		i.Config = c
+	case "hubspot":
+		var c HubspotConfigOut
+		err = json.Unmarshal(aux.Config, &c)
+		i.Config = c
+	case "segment":
+		var c SegmentConfigOut
+		err = json.Unmarshal(aux.Config, &c)
+		i.Config = c
+	case "shopify":
+		var c ShopifyConfigOut
+		err = json.Unmarshal(aux.Config, &c)
+		i.Config = c
+	case "slack":
+		var c SlackConfigOut
+		err = json.Unmarshal(aux.Config, &c)
+		i.Config = c
+	case "stripe":
+		var c StripeConfigOut
+		err = json.Unmarshal(aux.Config, &c)
+		i.Config = c
+	case "beehiiv", "brex", "clerk", "guesty", "incident-io", "lithic", "nash", "pleo", "replicate", "resend", "safebase", "sardine", "stych", "svix":
+		var c SvixConfigOut
+		err = json.Unmarshal(aux.Config, &c)
+		i.Config = c
+	case "zoom":
+		var c ZoomConfigOut
+		err = json.Unmarshal(aux.Config, &c)
+		i.Config = c
+	default:
+		// should be unreachable
+		return fmt.Errorf("unexpected type %s", i.Type)
+	}
+	return err
+}
+
+var IngestSourceOutTypeWithNoConfig = map[string]bool{
+	"generic-webhook": true,
+}
+
+func (i IngestSourceOut) MarshalJSON() ([]byte, error) {
+	type Alias IngestSourceOut
+	if _, found := IngestSourceOutTypeWithNoConfig[string(i.Type)]; found {
+		i.Config = emptyMap{}
+	}
+	return json.Marshal(&struct{ Alias }{Alias: (Alias)(i)})
+}

--- a/go/models/list_response_ingest_source_out.go
+++ b/go/models/list_response_ingest_source_out.go
@@ -1,0 +1,9 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type ListResponseIngestSourceOut struct {
+	Data         []IngestSourceOut `json:"data"`
+	Done         bool              `json:"done"`
+	Iterator     *string           `json:"iterator,omitempty"`
+	PrevIterator *string           `json:"prevIterator,omitempty"`
+}

--- a/go/models/message_attempt_exhausted_event.go
+++ b/go/models/message_attempt_exhausted_event.go
@@ -1,0 +1,8 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+// Sent when a message delivery has failed (all of the retry attempts have been exhausted).
+type MessageAttemptExhaustedEvent struct {
+	Data MessageAttemptExhaustedEventData `json:"data"`
+	Type string                           `json:"type"`
+}

--- a/go/models/message_attempt_exhausted_event_data.go
+++ b/go/models/message_attempt_exhausted_event_data.go
@@ -1,0 +1,12 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+// Sent when a message delivery has failed (all of the retry attempts have been exhausted) as a "message.attempt.exhausted" type or after it's failed four times as a "message.attempt.failing" event.
+type MessageAttemptExhaustedEventData struct {
+	AppId       string                   `json:"appId"`            // The Application's ID.
+	AppUid      *string                  `json:"appUid,omitempty"` // The Application's UID.
+	EndpointId  string                   `json:"endpointId"`       // The Endpoint's ID.
+	LastAttempt MessageAttemptFailedData `json:"lastAttempt"`
+	MsgEventId  *string                  `json:"msgEventId,omitempty"` // The Message's UID.
+	MsgId       string                   `json:"msgId"`                // The Message's ID.
+}

--- a/go/models/message_attempt_failed_data.go
+++ b/go/models/message_attempt_failed_data.go
@@ -1,0 +1,10 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+import "time"
+
+type MessageAttemptFailedData struct {
+	Id                 string    `json:"id"` // The MessageAttempt's ID.
+	ResponseStatusCode int16     `json:"responseStatusCode"`
+	Timestamp          time.Time `json:"timestamp"`
+}

--- a/go/models/message_attempt_failing_event.go
+++ b/go/models/message_attempt_failing_event.go
@@ -1,0 +1,9 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+// Sent after a message has been failing for a few times.
+// It's sent on the fourth failure. It complements `message.attempt.exhausted` which is sent after the last failure.
+type MessageAttemptFailingEvent struct {
+	Data MessageAttemptFailingEventData `json:"data"`
+	Type string                         `json:"type"`
+}

--- a/go/models/message_attempt_failing_event_data.go
+++ b/go/models/message_attempt_failing_event_data.go
@@ -1,0 +1,12 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+// Sent when a message delivery has failed (all of the retry attempts have been exhausted) as a "message.attempt.exhausted" type or after it's failed four times as a "message.attempt.failing" event.
+type MessageAttemptFailingEventData struct {
+	AppId       string                   `json:"appId"`            // The Application's ID.
+	AppUid      *string                  `json:"appUid,omitempty"` // The Application's UID.
+	EndpointId  string                   `json:"endpointId"`       // The Endpoint's ID.
+	LastAttempt MessageAttemptFailedData `json:"lastAttempt"`
+	MsgEventId  *string                  `json:"msgEventId,omitempty"` // The Message's UID.
+	MsgId       string                   `json:"msgId"`                // The Message's ID.
+}

--- a/go/models/message_attempt_recovered_event.go
+++ b/go/models/message_attempt_recovered_event.go
@@ -1,0 +1,8 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+// Sent on a successful dispatch after an earlier failure op webhook has already been sent.
+type MessageAttemptRecoveredEvent struct {
+	Data MessageAttemptRecoveredEventData `json:"data"`
+	Type string                           `json:"type"`
+}

--- a/go/models/message_attempt_recovered_event_data.go
+++ b/go/models/message_attempt_recovered_event_data.go
@@ -1,0 +1,12 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+// Sent when a message delivery has failed (all of the retry attempts have been exhausted) as a "message.attempt.exhausted" type or after it's failed four times as a "message.attempt.failing" event.
+type MessageAttemptRecoveredEventData struct {
+	AppId       string                   `json:"appId"`            // The Application's ID.
+	AppUid      *string                  `json:"appUid,omitempty"` // The Application's UID.
+	EndpointId  string                   `json:"endpointId"`       // The Endpoint's ID.
+	LastAttempt MessageAttemptFailedData `json:"lastAttempt"`
+	MsgEventId  *string                  `json:"msgEventId,omitempty"` // The Message's UID.
+	MsgId       string                   `json:"msgId"`                // The Message's ID.
+}

--- a/go/models/rotate_token_out.go
+++ b/go/models/rotate_token_out.go
@@ -1,0 +1,6 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type RotateTokenOut struct {
+	IngestUrl string `json:"ingestUrl"`
+}

--- a/go/models/segment_config.go
+++ b/go/models/segment_config.go
@@ -1,0 +1,6 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type SegmentConfig struct {
+	Secret *string `json:"secret,omitempty"`
+}

--- a/go/models/segment_config_out.go
+++ b/go/models/segment_config_out.go
@@ -1,0 +1,5 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type SegmentConfigOut struct {
+}

--- a/go/models/shopify_config.go
+++ b/go/models/shopify_config.go
@@ -1,0 +1,6 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type ShopifyConfig struct {
+	Secret string `json:"secret"`
+}

--- a/go/models/shopify_config_out.go
+++ b/go/models/shopify_config_out.go
@@ -1,0 +1,5 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type ShopifyConfigOut struct {
+}

--- a/go/models/slack_config.go
+++ b/go/models/slack_config.go
@@ -1,0 +1,6 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type SlackConfig struct {
+	Secret string `json:"secret"`
+}

--- a/go/models/slack_config_out.go
+++ b/go/models/slack_config_out.go
@@ -1,0 +1,5 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type SlackConfigOut struct {
+}

--- a/go/models/stripe_config.go
+++ b/go/models/stripe_config.go
@@ -1,0 +1,6 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type StripeConfig struct {
+	Secret string `json:"secret"`
+}

--- a/go/models/stripe_config_out.go
+++ b/go/models/stripe_config_out.go
@@ -1,0 +1,5 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type StripeConfigOut struct {
+}

--- a/go/models/svix_config.go
+++ b/go/models/svix_config.go
@@ -1,0 +1,6 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type SvixConfig struct {
+	Secret string `json:"secret"`
+}

--- a/go/models/svix_config_out.go
+++ b/go/models/svix_config_out.go
@@ -1,0 +1,5 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type SvixConfigOut struct {
+}

--- a/go/models/zoom_config.go
+++ b/go/models/zoom_config.go
@@ -1,0 +1,6 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type ZoomConfig struct {
+	Secret string `json:"secret"`
+}

--- a/go/models/zoom_config_out.go
+++ b/go/models/zoom_config_out.go
@@ -1,0 +1,5 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type ZoomConfigOut struct {
+}

--- a/go/svix_test.go
+++ b/go/svix_test.go
@@ -664,3 +664,86 @@ func TestListResponseOutModels(t *testing.T) {
 	}
 
 }
+
+func TestStructEnumWithFields(t *testing.T) {
+	expectedJson := `{"name":"Mendy","type":"cron","config":{"payload":"Hello from space","schedule":"0 0 0 * *"}}`
+	sourceIn := models.IngestSourceIn{
+		Name: "Mendy",
+		Type: models.IngestSourceInTypeCron,
+		Config: models.CronConfig{
+			Payload:  "Hello from space",
+			Schedule: "0 0 0 * *",
+		},
+	}
+	sourceInJson, err := json.Marshal(sourceIn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(sourceInJson) != expectedJson {
+		t.Errorf("Expected dumped json to match")
+	}
+}
+
+func TestStructEnumWithNoFields(t *testing.T) {
+	expectedJson := `{"name":"Mendy","uid":"very unique","type":"generic-webhook","config":{}}`
+	uid := "very unique"
+	sourceIn := models.IngestSourceIn{
+		Name: "Mendy",
+		Uid:  &uid,
+		Type: models.IngestSourceInTypeGenericWebhook,
+	}
+	sourceInJson, err := json.Marshal(sourceIn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(sourceInJson) != expectedJson {
+		t.Errorf("Expected dumped json to match")
+	}
+}
+
+func TestStructEnumWithNoFieldsNilConfig(t *testing.T) {
+	expectedJson := `{"name":"Mendy","uid":"very unique","type":"generic-webhook","config":{}}`
+	uid := "very unique"
+	sourceIn := models.IngestSourceIn{
+		Name:   "Mendy",
+		Uid:    &uid,
+		Type:   models.IngestSourceInTypeGenericWebhook,
+		Config: nil,
+	}
+	sourceInJson, err := json.Marshal(sourceIn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(sourceInJson) != expectedJson {
+		t.Errorf("Expected dumped json to match")
+	}
+}
+
+func TestReadStructEnumField(t *testing.T) {
+	jsonSourceIn := `{"name":"Mendy","type":"cron","config":{"payload":"Hello from space","schedule":"0 0 0 * *"}}`
+	var sourceIn models.IngestSourceIn
+	err := json.Unmarshal([]byte(jsonSourceIn), &sourceIn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sourceIn.Name != "Mendy" {
+		t.Fatal("Unexpected Name")
+	}
+	if sourceIn.Type != models.IngestSourceInTypeCron {
+		t.Fatal("Unexpected Type")
+	}
+	if sourceIn.Uid != nil {
+		t.Fatal("Unexpected Uid")
+	}
+	if cronConfig, ok := sourceIn.Config.(models.CronConfig); ok {
+		if cronConfig.Payload != "Hello from space" {
+			t.Fatal("Unexpected payload")
+		}
+		if cronConfig.Schedule != "0 0 0 * *" {
+			t.Fatal("Unexpected Schedule")
+		}
+	} else {
+		t.Fatal("Unexpected type for Config")
+	}
+
+}

--- a/go/svix_test.go
+++ b/go/svix_test.go
@@ -80,7 +80,7 @@ func getTestClient(t *testing.T) *svix.Svix {
 // Suppresses a request error response if it's a 409
 func isNotConflict(err error) error {
 	if err != nil {
-		var svixError svix.Error
+		var svixError *svix.Error
 		if errors.As(err, &svixError) {
 			if svixError.Status() == http.StatusConflict {
 				// Pass if we see the suppressed status

--- a/openapi-templates/go/component_type.go.jinja
+++ b/openapi-templates/go/component_type.go.jinja
@@ -1,7 +1,9 @@
 {% if type.kind == "struct" -%}
-	{% include "types/struct.go.jinja" ignore missing -%}
+	{% include "types/struct.go.jinja" -%}
 {% elif type.kind == "string_enum" -%}
-	{% include "types/string_enum.go.jinja" ignore missing -%}
+	{% include "types/string_enum.go.jinja" -%}
 {% elif type.kind == "integer_enum" -%}
-	{% include "types/integer_enum.go.jinja" ignore missing -%}
+	{% include "types/integer_enum.go.jinja" -%}
+{% elif type.kind == "struct_enum" -%}
+	{% include "types/struct_enum.go.jinja" -%}
 {% endif -%}

--- a/openapi-templates/go/types/struct.go.jinja
+++ b/openapi-templates/go/types/struct.go.jinja
@@ -6,28 +6,7 @@ import "github.com/svix/svix-webhooks/go/utils"
 {{ type.description | to_doc_comment(style="go")}}
 {% endif -%}
 type {{ type.name | to_upper_camel_case }} struct {
-	{% for field in type.fields -%}
-		{% set f_name = field.name | to_upper_camel_case -%}
-		{% set f_type = field.type.to_go() -%}
-		{% set use_nullable = type.name is endingwith "Patch" and field.nullable -%}
-		{% set json_annotation = "" -%}
-		{% if use_nullable -%}
-			{% set f_type %}utils.Nullable[{{ f_type }}]{% endset -%}
-		{% endif -%}
-		{% if (not field.required or field.nullable) and not use_nullable -%}
-			{% set json_annotation = ",omitempty" -%}
-			{% if not field.type.is_set() and not field.type.is_list() -%}
-				{% set f_type %}*{{ f_type }}{% endset -%}
-			{% endif -%}
-		{% endif -%}
-		{% if field.description is defined and "\n" in field.description -%}
-	{{ field.description | to_doc_comment(style="go") | indent(4) }}
-		{% endif -%}
-	{{ f_name }} {{ f_type }} `json:"{{ field.name }}{{ json_annotation }}"`
-		{%- if field.description is defined and "\n" not in field.description -%}
-		{{ field.description | to_doc_comment(style="go") }}
-		{%- endif %}
-	{% endfor -%}
+	{% include "types/struct_fields.go.jinja" -%}
 }
 {% if type.name is endingwith "Patch" -%}
 func (o {{ type.name | to_upper_camel_case }}) MarshalJSON() ([]byte, error) {

--- a/openapi-templates/go/types/struct_enum.go.jinja
+++ b/openapi-templates/go/types/struct_enum.go.jinja
@@ -1,0 +1,100 @@
+{% set ty_name =  type.name | to_upper_camel_case -%}
+{% set discriminator_field =  type.discriminator_field | to_upper_camel_case -%}
+{% set content_field =  type.content_field | to_upper_camel_case -%}
+{% set has_variant_with_no_schema_ref = type.variants | selectattr("schema_ref") | length != type.variants | length -%}
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+{% if type.description is defined -%}
+{{ type.description | to_doc_comment(style="go")}}
+{% endif -%}
+// When creating an {{ ty_name }}, use the appropriate {{ type.content_field }} structure based on the Type:
+{% for schema_ref, vars in type.variants | groupby("schema_ref") -%}
+	{% set use_type -%}
+		{% if schema_ref is defined -%}
+		Use {{ schema_ref | to_upper_camel_case }}
+		{% else -%}
+		No {{ type.content_field }} needed (nil or just ignore the {{ type.content_field }} field)
+		{% endif -%}
+	{% endset -%}
+//   - {% for v in vars %}"{{ v.name }}"{% if not loop.last %},{% endif %}{% endfor %}: {{ use_type }}
+{%- endfor -%}
+type {{ ty_name }} struct {
+    {% include "types/struct_fields.go.jinja" -%}	
+	{{ discriminator_field }} {{ ty_name }}{{ discriminator_field }} `json:"{{ type.discriminator_field }}"`
+	{{ content_field }} {{ ty_name }}{{ content_field }} `json:"{{ type.content_field }}"`
+}
+
+type {{ ty_name }}{{ discriminator_field }} string
+
+const (
+    {% for v in type.variants -%}
+	{{ ty_name }}{{ discriminator_field }}{{ v.name | to_upper_camel_case }} {{ ty_name }}{{ discriminator_field }} = "{{ v.name }}"
+    {% endfor -%}
+)
+
+
+type {{ ty_name }}{{ content_field }} interface {
+	is{{ ty_name }}{{ content_field }}()
+}
+
+{% for schema_ref in type.variants| map(attribute="schema_ref") | unique -%}
+	{% if schema_ref is defined -%}
+func ({{ schema_ref | to_upper_camel_case }}) is{{ ty_name }}{{ content_field }}(){}
+	{% else -%}
+func (emptyMap) is{{ ty_name }}{{ content_field }}(){}
+	{% endif -%}
+{% endfor %}
+
+func (i *{{ ty_name }}) UnmarshalJSON(data []byte) error {
+	type Alias {{ ty_name }}
+	aux := struct {
+		*Alias
+		{{ content_field }} json.RawMessage `json:"{{ type.content_field }}"`
+	}{Alias: (*Alias)(i)}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	var err error
+	switch i.Type {
+	{% for schema_ref, vars in type.variants | groupby("schema_ref") -%}
+		case {% for v in vars %}"{{ v.name }}"{%if not loop.last%},{% endif %}{% endfor %}:
+			{% if schema_ref is defined -%}
+			var c {{ schema_ref | to_upper_camel_case }}
+			err = json.Unmarshal(aux.{{ content_field }}, &c)
+			i.{{ content_field }} = c
+			{% endif -%}
+	{% endfor -%}
+	default:
+		// should be unreachable
+		return fmt.Errorf("unexpected type %s", i.Type)
+	}
+	return err
+}
+
+{% if has_variant_with_no_schema_ref -%}
+var {{ ty_name }}{{ discriminator_field }}WithNo{{ content_field }} = map[string]bool{
+	{% for v in type.variants -%}
+		{% if v.schema_ref is not defined -%}
+    "{{ v.name }}": true,
+		{% endif -%}
+	{% endfor -%}
+}
+{% endif -%}
+
+func (i {{ ty_name }}) MarshalJSON() ([]byte, error) {
+	type Alias {{ ty_name }}
+	{% if has_variant_with_no_schema_ref -%}
+	if _, found := {{ ty_name }}{{ discriminator_field }}WithNo{{ content_field }}[string(i.{{ discriminator_field }})]; found {
+ 	   i.{{ content_field }} = emptyMap{}
+	}
+	{% endif -%}
+	return json.Marshal(&struct {Alias}{Alias: (Alias)(i)})
+}

--- a/openapi-templates/go/types/struct_fields.go.jinja
+++ b/openapi-templates/go/types/struct_fields.go.jinja
@@ -1,0 +1,22 @@
+{% for field in type.fields -%}
+    {% set f_name = field.name | to_upper_camel_case -%}
+    {% set f_type = field.type.to_go() -%}
+    {% set use_nullable = type.name is endingwith "Patch" and field.nullable -%}
+    {% set json_annotation = "" -%}
+    {% if use_nullable -%}
+        {% set f_type %}utils.Nullable[{{ f_type }}]{% endset -%}
+    {% endif -%}
+    {% if (not field.required or field.nullable) and not use_nullable -%}
+        {% set json_annotation = ",omitempty" -%}
+        {% if not field.type.is_set() and not field.type.is_list() -%}
+            {% set f_type %}*{{ f_type }}{% endset -%}
+        {% endif -%}
+    {% endif -%}
+    {% if field.description is defined and "\n" in field.description -%}
+{{ field.description | to_doc_comment(style="go") | indent(4) }}
+    {% endif -%}
+{{ f_name }} {{ f_type }} `json:"{{ field.name }}{{ json_annotation }}"`
+    {%- if field.description is defined and "\n" not in field.description -%}
+    {{ field.description | to_doc_comment(style="go") }}
+    {%- endif %}
+{% endfor -%}


### PR DESCRIPTION
This is what the API will look like
```go
// struct enum with fields
sourceIn := models.IngestSourceIn{
	Name: "Mendy",
	Type: models.IngestSourceInTypeCron,
	Config: models.CronConfig{
		Payload:  "Hello from space",
		Schedule: "0 0 0 * *",
	},
}

// struct enum without fields
uid := "very unique"
sourceIn := models.IngestSourceIn{
	Name: "Mendy",
	Uid: &uid
	Type: models.IngestSourceInTypeGenericWebhook,
}

// read a field
if cronConfig, ok := sourceIn.Config.(models.CronConfig); ok {
	println(cronConfig.Payload)
}
```

edit(jplatte): Closes https://github.com/svix/monorepo-private/issues/9981, closes https://github.com/svix/monorepo-private/issues/10059