### PR TITLE
csharp: `SvixOptions` is now optional when initializing a new `SvixClient`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 * Libs/Python: Bring back the (deprecated) sync `dashboard_access` method, which was accidentally
   removed in v1.64.1
+* Libs/Csharp: The `options` argument to the `SvixClient` initializer is now optional.
 
 ## Version 1.64.1
 * Libs/JavaScript: Add `HTTPValidationError`, `HttpErrorOut`, `ValidationError` and `ApiException` to the top level exports.

--- a/csharp/Svix/SvixClient.cs
+++ b/csharp/Svix/SvixClient.cs
@@ -71,21 +71,23 @@ namespace Svix
 
         public ILogger? Logger { get; }
 
-        private readonly SvixOptions Options;
         public SvixHttpClient SvixHttpClient;
 
         public SvixClient(
             string token,
-            SvixOptions options,
+            SvixOptions? options = null,
             ILogger<SvixClient>? logger = null,
             SvixHttpClient? svixHttpClient = null
         )
         {
-            Options = options;
             Logger = logger;
             SvixHttpClient =
                 svixHttpClient
-                ?? new SvixHttpClient(token, options, $"svix-libs/{Version.version}/csharp");
+                ?? new SvixHttpClient(
+                    token,
+                    options ?? new SvixOptions(Utils.DefaultServerUrlFromToken(token)),
+                    $"svix-libs/{Version.version}/csharp"
+                );
         }
     }
 }

--- a/csharp/Svix/Utils.cs
+++ b/csharp/Svix/Utils.cs
@@ -23,5 +23,28 @@ namespace Svix
 
             return result == 0;
         }
+
+        internal static string DefaultServerUrlFromToken(string token)
+        {
+            string[] tokenParts = token.Split('.');
+            string region = tokenParts[tokenParts.Length - 1];
+
+            if (region == "us")
+            {
+                return "https://api.us.svix.com";
+            }
+            else if (region == "eu")
+            {
+                return "https://api.eu.svix.com";
+            }
+            else if (region == "in")
+            {
+                return "https://api.in.svix.com";
+            }
+            else
+            {
+                return "https://api.svix.com";
+            }
+        }
     }
 }


### PR DESCRIPTION
The baseUrl will be generated from the token

This makes the C# lib more consistent with the other SDKs