### PR TITLE
Only send `idempotency-key` on post requests

### DIFF
--- a/csharp/Svix.Tests/WiremockTests.cs
+++ b/csharp/Svix.Tests/WiremockTests.cs
@@ -327,27 +327,6 @@ namespace Svix.Tests
         }
 
         [Fact]
-        public void IdempotencyKeyIsSentForListRequest()
-        {
-            stub.Given(Request.Create().WithPath("/api/v1/app"))
-                .RespondWith(
-                    Response
-                        .Create()
-                        .WithStatusCode(200)
-                        .WithBody("""{"data":[],"iterator":null,"prevIterator":null,"done":true}""")
-                );
-            client.Application.List();
-
-            Assert.Equal(1, stub.LogEntries.Count);
-            Assert.True(stub.LogEntries[0].RequestMessage.Headers.ContainsKey("idempotency-key"));
-            Assert.StartsWith(
-                "auto_",
-                stub.LogEntries[0].RequestMessage.Headers["idempotency-key"][0]
-            );
-            Assert.Equal(1, stub.LogEntries.Count);
-        }
-
-        [Fact]
         public void IdempotencyKeyIsSentForCreateRequest()
         {
             stub.Given(Request.Create().WithPath("/api/v1/app"))

--- a/csharp/Svix/SvixHttpClient.cs
+++ b/csharp/Svix/SvixHttpClient.cs
@@ -59,7 +59,7 @@ namespace Svix
             {
                 headerParams = new Dictionary<string, string>();
             }
-            if (!headerParams.ContainsKey("idempotency-key"))
+            if (!headerParams.ContainsKey("idempotency-key") && method == HttpMethod.Post)
             {
                 headerParams["idempotency-key"] = "auto_" + Guid.NewGuid().ToString();
             }

--- a/go/internal/svix_http_client.go
+++ b/go/internal/svix_http_client.go
@@ -84,7 +84,7 @@ func ExecuteRequest[ReqBody any, ResBody any](
 	}
 
 	key, ok := headerParams["idempotency-key"]
-	if !ok || key == "" {
+	if (!ok || key == "") && strings.ToUpper(method) == "POST" {
 		req.Header.Set("idempotency-key", "auto_"+uuid.New().String())
 	}
 

--- a/go/svix_http_client_test.go
+++ b/go/svix_http_client_test.go
@@ -237,34 +237,6 @@ func TestOctothorpeUrlParam(t *testing.T) {
 	}
 }
 
-func TestIdempotencyKeyIsSentForListRequest(t *testing.T) {
-	svx := newMockClient()
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-
-	httpmock.RegisterResponder("GET", "http://testapi.test/api/v1/app",
-		func(r *http.Request) (*http.Response, error) {
-			idempotencyKey := r.Header.Get("idempotency-key")
-			if idempotencyKey == "" {
-				t.Errorf("Expected idempotency-key header to be set")
-			}
-			if !strings.HasPrefix(idempotencyKey, "auto_") {
-				t.Errorf("Expected idempotency-key to start with 'auto_', got: %s", idempotencyKey)
-			}
-			return httpmock.NewStringResponse(200, appListOut), nil
-		},
-	)
-
-	_, err := svx.Application.List(context.Background(), nil)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if httpmock.GetTotalCallCount() != 1 {
-		t.Errorf("Expected 1 request, got %v", httpmock.GetTotalCallCount())
-	}
-}
-
 func TestIdempotencyKeyIsSentForCreateRequest(t *testing.T) {
 	svx := newMockClient()
 	httpmock.Activate()

--- a/java/lib/src/main/java/com/svix/SvixHttpClient.java
+++ b/java/lib/src/main/java/com/svix/SvixHttpClient.java
@@ -55,8 +55,8 @@ public class SvixHttpClient {
         defaultHeaders.forEach(reqBuilder::addHeader);
 
         String idempotencyKey = headers == null ? null : headers.get("idempotency-key");
-        if (idempotencyKey == null || idempotencyKey.isEmpty()) {
-            reqBuilder.addHeader("idempotency-key", "auto_" + UUID.randomUUID().toString());
+        if ((idempotencyKey == null || idempotencyKey.isEmpty()) && method.toUpperCase() == "POST") {
+                reqBuilder.addHeader("idempotency-key", "auto_" + UUID.randomUUID().toString());
         }
 
         // Add custom headers if present

--- a/java/lib/src/test/com/svix/test/WiremockTests.java
+++ b/java/lib/src/test/com/svix/test/WiremockTests.java
@@ -508,21 +508,6 @@ public class WiremockTests {
     }
 
     @Test
-    public void testIdempotencyKeyIsSentForListRequest() throws Exception {
-        Svix svx = testClient();
-        wireMockRule.stubFor(
-                WireMock.get(urlEqualTo("/api/v1/app"))
-                        .willReturn(WireMock.ok().withBodyFile("ListResponseApplicationOut.json")));
-
-        svx.getApplication().list();
-
-        wireMockRule.verify(
-                1,
-                getRequestedFor(urlEqualTo("/api/v1/app"))
-                        .withHeader("idempotency-key", matching("auto_.*")));
-    }
-
-    @Test
     public void testIdempotencyKeyIsSentForCreateRequest() throws Exception {
         Svix svx = testClient();
         wireMockRule.stubFor(

--- a/javascript/src/mockttp.test.ts
+++ b/javascript/src/mockttp.test.ts
@@ -419,20 +419,6 @@ describe("mockttp tests", () => {
     );
   });
 
-  test("test idempotency key is sent for list request", async () => {
-    const endpointMock = await mockServer
-      .forGet("/api/v1/app")
-      .thenReply(200, ListResponseApplicationOut);
-    const svx = new Svix("token", { serverUrl: mockServer.url });
-
-    await svx.application.list();
-
-    const requests = await endpointMock.getSeenRequests();
-    expect(requests.length).toBe(1);
-    const idempotencyKey = requests[0].headers["idempotency-key"] as string;
-    expect(idempotencyKey.startsWith("auto_")).toBe(true);
-  });
-
   test("test idempotency key is sent for create request", async () => {
     const endpointMock = await mockServer
       .forPost("/api/v1/app")

--- a/javascript/src/request.ts
+++ b/javascript/src/request.ts
@@ -114,7 +114,10 @@ export class SvixRequest {
       url.searchParams.set(name, value);
     }
 
-    if (this.headerParams["idempotency-key"] === undefined) {
+    if (
+      this.headerParams["idempotency-key"] === undefined &&
+      this.method.toUpperCase() === "POST"
+    ) {
       this.headerParams["idempotency-key"] = "auto_" + uuidv4();
     }
 

--- a/kotlin/lib/src/main/kotlin/SvixHttpClient.kt
+++ b/kotlin/lib/src/main/kotlin/SvixHttpClient.kt
@@ -43,9 +43,9 @@ internal constructor(
             }
         }
 
-        if (headers?.get("idempotency-key") == null) {
-            val uuid = UUID.randomUUID().toString()
-            reqBuilder.addHeader("idempotency-key", "auto_" + uuid)
+        if (headers?.get("idempotency-key") == null && method == "POST") {
+                val uuid = UUID.randomUUID().toString()
+                reqBuilder.addHeader("idempotency-key", "auto_" + uuid)
         }
 
         reqBuilder.addHeader("svix-req-id", Random.nextULong().toString())

--- a/kotlin/lib/src/test/com/svix/kotlin/WiremockTests.kt
+++ b/kotlin/lib/src/test/com/svix/kotlin/WiremockTests.kt
@@ -446,21 +446,6 @@ class WiremockTests {
         )
     }
 
-  @Test
-  fun testIdempotencyKeyIsSentForListRequest() {
-    val svx = testClient()
-    wireMockServer.stubFor(
-        get(urlEqualTo("/api/v1/app"))
-            .willReturn(ok().withBodyFile("ListResponseApplicationOut.json")))
-
-    runBlocking { svx.application.list() }
-
-    wireMockServer.verify(
-        1,
-        getRequestedFor(urlEqualTo("/api/v1/app"))
-            .withHeader("idempotency-key", matching("auto_.*")),
-    )
-  }
 
   @Test
   fun testIdempotencyKeyIsSentForCreateRequest() {

--- a/python/svix/api/common.py
+++ b/python/svix/api/common.py
@@ -120,7 +120,7 @@ class ApiBase:
         if header_params is not None:
             headers.update(header_params)
 
-        if headers.get("idempotency-key") is None:
+        if headers.get("idempotency-key") is None and method.upper() == "POST":
             headers["idempotency-key"] = f"auto_{uuid.uuid4()}"
 
         httpx_kwargs = {

--- a/python/tests/test_httpretty.py
+++ b/python/tests/test_httpretty.py
@@ -52,22 +52,6 @@ def test_struct_enum_without_fields():
     assert isinstance(res.config, dict)
     assert res.config == {}
 
-
-@httpretty.activate(verbose=True, allow_net_connect=False)
-def test_idempotency_key_is_sent_for_list_request():
-    svx = svix.Svix("token", svix.SvixOptions(server_url="http://test.example"))
-    httpretty.register_uri(
-        httpretty.GET,
-        "http://test.example/api/v1/app",
-        body='{"data":[],"iterator":null,"prevIterator":null,"done":true}'
-    )
-    svx.application.list()
-
-    request = httpretty.latest_requests()[0]
-    assert "idempotency-key" in request.headers
-    assert request.headers["idempotency-key"].startswith("auto_")
-
-
 @httpretty.activate(verbose=True, allow_net_connect=False)
 def test_idempotency_key_is_sent_for_create_request():
     svx = svix.Svix("token", svix.SvixOptions(server_url="http://test.example"))

--- a/ruby/lib/svix/svix_http_client.rb
+++ b/ruby/lib/svix/svix_http_client.rb
@@ -53,7 +53,7 @@ module Svix
       headers.each { |key, value| request[key] = value }
 
       # Check if idempotency-key header already exists
-      if !request.key?("idempotency-key")
+      if !request.key?("idempotency-key") && method.to_s.upcase == "POST"
         request["idempotency-key"] = "auto_" + SecureRandom.uuid_v4.to_s
       end
 

--- a/ruby/spec/webmock_tests_spec.rb
+++ b/ruby/spec/webmock_tests_spec.rb
@@ -395,24 +395,6 @@ describe "API Client" do
     expect(WebMock).to(have_requested(:post, "#{host}/api/v1/app?get_if_exists=true"))
   end
 
-  it "test idempotency key is sent for list request" do
-    stub_request(:get, "#{host}/api/v1/app")
-      .to_return(
-        status: 200,
-        body: ListResponseAppOut_JSON
-      )
-
-    svx.application.list
-
-    expect(WebMock).to(
-      have_requested(:get, "#{host}/api/v1/app")
-    )
-
-    # Check that the idempotency key starts with "auto_"
-    request = WebMock::RequestRegistry.instance.requested_signatures.hash.first[0]
-    expect(request.headers["Idempotency-Key"]).to(start_with("auto_"))
-  end
-
   it "test idempotency key is sent for create request" do
     stub_request(:post, "#{host}/api/v1/app")
       .to_return(

--- a/rust/src/request.rs
+++ b/rust/src/request.rs
@@ -113,7 +113,8 @@ impl Request {
         self.header_params
             .insert("svix-req-id", rand::rng().random::<u32>().to_string());
 
-        if !self.header_params.contains_key("idempotency-key") {
+        if self.method == http1::Method::POST && !self.header_params.contains_key("idempotency-key")
+        {
             self.header_params
                 .insert("idempotency-key", format!("auto_{}", uuid::Uuid::new_v4()));
         }

--- a/rust/tests/it/wiremock_tests.rs
+++ b/rust/tests/it/wiremock_tests.rs
@@ -46,44 +46,6 @@ async fn test_urlencoded_octothorpe() {
 }
 
 #[tokio::test]
-async fn test_idempotency_key_is_sent_for_list_request() {
-    let mock_server = MockServer::start().await;
-
-    let json_body =
-        r#"{"data":[],"done":true,"iterator":"iterator-str","prevIterator":"prevIterator-str"}"#;
-    Mock::given(method("GET"))
-        .and(path("/api/v1/app"))
-        .respond_with(ResponseTemplate::new(200).set_body_string(json_body))
-        .mount(&mock_server)
-        .await;
-
-    let svx = Svix::new(
-        "token".to_string(),
-        Some(SvixOptions {
-            server_url: Some(mock_server.uri()),
-            ..Default::default()
-        }),
-    );
-
-    svx.application().list(None).await.unwrap();
-
-    let requests = mock_server
-        .received_requests()
-        .await
-        .expect("we should have sent a request");
-
-    assert_eq!(1, requests.len());
-    let idempotency_key = requests[0]
-        .headers
-        .get("idempotency-key")
-        .expect("idempotency-key header should be present");
-    assert!(
-        idempotency_key.to_str().unwrap().starts_with("auto_"),
-        "idempotency key should start with 'auto_', got: {idempotency_key:?}"
-    );
-}
-
-#[tokio::test]
 async fn test_idempotency_key_is_sent_for_create_request() {
     let mock_server = MockServer::start().await;
 


### PR DESCRIPTION
No need to send this on requests where the server won't use the `idempotency-key` at all