### PR TITLE
[PHP] Handle Badly Formatted Signatures

### DIFF
--- a/php/src/Webhook.php
+++ b/php/src/Webhook.php
@@ -54,6 +54,11 @@ class Webhook
         $passedSignatures = explode(' ', $msgSignature);
         foreach ($passedSignatures as $versionedSignature) {
             $sigParts = explode(',', $versionedSignature, 2);
+
+            if (count($sigParts) != 2) {
+                continue;
+            }
+
             $version = $sigParts[0];
             $passedSignature = $sigParts[1];
 

--- a/php/tests/WebhookTest.php
+++ b/php/tests/WebhookTest.php
@@ -58,7 +58,7 @@ final class WebhookTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage("No matching signature found");
 
         $testPayload = new TestPayload(time());
-        $testPayload->header['svix-signature'] = 'BAD_SIG_NA_TURE';
+        $testPayload->header['svix-signature'] = 'BAD_SIG_NATURE';
 
         $wh = new \Svix\Webhook($testPayload->secret);
         $wh->verify($testPayload->payload, $testPayload->header);

--- a/php/tests/WebhookTest.php
+++ b/php/tests/WebhookTest.php
@@ -52,6 +52,18 @@ final class WebhookTest extends \PHPUnit\Framework\TestCase
         $wh->verify($testPayload->payload, $testPayload->header);
     }
 
+    public function testBadlyFormattedSignatureThrowsException()
+    {
+        $this->expectException(\Svix\Exception\WebhookVerificationException::class);
+        $this->expectExceptionMessage("No matching signature found");
+
+        $testPayload = new TestPayload(time());
+        $testPayload->header['svix-signature'] = 'BAD_SIG_NA_TURE';
+
+        $wh = new \Svix\Webhook($testPayload->secret);
+        $wh->verify($testPayload->payload, $testPayload->header);
+    }
+
     public function testMissingIdThrowsException()
     {
         $this->expectException(\Svix\Exception\WebhookVerificationException::class);


### PR DESCRIPTION
Currently a notice will be thrown because of the invalid array access after splitting the signature. Would an exception be better here? signalling unexpected data from svix?

## Motivation

I ran into this while testing Svix integration in our app, and throwing random test data at it. I understand this data should come from Svix, but it seems like it should be handled gracefully anyway.

## Solution

If the signature in the header doesn't at least appear well formatted, skip it.