### PR TITLE
go: Disable HTTP/2.0

### DIFF
--- a/go/svix_http_client_test.go
+++ b/go/svix_http_client_test.go
@@ -65,7 +65,11 @@ func newMockClient() svix.Svix {
 	if err != nil {
 		panic(err)
 	}
-	svx, err := svix.New("randomToken", &svix.SvixOptions{ServerUrl: url})
+	svx, err := svix.New("randomToken", &svix.SvixOptions{
+		ServerUrl: url,
+		// need to explicitly use the default, which httpmock.Activate() modifies
+		HTTPClient: http.DefaultClient,
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/go/svix_test.go
+++ b/go/svix_test.go
@@ -70,6 +70,8 @@ func getTestClient(t *testing.T) *svix.Svix {
 	}
 	svx, err := svix.New(token, &svix.SvixOptions{
 		ServerUrl: serverUrl,
+		// need to explicitly use the default, which httpmock.Activate() modifies
+		HTTPClient: http.DefaultClient,
 	})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
## Motivation

Some customers are seeing HTTP 400 responses from our load balancer, only with the Go SDK and only with HTTP/2.0.

## Solution

Disable HTTP/2.0 for the Go SDK.