### PR TITLE
csharp: Bump csharpier to v1.0.1

### DIFF
--- a/.github/workflows/csharp-lint.yml
+++ b/.github/workflows/csharp-lint.yml
@@ -31,13 +31,13 @@ jobs:
         run: |
           cd csharp
           dotnet restore
-          dotnet tool install csharpier -g --version 0.30.6
+          dotnet tool install csharpier -g --version 1.0.1
 
       - name: Check formatting
         run: |
           cd csharp
-          dotnet csharpier --check Svix.Tests
-          dotnet csharpier --check Svix
+          csharpier check Svix.Tests
+          csharpier check Svix
 
       - name: Build
         run: dotnet build --configuration Release --no-restore

--- a/csharp/Svix.Tests/RetryScheduleTests.cs
+++ b/csharp/Svix.Tests/RetryScheduleTests.cs
@@ -59,8 +59,8 @@ namespace Svix.Tests
             {
                 if (index == 0)
                 {
-                    Assert.Throws<KeyNotFoundException>(
-                        () => stub.LogEntries[index].RequestMessage.Headers["svix-retry-count"]
+                    Assert.Throws<KeyNotFoundException>(() =>
+                        stub.LogEntries[index].RequestMessage.Headers["svix-retry-count"]
                     );
                     continue;
                 }

--- a/csharp/Svix.Tests/Svix.Tests.csproj
+++ b/csharp/Svix.Tests/Svix.Tests.csproj
@@ -1,11 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Moq" Version="4.16.1" />
@@ -20,9 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Svix\Svix.csproj" />
   </ItemGroup>
-
 </Project>

--- a/csharp/Svix.Tests/WebhookTest.cs
+++ b/csharp/Svix.Tests/WebhookTest.cs
@@ -51,8 +51,8 @@ namespace Svix.Tests
 
             var wh = new Webhook(testPayload.secret);
 
-            Assert.Throws<WebhookVerificationException>(
-                () => wh.Verify(testPayload.payload, testPayload.headers)
+            Assert.Throws<WebhookVerificationException>(() =>
+                wh.Verify(testPayload.payload, testPayload.headers)
             );
         }
 
@@ -64,8 +64,8 @@ namespace Svix.Tests
 
             var wh = new Webhook(testPayload.secret);
 
-            Assert.Throws<WebhookVerificationException>(
-                () => wh.Verify(testPayload.payload, testPayload.headers)
+            Assert.Throws<WebhookVerificationException>(() =>
+                wh.Verify(testPayload.payload, testPayload.headers)
             );
         }
 
@@ -77,8 +77,8 @@ namespace Svix.Tests
 
             var wh = new Webhook(testPayload.secret);
 
-            Assert.Throws<WebhookVerificationException>(
-                () => wh.Verify(testPayload.payload, testPayload.headers)
+            Assert.Throws<WebhookVerificationException>(() =>
+                wh.Verify(testPayload.payload, testPayload.headers)
             );
         }
 
@@ -93,8 +93,8 @@ namespace Svix.Tests
 
             var wh = new Webhook(testPayload.secret);
 
-            Assert.Throws<WebhookVerificationException>(
-                () => wh.Verify(testPayload.payload, testPayload.headers)
+            Assert.Throws<WebhookVerificationException>(() =>
+                wh.Verify(testPayload.payload, testPayload.headers)
             );
         }
 
@@ -140,8 +140,8 @@ namespace Svix.Tests
 
             var wh = new Webhook(testPayload.secret);
 
-            Assert.Throws<WebhookVerificationException>(
-                () => wh.Verify(testPayload.payload, testPayload.headers)
+            Assert.Throws<WebhookVerificationException>(() =>
+                wh.Verify(testPayload.payload, testPayload.headers)
             );
         }
 
@@ -154,8 +154,8 @@ namespace Svix.Tests
 
             var wh = new Webhook(testPayload.secret);
 
-            Assert.Throws<WebhookVerificationException>(
-                () => wh.Verify(testPayload.payload, testPayload.headers)
+            Assert.Throws<WebhookVerificationException>(() =>
+                wh.Verify(testPayload.payload, testPayload.headers)
             );
         }
 
@@ -166,8 +166,8 @@ namespace Svix.Tests
 
             var wh = new Webhook(testPayload.secret);
 
-            Assert.Throws<ArgumentNullException>(
-                () => wh.Verify(testPayload.payload, (WebHeaderCollection)null)
+            Assert.Throws<ArgumentNullException>(() =>
+                wh.Verify(testPayload.payload, (WebHeaderCollection)null)
             );
         }
 
@@ -178,8 +178,8 @@ namespace Svix.Tests
 
             var wh = new Webhook(testPayload.secret);
 
-            Assert.Throws<ArgumentNullException>(
-                () => wh.Verify(testPayload.payload, (Func<string, string>)null)
+            Assert.Throws<ArgumentNullException>(() =>
+                wh.Verify(testPayload.payload, (Func<string, string>)null)
             );
         }
 

--- a/csharp/Svix.Tests/WiremockTests.cs
+++ b/csharp/Svix.Tests/WiremockTests.cs
@@ -226,8 +226,8 @@ namespace Svix.Tests
         public async void ApplicationCreateAsync_WithoutApplication_ThrowsException()
         {
             // Don't need to create a stub since the ArgumentNullException will be raised before we try to use the server
-            await Assert.ThrowsAsync<ArgumentNullException>(
-                () => client.Application.CreateAsync(null, null, default)
+            await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                client.Application.CreateAsync(null, null, default)
             );
         }
 

--- a/csharp/Svix/Models/BackgroundTaskFinishedEvent.cs
+++ b/csharp/Svix/Models/BackgroundTaskFinishedEvent.cs
@@ -7,7 +7,6 @@ namespace Svix.Models
     /// <summary>
     /// Sent when a background task is finished.
     /// <summary>
-
     public class BackgroundTaskFinishedEvent
     {
         [JsonProperty("data", Required = Required.Always)]

--- a/csharp/Svix/Models/EndpointCreatedEvent.cs
+++ b/csharp/Svix/Models/EndpointCreatedEvent.cs
@@ -7,7 +7,6 @@ namespace Svix.Models
     /// <summary>
     /// Sent when an endpoint is created.
     /// <summary>
-
     public class EndpointCreatedEvent
     {
         [JsonProperty("data", Required = Required.Always)]

--- a/csharp/Svix/Models/EndpointCreatedEventData.cs
+++ b/csharp/Svix/Models/EndpointCreatedEventData.cs
@@ -7,7 +7,6 @@ namespace Svix.Models
     /// <summary>
     /// Sent when an endpoint is created, updated, or deleted
     /// <summary>
-
     public class EndpointCreatedEventData
     {
         [JsonProperty("appId", Required = Required.Always)]

--- a/csharp/Svix/Models/EndpointDeletedEvent.cs
+++ b/csharp/Svix/Models/EndpointDeletedEvent.cs
@@ -7,7 +7,6 @@ namespace Svix.Models
     /// <summary>
     /// Sent when an endpoint is deleted.
     /// <summary>
-
     public class EndpointDeletedEvent
     {
         [JsonProperty("data", Required = Required.Always)]

--- a/csharp/Svix/Models/EndpointDeletedEventData.cs
+++ b/csharp/Svix/Models/EndpointDeletedEventData.cs
@@ -7,7 +7,6 @@ namespace Svix.Models
     /// <summary>
     /// Sent when an endpoint is created, updated, or deleted
     /// <summary>
-
     public class EndpointDeletedEventData
     {
         [JsonProperty("appId", Required = Required.Always)]

--- a/csharp/Svix/Models/EndpointDisabledEvent.cs
+++ b/csharp/Svix/Models/EndpointDisabledEvent.cs
@@ -7,7 +7,6 @@ namespace Svix.Models
     /// <summary>
     /// Sent when an endpoint has been automatically disabled after continuous failures, or manually via an API call.
     /// <summary>
-
     public class EndpointDisabledEvent
     {
         [JsonProperty("data", Required = Required.Always)]

--- a/csharp/Svix/Models/EndpointDisabledEventData.cs
+++ b/csharp/Svix/Models/EndpointDisabledEventData.cs
@@ -7,7 +7,6 @@ namespace Svix.Models
     /// <summary>
     /// Sent when an endpoint has been automatically disabled after continuous failures, or manually via an API call.
     /// <summary>
-
     public class EndpointDisabledEventData
     {
         [JsonProperty("appId", Required = Required.Always)]

--- a/csharp/Svix/Models/EndpointEnabledEvent.cs
+++ b/csharp/Svix/Models/EndpointEnabledEvent.cs
@@ -7,7 +7,6 @@ namespace Svix.Models
     /// <summary>
     /// Sent when an endpoint has been enabled.
     /// <summary>
-
     public class EndpointEnabledEvent
     {
         [JsonProperty("data", Required = Required.Always)]

--- a/csharp/Svix/Models/EndpointEnabledEventData.cs
+++ b/csharp/Svix/Models/EndpointEnabledEventData.cs
@@ -7,7 +7,6 @@ namespace Svix.Models
     /// <summary>
     /// Sent when an endpoint has been enabled.
     /// <summary>
-
     public class EndpointEnabledEventData
     {
         [JsonProperty("appId", Required = Required.Always)]

--- a/csharp/Svix/Models/EndpointHeadersOut.cs
+++ b/csharp/Svix/Models/EndpointHeadersOut.cs
@@ -9,7 +9,6 @@ namespace Svix.Models
     ///
     /// Sensitive headers that have been redacted are returned in the sensitive field.
     /// <summary>
-
     public class EndpointHeadersOut
     {
         [JsonProperty("headers", Required = Required.Always)]

--- a/csharp/Svix/Models/EndpointMessageOut.cs
+++ b/csharp/Svix/Models/EndpointMessageOut.cs
@@ -7,7 +7,6 @@ namespace Svix.Models
     /// <summary>
     /// A model containing information on a given message plus additional fields on the last attempt for that message.
     /// <summary>
-
     public class EndpointMessageOut
     {
         [JsonProperty("channels")]

--- a/csharp/Svix/Models/EndpointUpdatedEvent.cs
+++ b/csharp/Svix/Models/EndpointUpdatedEvent.cs
@@ -7,7 +7,6 @@ namespace Svix.Models
     /// <summary>
     /// Sent when an endpoint is updated.
     /// <summary>
-
     public class EndpointUpdatedEvent
     {
         [JsonProperty("data", Required = Required.Always)]

--- a/csharp/Svix/Models/EndpointUpdatedEventData.cs
+++ b/csharp/Svix/Models/EndpointUpdatedEventData.cs
@@ -7,7 +7,6 @@ namespace Svix.Models
     /// <summary>
     /// Sent when an endpoint is created, updated, or deleted
     /// <summary>
-
     public class EndpointUpdatedEventData
     {
         [JsonProperty("appId", Required = Required.Always)]

--- a/csharp/Svix/Models/EventTypeImportOpenApiIn.cs
+++ b/csharp/Svix/Models/EventTypeImportOpenApiIn.cs
@@ -9,7 +9,6 @@ namespace Svix.Models
     ///
     /// The OpenAPI spec can be specified as either `spec` given the spec as a JSON object, or as `specRaw` (a `string`) which will be parsed as YAML or JSON by the server. Sending neither or both is invalid, resulting in a `400` **Bad Request**.
     /// <summary>
-
     public class EventTypeImportOpenApiIn
     {
         [JsonProperty("dryRun")]

--- a/csharp/Svix/Models/MessageAttemptExhaustedEvent.cs
+++ b/csharp/Svix/Models/MessageAttemptExhaustedEvent.cs
@@ -7,7 +7,6 @@ namespace Svix.Models
     /// <summary>
     /// Sent when a message delivery has failed (all of the retry attempts have been exhausted).
     /// <summary>
-
     public class MessageAttemptExhaustedEvent
     {
         [JsonProperty("data", Required = Required.Always)]

--- a/csharp/Svix/Models/MessageAttemptExhaustedEventData.cs
+++ b/csharp/Svix/Models/MessageAttemptExhaustedEventData.cs
@@ -7,7 +7,6 @@ namespace Svix.Models
     /// <summary>
     /// Sent when a message delivery has failed (all of the retry attempts have been exhausted) as a "message.attempt.exhausted" type or after it's failed four times as a "message.attempt.failing" event.
     /// <summary>
-
     public class MessageAttemptExhaustedEventData
     {
         [JsonProperty("appId", Required = Required.Always)]

--- a/csharp/Svix/Models/MessageAttemptFailingEvent.cs
+++ b/csharp/Svix/Models/MessageAttemptFailingEvent.cs
@@ -8,7 +8,6 @@ namespace Svix.Models
     /// Sent after a message has been failing for a few times.
     /// It's sent on the fourth failure. It complements `message.attempt.exhausted` which is sent after the last failure.
     /// <summary>
-
     public class MessageAttemptFailingEvent
     {
         [JsonProperty("data", Required = Required.Always)]

--- a/csharp/Svix/Models/MessageAttemptFailingEventData.cs
+++ b/csharp/Svix/Models/MessageAttemptFailingEventData.cs
@@ -7,7 +7,6 @@ namespace Svix.Models
     /// <summary>
     /// Sent when a message delivery has failed (all of the retry attempts have been exhausted) as a "message.attempt.exhausted" type or after it's failed four times as a "message.attempt.failing" event.
     /// <summary>
-
     public class MessageAttemptFailingEventData
     {
         [JsonProperty("appId", Required = Required.Always)]

--- a/csharp/Svix/Models/MessageAttemptRecoveredEvent.cs
+++ b/csharp/Svix/Models/MessageAttemptRecoveredEvent.cs
@@ -7,7 +7,6 @@ namespace Svix.Models
     /// <summary>
     /// Sent on a successful dispatch after an earlier failure op webhook has already been sent.
     /// <summary>
-
     public class MessageAttemptRecoveredEvent
     {
         [JsonProperty("data", Required = Required.Always)]

--- a/csharp/Svix/Models/MessageAttemptRecoveredEventData.cs
+++ b/csharp/Svix/Models/MessageAttemptRecoveredEventData.cs
@@ -7,7 +7,6 @@ namespace Svix.Models
     /// <summary>
     /// Sent when a message delivery has failed (all of the retry attempts have been exhausted) as a "message.attempt.exhausted" type or after it's failed four times as a "message.attempt.failing" event.
     /// <summary>
-
     public class MessageAttemptRecoveredEventData
     {
         [JsonProperty("appId", Required = Required.Always)]

--- a/csharp/Svix/Models/PollingEndpointMessageOut.cs
+++ b/csharp/Svix/Models/PollingEndpointMessageOut.cs
@@ -7,7 +7,6 @@ namespace Svix.Models
     /// <summary>
     /// The MessageOut equivalent of polling endpoint
     /// <summary>
-
     public class PollingEndpointMessageOut
     {
         [JsonProperty("channels")]

--- a/csharp/Svix/Svix.csproj
+++ b/csharp/Svix/Svix.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <PackageId>Svix</PackageId>
@@ -13,7 +12,6 @@
     <RepositoryUrl>https://github.com/svix/svix-webhooks.git</RepositoryUrl>
     <PackageProjectUrl>https://github.com/svix/svix-webhooks/tree/main/csharp</PackageProjectUrl>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/regen_openapi.py
+++ b/regen_openapi.py
@@ -15,7 +15,7 @@ except ImportError:
     print("Python 3.11 or greater is required to run the codegen")
     exit(1)
 
-OPENAPI_CODEGEN_IMAGE = "ghcr.io/svix/openapi-codegen:20250414-293"
+OPENAPI_CODEGEN_IMAGE = "ghcr.io/svix/openapi-codegen:20250506-295"
 REPO_ROOT = pathlib.Path(__file__).parent.resolve()
 DEBUG = os.getenv("DEBUG") is not None
 GREEN = "\033[92m"


### PR DESCRIPTION
Ci will fail because I am waiting for https://github.com/svix/openapi-codegen/pull/108 before I can update the codegen image

All of the changes to the `*.cs` files were created from running 
```bash
cd csharp
csharpier format .
```