### PR TITLE
Codegen: allow staged during cargo fix

### DIFF
--- a/codegen.toml
+++ b/codegen.toml
@@ -50,7 +50,7 @@ extra_codegen_args = ["--include-mode=public-and-hidden"]
 template_dir = "svix-cli/templates"
 extra_mounts = { "svix-cli/.rustfmt.toml" = "/app/.rustfmt.toml" }
 extra_shell_commands = [
-   "cargo fix --manifest-path svix-cli/Cargo.toml --allow-dirty",
+   "cargo fix --manifest-path svix-cli/Cargo.toml --allow-dirty --allow-staged",
    "cargo fmt --manifest-path svix-cli/Cargo.toml",
    "rm svix-cli/src/cmds/api/{ingest,ingest_source,operational_webhook,background_task,health,operational_webhook_endpoint,statistics}.rs",
 ]


### PR DESCRIPTION
This is a nice to have when codegen has problems and you are trying to iterate as you work through the issues.
