### PR TITLE
js: Fix handling of optional dates in response bodies

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* Libs/JavaScript: Fix response processing code for endpoints with an optional datetime field in the response body
+
 ## Version 1.65.0
 * Libs/Python: Bring back the (deprecated) sync `dashboard_access` method, which was accidentally
   removed in v1.64.1
@@ -16,7 +19,7 @@
 * Server: Add response duration tracking to webhook message attempts by @CodeMan62 in https://github.com/svix/svix-webhooks/pull/1877
 * Libs/Python: Specify minimum version of pydantic `pydantic >=2.10` in setup.py.
 
-## Version 1.64.0 
+## Version 1.64.0
 * CLI: Add interactive login with dashboard.svix.com
 
 ## Version 1.63.2

--- a/codegen-templates/javascript/types/macros.ts.jinja
+++ b/codegen-templates/javascript/types/macros.ts.jinja
@@ -1,6 +1,10 @@
 {% macro field_from_json(field_expr, type, field_required) %}
     {%- if type.is_datetime() -%}
-        new Date({{ field_expr }})
+        {% if not field_required -%}
+            {{ field_expr }} ? new Date({{ field_expr }}) : null
+        {%- else -%}
+            new Date({{ field_expr }})
+        {%- endif -%}
     {%- elif type.is_schema_ref() -%}
         {# TODO(10055) remove this hack #}
         {% if type.to_js() == "any" -%}

--- a/codegen-templates/javascript/types/macros.ts.jinja
+++ b/codegen-templates/javascript/types/macros.ts.jinja
@@ -20,7 +20,8 @@
             or inner_t.is_list()
             or inner_t.is_set()
             or inner_t.is_map() -%}
-            ?.map((item: {{ inner_t.to_js() }}) => {{ field_from_json("item", inner_t, true) }})
+            {% if not field_required -%}?{% endif -%}
+            .map((item: {{ inner_t.to_js() }}) => {{ field_from_json("item", inner_t, true) }})
         {%- endif -%}
     {%- elif type.is_map() -%}
         {%- set value_t = type.value_type() -%}

--- a/javascript/src/models/apiTokenCensoredOut.ts
+++ b/javascript/src/models/apiTokenCensoredOut.ts
@@ -16,7 +16,7 @@ export const ApiTokenCensoredOutSerializer = {
     return {
       censoredToken: object["censoredToken"],
       createdAt: new Date(object["createdAt"]),
-      expiresAt: new Date(object["expiresAt"]),
+      expiresAt: object["expiresAt"] ? new Date(object["expiresAt"]) : null,
       id: object["id"],
       name: object["name"],
       scopes: object["scopes"],

--- a/javascript/src/models/apiTokenOut.ts
+++ b/javascript/src/models/apiTokenOut.ts
@@ -15,7 +15,7 @@ export const ApiTokenOutSerializer = {
   _fromJsonObject(object: any): ApiTokenOut {
     return {
       createdAt: new Date(object["createdAt"]),
-      expiresAt: new Date(object["expiresAt"]),
+      expiresAt: object["expiresAt"] ? new Date(object["expiresAt"]) : null,
       id: object["id"],
       name: object["name"],
       scopes: object["scopes"],

--- a/javascript/src/models/endpointDisabledEventData.ts
+++ b/javascript/src/models/endpointDisabledEventData.ts
@@ -26,7 +26,7 @@ export const EndpointDisabledEventDataSerializer = {
       appUid: object["appUid"],
       endpointId: object["endpointId"],
       endpointUid: object["endpointUid"],
-      failSince: new Date(object["failSince"]),
+      failSince: object["failSince"] ? new Date(object["failSince"]) : null,
       trigger: object["trigger"]
         ? EndpointDisabledTriggerSerializer._fromJsonObject(object["trigger"])
         : undefined,

--- a/javascript/src/models/endpointMessageOut.ts
+++ b/javascript/src/models/endpointMessageOut.ts
@@ -26,7 +26,7 @@ export const EndpointMessageOutSerializer = {
       eventId: object["eventId"],
       eventType: object["eventType"],
       id: object["id"],
-      nextAttempt: new Date(object["nextAttempt"]),
+      nextAttempt: object["nextAttempt"] ? new Date(object["nextAttempt"]) : null,
       payload: object["payload"],
       status: MessageStatusSerializer._fromJsonObject(object["status"]),
       tags: object["tags"],

--- a/javascript/src/models/environmentOut.ts
+++ b/javascript/src/models/environmentOut.ts
@@ -15,11 +15,11 @@ export const EnvironmentOutSerializer = {
   _fromJsonObject(object: any): EnvironmentOut {
     return {
       createdAt: new Date(object["createdAt"]),
-      eventTypes: object["eventTypes"]?.map((item: EventTypeOut) =>
+      eventTypes: object["eventTypes"].map((item: EventTypeOut) =>
         EventTypeOutSerializer._fromJsonObject(item)
       ),
       settings: object["settings"],
-      transformationTemplates: object["transformationTemplates"]?.map(
+      transformationTemplates: object["transformationTemplates"].map(
         (item: ConnectorOut) => ConnectorOutSerializer._fromJsonObject(item)
       ),
       version: object["version"],

--- a/javascript/src/models/listResponseApiTokenCensoredOut.ts
+++ b/javascript/src/models/listResponseApiTokenCensoredOut.ts
@@ -15,7 +15,7 @@ export interface ListResponseApiTokenCensoredOut {
 export const ListResponseApiTokenCensoredOutSerializer = {
   _fromJsonObject(object: any): ListResponseApiTokenCensoredOut {
     return {
-      data: object["data"]?.map((item: ApiTokenCensoredOut) =>
+      data: object["data"].map((item: ApiTokenCensoredOut) =>
         ApiTokenCensoredOutSerializer._fromJsonObject(item)
       ),
       done: object["done"],

--- a/javascript/src/models/listResponseApplicationOut.ts
+++ b/javascript/src/models/listResponseApplicationOut.ts
@@ -12,7 +12,7 @@ export interface ListResponseApplicationOut {
 export const ListResponseApplicationOutSerializer = {
   _fromJsonObject(object: any): ListResponseApplicationOut {
     return {
-      data: object["data"]?.map((item: ApplicationOut) =>
+      data: object["data"].map((item: ApplicationOut) =>
         ApplicationOutSerializer._fromJsonObject(item)
       ),
       done: object["done"],

--- a/javascript/src/models/listResponseBackgroundTaskOut.ts
+++ b/javascript/src/models/listResponseBackgroundTaskOut.ts
@@ -12,7 +12,7 @@ export interface ListResponseBackgroundTaskOut {
 export const ListResponseBackgroundTaskOutSerializer = {
   _fromJsonObject(object: any): ListResponseBackgroundTaskOut {
     return {
-      data: object["data"]?.map((item: BackgroundTaskOut) =>
+      data: object["data"].map((item: BackgroundTaskOut) =>
         BackgroundTaskOutSerializer._fromJsonObject(item)
       ),
       done: object["done"],

--- a/javascript/src/models/listResponseEndpointMessageOut.ts
+++ b/javascript/src/models/listResponseEndpointMessageOut.ts
@@ -12,7 +12,7 @@ export interface ListResponseEndpointMessageOut {
 export const ListResponseEndpointMessageOutSerializer = {
   _fromJsonObject(object: any): ListResponseEndpointMessageOut {
     return {
-      data: object["data"]?.map((item: EndpointMessageOut) =>
+      data: object["data"].map((item: EndpointMessageOut) =>
         EndpointMessageOutSerializer._fromJsonObject(item)
       ),
       done: object["done"],

--- a/javascript/src/models/listResponseEndpointOut.ts
+++ b/javascript/src/models/listResponseEndpointOut.ts
@@ -12,7 +12,7 @@ export interface ListResponseEndpointOut {
 export const ListResponseEndpointOutSerializer = {
   _fromJsonObject(object: any): ListResponseEndpointOut {
     return {
-      data: object["data"]?.map((item: EndpointOut) =>
+      data: object["data"].map((item: EndpointOut) =>
         EndpointOutSerializer._fromJsonObject(item)
       ),
       done: object["done"],

--- a/javascript/src/models/listResponseEventTypeOut.ts
+++ b/javascript/src/models/listResponseEventTypeOut.ts
@@ -12,7 +12,7 @@ export interface ListResponseEventTypeOut {
 export const ListResponseEventTypeOutSerializer = {
   _fromJsonObject(object: any): ListResponseEventTypeOut {
     return {
-      data: object["data"]?.map((item: EventTypeOut) =>
+      data: object["data"].map((item: EventTypeOut) =>
         EventTypeOutSerializer._fromJsonObject(item)
       ),
       done: object["done"],

--- a/javascript/src/models/listResponseIngestEndpointOut.ts
+++ b/javascript/src/models/listResponseIngestEndpointOut.ts
@@ -12,7 +12,7 @@ export interface ListResponseIngestEndpointOut {
 export const ListResponseIngestEndpointOutSerializer = {
   _fromJsonObject(object: any): ListResponseIngestEndpointOut {
     return {
-      data: object["data"]?.map((item: IngestEndpointOut) =>
+      data: object["data"].map((item: IngestEndpointOut) =>
         IngestEndpointOutSerializer._fromJsonObject(item)
       ),
       done: object["done"],

--- a/javascript/src/models/listResponseIngestSourceOut.ts
+++ b/javascript/src/models/listResponseIngestSourceOut.ts
@@ -12,7 +12,7 @@ export interface ListResponseIngestSourceOut {
 export const ListResponseIngestSourceOutSerializer = {
   _fromJsonObject(object: any): ListResponseIngestSourceOut {
     return {
-      data: object["data"]?.map((item: IngestSourceOut) =>
+      data: object["data"].map((item: IngestSourceOut) =>
         IngestSourceOutSerializer._fromJsonObject(item)
       ),
       done: object["done"],

--- a/javascript/src/models/listResponseIntegrationOut.ts
+++ b/javascript/src/models/listResponseIntegrationOut.ts
@@ -12,7 +12,7 @@ export interface ListResponseIntegrationOut {
 export const ListResponseIntegrationOutSerializer = {
   _fromJsonObject(object: any): ListResponseIntegrationOut {
     return {
-      data: object["data"]?.map((item: IntegrationOut) =>
+      data: object["data"].map((item: IntegrationOut) =>
         IntegrationOutSerializer._fromJsonObject(item)
       ),
       done: object["done"],

--- a/javascript/src/models/listResponseMessageAttemptOut.ts
+++ b/javascript/src/models/listResponseMessageAttemptOut.ts
@@ -12,7 +12,7 @@ export interface ListResponseMessageAttemptOut {
 export const ListResponseMessageAttemptOutSerializer = {
   _fromJsonObject(object: any): ListResponseMessageAttemptOut {
     return {
-      data: object["data"]?.map((item: MessageAttemptOut) =>
+      data: object["data"].map((item: MessageAttemptOut) =>
         MessageAttemptOutSerializer._fromJsonObject(item)
       ),
       done: object["done"],

--- a/javascript/src/models/listResponseMessageEndpointOut.ts
+++ b/javascript/src/models/listResponseMessageEndpointOut.ts
@@ -12,7 +12,7 @@ export interface ListResponseMessageEndpointOut {
 export const ListResponseMessageEndpointOutSerializer = {
   _fromJsonObject(object: any): ListResponseMessageEndpointOut {
     return {
-      data: object["data"]?.map((item: MessageEndpointOut) =>
+      data: object["data"].map((item: MessageEndpointOut) =>
         MessageEndpointOutSerializer._fromJsonObject(item)
       ),
       done: object["done"],

--- a/javascript/src/models/listResponseMessageOut.ts
+++ b/javascript/src/models/listResponseMessageOut.ts
@@ -12,7 +12,7 @@ export interface ListResponseMessageOut {
 export const ListResponseMessageOutSerializer = {
   _fromJsonObject(object: any): ListResponseMessageOut {
     return {
-      data: object["data"]?.map((item: MessageOut) =>
+      data: object["data"].map((item: MessageOut) =>
         MessageOutSerializer._fromJsonObject(item)
       ),
       done: object["done"],

--- a/javascript/src/models/listResponseOperationalWebhookEndpointOut.ts
+++ b/javascript/src/models/listResponseOperationalWebhookEndpointOut.ts
@@ -15,7 +15,7 @@ export interface ListResponseOperationalWebhookEndpointOut {
 export const ListResponseOperationalWebhookEndpointOutSerializer = {
   _fromJsonObject(object: any): ListResponseOperationalWebhookEndpointOut {
     return {
-      data: object["data"]?.map((item: OperationalWebhookEndpointOut) =>
+      data: object["data"].map((item: OperationalWebhookEndpointOut) =>
         OperationalWebhookEndpointOutSerializer._fromJsonObject(item)
       ),
       done: object["done"],

--- a/javascript/src/models/messageEndpointOut.ts
+++ b/javascript/src/models/messageEndpointOut.ts
@@ -31,7 +31,7 @@ export const MessageEndpointOutSerializer = {
       disabled: object["disabled"],
       filterTypes: object["filterTypes"],
       id: object["id"],
-      nextAttempt: new Date(object["nextAttempt"]),
+      nextAttempt: object["nextAttempt"] ? new Date(object["nextAttempt"]) : null,
       rateLimit: object["rateLimit"],
       status: MessageStatusSerializer._fromJsonObject(object["status"]),
       uid: object["uid"],

--- a/javascript/src/models/pollingEndpointOut.ts
+++ b/javascript/src/models/pollingEndpointOut.ts
@@ -14,7 +14,7 @@ export interface PollingEndpointOut {
 export const PollingEndpointOutSerializer = {
   _fromJsonObject(object: any): PollingEndpointOut {
     return {
-      data: object["data"]?.map((item: PollingEndpointMessageOut) =>
+      data: object["data"].map((item: PollingEndpointMessageOut) =>
         PollingEndpointMessageOutSerializer._fromJsonObject(item)
       ),
       done: object["done"],

--- a/javascript/src/models/recoverIn.ts
+++ b/javascript/src/models/recoverIn.ts
@@ -10,7 +10,7 @@ export const RecoverInSerializer = {
   _fromJsonObject(object: any): RecoverIn {
     return {
       since: new Date(object["since"]),
-      until: new Date(object["until"]),
+      until: object["until"] ? new Date(object["until"]) : null,
     };
   },
 

--- a/javascript/src/models/replayIn.ts
+++ b/javascript/src/models/replayIn.ts
@@ -10,7 +10,7 @@ export const ReplayInSerializer = {
   _fromJsonObject(object: any): ReplayIn {
     return {
       since: new Date(object["since"]),
-      until: new Date(object["until"]),
+      until: object["until"] ? new Date(object["until"]) : null,
     };
   },
 


### PR DESCRIPTION
## Motivation

It's a bug! Actually produces invalid data as far as I can tell, as `new Date(null)` of course produces a valid date, rather than raising an exception...

## Solution

Only call `new Date` on non-null data. The other change (first commit) is a drive-by improvement.