### PR TITLE
python: Raise minimum version for setuptools, remove maximum version

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 python_dateutil>=2.5.3,<3
-setuptools>=21.0.0,<22
+setuptools>=70
 urllib3>=1.25.3,<2
 Deprecated>=1.2.13,<2
 types-deprecated>=1.2.5,<2


### PR DESCRIPTION
In https://github.com/svix/svix-webhooks/pull/1869, I accidentally changed the version requirement of setuptools to an ancient version. Everything <70 is affected by a security issue, so bump the minimum version to that and remove the upper bound again.