### PR TITLE
csharp: Add nuget package metadata

### DIFF
--- a/csharp/Svix/Svix.csproj
+++ b/csharp/Svix/Svix.csproj
@@ -9,6 +9,9 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/svix/svix-webhooks.git</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/svix/svix-webhooks/tree/main/csharp</PackageProjectUrl>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This results in the fowling fields added to the generated `Svix.nuspec` file (the file is generated when release CI runs `dotnet build --configuration Release Svix`)

```xml
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
  <metadata>
    + <license type="expression">MIT</license>
    + <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
    + <projectUrl>https://github.com/svix/svix-webhooks/tree/main/csharp</projectUrl>
    + <repository type="git" url="https://github.com/svix/svix-webhooks.git" commit="da87aa3647219021fc5b60733e6c042fb75f2bfc" />
  </metadata>
</package>
```

Closes https://github.com/svix/svix-webhooks/issues/1911
