### PR TITLE
Bridge: update to use new rust lib, refactor poller input

### DIFF
--- a/.github/workflows/bridge-ci.yml
+++ b/.github/workflows/bridge-ci.yml
@@ -6,11 +6,14 @@ on:
       - main
     paths:
       - 'bridge/**'
+      - 'rust/**'
       - '.github/workflows/bridge-ci.yml'
   pull_request:
     paths:
       - 'bridge/**'
       - '.github/workflows/bridge-ci.yml'
+      - 'rust/**'
+      - 'lib-openapi.json'
 
 # When pushing to a PR, cancel any jobs still running for the previous head commit of the PR
 concurrency:

--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -1363,7 +1363,7 @@ dependencies = [
  "swc_ecma_parser",
  "swc_eq_ignore_macros",
  "text_lines",
- "thiserror 2.0.6",
+ "thiserror 2.0.11",
  "unicode-width",
  "url",
 ]
@@ -1887,8 +1887,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2585,6 +2597,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2597,6 +2618,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "js_option"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68421373957a1593a767013698dbf206e2b221eefe97a44d98d18672ff38423c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2778,7 +2808,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -2833,7 +2863,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "serde",
 ]
 
@@ -3058,7 +3088,7 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
@@ -3097,7 +3127,7 @@ dependencies = [
  "hmac",
  "pkcs12",
  "pkcs5",
- "rand",
+ "rand 0.8.5",
  "rc2",
  "sha1",
  "sha2",
@@ -3192,7 +3222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -3351,7 +3381,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -3488,8 +3518,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.2",
+ "zerocopy 0.8.21",
 ]
 
 [[package]]
@@ -3499,7 +3540,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.2",
 ]
 
 [[package]]
@@ -3508,7 +3559,17 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a509b1a2ffbe92afab0e55c8fd99dea1c280e8171bd2d88682bb20bc41cbc2c"
+dependencies = [
+ "getrandom 0.3.1",
+ "zerocopy 0.8.21",
 ]
 
 [[package]]
@@ -3697,7 +3758,7 @@ checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -4334,9 +4395,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svix"
-version = "1.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2f4d2c5bc0f080fa6127b8fb70ac083cc27218bfbaae40508c3dab68509e41"
+version = "1.62.0"
 dependencies = [
  "base64 0.13.1",
  "hmac-sha256",
@@ -4345,13 +4404,14 @@ dependencies = [
  "http-body-util",
  "hyper 1.5.1",
  "hyper-rustls 0.26.0",
- "hyper-tls",
  "hyper-util",
+ "itertools 0.14.0",
+ "js_option",
+ "rand 0.9.0",
  "serde",
- "serde_derive",
  "serde_json",
  "serde_repr",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "time",
  "tokio",
  "url",
@@ -4451,7 +4511,7 @@ checksum = "66f014385b7fc154f59e9480770c2187b6e61037c2439895788a9a4d421d7859"
 dependencies = [
  "base-encode",
  "byteorder",
- "getrandom",
+ "getrandom 0.2.15",
  "time",
 ]
 
@@ -4686,11 +4746,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.6"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 2.0.6",
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -4706,9 +4766,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.6"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4989,7 +5049,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -5280,6 +5340,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -5659,6 +5728,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5744,7 +5822,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf01143b2dd5d134f11f545cf9f1431b13b749695cb33bcce051e7568f99478"
+dependencies = [
+ "zerocopy-derive 0.8.21",
 ]
 
 [[package]]
@@ -5752,6 +5839,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712c8386f4f4299382c9abee219bee7084f78fb939d88b6840fcc1320d5f6da2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bridge/svix-bridge-plugin-queue/src/lib.rs
+++ b/bridge/svix-bridge-plugin-queue/src/lib.rs
@@ -231,14 +231,14 @@ async fn run_inner(consumer: &(impl Consumer + Send + Sync)) -> ! {
 ))]
 async fn create_svix_message(
     svix: &Svix,
-    CreateMessageRequest {
-        app_id,
-        message,
-        post_options,
-    }: CreateMessageRequest,
+    CreateMessageRequest { app_id, message }: CreateMessageRequest,
 ) -> std::io::Result<()> {
     svix.message()
-        .create(app_id, message, post_options.map(Into::into))
+        .create(
+            app_id, message,
+            // FIXME: add a way for the caller to give an idempotency key like we have in kafka
+            None,
+        )
         .await
         .map_err(Error::from)?;
     Ok(())

--- a/bridge/svix-bridge-plugin-queue/tests/it/gcp_pubsub_consumer.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/it/gcp_pubsub_consumer.rs
@@ -157,7 +157,6 @@ async fn test_consume_ok() {
     let msg = CreateMessageRequest {
         app_id: "app_1234".into(),
         message: MessageIn::new("testing.things".into(), json!({"hi": "there"})),
-        post_options: None,
     };
 
     publish(&topic, &serde_json::to_string(&msg).unwrap()).await;
@@ -233,7 +232,6 @@ async fn test_consume_transformed_json_ok() {
     let msg = CreateMessageRequest {
         app_id: "app_1234".into(),
         message: MessageIn::new("testing.things".into(), json!({"hi": "there"})),
-        post_options: None,
     };
 
     publish(&topic, &serde_json::to_string(&msg).unwrap()).await;
@@ -437,7 +435,8 @@ async fn test_consume_svix_503() {
         // N.b. this test case is different than other backend flavors of these since there's a
         // minimum of 5 delivery attempts made before messages are forwarded to the dead letter topic.
         // In other cases this can happen immediately, but not with gcp pubsub.
-        .up_to_n_times(MAX_DELIVERY_ATTEMPTS.try_into().unwrap())
+        // Additionally, the Rust sdk does automatic retries on 5xx
+        .up_to_n_times((MAX_DELIVERY_ATTEMPTS * 3).try_into().unwrap())
         .expect(1..);
     mock_server.register(mock).await;
 
@@ -455,7 +454,6 @@ async fn test_consume_svix_503() {
         &serde_json::to_string(&CreateMessageRequest {
             app_id: "app_1234".into(),
             message: MessageIn::new("testing.things".into(), json!({"hi": "there"})),
-            post_options: None,
         })
         .unwrap(),
     )
@@ -496,7 +494,6 @@ async fn test_consume_svix_offline() {
         &serde_json::to_string(&CreateMessageRequest {
             app_id: "app_1234".into(),
             message: MessageIn::new("testing.things".into(), json!({"hi": "there"})),
-            post_options: None,
         })
         .unwrap(),
     )

--- a/bridge/svix-bridge-plugin-queue/tests/it/rabbitmq_consumer.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/it/rabbitmq_consumer.rs
@@ -135,7 +135,6 @@ async fn test_consume_ok() {
     let msg = CreateMessageRequest {
         app_id: "app_1234".into(),
         message: MessageIn::new("testing.things".into(), json!({"hi": "there"})),
-        post_options: None,
     };
 
     publish(&channel, queue_name, &serde_json::to_vec(&msg).unwrap()).await;
@@ -214,7 +213,6 @@ async fn test_consume_transformed_json_ok() {
     let msg = CreateMessageRequest {
         app_id: "app_1234".into(),
         message: MessageIn::new("testing.things".into(), json!({"hi": "there"})),
-        post_options: None,
     };
 
     publish(&channel, queue_name, &serde_json::to_vec(&msg).unwrap()).await;
@@ -433,7 +431,8 @@ async fn test_consume_svix_503() {
     let mock = Mock::given(method("POST"))
         .respond_with(ResponseTemplate::new(503))
         .named("create_message")
-        .expect(1);
+        // Rust sdk does automatic retries on 5xx
+        .expect(3);
     mock_server.register(mock).await;
 
     let plugin = get_test_plugin(mock_server.uri(), MQ_URI, queue_name, None);
@@ -451,7 +450,6 @@ async fn test_consume_svix_503() {
         &serde_json::to_vec(&CreateMessageRequest {
             app_id: "app_1234".into(),
             message: MessageIn::new("testing.things".into(), json!({"hi": "there"})),
-            post_options: None,
         })
         .unwrap(),
     )
@@ -497,7 +495,6 @@ async fn test_consume_svix_offline() {
         &serde_json::to_vec(&CreateMessageRequest {
             app_id: "app_1234".into(),
             message: MessageIn::new("testing.things".into(), json!({"hi": "there"})),
-            post_options: None,
         })
         .unwrap(),
     )

--- a/bridge/svix-bridge-plugin-queue/tests/it/redis_stream_consumer.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/it/redis_stream_consumer.rs
@@ -120,7 +120,6 @@ async fn test_consume_ok() {
     let msg = CreateMessageRequest {
         app_id: "app_1234".into(),
         message: MessageIn::new("testing.things".into(), json!({"hi": "there"})),
-        post_options: None,
     };
 
     publish(&client, &key, &serde_json::to_string(&msg).unwrap()).await;
@@ -194,7 +193,6 @@ async fn test_consume_transformed_json_ok() {
     let msg = CreateMessageRequest {
         app_id: "app_1234".into(),
         message: MessageIn::new("testing.things".into(), json!({"hi": "there"})),
-        post_options: None,
     };
 
     publish(&client, &key, &serde_json::to_string(&msg).unwrap()).await;
@@ -390,7 +388,8 @@ async fn test_consume_svix_503() {
     let mock = Mock::given(method("POST"))
         .respond_with(ResponseTemplate::new(503))
         .named("create_message")
-        .expect(1);
+        // Rust sdk does automatic retries on 5xx
+        .expect(3);
     mock_server.register(mock).await;
 
     let plugin = get_test_plugin(mock_server.uri(), key.clone(), None);
@@ -408,7 +407,6 @@ async fn test_consume_svix_503() {
         &serde_json::to_string(&CreateMessageRequest {
             app_id: "app_1234".into(),
             message: MessageIn::new("testing.things".into(), json!({"hi": "there"})),
-            post_options: None,
         })
         .unwrap(),
     )
@@ -449,7 +447,6 @@ async fn test_consume_svix_offline() {
         &serde_json::to_string(&CreateMessageRequest {
             app_id: "app_1234".into(),
             message: MessageIn::new("testing.things".into(), json!({"hi": "there"})),
-            post_options: None,
         })
         .unwrap(),
     )

--- a/bridge/svix-bridge-plugin-queue/tests/it/sqs_consumer.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/it/sqs_consumer.rs
@@ -130,7 +130,6 @@ async fn test_consume_ok() {
     let msg = CreateMessageRequest {
         app_id: "app_1234".into(),
         message: MessageIn::new("testing.things".into(), json!({"hi": "there"})),
-        post_options: None,
     };
 
     publish(&client, &queue_url, &serde_json::to_string(&msg).unwrap()).await;
@@ -213,7 +212,6 @@ async fn test_consume_transformed_json_ok() {
     let msg = CreateMessageRequest {
         app_id: "app_1234".into(),
         message: MessageIn::new("testing.things".into(), json!({"hi": "there"})),
-        post_options: None,
     };
 
     publish(&client, &queue_url, &serde_json::to_string(&msg).unwrap()).await;
@@ -439,7 +437,8 @@ async fn test_consume_svix_503() {
     let mock = Mock::given(method("POST"))
         .respond_with(ResponseTemplate::new(503))
         .named("create_message")
-        .expect(1);
+        // Rust sdk does automatic retries on 5xx
+        .expect(3);
     mock_server.register(mock).await;
 
     let plugin = get_test_plugin(mock_server.uri(), queue_url.clone(), None);
@@ -457,7 +456,6 @@ async fn test_consume_svix_503() {
         &serde_json::to_string(&CreateMessageRequest {
             app_id: "app_1234".into(),
             message: MessageIn::new("testing.things".into(), json!({"hi": "there"})),
-            post_options: None,
         })
         .unwrap(),
     )
@@ -505,7 +503,6 @@ async fn test_consume_svix_offline() {
         &serde_json::to_string(&CreateMessageRequest {
             app_id: "app_1234".into(),
             message: MessageIn::new("testing.things".into(), json!({"hi": "there"})),
-            post_options: None,
         })
         .unwrap(),
     )

--- a/bridge/svix-bridge-types/Cargo.toml
+++ b/bridge/svix-bridge-types/Cargo.toml
@@ -9,7 +9,7 @@ async-trait = "0.1"
 tokio.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-svix = { version = "1.25.0", features = ["svix_beta"] }
+svix = { path = "../../rust", features = ["svix_beta"] }
 
 [lints]
 workspace = true

--- a/bridge/svix-bridge/src/config/tests.rs
+++ b/bridge/svix-bridge/src/config/tests.rs
@@ -618,8 +618,11 @@ fn test_pollers_parse_ok() {
     receivers:
       - name: "poller-to-rabbitmq-example"
         input:
-          type: "svix-events"
-          subscription_token: "eyJ0b2tlbiI6InRlc3Rza19hcHBfNTN0ZTBWNnJIdUs4R205VUNhYkxJOE5ieExTOGJ5MzEuZXUiLCJhcHBJZCI6ImFwcF8yajFvOGs1NFo4dXVscEVPb3k5VmZ6WUR0aE4iLCJzdWJzY3JpcHRpb25JZCI6Im15LWNvbnN1bWVyIn0="
+          type: "svix-polling-endpoint"
+          consumer_id: "my-consumer"
+          app_id: "app_AbCd"
+          sink_id: "poll_aBcD"
+          token: "xxxx"
         output:
           type: "rabbitmq"
           uri: "amqp://guest:guest@localhost:5672/%2f"


### PR DESCRIPTION
This diff updates bridge's `PollerInput` to be based on the newer stream API exposed by Polling Endpoints.