### PR TITLE
Move `SvixHttpClient` to internal package

### DIFF
--- a/go/application.go
+++ b/go/application.go
@@ -4,14 +4,15 @@ package svix
 import (
 	"context"
 
+	"github.com/svix/svix-webhooks/go/internal"
 	"github.com/svix/svix-webhooks/go/models"
 )
 
 type Application struct {
-	client *SvixHttpClient
+	client *internal.SvixHttpClient
 }
 
-func newApplication(client *SvixHttpClient) *Application {
+func newApplication(client *internal.SvixHttpClient) *Application {
 	return &Application{
 		client: client,
 	}
@@ -39,14 +40,14 @@ func (application *Application) List(
 	queryMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("limit", o.Limit, queryMap, &err)
-		serializeParamToMap("iterator", o.Iterator, queryMap, &err)
-		serializeParamToMap("order", o.Order, queryMap, &err)
+		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
+		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
+		internal.SerializeParamToMap("order", o.Order, queryMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[any, models.ListResponseApplicationOut](
+	return internal.ExecuteRequest[any, models.ListResponseApplicationOut](
 		ctx,
 		application.client,
 		"GET",
@@ -70,12 +71,12 @@ func (application *Application) Create(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[models.ApplicationIn, models.ApplicationOut](
+	return internal.ExecuteRequest[models.ApplicationIn, models.ApplicationOut](
 		ctx,
 		application.client,
 		"POST",
@@ -100,13 +101,13 @@ func (application *Application) GetOrCreate(
 
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return executeRequest[models.ApplicationIn, models.ApplicationOut](
+	return internal.ExecuteRequest[models.ApplicationIn, models.ApplicationOut](
 		ctx,
 		application.client,
 		"POST",
@@ -126,7 +127,7 @@ func (application *Application) Get(
 	pathMap := map[string]string{
 		"app_id": appId,
 	}
-	return executeRequest[any, models.ApplicationOut](
+	return internal.ExecuteRequest[any, models.ApplicationOut](
 		ctx,
 		application.client,
 		"GET",
@@ -147,7 +148,7 @@ func (application *Application) Update(
 	pathMap := map[string]string{
 		"app_id": appId,
 	}
-	return executeRequest[models.ApplicationIn, models.ApplicationOut](
+	return internal.ExecuteRequest[models.ApplicationIn, models.ApplicationOut](
 		ctx,
 		application.client,
 		"PUT",
@@ -167,7 +168,7 @@ func (application *Application) Delete(
 	pathMap := map[string]string{
 		"app_id": appId,
 	}
-	_, err := executeRequest[any, any](
+	_, err := internal.ExecuteRequest[any, any](
 		ctx,
 		application.client,
 		"DELETE",
@@ -189,7 +190,7 @@ func (application *Application) Patch(
 	pathMap := map[string]string{
 		"app_id": appId,
 	}
-	return executeRequest[models.ApplicationPatch, models.ApplicationOut](
+	return internal.ExecuteRequest[models.ApplicationPatch, models.ApplicationOut](
 		ctx,
 		application.client,
 		"PATCH",

--- a/go/authentication.go
+++ b/go/authentication.go
@@ -4,14 +4,15 @@ package svix
 import (
 	"context"
 
+	"github.com/svix/svix-webhooks/go/internal"
 	"github.com/svix/svix-webhooks/go/models"
 )
 
 type Authentication struct {
-	client *SvixHttpClient
+	client *internal.SvixHttpClient
 }
 
-func newAuthentication(client *SvixHttpClient) *Authentication {
+func newAuthentication(client *internal.SvixHttpClient) *Authentication {
 	return &Authentication{
 		client: client,
 	}
@@ -42,12 +43,12 @@ func (authentication *Authentication) AppPortalAccess(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[models.AppPortalAccessIn, models.AppPortalAccessOut](
+	return internal.ExecuteRequest[models.AppPortalAccessIn, models.AppPortalAccessOut](
 		ctx,
 		authentication.client,
 		"POST",
@@ -72,12 +73,12 @@ func (authentication *Authentication) ExpireAll(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return err
 		}
 	}
-	_, err = executeRequest[models.ApplicationTokenExpireIn, any](
+	_, err = internal.ExecuteRequest[models.ApplicationTokenExpireIn, any](
 		ctx,
 		authentication.client,
 		"POST",
@@ -102,12 +103,12 @@ func (authentication *Authentication) DashboardAccess(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[any, models.DashboardAccessOut](
+	return internal.ExecuteRequest[any, models.DashboardAccessOut](
 		ctx,
 		authentication.client,
 		"POST",
@@ -129,12 +130,12 @@ func (authentication *Authentication) Logout(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return err
 		}
 	}
-	_, err = executeRequest[any, any](
+	_, err = internal.ExecuteRequest[any, any](
 		ctx,
 		authentication.client,
 		"POST",

--- a/go/background_task.go
+++ b/go/background_task.go
@@ -4,14 +4,15 @@ package svix
 import (
 	"context"
 
+	"github.com/svix/svix-webhooks/go/internal"
 	"github.com/svix/svix-webhooks/go/models"
 )
 
 type BackgroundTask struct {
-	client *SvixHttpClient
+	client *internal.SvixHttpClient
 }
 
-func newBackgroundTask(client *SvixHttpClient) *BackgroundTask {
+func newBackgroundTask(client *internal.SvixHttpClient) *BackgroundTask {
 	return &BackgroundTask{
 		client: client,
 	}
@@ -41,16 +42,16 @@ func (backgroundTask *BackgroundTask) List(
 	queryMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("status", o.Status, queryMap, &err)
-		serializeParamToMap("task", o.Task, queryMap, &err)
-		serializeParamToMap("limit", o.Limit, queryMap, &err)
-		serializeParamToMap("iterator", o.Iterator, queryMap, &err)
-		serializeParamToMap("order", o.Order, queryMap, &err)
+		internal.SerializeParamToMap("status", o.Status, queryMap, &err)
+		internal.SerializeParamToMap("task", o.Task, queryMap, &err)
+		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
+		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
+		internal.SerializeParamToMap("order", o.Order, queryMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[any, models.ListResponseBackgroundTaskOut](
+	return internal.ExecuteRequest[any, models.ListResponseBackgroundTaskOut](
 		ctx,
 		backgroundTask.client,
 		"GET",
@@ -70,7 +71,7 @@ func (backgroundTask *BackgroundTask) Get(
 	pathMap := map[string]string{
 		"task_id": taskId,
 	}
-	return executeRequest[any, models.BackgroundTaskOut](
+	return internal.ExecuteRequest[any, models.BackgroundTaskOut](
 		ctx,
 		backgroundTask.client,
 		"GET",

--- a/go/endpoint.go
+++ b/go/endpoint.go
@@ -5,14 +5,15 @@ import (
 	"context"
 	"time"
 
+	"github.com/svix/svix-webhooks/go/internal"
 	"github.com/svix/svix-webhooks/go/models"
 )
 
 type Endpoint struct {
-	client *SvixHttpClient
+	client *internal.SvixHttpClient
 }
 
-func newEndpoint(client *SvixHttpClient) *Endpoint {
+func newEndpoint(client *internal.SvixHttpClient) *Endpoint {
 	return &Endpoint{
 		client: client,
 	}
@@ -67,14 +68,14 @@ func (endpoint *Endpoint) List(
 	queryMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("limit", o.Limit, queryMap, &err)
-		serializeParamToMap("iterator", o.Iterator, queryMap, &err)
-		serializeParamToMap("order", o.Order, queryMap, &err)
+		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
+		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
+		internal.SerializeParamToMap("order", o.Order, queryMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[any, models.ListResponseEndpointOut](
+	return internal.ExecuteRequest[any, models.ListResponseEndpointOut](
 		ctx,
 		endpoint.client,
 		"GET",
@@ -101,12 +102,12 @@ func (endpoint *Endpoint) Create(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[models.EndpointIn, models.EndpointOut](
+	return internal.ExecuteRequest[models.EndpointIn, models.EndpointOut](
 		ctx,
 		endpoint.client,
 		"POST",
@@ -128,7 +129,7 @@ func (endpoint *Endpoint) Get(
 		"app_id":      appId,
 		"endpoint_id": endpointId,
 	}
-	return executeRequest[any, models.EndpointOut](
+	return internal.ExecuteRequest[any, models.EndpointOut](
 		ctx,
 		endpoint.client,
 		"GET",
@@ -151,7 +152,7 @@ func (endpoint *Endpoint) Update(
 		"app_id":      appId,
 		"endpoint_id": endpointId,
 	}
-	return executeRequest[models.EndpointUpdate, models.EndpointOut](
+	return internal.ExecuteRequest[models.EndpointUpdate, models.EndpointOut](
 		ctx,
 		endpoint.client,
 		"PUT",
@@ -173,7 +174,7 @@ func (endpoint *Endpoint) Delete(
 		"app_id":      appId,
 		"endpoint_id": endpointId,
 	}
-	_, err := executeRequest[any, any](
+	_, err := internal.ExecuteRequest[any, any](
 		ctx,
 		endpoint.client,
 		"DELETE",
@@ -197,7 +198,7 @@ func (endpoint *Endpoint) Patch(
 		"app_id":      appId,
 		"endpoint_id": endpointId,
 	}
-	return executeRequest[models.EndpointPatch, models.EndpointOut](
+	return internal.ExecuteRequest[models.EndpointPatch, models.EndpointOut](
 		ctx,
 		endpoint.client,
 		"PATCH",
@@ -219,7 +220,7 @@ func (endpoint *Endpoint) GetHeaders(
 		"app_id":      appId,
 		"endpoint_id": endpointId,
 	}
-	return executeRequest[any, models.EndpointHeadersOut](
+	return internal.ExecuteRequest[any, models.EndpointHeadersOut](
 		ctx,
 		endpoint.client,
 		"GET",
@@ -242,7 +243,7 @@ func (endpoint *Endpoint) UpdateHeaders(
 		"app_id":      appId,
 		"endpoint_id": endpointId,
 	}
-	_, err := executeRequest[models.EndpointHeadersIn, any](
+	_, err := internal.ExecuteRequest[models.EndpointHeadersIn, any](
 		ctx,
 		endpoint.client,
 		"PUT",
@@ -266,7 +267,7 @@ func (endpoint *Endpoint) PatchHeaders(
 		"app_id":      appId,
 		"endpoint_id": endpointId,
 	}
-	_, err := executeRequest[models.EndpointHeadersPatchIn, any](
+	_, err := internal.ExecuteRequest[models.EndpointHeadersPatchIn, any](
 		ctx,
 		endpoint.client,
 		"PATCH",
@@ -296,12 +297,12 @@ func (endpoint *Endpoint) Recover(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[models.RecoverIn, models.RecoverOut](
+	return internal.ExecuteRequest[models.RecoverIn, models.RecoverOut](
 		ctx,
 		endpoint.client,
 		"POST",
@@ -331,12 +332,12 @@ func (endpoint *Endpoint) ReplayMissing(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[models.ReplayIn, models.ReplayOut](
+	return internal.ExecuteRequest[models.ReplayIn, models.ReplayOut](
 		ctx,
 		endpoint.client,
 		"POST",
@@ -361,7 +362,7 @@ func (endpoint *Endpoint) GetSecret(
 		"app_id":      appId,
 		"endpoint_id": endpointId,
 	}
-	return executeRequest[any, models.EndpointSecretOut](
+	return internal.ExecuteRequest[any, models.EndpointSecretOut](
 		ctx,
 		endpoint.client,
 		"GET",
@@ -390,12 +391,12 @@ func (endpoint *Endpoint) RotateSecret(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return err
 		}
 	}
-	_, err = executeRequest[models.EndpointSecretRotateIn, any](
+	_, err = internal.ExecuteRequest[models.EndpointSecretRotateIn, any](
 		ctx,
 		endpoint.client,
 		"POST",
@@ -423,12 +424,12 @@ func (endpoint *Endpoint) SendExample(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[models.EventExampleIn, models.MessageOut](
+	return internal.ExecuteRequest[models.EventExampleIn, models.MessageOut](
 		ctx,
 		endpoint.client,
 		"POST",
@@ -454,13 +455,13 @@ func (endpoint *Endpoint) GetStats(
 	queryMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("since", o.Since, queryMap, &err)
-		serializeParamToMap("until", o.Until, queryMap, &err)
+		internal.SerializeParamToMap("since", o.Since, queryMap, &err)
+		internal.SerializeParamToMap("until", o.Until, queryMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[any, models.EndpointStats](
+	return internal.ExecuteRequest[any, models.EndpointStats](
 		ctx,
 		endpoint.client,
 		"GET",
@@ -482,7 +483,7 @@ func (endpoint *Endpoint) TransformationGet(
 		"app_id":      appId,
 		"endpoint_id": endpointId,
 	}
-	return executeRequest[any, models.EndpointTransformationOut](
+	return internal.ExecuteRequest[any, models.EndpointTransformationOut](
 		ctx,
 		endpoint.client,
 		"GET",
@@ -505,7 +506,7 @@ func (endpoint *Endpoint) TransformationPartialUpdate(
 		"app_id":      appId,
 		"endpoint_id": endpointId,
 	}
-	_, err := executeRequest[models.EndpointTransformationIn, any](
+	_, err := internal.ExecuteRequest[models.EndpointTransformationIn, any](
 		ctx,
 		endpoint.client,
 		"PATCH",

--- a/go/environment.go
+++ b/go/environment.go
@@ -4,14 +4,15 @@ package svix
 import (
 	"context"
 
+	"github.com/svix/svix-webhooks/go/internal"
 	"github.com/svix/svix-webhooks/go/models"
 )
 
 type Environment struct {
-	client *SvixHttpClient
+	client *internal.SvixHttpClient
 }
 
-func newEnvironment(client *SvixHttpClient) *Environment {
+func newEnvironment(client *internal.SvixHttpClient) *Environment {
 	return &Environment{
 		client: client,
 	}
@@ -33,12 +34,12 @@ func (environment *Environment) Export(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[any, models.EnvironmentOut](
+	return internal.ExecuteRequest[any, models.EnvironmentOut](
 		ctx,
 		environment.client,
 		"POST",
@@ -61,12 +62,12 @@ func (environment *Environment) Import(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return err
 		}
 	}
-	_, err = executeRequest[models.EnvironmentIn, any](
+	_, err = internal.ExecuteRequest[models.EnvironmentIn, any](
 		ctx,
 		environment.client,
 		"POST",

--- a/go/errors.go
+++ b/go/errors.go
@@ -1,23 +1,5 @@
 package svix
 
-// Error provides access to the body, status, and error on returned errors.
-type Error struct {
-	status int
-	body   []byte
-	error  string
-}
+import "github.com/svix/svix-webhooks/go/internal"
 
-// Error returns non-empty string if there was an error.
-func (e Error) Error() string {
-	return e.error
-}
-
-// Body returns the raw bytes of the response.
-func (e Error) Body() []byte {
-	return e.body
-}
-
-// Status returns the HTTP status of the error.
-func (e Error) Status() int {
-	return e.status
-}
+type Error = internal.Error

--- a/go/event_type.go
+++ b/go/event_type.go
@@ -4,14 +4,15 @@ package svix
 import (
 	"context"
 
+	"github.com/svix/svix-webhooks/go/internal"
 	"github.com/svix/svix-webhooks/go/models"
 )
 
 type EventType struct {
-	client *SvixHttpClient
+	client *internal.SvixHttpClient
 }
 
-func newEventType(client *SvixHttpClient) *EventType {
+func newEventType(client *internal.SvixHttpClient) *EventType {
 	return &EventType{
 		client: client,
 	}
@@ -52,16 +53,16 @@ func (eventType *EventType) List(
 	queryMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("limit", o.Limit, queryMap, &err)
-		serializeParamToMap("iterator", o.Iterator, queryMap, &err)
-		serializeParamToMap("order", o.Order, queryMap, &err)
-		serializeParamToMap("include_archived", o.IncludeArchived, queryMap, &err)
-		serializeParamToMap("with_content", o.WithContent, queryMap, &err)
+		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
+		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
+		internal.SerializeParamToMap("order", o.Order, queryMap, &err)
+		internal.SerializeParamToMap("include_archived", o.IncludeArchived, queryMap, &err)
+		internal.SerializeParamToMap("with_content", o.WithContent, queryMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[any, models.ListResponseEventTypeOut](
+	return internal.ExecuteRequest[any, models.ListResponseEventTypeOut](
 		ctx,
 		eventType.client,
 		"GET",
@@ -86,12 +87,12 @@ func (eventType *EventType) Create(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[models.EventTypeIn, models.EventTypeOut](
+	return internal.ExecuteRequest[models.EventTypeIn, models.EventTypeOut](
 		ctx,
 		eventType.client,
 		"POST",
@@ -116,12 +117,12 @@ func (eventType *EventType) ImportOpenapi(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[models.EventTypeImportOpenApiIn, models.EventTypeImportOpenApiOut](
+	return internal.ExecuteRequest[models.EventTypeImportOpenApiIn, models.EventTypeImportOpenApiOut](
 		ctx,
 		eventType.client,
 		"POST",
@@ -141,7 +142,7 @@ func (eventType *EventType) Get(
 	pathMap := map[string]string{
 		"event_type_name": eventTypeName,
 	}
-	return executeRequest[any, models.EventTypeOut](
+	return internal.ExecuteRequest[any, models.EventTypeOut](
 		ctx,
 		eventType.client,
 		"GET",
@@ -162,7 +163,7 @@ func (eventType *EventType) Update(
 	pathMap := map[string]string{
 		"event_type_name": eventTypeName,
 	}
-	return executeRequest[models.EventTypeUpdate, models.EventTypeOut](
+	return internal.ExecuteRequest[models.EventTypeUpdate, models.EventTypeOut](
 		ctx,
 		eventType.client,
 		"PUT",
@@ -191,12 +192,12 @@ func (eventType *EventType) Delete(
 	queryMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("expunge", o.Expunge, queryMap, &err)
+		internal.SerializeParamToMap("expunge", o.Expunge, queryMap, &err)
 		if err != nil {
 			return err
 		}
 	}
-	_, err = executeRequest[any, any](
+	_, err = internal.ExecuteRequest[any, any](
 		ctx,
 		eventType.client,
 		"DELETE",
@@ -218,7 +219,7 @@ func (eventType *EventType) Patch(
 	pathMap := map[string]string{
 		"event_type_name": eventTypeName,
 	}
-	return executeRequest[models.EventTypePatch, models.EventTypeOut](
+	return internal.ExecuteRequest[models.EventTypePatch, models.EventTypeOut](
 		ctx,
 		eventType.client,
 		"PATCH",

--- a/go/ingest.go
+++ b/go/ingest.go
@@ -4,16 +4,17 @@ package svix
 import (
 	"context"
 
+	"github.com/svix/svix-webhooks/go/internal"
 	"github.com/svix/svix-webhooks/go/models"
 )
 
 type Ingest struct {
-	client   *SvixHttpClient
+	client   *internal.SvixHttpClient
 	Endpoint *IngestEndpoint
 	Source   *IngestSource
 }
 
-func newIngest(client *SvixHttpClient) *Ingest {
+func newIngest(client *internal.SvixHttpClient) *Ingest {
 	return &Ingest{
 		client:   client,
 		Endpoint: newIngestEndpoint(client),
@@ -38,12 +39,12 @@ func (ingest *Ingest) Dashboard(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[models.IngestSourceConsumerPortalAccessIn, models.DashboardAccessOut](
+	return internal.ExecuteRequest[models.IngestSourceConsumerPortalAccessIn, models.DashboardAccessOut](
 		ctx,
 		ingest.client,
 		"POST",

--- a/go/ingest_endpoint.go
+++ b/go/ingest_endpoint.go
@@ -4,14 +4,15 @@ package svix
 import (
 	"context"
 
+	"github.com/svix/svix-webhooks/go/internal"
 	"github.com/svix/svix-webhooks/go/models"
 )
 
 type IngestEndpoint struct {
-	client *SvixHttpClient
+	client *internal.SvixHttpClient
 }
 
-func newIngestEndpoint(client *SvixHttpClient) *IngestEndpoint {
+func newIngestEndpoint(client *internal.SvixHttpClient) *IngestEndpoint {
 	return &IngestEndpoint{
 		client: client,
 	}
@@ -43,14 +44,14 @@ func (ingestEndpoint *IngestEndpoint) List(
 	queryMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("limit", o.Limit, queryMap, &err)
-		serializeParamToMap("iterator", o.Iterator, queryMap, &err)
-		serializeParamToMap("order", o.Order, queryMap, &err)
+		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
+		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
+		internal.SerializeParamToMap("order", o.Order, queryMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[any, models.ListResponseIngestEndpointOut](
+	return internal.ExecuteRequest[any, models.ListResponseIngestEndpointOut](
 		ctx,
 		ingestEndpoint.client,
 		"GET",
@@ -71,12 +72,12 @@ func (ingestEndpoint *IngestEndpoint) Create(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[models.IngestEndpointIn, models.IngestEndpointOut](
+	return internal.ExecuteRequest[models.IngestEndpointIn, models.IngestEndpointOut](
 		ctx,
 		ingestEndpoint.client,
 		"POST",
@@ -96,7 +97,7 @@ func (ingestEndpoint *IngestEndpoint) Get(
 	pathMap := map[string]string{
 		"endpoint_id": endpointId,
 	}
-	return executeRequest[any, models.IngestEndpointOut](
+	return internal.ExecuteRequest[any, models.IngestEndpointOut](
 		ctx,
 		ingestEndpoint.client,
 		"GET",
@@ -117,7 +118,7 @@ func (ingestEndpoint *IngestEndpoint) Update(
 	pathMap := map[string]string{
 		"endpoint_id": endpointId,
 	}
-	return executeRequest[models.IngestEndpointUpdate, models.IngestEndpointOut](
+	return internal.ExecuteRequest[models.IngestEndpointUpdate, models.IngestEndpointOut](
 		ctx,
 		ingestEndpoint.client,
 		"PUT",
@@ -137,7 +138,7 @@ func (ingestEndpoint *IngestEndpoint) Delete(
 	pathMap := map[string]string{
 		"endpoint_id": endpointId,
 	}
-	_, err := executeRequest[any, any](
+	_, err := internal.ExecuteRequest[any, any](
 		ctx,
 		ingestEndpoint.client,
 		"DELETE",
@@ -158,7 +159,7 @@ func (ingestEndpoint *IngestEndpoint) GetHeaders(
 	pathMap := map[string]string{
 		"endpoint_id": endpointId,
 	}
-	return executeRequest[any, models.IngestEndpointHeadersOut](
+	return internal.ExecuteRequest[any, models.IngestEndpointHeadersOut](
 		ctx,
 		ingestEndpoint.client,
 		"GET",
@@ -179,7 +180,7 @@ func (ingestEndpoint *IngestEndpoint) UpdateHeaders(
 	pathMap := map[string]string{
 		"endpoint_id": endpointId,
 	}
-	_, err := executeRequest[models.IngestEndpointHeadersIn, any](
+	_, err := internal.ExecuteRequest[models.IngestEndpointHeadersIn, any](
 		ctx,
 		ingestEndpoint.client,
 		"PUT",
@@ -203,7 +204,7 @@ func (ingestEndpoint *IngestEndpoint) GetSecret(
 	pathMap := map[string]string{
 		"endpoint_id": endpointId,
 	}
-	return executeRequest[any, models.IngestEndpointSecretOut](
+	return internal.ExecuteRequest[any, models.IngestEndpointSecretOut](
 		ctx,
 		ingestEndpoint.client,
 		"GET",
@@ -230,12 +231,12 @@ func (ingestEndpoint *IngestEndpoint) RotateSecret(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return err
 		}
 	}
-	_, err = executeRequest[models.IngestEndpointSecretIn, any](
+	_, err = internal.ExecuteRequest[models.IngestEndpointSecretIn, any](
 		ctx,
 		ingestEndpoint.client,
 		"POST",

--- a/go/ingest_source.go
+++ b/go/ingest_source.go
@@ -4,14 +4,15 @@ package svix
 import (
 	"context"
 
+	"github.com/svix/svix-webhooks/go/internal"
 	"github.com/svix/svix-webhooks/go/models"
 )
 
 type IngestSource struct {
-	client *SvixHttpClient
+	client *internal.SvixHttpClient
 }
 
-func newIngestSource(client *SvixHttpClient) *IngestSource {
+func newIngestSource(client *internal.SvixHttpClient) *IngestSource {
 	return &IngestSource{
 		client: client,
 	}
@@ -43,14 +44,14 @@ func (ingestSource *IngestSource) List(
 	queryMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("limit", o.Limit, queryMap, &err)
-		serializeParamToMap("iterator", o.Iterator, queryMap, &err)
-		serializeParamToMap("order", o.Order, queryMap, &err)
+		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
+		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
+		internal.SerializeParamToMap("order", o.Order, queryMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[any, models.ListResponseIngestSourceOut](
+	return internal.ExecuteRequest[any, models.ListResponseIngestSourceOut](
 		ctx,
 		ingestSource.client,
 		"GET",
@@ -71,12 +72,12 @@ func (ingestSource *IngestSource) Create(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[models.IngestSourceIn, models.IngestSourceOut](
+	return internal.ExecuteRequest[models.IngestSourceIn, models.IngestSourceOut](
 		ctx,
 		ingestSource.client,
 		"POST",
@@ -96,7 +97,7 @@ func (ingestSource *IngestSource) Get(
 	pathMap := map[string]string{
 		"source_id": sourceId,
 	}
-	return executeRequest[any, models.IngestSourceOut](
+	return internal.ExecuteRequest[any, models.IngestSourceOut](
 		ctx,
 		ingestSource.client,
 		"GET",
@@ -117,7 +118,7 @@ func (ingestSource *IngestSource) Update(
 	pathMap := map[string]string{
 		"source_id": sourceId,
 	}
-	return executeRequest[models.IngestSourceIn, models.IngestSourceOut](
+	return internal.ExecuteRequest[models.IngestSourceIn, models.IngestSourceOut](
 		ctx,
 		ingestSource.client,
 		"PUT",
@@ -137,7 +138,7 @@ func (ingestSource *IngestSource) Delete(
 	pathMap := map[string]string{
 		"source_id": sourceId,
 	}
-	_, err := executeRequest[any, any](
+	_, err := internal.ExecuteRequest[any, any](
 		ctx,
 		ingestSource.client,
 		"DELETE",
@@ -167,12 +168,12 @@ func (ingestSource *IngestSource) RotateToken(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[any, models.RotateTokenOut](
+	return internal.ExecuteRequest[any, models.RotateTokenOut](
 		ctx,
 		ingestSource.client,
 		"POST",

--- a/go/integration.go
+++ b/go/integration.go
@@ -4,14 +4,15 @@ package svix
 import (
 	"context"
 
+	"github.com/svix/svix-webhooks/go/internal"
 	"github.com/svix/svix-webhooks/go/models"
 )
 
 type Integration struct {
-	client *SvixHttpClient
+	client *internal.SvixHttpClient
 }
 
-func newIntegration(client *SvixHttpClient) *Integration {
+func newIntegration(client *internal.SvixHttpClient) *Integration {
 	return &Integration{
 		client: client,
 	}
@@ -47,14 +48,14 @@ func (integration *Integration) List(
 	queryMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("limit", o.Limit, queryMap, &err)
-		serializeParamToMap("iterator", o.Iterator, queryMap, &err)
-		serializeParamToMap("order", o.Order, queryMap, &err)
+		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
+		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
+		internal.SerializeParamToMap("order", o.Order, queryMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[any, models.ListResponseIntegrationOut](
+	return internal.ExecuteRequest[any, models.ListResponseIntegrationOut](
 		ctx,
 		integration.client,
 		"GET",
@@ -79,12 +80,12 @@ func (integration *Integration) Create(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[models.IntegrationIn, models.IntegrationOut](
+	return internal.ExecuteRequest[models.IntegrationIn, models.IntegrationOut](
 		ctx,
 		integration.client,
 		"POST",
@@ -106,7 +107,7 @@ func (integration *Integration) Get(
 		"app_id":   appId,
 		"integ_id": integId,
 	}
-	return executeRequest[any, models.IntegrationOut](
+	return internal.ExecuteRequest[any, models.IntegrationOut](
 		ctx,
 		integration.client,
 		"GET",
@@ -129,7 +130,7 @@ func (integration *Integration) Update(
 		"app_id":   appId,
 		"integ_id": integId,
 	}
-	return executeRequest[models.IntegrationUpdate, models.IntegrationOut](
+	return internal.ExecuteRequest[models.IntegrationUpdate, models.IntegrationOut](
 		ctx,
 		integration.client,
 		"PUT",
@@ -151,7 +152,7 @@ func (integration *Integration) Delete(
 		"app_id":   appId,
 		"integ_id": integId,
 	}
-	_, err := executeRequest[any, any](
+	_, err := internal.ExecuteRequest[any, any](
 		ctx,
 		integration.client,
 		"DELETE",
@@ -176,7 +177,7 @@ func (integration *Integration) GetKey(
 		"app_id":   appId,
 		"integ_id": integId,
 	}
-	return executeRequest[any, models.IntegrationKeyOut](
+	return internal.ExecuteRequest[any, models.IntegrationKeyOut](
 		ctx,
 		integration.client,
 		"GET",
@@ -202,12 +203,12 @@ func (integration *Integration) RotateKey(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[any, models.IntegrationKeyOut](
+	return internal.ExecuteRequest[any, models.IntegrationKeyOut](
 		ctx,
 		integration.client,
 		"POST",

--- a/go/internal/error.go
+++ b/go/internal/error.go
@@ -1,0 +1,23 @@
+package internal
+
+// Error provides access to the body, status, and error on returned errors.
+type Error struct {
+	status int
+	body   []byte
+	error  string
+}
+
+// Error returns non-empty string if there was an error.
+func (e Error) Error() string {
+	return e.error
+}
+
+// Body returns the raw bytes of the response.
+func (e Error) Body() []byte {
+	return e.body
+}
+
+// Status returns the HTTP status of the error.
+func (e Error) Status() int {
+	return e.status
+}

--- a/go/internal/svix_http_client.go
+++ b/go/internal/svix_http_client.go
@@ -1,4 +1,4 @@
-package svix
+package internal
 
 import (
 	"bytes"
@@ -25,7 +25,7 @@ type SvixHttpClient struct {
 	Debug          bool
 }
 
-func defaultSvixHttpClient(defaultBaseUrl string) SvixHttpClient {
+func DefaultSvixHttpClient(defaultBaseUrl string) SvixHttpClient {
 	return SvixHttpClient{
 		DefaultHeaders: map[string]string{},
 		HTTPClient:     &http.Client{Timeout: 60 * time.Second},
@@ -35,7 +35,7 @@ func defaultSvixHttpClient(defaultBaseUrl string) SvixHttpClient {
 	}
 }
 
-func executeRequest[ReqBody any, ResBody any](
+func ExecuteRequest[ReqBody any, ResBody any](
 	ctx context.Context,
 	client *SvixHttpClient,
 	method string,
@@ -156,7 +156,7 @@ func addQueryParams(baseURL string, params map[string]string) (string, error) {
 	return parsedURL.String(), nil
 }
 
-func serializeParamToMap(key string, val interface{}, d map[string]string, err *error) {
+func SerializeParamToMap(key string, val interface{}, d map[string]string, err *error) {
 	// I pass the error in here so I don't have to "if err != nil" for every query param
 	if *err != nil {
 		return

--- a/go/management.go
+++ b/go/management.go
@@ -1,11 +1,15 @@
 // Package svix this file is @generated DO NOT EDIT
 package svix
 
+import (
+	"github.com/svix/svix-webhooks/go/internal"
+)
+
 type Management struct {
 	Authentication *ManagementAuthentication
 }
 
-func newManagement(client *SvixHttpClient) *Management {
+func newManagement(client *internal.SvixHttpClient) *Management {
 	return &Management{
 		Authentication: newManagementAuthentication(client),
 	}

--- a/go/management_authentication.go
+++ b/go/management_authentication.go
@@ -4,14 +4,15 @@ package svix
 import (
 	"context"
 
+	"github.com/svix/svix-webhooks/go/internal"
 	"github.com/svix/svix-webhooks/go/models"
 )
 
 type ManagementAuthentication struct {
-	client *SvixHttpClient
+	client *internal.SvixHttpClient
 }
 
-func newManagementAuthentication(client *SvixHttpClient) *ManagementAuthentication {
+func newManagementAuthentication(client *internal.SvixHttpClient) *ManagementAuthentication {
 	return &ManagementAuthentication{
 		client: client,
 	}
@@ -43,14 +44,14 @@ func (managementAuthentication *ManagementAuthentication) ListApiTokens(
 	queryMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("limit", o.Limit, queryMap, &err)
-		serializeParamToMap("iterator", o.Iterator, queryMap, &err)
-		serializeParamToMap("order", o.Order, queryMap, &err)
+		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
+		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
+		internal.SerializeParamToMap("order", o.Order, queryMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[any, models.ListResponseApiTokenCensoredOut](
+	return internal.ExecuteRequest[any, models.ListResponseApiTokenCensoredOut](
 		ctx,
 		managementAuthentication.client,
 		"GET",
@@ -71,12 +72,12 @@ func (managementAuthentication *ManagementAuthentication) CreateApiToken(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[models.ApiTokenIn, models.ApiTokenOut](
+	return internal.ExecuteRequest[models.ApiTokenIn, models.ApiTokenOut](
 		ctx,
 		managementAuthentication.client,
 		"POST",
@@ -101,12 +102,12 @@ func (managementAuthentication *ManagementAuthentication) ExpireApiToken(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return err
 		}
 	}
-	_, err = executeRequest[models.ApiTokenExpireIn, any](
+	_, err = internal.ExecuteRequest[models.ApiTokenExpireIn, any](
 		ctx,
 		managementAuthentication.client,
 		"POST",

--- a/go/message.go
+++ b/go/message.go
@@ -5,15 +5,16 @@ import (
 	"context"
 	"time"
 
+	"github.com/svix/svix-webhooks/go/internal"
 	"github.com/svix/svix-webhooks/go/models"
 )
 
 type Message struct {
-	client *SvixHttpClient
+	client *internal.SvixHttpClient
 	Poller *MessagePoller
 }
 
-func newMessage(client *SvixHttpClient) *Message {
+func newMessage(client *internal.SvixHttpClient) *Message {
 	return &Message{
 		client: client,
 		Poller: newMessagePoller(client),
@@ -74,19 +75,19 @@ func (message *Message) List(
 	queryMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("limit", o.Limit, queryMap, &err)
-		serializeParamToMap("iterator", o.Iterator, queryMap, &err)
-		serializeParamToMap("channel", o.Channel, queryMap, &err)
-		serializeParamToMap("before", o.Before, queryMap, &err)
-		serializeParamToMap("after", o.After, queryMap, &err)
-		serializeParamToMap("with_content", o.WithContent, queryMap, &err)
-		serializeParamToMap("tag", o.Tag, queryMap, &err)
-		serializeParamToMap("event_types", o.EventTypes, queryMap, &err)
+		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
+		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
+		internal.SerializeParamToMap("channel", o.Channel, queryMap, &err)
+		internal.SerializeParamToMap("before", o.Before, queryMap, &err)
+		internal.SerializeParamToMap("after", o.After, queryMap, &err)
+		internal.SerializeParamToMap("with_content", o.WithContent, queryMap, &err)
+		internal.SerializeParamToMap("tag", o.Tag, queryMap, &err)
+		internal.SerializeParamToMap("event_types", o.EventTypes, queryMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[any, models.ListResponseMessageOut](
+	return internal.ExecuteRequest[any, models.ListResponseMessageOut](
 		ctx,
 		message.client,
 		"GET",
@@ -120,13 +121,13 @@ func (message *Message) Create(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
-		serializeParamToMap("with_content", o.WithContent, queryMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("with_content", o.WithContent, queryMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[models.MessageIn, models.MessageOut](
+	return internal.ExecuteRequest[models.MessageIn, models.MessageOut](
 		ctx,
 		message.client,
 		"POST",
@@ -152,12 +153,12 @@ func (message *Message) ExpungeAllContents(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[any, models.ExpungeAllContentsOut](
+	return internal.ExecuteRequest[any, models.ExpungeAllContentsOut](
 		ctx,
 		message.client,
 		"POST",
@@ -183,12 +184,12 @@ func (message *Message) Get(
 	queryMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("with_content", o.WithContent, queryMap, &err)
+		internal.SerializeParamToMap("with_content", o.WithContent, queryMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[any, models.MessageOut](
+	return internal.ExecuteRequest[any, models.MessageOut](
 		ctx,
 		message.client,
 		"GET",
@@ -213,7 +214,7 @@ func (message *Message) ExpungeContent(
 		"app_id": appId,
 		"msg_id": msgId,
 	}
-	_, err := executeRequest[any, any](
+	_, err := internal.ExecuteRequest[any, any](
 		ctx,
 		message.client,
 		"DELETE",

--- a/go/message_attempt.go
+++ b/go/message_attempt.go
@@ -5,14 +5,15 @@ import (
 	"context"
 	"time"
 
+	"github.com/svix/svix-webhooks/go/internal"
 	"github.com/svix/svix-webhooks/go/models"
 )
 
 type MessageAttempt struct {
-	client *SvixHttpClient
+	client *internal.SvixHttpClient
 }
 
-func newMessageAttempt(client *SvixHttpClient) *MessageAttempt {
+func newMessageAttempt(client *internal.SvixHttpClient) *MessageAttempt {
 	return &MessageAttempt{
 		client: client,
 	}
@@ -124,22 +125,22 @@ func (messageAttempt *MessageAttempt) ListByEndpoint(
 	queryMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("limit", o.Limit, queryMap, &err)
-		serializeParamToMap("iterator", o.Iterator, queryMap, &err)
-		serializeParamToMap("status", o.Status, queryMap, &err)
-		serializeParamToMap("status_code_class", o.StatusCodeClass, queryMap, &err)
-		serializeParamToMap("channel", o.Channel, queryMap, &err)
-		serializeParamToMap("tag", o.Tag, queryMap, &err)
-		serializeParamToMap("before", o.Before, queryMap, &err)
-		serializeParamToMap("after", o.After, queryMap, &err)
-		serializeParamToMap("with_content", o.WithContent, queryMap, &err)
-		serializeParamToMap("with_msg", o.WithMsg, queryMap, &err)
-		serializeParamToMap("event_types", o.EventTypes, queryMap, &err)
+		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
+		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
+		internal.SerializeParamToMap("status", o.Status, queryMap, &err)
+		internal.SerializeParamToMap("status_code_class", o.StatusCodeClass, queryMap, &err)
+		internal.SerializeParamToMap("channel", o.Channel, queryMap, &err)
+		internal.SerializeParamToMap("tag", o.Tag, queryMap, &err)
+		internal.SerializeParamToMap("before", o.Before, queryMap, &err)
+		internal.SerializeParamToMap("after", o.After, queryMap, &err)
+		internal.SerializeParamToMap("with_content", o.WithContent, queryMap, &err)
+		internal.SerializeParamToMap("with_msg", o.WithMsg, queryMap, &err)
+		internal.SerializeParamToMap("event_types", o.EventTypes, queryMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[any, models.ListResponseMessageAttemptOut](
+	return internal.ExecuteRequest[any, models.ListResponseMessageAttemptOut](
 		ctx,
 		messageAttempt.client,
 		"GET",
@@ -170,22 +171,22 @@ func (messageAttempt *MessageAttempt) ListByMsg(
 	queryMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("limit", o.Limit, queryMap, &err)
-		serializeParamToMap("iterator", o.Iterator, queryMap, &err)
-		serializeParamToMap("status", o.Status, queryMap, &err)
-		serializeParamToMap("status_code_class", o.StatusCodeClass, queryMap, &err)
-		serializeParamToMap("channel", o.Channel, queryMap, &err)
-		serializeParamToMap("tag", o.Tag, queryMap, &err)
-		serializeParamToMap("endpoint_id", o.EndpointId, queryMap, &err)
-		serializeParamToMap("before", o.Before, queryMap, &err)
-		serializeParamToMap("after", o.After, queryMap, &err)
-		serializeParamToMap("with_content", o.WithContent, queryMap, &err)
-		serializeParamToMap("event_types", o.EventTypes, queryMap, &err)
+		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
+		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
+		internal.SerializeParamToMap("status", o.Status, queryMap, &err)
+		internal.SerializeParamToMap("status_code_class", o.StatusCodeClass, queryMap, &err)
+		internal.SerializeParamToMap("channel", o.Channel, queryMap, &err)
+		internal.SerializeParamToMap("tag", o.Tag, queryMap, &err)
+		internal.SerializeParamToMap("endpoint_id", o.EndpointId, queryMap, &err)
+		internal.SerializeParamToMap("before", o.Before, queryMap, &err)
+		internal.SerializeParamToMap("after", o.After, queryMap, &err)
+		internal.SerializeParamToMap("with_content", o.WithContent, queryMap, &err)
+		internal.SerializeParamToMap("event_types", o.EventTypes, queryMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[any, models.ListResponseMessageAttemptOut](
+	return internal.ExecuteRequest[any, models.ListResponseMessageAttemptOut](
 		ctx,
 		messageAttempt.client,
 		"GET",
@@ -218,20 +219,20 @@ func (messageAttempt *MessageAttempt) ListAttemptedMessages(
 	queryMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("limit", o.Limit, queryMap, &err)
-		serializeParamToMap("iterator", o.Iterator, queryMap, &err)
-		serializeParamToMap("channel", o.Channel, queryMap, &err)
-		serializeParamToMap("tag", o.Tag, queryMap, &err)
-		serializeParamToMap("status", o.Status, queryMap, &err)
-		serializeParamToMap("before", o.Before, queryMap, &err)
-		serializeParamToMap("after", o.After, queryMap, &err)
-		serializeParamToMap("with_content", o.WithContent, queryMap, &err)
-		serializeParamToMap("event_types", o.EventTypes, queryMap, &err)
+		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
+		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
+		internal.SerializeParamToMap("channel", o.Channel, queryMap, &err)
+		internal.SerializeParamToMap("tag", o.Tag, queryMap, &err)
+		internal.SerializeParamToMap("status", o.Status, queryMap, &err)
+		internal.SerializeParamToMap("before", o.Before, queryMap, &err)
+		internal.SerializeParamToMap("after", o.After, queryMap, &err)
+		internal.SerializeParamToMap("with_content", o.WithContent, queryMap, &err)
+		internal.SerializeParamToMap("event_types", o.EventTypes, queryMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[any, models.ListResponseEndpointMessageOut](
+	return internal.ExecuteRequest[any, models.ListResponseEndpointMessageOut](
 		ctx,
 		messageAttempt.client,
 		"GET",
@@ -255,7 +256,7 @@ func (messageAttempt *MessageAttempt) Get(
 		"msg_id":     msgId,
 		"attempt_id": attemptId,
 	}
-	return executeRequest[any, models.MessageAttemptOut](
+	return internal.ExecuteRequest[any, models.MessageAttemptOut](
 		ctx,
 		messageAttempt.client,
 		"GET",
@@ -282,7 +283,7 @@ func (messageAttempt *MessageAttempt) ExpungeContent(
 		"msg_id":     msgId,
 		"attempt_id": attemptId,
 	}
-	_, err := executeRequest[any, any](
+	_, err := internal.ExecuteRequest[any, any](
 		ctx,
 		messageAttempt.client,
 		"DELETE",
@@ -312,13 +313,13 @@ func (messageAttempt *MessageAttempt) ListAttemptedDestinations(
 	queryMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("limit", o.Limit, queryMap, &err)
-		serializeParamToMap("iterator", o.Iterator, queryMap, &err)
+		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
+		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[any, models.ListResponseMessageEndpointOut](
+	return internal.ExecuteRequest[any, models.ListResponseMessageEndpointOut](
 		ctx,
 		messageAttempt.client,
 		"GET",
@@ -346,12 +347,12 @@ func (messageAttempt *MessageAttempt) Resend(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return err
 		}
 	}
-	_, err = executeRequest[any, any](
+	_, err = internal.ExecuteRequest[any, any](
 		ctx,
 		messageAttempt.client,
 		"POST",

--- a/go/message_poller.go
+++ b/go/message_poller.go
@@ -5,14 +5,15 @@ import (
 	"context"
 	"time"
 
+	"github.com/svix/svix-webhooks/go/internal"
 	"github.com/svix/svix-webhooks/go/models"
 )
 
 type MessagePoller struct {
-	client *SvixHttpClient
+	client *internal.SvixHttpClient
 }
 
-func newMessagePoller(client *SvixHttpClient) *MessagePoller {
+func newMessagePoller(client *internal.SvixHttpClient) *MessagePoller {
 	return &MessagePoller{
 		client: client,
 	}
@@ -59,16 +60,16 @@ func (messagePoller *MessagePoller) Poll(
 	queryMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("limit", o.Limit, queryMap, &err)
-		serializeParamToMap("iterator", o.Iterator, queryMap, &err)
-		serializeParamToMap("event_type", o.EventType, queryMap, &err)
-		serializeParamToMap("channel", o.Channel, queryMap, &err)
-		serializeParamToMap("after", o.After, queryMap, &err)
+		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
+		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
+		internal.SerializeParamToMap("event_type", o.EventType, queryMap, &err)
+		internal.SerializeParamToMap("channel", o.Channel, queryMap, &err)
+		internal.SerializeParamToMap("after", o.After, queryMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[any, models.PollingEndpointOut](
+	return internal.ExecuteRequest[any, models.PollingEndpointOut](
 		ctx,
 		messagePoller.client,
 		"GET",
@@ -97,15 +98,15 @@ func (messagePoller *MessagePoller) ConsumerPoll(
 	queryMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("limit", o.Limit, queryMap, &err)
-		serializeParamToMap("iterator", o.Iterator, queryMap, &err)
-		serializeParamToMap("event_type", o.EventType, queryMap, &err)
-		serializeParamToMap("channel", o.Channel, queryMap, &err)
+		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
+		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
+		internal.SerializeParamToMap("event_type", o.EventType, queryMap, &err)
+		internal.SerializeParamToMap("channel", o.Channel, queryMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[any, models.PollingEndpointOut](
+	return internal.ExecuteRequest[any, models.PollingEndpointOut](
 		ctx,
 		messagePoller.client,
 		"GET",
@@ -134,12 +135,12 @@ func (messagePoller *MessagePoller) ConsumerSeek(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[models.PollingEndpointConsumerSeekIn, models.PollingEndpointConsumerSeekOut](
+	return internal.ExecuteRequest[models.PollingEndpointConsumerSeekIn, models.PollingEndpointConsumerSeekOut](
 		ctx,
 		messagePoller.client,
 		"POST",

--- a/go/operational_webhook.go
+++ b/go/operational_webhook.go
@@ -1,11 +1,15 @@
 // Package svix this file is @generated DO NOT EDIT
 package svix
 
+import (
+	"github.com/svix/svix-webhooks/go/internal"
+)
+
 type OperationalWebhook struct {
 	Endpoint *OperationalWebhookEndpoint
 }
 
-func newOperationalWebhook(client *SvixHttpClient) *OperationalWebhook {
+func newOperationalWebhook(client *internal.SvixHttpClient) *OperationalWebhook {
 	return &OperationalWebhook{
 		Endpoint: newOperationalWebhookEndpoint(client),
 	}

--- a/go/operational_webhook_endpoint.go
+++ b/go/operational_webhook_endpoint.go
@@ -4,14 +4,15 @@ package svix
 import (
 	"context"
 
+	"github.com/svix/svix-webhooks/go/internal"
 	"github.com/svix/svix-webhooks/go/models"
 )
 
 type OperationalWebhookEndpoint struct {
-	client *SvixHttpClient
+	client *internal.SvixHttpClient
 }
 
-func newOperationalWebhookEndpoint(client *SvixHttpClient) *OperationalWebhookEndpoint {
+func newOperationalWebhookEndpoint(client *internal.SvixHttpClient) *OperationalWebhookEndpoint {
 	return &OperationalWebhookEndpoint{
 		client: client,
 	}
@@ -43,14 +44,14 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) List(
 	queryMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("limit", o.Limit, queryMap, &err)
-		serializeParamToMap("iterator", o.Iterator, queryMap, &err)
-		serializeParamToMap("order", o.Order, queryMap, &err)
+		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
+		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
+		internal.SerializeParamToMap("order", o.Order, queryMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[any, models.ListResponseOperationalWebhookEndpointOut](
+	return internal.ExecuteRequest[any, models.ListResponseOperationalWebhookEndpointOut](
 		ctx,
 		operationalWebhookEndpoint.client,
 		"GET",
@@ -71,12 +72,12 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) Create(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[models.OperationalWebhookEndpointIn, models.OperationalWebhookEndpointOut](
+	return internal.ExecuteRequest[models.OperationalWebhookEndpointIn, models.OperationalWebhookEndpointOut](
 		ctx,
 		operationalWebhookEndpoint.client,
 		"POST",
@@ -96,7 +97,7 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) Get(
 	pathMap := map[string]string{
 		"endpoint_id": endpointId,
 	}
-	return executeRequest[any, models.OperationalWebhookEndpointOut](
+	return internal.ExecuteRequest[any, models.OperationalWebhookEndpointOut](
 		ctx,
 		operationalWebhookEndpoint.client,
 		"GET",
@@ -117,7 +118,7 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) Update(
 	pathMap := map[string]string{
 		"endpoint_id": endpointId,
 	}
-	return executeRequest[models.OperationalWebhookEndpointUpdate, models.OperationalWebhookEndpointOut](
+	return internal.ExecuteRequest[models.OperationalWebhookEndpointUpdate, models.OperationalWebhookEndpointOut](
 		ctx,
 		operationalWebhookEndpoint.client,
 		"PUT",
@@ -137,7 +138,7 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) Delete(
 	pathMap := map[string]string{
 		"endpoint_id": endpointId,
 	}
-	_, err := executeRequest[any, any](
+	_, err := internal.ExecuteRequest[any, any](
 		ctx,
 		operationalWebhookEndpoint.client,
 		"DELETE",
@@ -158,7 +159,7 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) GetHeaders(
 	pathMap := map[string]string{
 		"endpoint_id": endpointId,
 	}
-	return executeRequest[any, models.OperationalWebhookEndpointHeadersOut](
+	return internal.ExecuteRequest[any, models.OperationalWebhookEndpointHeadersOut](
 		ctx,
 		operationalWebhookEndpoint.client,
 		"GET",
@@ -179,7 +180,7 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) UpdateHeaders(
 	pathMap := map[string]string{
 		"endpoint_id": endpointId,
 	}
-	_, err := executeRequest[models.OperationalWebhookEndpointHeadersIn, any](
+	_, err := internal.ExecuteRequest[models.OperationalWebhookEndpointHeadersIn, any](
 		ctx,
 		operationalWebhookEndpoint.client,
 		"PUT",
@@ -203,7 +204,7 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) GetSecret(
 	pathMap := map[string]string{
 		"endpoint_id": endpointId,
 	}
-	return executeRequest[any, models.OperationalWebhookEndpointSecretOut](
+	return internal.ExecuteRequest[any, models.OperationalWebhookEndpointSecretOut](
 		ctx,
 		operationalWebhookEndpoint.client,
 		"GET",
@@ -230,12 +231,12 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) RotateSecret(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return err
 		}
 	}
-	_, err = executeRequest[models.OperationalWebhookEndpointSecretIn, any](
+	_, err = internal.ExecuteRequest[models.OperationalWebhookEndpointSecretIn, any](
 		ctx,
 		operationalWebhookEndpoint.client,
 		"POST",

--- a/go/statistics.go
+++ b/go/statistics.go
@@ -4,14 +4,15 @@ package svix
 import (
 	"context"
 
+	"github.com/svix/svix-webhooks/go/internal"
 	"github.com/svix/svix-webhooks/go/models"
 )
 
 type Statistics struct {
-	client *SvixHttpClient
+	client *internal.SvixHttpClient
 }
 
-func newStatistics(client *SvixHttpClient) *Statistics {
+func newStatistics(client *internal.SvixHttpClient) *Statistics {
 	return &Statistics{
 		client: client,
 	}
@@ -33,12 +34,12 @@ func (statistics *Statistics) AggregateAppStats(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[models.AppUsageStatsIn, models.AppUsageStatsOut](
+	return internal.ExecuteRequest[models.AppUsageStatsIn, models.AppUsageStatsOut](
 		ctx,
 		statistics.client,
 		"POST",
@@ -57,7 +58,7 @@ func (statistics *Statistics) AggregateAppStats(
 func (statistics *Statistics) AggregateEventTypes(
 	ctx context.Context,
 ) (*models.AggregateEventTypesOut, error) {
-	return executeRequest[any, models.AggregateEventTypesOut](
+	return internal.ExecuteRequest[any, models.AggregateEventTypesOut](
 		ctx,
 		statistics.client,
 		"PUT",

--- a/go/svix.go
+++ b/go/svix.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/svix/svix-webhooks/go/internal"
 )
 
 type (
@@ -33,7 +35,7 @@ type (
 )
 
 func New(token string, options *SvixOptions) (*Svix, error) {
-	svixHttpClient := defaultSvixHttpClient(getDefaultBaseUrl(token))
+	svixHttpClient := internal.DefaultSvixHttpClient(getDefaultBaseUrl(token))
 
 	if options != nil {
 		if options.ServerUrl != nil {

--- a/openapi-templates/go/api_extra/application_create.go
+++ b/openapi-templates/go/api_extra/application_create.go
@@ -11,13 +11,13 @@ func (application *Application) GetOrCreate(
 
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return executeRequest[models.ApplicationIn, models.ApplicationOut](
+	return internal.ExecuteRequest[models.ApplicationIn, models.ApplicationOut](
 		ctx,
 		application.client,
 		"POST",

--- a/openapi-templates/go/api_extra/authentication_expire_all.go
+++ b/openapi-templates/go/api_extra/authentication_expire_all.go
@@ -10,12 +10,12 @@ func (authentication *Authentication) DashboardAccess(
 	headerMap := map[string]string{}
 	var err error
 	if o != nil {
-		serializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
+		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return executeRequest[any, models.DashboardAccessOut](
+	return internal.ExecuteRequest[any, models.DashboardAccessOut](
 		ctx,
 		authentication.client,
 		"POST",

--- a/openapi-templates/go/api_resource.go.jinja
+++ b/openapi-templates/go/api_resource.go.jinja
@@ -10,19 +10,20 @@ import (
 	"encoding/json"
 
 	"github.com/svix/svix-webhooks/go/models"
+	"github.com/svix/svix-webhooks/go/internal"
 )
 
 
 type {{ resource_type_name }} struct {
 	{% if resource.operations | length > 0 -%}
-	client *SvixHttpClient
+	client *internal.SvixHttpClient
 	{%- endif %}
 	{%- for name, sub in resource.subresources | items %}
 	{{ name | to_upper_camel_case }} *{{ sub.name | to_upper_camel_case }}
 	{%- endfor %}
 }
 
-func new{{ resource_type_name }}(client *SvixHttpClient) *{{ resource_type_name }} {
+func new{{ resource_type_name }}(client *internal.SvixHttpClient) *{{ resource_type_name }} {
 	return &{{ resource_type_name }}{
 		{% if resource.operations | length > 0 -%}
 		client: client,
@@ -128,14 +129,14 @@ func ({{ resource_self_name }} *{{ resource_type_name }}) {{ op.name | to_upper_
 		{# header params -#}
 		{% if op.header_params | length > 0 -%}
 			{% for p in op.header_params -%}
-		serializeParamToMap("{{ p.name }}", o.{{ p.name | to_upper_camel_case }}, headerMap, &err)
+		internal.SerializeParamToMap("{{ p.name }}", o.{{ p.name | to_upper_camel_case }}, headerMap, &err)
 			{% endfor -%}
 		{% endif -%}
 
 		{# query params -#}
 		{% if op.query_params | length >0 -%}
 			{% for p in op.query_params -%}
-		serializeParamToMap("{{ p.name }}", o.{{ p.name | to_upper_camel_case }}, queryMap, &err)
+		internal.SerializeParamToMap("{{ p.name }}", o.{{ p.name | to_upper_camel_case }}, queryMap, &err)
 			{% endfor -%}
 		{% endif -%}
 
@@ -152,7 +153,7 @@ func ({{ resource_self_name }} *{{ resource_type_name }}) {{ op.name | to_upper_
 	{% else -%}
 		{% set generic_ret_type -%}any,{{ ret_type }}{% endset -%}
 	{% endif -%}
-	{% if has_return %}return {% else %} _,err {% if not used_err%}:{% endif%}= {% endif %}executeRequest[{{ generic_ret_type }}](
+	{% if has_return %}return {% else %} _,err {% if not used_err%}:{% endif%}= {% endif %}internal.ExecuteRequest[{{ generic_ret_type }}](
 		ctx,
 		{{ resource_self_name }}.client,
 		"{{ op.method | upper }}",


### PR DESCRIPTION
This is done in preparation for the new internal API client

In Go, the `internal` package has special semantics. https://pkg.go.dev/cmd/go#hdr-Internal_Directories
So we can define public  method for our SDK to consume, but external packages wont be able to import the internal package
For example this is the error I get when trying to import the internal package in the TF provider
```
package github.com/svix/terraform-provider-svix
        main.go:10:3: use of internal package github.com/svix/svix-webhooks/go/internal not allowed
```


This is technically a breaking change, because the `svix.SvixHttpClient` struct will no longer be available 
However, this is not an issue. Since there is no use in defining the `svix.SvixHttpClient` by hand, because the only use case it has is to be part of the resource structs
```go
type Application struct {
	client *SvixHttpClient
}
```
But a user of our SDK would not be define the `Application` struct, because `client` is not an exported field.

