### PR TITLE
Remove src/openapi from javascript/.gitignore

### DIFF
--- a/javascript/.gitignore
+++ b/javascript/.gitignore
@@ -1,4 +1,3 @@
 /dist
-/src/openapi
 
 node_modules


### PR DESCRIPTION
This directory should be removed from existing cloned of the repo.
