### PR TITLE
php: Bump minimum version to 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": "^8.0",
         "ext-json": "*"
-      },
+    },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^11.0",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "phpstan/phpstan": "^0.12.89"
+        "phpstan/phpstan": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/php/src/Exception/WebhookSigningException.php
+++ b/php/src/Exception/WebhookSigningException.php
@@ -4,7 +4,7 @@ namespace Svix\Exception;
 
 class WebhookSigningException extends \Exception
 {
-    public function __construct($message, $code = 0, \Throwable $previous = null)
+    public function __construct($message, $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/php/src/Exception/WebhookVerificationException.php
+++ b/php/src/Exception/WebhookVerificationException.php
@@ -4,7 +4,7 @@ namespace Svix\Exception;
 
 class WebhookVerificationException extends \Exception
 {
-    public function __construct($message, $code = 0, \Throwable $previous = null)
+    public function __construct($message, $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/php/src/Webhook.php
+++ b/php/src/Webhook.php
@@ -46,7 +46,7 @@ class Webhook
         }
 
 
-        $timestamp = self::verifyTimestamp($msgTimestamp);
+        $timestamp = $this->verifyTimestamp($msgTimestamp);
 
         $signature = $this->sign($msgId, $timestamp, $payload);
         $expectedSignature = explode(',', $signature, 2)[1];
@@ -70,7 +70,7 @@ class Webhook
 
     public function sign($msgId, $timestamp, $payload)
     {
-        if (!self::isPositiveInteger($timestamp)) {
+        if (!$this->isPositiveInteger($timestamp)) {
             throw new Exception\WebhookSigningException("Invalid timestamp");
         }
         $toSign = "{$msgId}.{$timestamp}.{$payload}";


### PR DESCRIPTION
Officially [supported versions](https://www.php.net/supported-versions) are currently 8.1 - 8.4.
