### PR TITLE
Switch C# TargetFramework to netstandard2.0

### DIFF
--- a/csharp/Svix/Svix.csproj
+++ b/csharp/Svix/Svix.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Svix</PackageId>
     <Version>1.64.1</Version>
     <Authors>Svix</Authors>


### PR DESCRIPTION
After re-reading https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-1-0, I'm thinking this might be the best target, if it works.