### PR TITLE
server: Support sending raw (pre-formatted) payloads

### DIFF
--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -799,6 +799,7 @@ async fn send_example(
         payload: RawPayload::from_string(example).unwrap(),
         uid: None,
         payload_retention_period: 90,
+        extra_params: None,
     };
 
     let create_message =

--- a/server/svix-server/tests/it/utils/common_calls.rs
+++ b/server/svix-server/tests/it/utils/common_calls.rs
@@ -123,6 +123,7 @@ pub fn message_in<T: Serialize>(event_type: &str, payload: T) -> Result<MessageI
         payload_retention_period: 5,
         channels: None,
         uid: None,
+        extra_params: None,
     })
 }
 


### PR DESCRIPTION
Based on #1929.
Closes https://github.com/svix/svix-webhooks/issues/1927.