### PR TITLE
Make sed command work both on macos/linux

### DIFF
--- a/codegen.toml
+++ b/codegen.toml
@@ -104,7 +104,8 @@ output_dir = "java/lib/src/main/java/com/svix/models"
 template_dir = "codegen-templates/go"
 extra_shell_commands = [
    "rm go/health.go",
-   "sed -i 's/package svix/package internalapi/g' go/internalapi/management*"
+   "sed -i.bak 's/package svix/package internalapi/g' go/internalapi/management* && rm go/internalapi/management*.bak"
+
 ]
 [[go.task]]
 template = "codegen-templates/go/api_resource.go.jinja"


### PR DESCRIPTION
We use `sed` to do a quick text replace as part of the libs codegen

Macos ships a BSD `sed` and (most) linux distros ship a GNU `sed`, they are not exactly 1-1 compatible 

This PR makes the `sed` command work on both GNU/BSD sed

