### PR TITLE
go: Add `SetUserAgentSuffix`

### DIFF
--- a/go/internalapi/internalapi.go
+++ b/go/internalapi/internalapi.go
@@ -16,12 +16,12 @@ type (
 	}
 )
 
-func New(token string, serverUrl *url.URL, debug bool) (*InternalSvix, error) {
+func New(token string, serverUrl *url.URL, debug bool, userAgentSuffix string) (*InternalSvix, error) {
 	svixHttpClient := internal.DefaultSvixHttpClient(serverUrl.String())
 	svixHttpClient.Debug = debug
 
 	svixHttpClient.DefaultHeaders["Authorization"] = fmt.Sprintf("Bearer %s", token)
-	svixHttpClient.DefaultHeaders["User-Agent"] = fmt.Sprintf("svix-libs/%s/go", svix.Version)
+	svixHttpClient.DefaultHeaders["User-Agent"] = fmt.Sprintf("svix-libs/%s/go/%s", svix.Version, userAgentSuffix)
 
 	svx := InternalSvix{
 		Management: newManagement(&svixHttpClient),


### PR DESCRIPTION
This allows users of the go lib to suffix the `user-agent` with whatever custom string they chose

This will be used in the terraform provider, to indicate that requests are coming from the provider

The providers user agent will looks like this

`svix-libs/1.64.1/go/tf-provider-v0.1.1`