### PR TITLE
python: Fix minimum version for pydantic

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,7 +1,7 @@
-python_dateutil >= 2.5.3
-setuptools >= 21.0.0
-urllib3 >= 1.25.3
-Deprecated >= 1.2.13
-types-deprecated >= 1.2.5
-types-python-dateutil >= 2.8.9
-pydantic >= 2.10
+python_dateutil>=2.5.3,<3
+setuptools>=21.0.0,<22
+urllib3>=1.25.3,<2
+Deprecated>=1.2.13,<2
+types-deprecated>=1.2.5,<2
+types-python-dateutil>=2.8.9,<3
+pydantic>=2.10,<3

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -4,4 +4,4 @@ urllib3 >= 1.25.3
 Deprecated >= 1.2.13
 types-deprecated >= 1.2.5
 types-python-dateutil >= 2.8.9
-pydantic >= 2
+pydantic >= 2.10


### PR DESCRIPTION
We are using ModelWrapValidatorHandler, which was introduced in 2.10

Also add maximum versions because it seems wrong that we don't have them.