### PR TITLE
ruby: Fix bug with boolean get_if_exists

### DIFF
--- a/ruby/lib/svix/api/application.rb
+++ b/ruby/lib/svix/api/application.rb
@@ -43,7 +43,7 @@ module Svix
         "POST",
         path,
         query_params: {
-          "get_if_exists" => true
+          "get_if_exists" => "true"
         },
         headers: {
           "idempotency-key" => options["idempotency-key"]

--- a/ruby/spec/json_responses.rb
+++ b/ruby/spec/json_responses.rb
@@ -218,3 +218,15 @@ ListResponseMessageAttemptOut_without_msg_JSON='{
       "prevIterator": "-iterator",
       "done": true
 }'
+ApplicationOut_JSON='{
+  "uid": "unique-identifier",
+  "name": "My first application",
+  "rateLimit": 0,
+  "id": "app_1srOrx2ZWZBpBUvZwXKQmoEYga2",
+  "createdAt": "2019-08-24T14:15:22Z",
+  "updatedAt": "2019-08-24T14:15:22Z",
+  "metadata": {
+    "property1": "string",
+    "property2": "string"
+  }
+}'

--- a/ruby/spec/webmock_tests_spec.rb
+++ b/ruby/spec/webmock_tests_spec.rb
@@ -359,7 +359,6 @@ describe "API Client" do
     expect(loaded_from_json.config.schedule).to eql(source_in.config.schedule)
   end
 
-
   it "struct enum without any fields" do
     json_source_in = '{"name":"My Stripe Source","uid":"src_123","type":"generic-webhook","config":{}}';
     source_in = Svix::IngestSourceIn.new(
@@ -376,10 +375,23 @@ describe "API Client" do
     ))
     expect(loaded_from_json.config.class).to eql(Svix::IngestSourceInConfig::GenericWebhook)
   end
+
   it "op webhook body" do
     json_event = '{"data":{"data":{"appStats":[{"appId":"app_1srOrx2ZWZBpBUvZwXKQmoEYga2","appUid":null,"messageDestinations":343}]},"status":"finished","task":"application.stats","taskId":"qtask_1srOrx2ZWZBpBUvZwXKQmoEYga2"},"type":"background_task.finished"}';
     loaded_from_json = Svix::BackgroundTaskFinishedEvent.deserialize(JSON.parse(json_event))
 
     expect(loaded_from_json.to_json).to eql(json_event)
+  end
+
+  it "application get_or_create" do
+    stub_request(:post, "#{host}/api/v1/app?get_if_exists=true")
+      .to_return(
+        status: 200,
+        body: ApplicationOut_JSON
+      )
+
+    svx.application.get_or_create({})
+
+    expect(WebMock).to(have_requested(:post, "#{host}/api/v1/app?get_if_exists=true"))
   end
 end

--- a/ruby/templates/api_extra/application_create.rb
+++ b/ruby/templates/api_extra/application_create.rb
@@ -5,7 +5,7 @@ def get_or_create(application_in, options = {})
     "POST",
     path,
     query_params: {
-      "get_if_exists" => true
+      "get_if_exists" => "true"
     },
     headers: {
       "idempotency-key" => options["idempotency-key"]


### PR DESCRIPTION
The current code results in this error
```ruby
Failure/Error: encoded_query_pairs.append("#{k}=#{CGI::escape(v)}")

TypeError:
  no implicit conversion of true into String
```