### PR TITLE
feat(svix-server): server healthchecks

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -14,6 +14,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM chef AS build
 
 RUN apt-get update && apt-get install -y \
+        curl=7.* \
         build-essential=12.* \
         checkinstall=1.* \
         zlib1g-dev=1:* \

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -13,11 +13,18 @@ services:
     ports:
       - "8071:8071"
     depends_on:
-    - pgbouncer
-    - redis
+      pgbouncer:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
 
   postgres:
     image: "docker.io/postgres:13.4"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 1s
+      timeout: 1s
+      retries: 600
     volumes:
       - "postgres-data:/var/lib/postgresql/data/"
     environment:
@@ -36,10 +43,16 @@ services:
       DB_PASSWORD: "postgres"
       MAX_CLIENT_CONN: 500
     depends_on:
-    - postgres
+      postgres:
+        condition: service_healthy
 
   redis:
     image: "docker.io/redis:7-alpine"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 1s
+      timeout: 1s
+      retries: 600
     # Enable persistence
     command: "--save 60 500 --appendonly yes --appendfsync everysec"
     volumes:

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -5,6 +5,12 @@ services:
       context: .
       dockerfile: Dockerfile
     image: svix/svix-server
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8071/api/v1/health"]
+      # test: ["CMD-SHELL", "svix-server healthcheck"]
+      interval: 1s
+      timeout: 1s
+      retries: 600
     environment:
       WAIT_FOR: "true"  # We want to wait for the default services
       SVIX_REDIS_DSN: "redis://redis:6379"


### PR DESCRIPTION
## Motivation

As discussed in the community slack, the server lacks of healthcheck which is easily available for instrumentalisation (docker-compose, kubernetes, etc)

## Solution

I'm personally inclined not to have a command in the svix-server binary, mostly because it would not self-introspect a running server but rather "just fetch the healthcheck endpoint", therefore adding curl to the docker image seems lighter and less invasive imho.

I've implemented both solutions:

1. a healthcheck command which makes a `HEAD /v1/health` request and returns `Ok()` on 200 (error otherwise)
2. added curl in the server's Dockerfile
3. implemented both tests in the docker-compose

## Note

1. As requested i've also added the healthcheck commands and condition status of the dependencies in the docker-compose file
2. Please be gentle in the review as I'm not fluent in rust
