### PR TITLE
ci: Check for unused dependencies

### DIFF
--- a/.github/workflows/bridge-ci.yml
+++ b/.github/workflows/bridge-ci.yml
@@ -41,6 +41,17 @@ jobs:
         run: cargo fmt -- --check
         working-directory: bridge
 
+  check-unused-deps:
+    name: Check for unused dependencies
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: taiki-e/install-action@cargo-machete
+
+      - run: cargo machete
+        working-directory: bridge
+
   test-versions:
     name: Webhook Bridge CI
     runs-on: ubuntu-24.04

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -38,6 +38,17 @@ jobs:
         run: cargo fmt -- --check
         working-directory: rust
 
+  check-unused-deps:
+    name: Check for unused dependencies
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: taiki-e/install-action@cargo-machete
+
+      - run: cargo machete
+        working-directory: rust
+
   test-versions:
     name: Rust Lint
     runs-on: ubuntu-24.04

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -38,6 +38,17 @@ jobs:
         run: cargo fmt -- --check
         working-directory: server
 
+  check-unused-deps:
+    name: Check for unused dependencies
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: taiki-e/install-action@cargo-machete
+
+      - run: cargo machete
+        working-directory: server
+
   test-versions:
     name: Server CI
     runs-on: ubuntu-24.04

--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -4423,7 +4423,6 @@ version = "1.63.0"
 dependencies = [
  "anyhow",
  "axum",
- "base64 0.13.1",
  "chrono",
  "clap",
  "deadpool 0.12.1",

--- a/bridge/svix-bridge/Cargo.toml
+++ b/bridge/svix-bridge/Cargo.toml
@@ -6,7 +6,6 @@ publish = false
 
 [dependencies]
 anyhow = "1"
-base64 = "0.13.1"
 clap = { version = "4.2.4", features = ["env", "derive"] }
 axum = { version = "0.7.7", features = ["macros"] }
 enum_dispatch = "0.3"

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -6,6 +6,12 @@ publish = false
 edition.workspace = true
 license.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = [
+    # not a direct dependency, but we want to pin its version
+    "idna_adapter",
+]
+
 [dependencies]
 svix-server_derive = { path = "../svix-server_derive" }
 


### PR DESCRIPTION
## Motivation

It has happened from time to time that dependencies have gone unused but we didn't notice. This should fix that once and for all :)

## Solution

Add [`cargo-machete`](https://github.com/bnjbvr/cargo-machete#readme) to CI.