### PR TITLE
Ci: pin csharpier to 0.30.6 

### DIFF
--- a/.github/workflows/csharp-lint.yml
+++ b/.github/workflows/csharp-lint.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           cd csharp
           dotnet restore
-          dotnet tool install csharpier -g
+          dotnet tool install csharpier -g --version 0.30.6
 
       - name: Check formatting
         run: |


### PR DESCRIPTION
This will help with borked CI in https://github.com/svix/svix-webhooks/pull/1906
