### PR TITLE
CLI: add support for Polling Endpoint Consumers

### DIFF
--- a/codegen.toml
+++ b/codegen.toml
@@ -50,7 +50,7 @@ extra_codegen_args = ["--include-mode=public-and-hidden"]
 template_dir = "svix-cli/templates"
 extra_mounts = { "svix-cli/.rustfmt.toml" = "/app/.rustfmt.toml" }
 extra_shell_commands = [
-   "cargo fix --manifest-path svix-cli/Cargo.toml --allow-dirty --allow-staged",
+   "cargo fix --all-targets --all-features --manifest-path svix-cli/Cargo.toml --allow-dirty --allow-staged",
    "cargo fmt --manifest-path svix-cli/Cargo.toml",
    "rm svix-cli/src/cmds/api/{ingest,ingest_source,operational_webhook,background_task,health,operational_webhook_endpoint,statistics}.rs",
 ]

--- a/svix-cli/Cargo.toml
+++ b/svix-cli/Cargo.toml
@@ -52,6 +52,10 @@ tokio-tungstenite = { version = "0.26.0", features = ["rustls-tls-native-roots"]
 toml = "0.8.19"
 url = "2.5.4"
 
+[features]
+default = []
+svix_beta = ["svix/svix_beta"]
+
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"

--- a/svix-cli/src/cmds/api/events_public.rs
+++ b/svix-cli/src/cmds/api/events_public.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use clap::{Args, Subcommand};
 use svix::api::*;
 

--- a/svix-cli/src/cmds/api/mod.rs
+++ b/svix-cli/src/cmds/api/mod.rs
@@ -3,6 +3,8 @@ pub mod authentication;
 pub mod endpoint;
 pub mod environment;
 pub mod event_type;
+#[cfg(feature = "svix_beta")]
+pub mod events_public;
 pub mod integration;
 pub mod message;
 pub mod message_attempt;

--- a/svix-cli/src/main.rs
+++ b/svix-cli/src/main.rs
@@ -5,6 +5,8 @@ use colored_json::{ColorMode, Output};
 use concolor_clap::{Color, ColorChoice};
 use svix::api::SvixOptions;
 
+#[cfg(feature = "svix_beta")]
+use crate::cmds::api::events_public::EventsPublicArgs;
 use crate::{
     cmds::{
         api::{
@@ -65,6 +67,9 @@ enum RootCommands {
     Endpoint(EndpointArgs),
     /// Import or export environments
     Environment(EnvironmentArgs),
+    #[cfg(feature = "svix_beta")]
+    /// Iterate over messages for a Polling Endpoint
+    EventsPublic(EventsPublicArgs),
     /// List, create & modify event types
     EventType(EventTypeArgs),
     /// List integrations by app id
@@ -107,6 +112,11 @@ async fn main() -> Result<()> {
         RootCommands::Authentication(args) => {
             let cfg = cfg?;
             let client = get_client(&cfg)?;
+            args.command.exec(&client, color_mode).await?;
+        }
+        #[cfg(feature = "svix_beta")]
+        RootCommands::EventsPublic(args) => {
+            let client = get_client(&cfg?)?;
             args.command.exec(&client, color_mode).await?;
         }
         RootCommands::EventType(args) => {


### PR DESCRIPTION
Adds support for using `v1.events-public.consumer` and `v1.events-public.consumer-seek`, but gated behind a `svix_beta` cargo feature.
