### PR TITLE
rust: Generate api/mod.rs

### DIFF
--- a/codegen-templates/rust/api_summary.rs.jinja
+++ b/codegen-templates/rust/api_summary.rs.jinja
@@ -1,17 +1,63 @@
-{% for resource in api.resources -%}
+// this file is @generated
+#![warn(unreachable_pub)]
+
+mod client;
+mod deprecated;
+
+pub use self::client::{Svix, SvixOptions};
+pub use crate::models::*;
+
+{% macro resource_mods(resource) -%}
+{% if resource.name != "health" -%}
     mod {{ resource.name | to_snake_case }};
+    {%- for _, sub in resource.subresources | items -%}
+        {{- resource_mods(sub) -}}
+    {%- endfor -%}
+{% endif -%}
+{% endmacro -%}
+
+{% for res in api.resources -%}
+    {{ resource_mods(res) -}}
 {% endfor %}
 
+{% macro resource_reexports(resource) -%}
+{% if resource.name != "health" -%}
+    {% set resource_type_name = resource.name | to_upper_camel_case -%}
+    {{ resource.name | to_snake_case }}::{
+        {{ resource_type_name }},
+        {% for op in resource.operations -%}
+            {% if op | has_query_or_header_params -%}
+                {{ resource_type_name }}{{ op.name | to_upper_camel_case }}Options,
+            {% endif -%}
+        {% endfor -%}
+    },
+    {% for _, sub in resource.subresources | items -%}
+        {{ resource_reexports(sub) -}}
+    {% endfor -%}
+{% endif -%}
+{% endmacro -%}
+
+#[cfg(feature = "svix_beta")]
+pub use self::message::{V1MessageEventsParams, V1MessageEventsSubscriptionParams};
 pub use self::{
-    {% for resource in api.resources -%}
-        {% set resource_type_name = resource.name | to_upper_camel_case -%}
-        {{ resource.name | to_snake_case }}::{
-            {{ resource_type_name }},
-            {% for op in resource.operations -%}
-                {% if op | has_query_or_header_params -%}
-                    {{ resource_type_name }}{{ op.name | to_upper_camel_case }}Options,
-                {% endif -%}
-            {% endfor -%}
-        },
+    {% for res in api.resources -%}
+        {{ resource_reexports(res) }}
     {% endfor -%}
 };
+pub use self::deprecated::*;
+
+impl Svix {
+    {% for resource in api.resources -%}
+        {% if resource.name != "health" -%}
+            {% set resource_type_name = resource.name | to_upper_camel_case -%}
+            pub fn {{ resource.name | to_snake_case }}(&self) -> {{ resource_type_name }}<'_> {
+                {{ resource_type_name }}::new(&self.cfg)
+            }
+        {% endif%}
+    {% endfor -%}
+
+    #[deprecated = "Use .operational_webhook().endpoint() instead"]
+    pub fn operational_webhook_endpoint(&self) -> OperationalWebhookEndpoint<'_> {
+        OperationalWebhookEndpoint::new(&self.cfg)
+    }
+}

--- a/codegen.toml
+++ b/codegen.toml
@@ -9,6 +9,9 @@ extra_shell_commands = ["rm rust/src/api/health.rs"]
 template = "codegen-templates/rust/api_resource.rs.jinja"
 output_dir = "rust/src/api"
 [[rust.task]]
+template = "codegen-templates/rust/api_summary.rs.jinja"
+output_dir = "rust/src/api"
+[[rust.task]]
 template = "codegen-templates/rust/component_type_summary.rs.jinja"
 output_dir = "rust/src/models"
 [[rust.task]]

--- a/rust/src/api/mod.rs
+++ b/rust/src/api/mod.rs
@@ -1,6 +1,8 @@
+// this file is @generated
 #![warn(unreachable_pub)]
 
 mod client;
+mod deprecated;
 
 pub use self::client::{Svix, SvixOptions};
 pub use crate::models::*;
@@ -8,7 +10,6 @@ pub use crate::models::*;
 mod application;
 mod authentication;
 mod background_task;
-mod deprecated;
 mod endpoint;
 mod environment;
 mod event_type;
@@ -85,12 +86,12 @@ pub use self::{
 };
 
 impl Svix {
-    pub fn authentication(&self) -> Authentication<'_> {
-        Authentication::new(&self.cfg)
-    }
-
     pub fn application(&self) -> Application<'_> {
         Application::new(&self.cfg)
+    }
+
+    pub fn authentication(&self) -> Authentication<'_> {
+        Authentication::new(&self.cfg)
     }
 
     pub fn background_task(&self) -> BackgroundTask<'_> {
@@ -105,16 +106,16 @@ impl Svix {
         Environment::new(&self.cfg)
     }
 
+    pub fn event_type(&self) -> EventType<'_> {
+        EventType::new(&self.cfg)
+    }
+
     pub fn ingest(&self) -> Ingest<'_> {
         Ingest::new(&self.cfg)
     }
 
     pub fn integration(&self) -> Integration<'_> {
         Integration::new(&self.cfg)
-    }
-
-    pub fn event_type(&self) -> EventType<'_> {
-        EventType::new(&self.cfg)
     }
 
     pub fn management(&self) -> Management<'_> {
@@ -133,11 +134,12 @@ impl Svix {
         OperationalWebhook::new(&self.cfg)
     }
 
-    pub fn operational_webhook_endpoint(&self) -> OperationalWebhookEndpoint<'_> {
-        OperationalWebhookEndpoint::new(&self.cfg)
-    }
-
     pub fn statistics(&self) -> Statistics<'_> {
         Statistics::new(&self.cfg)
+    }
+
+    #[deprecated = "Use .operational_webhook().endpoint() instead"]
+    pub fn operational_webhook_endpoint(&self) -> OperationalWebhookEndpoint<'_> {
+        OperationalWebhookEndpoint::new(&self.cfg)
     }
 }


### PR DESCRIPTION
Whenever we added a new API, postprocessing for Svix CLI was failing because the new API wasn't yet re-exported in this file, so the Rust SDK imports inside the CLI were failing to resolve. This fixes that.
