### PR TITLE
Bump Rust toolchain to 1.86

### DIFF
--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -1,5 +1,5 @@
 # Base build
-FROM rust:1.81-slim-bookworm AS build
+FROM rust:1.86-slim-bookworm AS build
 
 RUN apt-get update && apt-get install -y \
     build-essential=12.* \

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,5 @@
 # Base build
-FROM rust:1.83-slim-bookworm AS build
+FROM rust:1.86-slim-bookworm AS build
 
 RUN apt-get update && apt-get install -y \
         build-essential=12.* \

--- a/svix-cli/Dockerfile
+++ b/svix-cli/Dockerfile
@@ -1,5 +1,5 @@
 # Base build
-FROM rust:1.81-slim-bookworm AS build
+FROM rust:1.86-slim-bookworm AS build
 
 RUN apt-get update && apt-get install -y \
     build-essential=12.* \


### PR DESCRIPTION
Upgrade our Dockerfile's to the latest stable Rust toolchain (the only officially-supported one).