### PR TITLE
Automatically send an idempotency key on all requests

### DIFF
--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -4415,6 +4415,7 @@ dependencies = [
  "time",
  "tokio",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -5277,6 +5278,9 @@ name = "uuid"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+dependencies = [
+ "getrandom 0.2.15",
+]
 
 [[package]]
 name = "v8"

--- a/csharp/Svix/SvixHttpClient.cs
+++ b/csharp/Svix/SvixHttpClient.cs
@@ -55,6 +55,15 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (headerParams == null)
+            {
+                headerParams = new Dictionary<string, string>();
+            }
+            if (!headerParams.ContainsKey("idempotency-key"))
+            {
+                headerParams["idempotency-key"] = "auto_" + Guid.NewGuid().ToString();
+            }
+
             byte[] randomBytes = new byte[8];
             new Random().NextBytes(randomBytes);
             ulong req_id = BitConverter.ToUInt64(randomBytes, 0);

--- a/csharp/justfile
+++ b/csharp/justfile
@@ -2,5 +2,5 @@ _default:
     just --list --justfile {{ justfile() }}
 
 fmt *args='':
-    dotnet csharpier Svix {{ args }}
-    dotnet csharpier Svix.Tests {{ args }}
+    csharpier format Svix {{ args }}
+    csharpier format Svix.Tests {{ args }}

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ retract (
 	v1.46.0
 )
 
-require gopkg.in/validator.v2 v2.0.1
-
-require github.com/jarcoal/httpmock v1.3.1 // indirect
+require (
+	github.com/google/uuid v1.6.0
+	github.com/jarcoal/httpmock v1.3.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,6 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jarcoal/httpmock v1.3.1 h1:iUx3whfZWVf3jT01hQTO/Eo5sAYtB2/rqaUuOtpInww=
 github.com/jarcoal/httpmock v1.3.1/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
-github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
-gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
-gopkg.in/validator.v2 v2.0.1 h1:xF0KWyGWXm/LM2G1TrEjqOu4pa6coO9AlWSf3msVfDY=
-gopkg.in/validator.v2 v2.0.1/go.mod h1:lIUZBlB3Im4s/eYp39Ry/wkR02yOPhZ9IwIRBjuPuG8=
+github.com/maxatome/go-testdeep v1.12.0 h1:Ql7Go8Tg0C1D/uMMX59LAoYK7LffeJQ6X2T04nTH68g=

--- a/go/internal/svix_http_client.go
+++ b/go/internal/svix_http_client.go
@@ -81,6 +81,11 @@ func ExecuteRequest[ReqBody any, ResBody any](
 
 	}
 
+	key, ok := headerParams["idempotency-key"]
+	if !ok || key == "" {
+		req.Header.Set("idempotency-key", "auto_"+strconv.FormatUint(rand.Uint64(), 10))
+	}
+
 	req.Header.Set("svix-req-id", strconv.FormatUint(rand.Uint64(), 10))
 	for hKey, hVal := range client.DefaultHeaders {
 		req.Header.Add(hKey, hVal)

--- a/go/internal/svix_http_client.go
+++ b/go/internal/svix_http_client.go
@@ -16,6 +16,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type SvixHttpClient struct {
@@ -83,7 +85,7 @@ func ExecuteRequest[ReqBody any, ResBody any](
 
 	key, ok := headerParams["idempotency-key"]
 	if !ok || key == "" {
-		req.Header.Set("idempotency-key", "auto_"+strconv.FormatUint(rand.Uint64(), 10))
+		req.Header.Set("idempotency-key", "auto_"+uuid.New().String())
 	}
 
 	req.Header.Set("svix-req-id", strconv.FormatUint(rand.Uint64(), 10))

--- a/go/svix_http_client_test.go
+++ b/go/svix_http_client_test.go
@@ -60,6 +60,19 @@ var appListOut = `{
   "done": true
 }`
 
+var appCreateOut = `{
+	"uid": "unique-identifier",
+	"name": "My first application",
+	"rateLimit": 0,
+	"id": "app_1srOrx2ZWZBpBUvZwXKQmoEYga2",
+	"createdAt": "2019-08-24T14:15:22Z",
+	"updatedAt": "2019-08-24T14:15:22Z",
+	"metadata": {
+		"property1": "string",
+		"property2": "string"
+	}
+}`
+
 func newMockClient() svix.Svix {
 	url, err := url.Parse("http://testapi.test")
 	if err != nil {
@@ -221,5 +234,100 @@ func TestOctothorpeUrlParam(t *testing.T) {
 	_, err := svx.Message.List(context.Background(), "random_app_id", &listOpts)
 	if err != nil {
 		t.Error(err)
+	}
+}
+
+func TestIdempotencyKeyIsSentForListRequest(t *testing.T) {
+	svx := newMockClient()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("GET", "http://testapi.test/api/v1/app",
+		func(r *http.Request) (*http.Response, error) {
+			idempotencyKey := r.Header.Get("idempotency-key")
+			if idempotencyKey == "" {
+				t.Errorf("Expected idempotency-key header to be set")
+			}
+			if !strings.HasPrefix(idempotencyKey, "auto_") {
+				t.Errorf("Expected idempotency-key to start with 'auto_', got: %s", idempotencyKey)
+			}
+			return httpmock.NewStringResponse(200, appListOut), nil
+		},
+	)
+
+	_, err := svx.Application.List(context.Background(), nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if httpmock.GetTotalCallCount() != 1 {
+		t.Errorf("Expected 1 request, got %v", httpmock.GetTotalCallCount())
+	}
+}
+
+func TestIdempotencyKeyIsSentForCreateRequest(t *testing.T) {
+	svx := newMockClient()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("POST", "http://testapi.test/api/v1/app",
+		func(r *http.Request) (*http.Response, error) {
+			idempotencyKey := r.Header.Get("idempotency-key")
+			if idempotencyKey == "" {
+				t.Errorf("Expected idempotency-key header to be set")
+			}
+			if !strings.HasPrefix(idempotencyKey, "auto_") {
+				t.Errorf("Expected idempotency-key to start with 'auto_', got: %s", idempotencyKey)
+			}
+			return httpmock.NewStringResponse(200, appCreateOut), nil
+		},
+	)
+
+	appIn := models.ApplicationIn{
+		Name: "test app",
+	}
+	_, err := svx.Application.Create(context.Background(), appIn, nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if httpmock.GetTotalCallCount() != 1 {
+		t.Errorf("Expected 1 request, got %v", httpmock.GetTotalCallCount())
+	}
+}
+
+func TestClientProvidedIdempotencyKeyIsNotOverridden(t *testing.T) {
+	svx := newMockClient()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	clientProvidedKey := "test-key-123"
+
+	httpmock.RegisterResponder("POST", "http://testapi.test/api/v1/app",
+		func(r *http.Request) (*http.Response, error) {
+			idempotencyKey := r.Header.Get("idempotency-key")
+			if idempotencyKey == "" {
+				t.Errorf("Expected idempotency-key header to be set")
+			}
+			if idempotencyKey != clientProvidedKey {
+				t.Errorf("Expected idempotency-key to be %s, got: %s", clientProvidedKey, idempotencyKey)
+			}
+			return httpmock.NewStringResponse(200, appCreateOut), nil
+		},
+	)
+
+	appIn := models.ApplicationIn{
+		Name: "test app",
+	}
+	createOpts := svix.ApplicationCreateOptions{
+		IdempotencyKey: &clientProvidedKey,
+	}
+	_, err := svx.Application.Create(context.Background(), appIn, &createOpts)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if httpmock.GetTotalCallCount() != 1 {
+		t.Errorf("Expected 1 request, got %v", httpmock.GetTotalCallCount())
 	}
 }

--- a/java/lib/src/main/java/com/svix/SvixHttpClient.java
+++ b/java/lib/src/main/java/com/svix/SvixHttpClient.java
@@ -53,6 +53,11 @@ public class SvixHttpClient {
         // Add default headers
         defaultHeaders.forEach(reqBuilder::addHeader);
 
+        String idempotencyKey = headers == null ? null : headers.get("idempotency-key");
+        if (idempotencyKey == null || idempotencyKey.isEmpty()) {
+            reqBuilder.addHeader("idempotency-key", "auto_" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE));
+        }
+
         // Add custom headers if present
         if (headers != null) {
             headers.forEach(pair -> reqBuilder.addHeader(pair.getFirst(), pair.getSecond()));

--- a/java/lib/src/main/java/com/svix/SvixHttpClient.java
+++ b/java/lib/src/main/java/com/svix/SvixHttpClient.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.locks.LockSupport;
+import java.util.UUID;
 
 public class SvixHttpClient {
     private final HttpUrl baseUrl;
@@ -55,7 +56,7 @@ public class SvixHttpClient {
 
         String idempotencyKey = headers == null ? null : headers.get("idempotency-key");
         if (idempotencyKey == null || idempotencyKey.isEmpty()) {
-            reqBuilder.addHeader("idempotency-key", "auto_" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE));
+            reqBuilder.addHeader("idempotency-key", "auto_" + UUID.randomUUID().toString());
         }
 
         // Add custom headers if present

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -34,13 +34,15 @@
     "es6-promise": "^4.2.8",
     "fast-sha256": "^1.3.0",
     "svix-fetch": "^3.0.0",
-    "url-parse": "^1.5.10"
+    "url-parse": "^1.5.10",
+    "uuid": "^10.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@stablelib/utf8": "^2.0.0",
     "@types/jest": "^29.5.13",
     "@types/url-parse": "1.4.11",
+    "@types/uuid": "^10.0.0",
     "eslint": "^9.20.1",
     "globals": "^15.15.0",
     "jest": "^29.7.0",

--- a/javascript/src/mockttp.test.ts
+++ b/javascript/src/mockttp.test.ts
@@ -429,7 +429,8 @@ describe("mockttp tests", () => {
 
     const requests = await endpointMock.getSeenRequests();
     expect(requests.length).toBe(1);
-    expect(requests[0].headers["idempotency-key"]).toMatch(/^auto_\d+$/);
+    const idempotencyKey = requests[0].headers["idempotency-key"] as string;
+    expect(idempotencyKey.startsWith("auto_")).toBe(true);
   });
 
   test("test idempotency key is sent for create request", async () => {
@@ -442,7 +443,8 @@ describe("mockttp tests", () => {
 
     const requests = await endpointMock.getSeenRequests();
     expect(requests.length).toBe(1);
-    expect(requests[0].headers["idempotency-key"]).toMatch(/^auto_\d+$/);
+    const idempotencyKey = requests[0].headers["idempotency-key"] as string;
+    expect(idempotencyKey.startsWith("auto_")).toBe(true);
   });
 
   test("test client provided idempotency key is not overridden", async () => {

--- a/javascript/src/mockttp.test.ts
+++ b/javascript/src/mockttp.test.ts
@@ -418,4 +418,47 @@ describe("mockttp tests", () => {
       '{"type":"generic-webhook","config":{},"name":"generic over <T>"}'
     );
   });
+
+  test("test idempotency key is sent for list request", async () => {
+    const endpointMock = await mockServer
+      .forGet("/api/v1/app")
+      .thenReply(200, ListResponseApplicationOut);
+    const svx = new Svix("token", { serverUrl: mockServer.url });
+
+    await svx.application.list();
+
+    const requests = await endpointMock.getSeenRequests();
+    expect(requests.length).toBe(1);
+    expect(requests[0].headers["idempotency-key"]).toMatch(/^auto_\d+$/);
+  });
+
+  test("test idempotency key is sent for create request", async () => {
+    const endpointMock = await mockServer
+      .forPost("/api/v1/app")
+      .thenReply(200, ApplicationOut);
+    const svx = new Svix("token", { serverUrl: mockServer.url });
+
+    await svx.application.create({ name: "test app" });
+
+    const requests = await endpointMock.getSeenRequests();
+    expect(requests.length).toBe(1);
+    expect(requests[0].headers["idempotency-key"]).toMatch(/^auto_\d+$/);
+  });
+
+  test("test client provided idempotency key is not overridden", async () => {
+    const endpointMock = await mockServer
+      .forPost("/api/v1/app")
+      .thenReply(200, ApplicationOut);
+    const svx = new Svix("token", { serverUrl: mockServer.url });
+
+    const clientProvidedKey = "test-key-123";
+    await svx.application.create(
+      { name: "test app" },
+      { idempotencyKey: clientProvidedKey }
+    );
+
+    const requests = await endpointMock.getSeenRequests();
+    expect(requests.length).toBe(1);
+    expect(requests[0].headers["idempotency-key"]).toBe(clientProvidedKey);
+  });
 });

--- a/javascript/src/request.ts
+++ b/javascript/src/request.ts
@@ -113,6 +113,11 @@ export class SvixRequest {
       url.searchParams.set(name, value);
     }
 
+    if (this.headerParams["idempotency-key"] === undefined) {
+      this.headerParams["idempotency-key"] =
+        "auto_" + Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
+    }
+
     const randomId = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
 
     if (this.body != null) {

--- a/javascript/src/request.ts
+++ b/javascript/src/request.ts
@@ -1,6 +1,7 @@
 import "svix-fetch";
 import { ApiException } from "./util";
 import { HttpErrorOut, HTTPValidationError } from "./HttpErrors";
+import { v4 as uuidv4 } from "uuid";
 
 export const LIB_VERSION = "1.67.0";
 const USER_AGENT = `svix-libs/${LIB_VERSION}/javascript`;
@@ -114,8 +115,7 @@ export class SvixRequest {
     }
 
     if (this.headerParams["idempotency-key"] === undefined) {
-      this.headerParams["idempotency-key"] =
-        "auto_" + Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
+      this.headerParams["idempotency-key"] = "auto_" + uuidv4();
     }
 
     const randomId = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);

--- a/javascript/yarn.lock
+++ b/javascript/yarn.lock
@@ -874,6 +874,11 @@
   resolved "https://registry.yarnpkg.com/@types/url-parse/-/url-parse-1.4.11.tgz#01f8faa7b8bfd438e5f5efb8337a74513a15602b"
   integrity sha512-FKvKIqRaykZtd4n47LbK/W/5fhQQ1X7cxxzG9A48h0BGN+S04NH7ervcCjM8tyR0lyGru83FAHSmw2ObgKoESg==
 
+"@types/uuid@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-10.0.0.tgz#e9c07fe50da0f53dc24970cca94d619ff03f6f6d"
+  integrity sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==
+
 "@types/ws@*":
   version "8.5.14"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.14.tgz#93d44b268c9127d96026cf44353725dd9b6c3c21"
@@ -4024,6 +4029,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
+
+uuid@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
+  integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
 
 uuid@^8.3.2:
   version "8.3.2"

--- a/kotlin/lib/src/main/kotlin/SvixHttpClient.kt
+++ b/kotlin/lib/src/main/kotlin/SvixHttpClient.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.delay
 import kotlinx.serialization.json.Json
 import okhttp3.*
 import okhttp3.RequestBody.Companion.toRequestBody
+import java.util.UUID
 
 open class SvixHttpClient
 internal constructor(
@@ -43,7 +44,8 @@ internal constructor(
         }
 
         if (headers?.get("idempotency-key") == null) {
-            reqBuilder.addHeader("idempotency-key", "auto_" + Random.nextULong().toString())
+            val uuid = UUID.randomUUID().toString()
+            reqBuilder.addHeader("idempotency-key", "auto_" + uuid)
         }
 
         reqBuilder.addHeader("svix-req-id", Random.nextULong().toString())

--- a/kotlin/lib/src/main/kotlin/SvixHttpClient.kt
+++ b/kotlin/lib/src/main/kotlin/SvixHttpClient.kt
@@ -41,6 +41,11 @@ internal constructor(
                 reqBuilder.addHeader(k, v)
             }
         }
+
+        if (headers?.get("idempotency-key") == null) {
+            reqBuilder.addHeader("idempotency-key", "auto_" + Random.nextULong().toString())
+        }
+
         reqBuilder.addHeader("svix-req-id", Random.nextULong().toString())
 
         val request = reqBuilder.build()

--- a/kotlin/lib/src/test/resources/__files/ApplicationOut.json
+++ b/kotlin/lib/src/test/resources/__files/ApplicationOut.json
@@ -1,0 +1,12 @@
+{
+  "uid": "unique-identifier",
+  "name": "My first application",
+  "rateLimit": 0,
+  "id": "app_1srOrx2ZWZBpBUvZwXKQmoEYga2",
+  "createdAt": "2019-08-24T14:15:22Z",
+  "updatedAt": "2019-08-24T14:15:22Z",
+  "metadata": {
+    "property1": "string",
+    "property2": "string"
+  }
+}

--- a/python/svix/api/common.py
+++ b/python/svix/api/common.py
@@ -4,7 +4,7 @@ import time
 import typing as t
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
-
+import uuid
 import httpx
 
 from .client import AuthenticatedClient
@@ -119,6 +119,9 @@ class ApiBase:
         }
         if header_params is not None:
             headers.update(header_params)
+
+        if headers.get("idempotency-key") is None:
+            headers["idempotency-key"] = f"auto_{uuid.uuid4()}"
 
         httpx_kwargs = {
             "method": method.upper(),

--- a/python/tests/test_httpretty.py
+++ b/python/tests/test_httpretty.py
@@ -1,5 +1,5 @@
 import svix
-from svix.api import MessageListOptions,IngestSourceIn, CronConfig
+from svix.api import MessageListOptions,IngestSourceIn, CronConfig, ApplicationIn, ApplicationCreateOptions
 from svix.api.ingest_source import IngestSource
 
 import httpretty
@@ -51,3 +51,53 @@ def test_struct_enum_without_fields():
 
     assert isinstance(res.config, dict)
     assert res.config == {}
+
+
+@httpretty.activate(verbose=True, allow_net_connect=False)
+def test_idempotency_key_is_sent_for_list_request():
+    svx = svix.Svix("token", svix.SvixOptions(server_url="http://test.example"))
+    httpretty.register_uri(
+        httpretty.GET,
+        "http://test.example/api/v1/app",
+        body='{"data":[],"iterator":null,"prevIterator":null,"done":true}'
+    )
+    svx.application.list()
+
+    request = httpretty.latest_requests()[0]
+    assert "idempotency-key" in request.headers
+    assert request.headers["idempotency-key"].startswith("auto_")
+
+
+@httpretty.activate(verbose=True, allow_net_connect=False)
+def test_idempotency_key_is_sent_for_create_request():
+    svx = svix.Svix("token", svix.SvixOptions(server_url="http://test.example"))
+    httpretty.register_uri(
+        httpretty.POST,
+        "http://test.example/api/v1/app",
+        body='{"uid":"unique-identifier","name":"My first application","rateLimit":0,"id":"app_1srOrx2ZWZBpBUvZwXKQmoEYga2","createdAt":"2019-08-24T14:15:22Z","updatedAt":"2019-08-24T14:15:22Z","metadata":{"property1":"string","property2":"string"}}'
+    )
+    svx.application.create(ApplicationIn(name="test app"))
+
+    request = httpretty.latest_requests()[0]
+    assert "idempotency-key" in request.headers
+    assert request.headers["idempotency-key"].startswith("auto_")
+
+
+@httpretty.activate(verbose=True, allow_net_connect=False)
+def test_client_provided_idempotency_key_is_not_overridden():
+    svx = svix.Svix("token", svix.SvixOptions(server_url="http://test.example"))
+    httpretty.register_uri(
+        httpretty.POST,
+        "http://test.example/api/v1/app",
+        body='{"uid":"unique-identifier","name":"My first application","rateLimit":0,"id":"app_1srOrx2ZWZBpBUvZwXKQmoEYga2","createdAt":"2019-08-24T14:15:22Z","updatedAt":"2019-08-24T14:15:22Z","metadata":{"property1":"string","property2":"string"}}'
+    )
+    
+    client_provided_key = "test-key-123"
+    svx.application.create(
+        ApplicationIn(name="test app"),
+        ApplicationCreateOptions(idempotency_key=client_provided_key)
+    )
+
+    request = httpretty.latest_requests()[0]
+    assert "idempotency-key" in request.headers
+    assert request.headers["idempotency-key"] == client_provided_key

--- a/ruby/lib/svix/svix_http_client.rb
+++ b/ruby/lib/svix/svix_http_client.rb
@@ -50,6 +50,11 @@ module Svix
       # Add headers
       headers.each { |key, value| request[key] = value }
 
+      # Check if idempotency-key header already exists
+      if !request.key?("idempotency-key")
+        request["idempotency-key"] = "auto_" + rand(0...(2 ** 64)).to_s
+      end
+
       # Add body for non-GET requests
       if %w[POST PUT PATCH].include?(method.to_s.upcase) && !body.nil?
         request.body = body.to_json

--- a/ruby/lib/svix/svix_http_client.rb
+++ b/ruby/lib/svix/svix_http_client.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 require "uri"
 require "net/http"
+require "securerandom"
+
 
 module Svix
   class SvixHttpClient
@@ -52,7 +54,7 @@ module Svix
 
       # Check if idempotency-key header already exists
       if !request.key?("idempotency-key")
-        request["idempotency-key"] = "auto_" + rand(0...(2 ** 64)).to_s
+        request["idempotency-key"] = "auto_" + SecureRandom.uuid_v4.to_s
       end
 
       # Add body for non-GET requests

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -44,6 +44,7 @@ thiserror = "2.0.11"
 time = "0.3"
 tokio = { version = "1.41.0", features = ["time"] }
 url = "2.2"
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 tokio = { version = "1.41.0", features = ["macros"] }

--- a/rust/src/request.rs
+++ b/rust/src/request.rs
@@ -114,10 +114,8 @@ impl Request {
             .insert("svix-req-id", rand::rng().random::<u32>().to_string());
 
         if !self.header_params.contains_key("idempotency-key") {
-            self.header_params.insert(
-                "idempotency-key",
-                format!("auto_{}", rand::rng().random::<u64>()),
-            );
+            self.header_params
+                .insert("idempotency-key", format!("auto_{}", uuid::Uuid::new_v4()));
         }
 
         loop {

--- a/rust/src/request.rs
+++ b/rust/src/request.rs
@@ -113,6 +113,13 @@ impl Request {
         self.header_params
             .insert("svix-req-id", rand::rng().random::<u32>().to_string());
 
+        if !self.header_params.contains_key("idempotency-key") {
+            self.header_params.insert(
+                "idempotency-key",
+                format!("auto_{}", rand::rng().random::<u64>()),
+            );
+        }
+
         loop {
             match self.clone().execute_inner(conf).await {
                 Ok(result) => return Ok(result),

--- a/rust/tests/it/wiremock_tests.rs
+++ b/rust/tests/it/wiremock_tests.rs
@@ -44,3 +44,128 @@ async fn test_urlencoded_octothorpe() {
     assert_eq!(1, requests.len());
     assert_eq!(Some("tag=test%23test"), requests[0].url.query());
 }
+
+#[tokio::test]
+async fn test_idempotency_key_is_sent_for_list_request() {
+    let mock_server = MockServer::start().await;
+
+    let json_body =
+        r#"{"data":[],"done":true,"iterator":"iterator-str","prevIterator":"prevIterator-str"}"#;
+    Mock::given(method("GET"))
+        .and(path("/api/v1/app"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(json_body))
+        .mount(&mock_server)
+        .await;
+
+    let svx = Svix::new(
+        "token".to_string(),
+        Some(SvixOptions {
+            server_url: Some(mock_server.uri()),
+            ..Default::default()
+        }),
+    );
+
+    svx.application().list(None).await.unwrap();
+
+    let requests = mock_server
+        .received_requests()
+        .await
+        .expect("we should have sent a request");
+
+    assert_eq!(1, requests.len());
+    let idempotency_key = requests[0]
+        .headers
+        .get("idempotency-key")
+        .expect("idempotency-key header should be present");
+    assert!(
+        idempotency_key.to_str().unwrap().starts_with("auto_"),
+        "idempotency key should start with 'auto_', got: {idempotency_key:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_idempotency_key_is_sent_for_create_request() {
+    let mock_server = MockServer::start().await;
+
+    let json_body = r#"{"uid":"unique-identifier","name":"My first application","rateLimit":0,"id":"app_1srOrx2ZWZBpBUvZwXKQmoEYga2","createdAt":"2019-08-24T14:15:22Z","updatedAt":"2019-08-24T14:15:22Z","metadata":{"property1":"string","property2":"string"}}"#;
+    Mock::given(method("POST"))
+        .and(path("/api/v1/app"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(json_body))
+        .mount(&mock_server)
+        .await;
+
+    let svx = Svix::new(
+        "token".to_string(),
+        Some(SvixOptions {
+            server_url: Some(mock_server.uri()),
+            ..Default::default()
+        }),
+    );
+
+    svx.application()
+        .create(svix::api::ApplicationIn::new("test app".to_string()), None)
+        .await
+        .unwrap();
+
+    let requests = mock_server
+        .received_requests()
+        .await
+        .expect("we should have sent a request");
+
+    assert_eq!(1, requests.len());
+    let idempotency_key = requests[0]
+        .headers
+        .get("idempotency-key")
+        .expect("idempotency-key header should be present");
+    assert!(
+        idempotency_key.to_str().unwrap().starts_with("auto_"),
+        "idempotency key should start with 'auto_', got: {idempotency_key:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_client_provided_idempotency_key_is_not_overridden() {
+    let mock_server = MockServer::start().await;
+
+    let json_body = r#"{"uid":"unique-identifier","name":"My first application","rateLimit":0,"id":"app_1srOrx2ZWZBpBUvZwXKQmoEYga2","createdAt":"2019-08-24T14:15:22Z","updatedAt":"2019-08-24T14:15:22Z","metadata":{"property1":"string","property2":"string"}}"#;
+    Mock::given(method("POST"))
+        .and(path("/api/v1/app"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(json_body))
+        .mount(&mock_server)
+        .await;
+
+    let svx = Svix::new(
+        "token".to_string(),
+        Some(SvixOptions {
+            server_url: Some(mock_server.uri()),
+            ..Default::default()
+        }),
+    );
+
+    let client_provided_key = "test-key-123";
+    svx.application()
+        .create(
+            svix::api::ApplicationIn::new("test app".to_string()),
+            Some(svix::api::ApplicationCreateOptions {
+                idempotency_key: Some(client_provided_key.to_string()),
+            }),
+        )
+        .await
+        .unwrap();
+
+    let requests = mock_server
+        .received_requests()
+        .await
+        .expect("we should have sent a request");
+
+    assert_eq!(1, requests.len());
+    let idempotency_key = requests[0]
+        .headers
+        .get("idempotency-key")
+        .expect("idempotency-key header should be present");
+    assert_eq!(
+        client_provided_key,
+        idempotency_key.to_str().unwrap(),
+        "client provided idempotency key should not be overridden"
+    );
+}

--- a/svix-cli/Cargo.lock
+++ b/svix-cli/Cargo.lock
@@ -1578,6 +1578,7 @@ dependencies = [
  "time",
  "tokio",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -2004,6 +2005,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "getrandom 0.3.1",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version_check"


### PR DESCRIPTION
... If the user of the SDK did not already add an idempotency key


Closes: https://github.com/svix/monorepo-private/issues/10619