### PR TITLE
bridge: Wait longer before aborting tests

### DIFF
--- a/bridge/.config/nextest.toml
+++ b/bridge/.config/nextest.toml
@@ -1,3 +1,3 @@
 [profile.default]
 retries = 2
-slow-timeout = { period = "30s", terminate-after = 2 }
+slow-timeout = { period = "30s", terminate-after = 4 }


### PR DESCRIPTION
Maybe this will help with the kafka tests.

I checked a successful test run and it only took 12s, but I think there's still a chance that this will be of use.