### PR TITLE
server: Reduce allocations

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -4796,7 +4796,7 @@ dependencies = [
  "assert_matches",
  "axum",
  "axum-server",
- "base64 0.13.1",
+ "base64 0.22.1",
  "bb8",
  "bb8-redis",
  "blake2",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -4822,6 +4822,7 @@ dependencies = [
  "idna_adapter",
  "indexmap 1.9.3",
  "ipnet",
+ "itertools 0.14.0",
  "jsonschema",
  "jwt-simple",
  "lapin",

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -21,7 +21,7 @@ dotenvy = "0.15.7"
 hmac-sha256 = "1"
 clap = { version = "4.1.8", features = ["derive"] }
 axum = { version = "0.6.1", features = ["headers"] }
-base64 = "0.13.0"
+base64 = "0.22"
 hyper = { version = "=0.14.28", features = ["full"] }
 hyper-openssl = "0.9.2"
 hyper-socks2 = "0.8.0"

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -85,6 +85,7 @@ omniqueue = { git = "https://github.com/svix/omniqueue-rs", rev = "63fe1f303c547
 hyper-proxy = { version = "=0.9.1", default-features = false, features = ["openssl-tls"] }
 hex = "0.4.3"
 anyhow = "1.0.56"
+itertools = "0.14"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.5", optional = true }

--- a/server/svix-server/src/core/cryptography.rs
+++ b/server/svix-server/src/core/cryptography.rs
@@ -3,6 +3,7 @@
 
 use std::fmt::Debug;
 
+use base64::{engine::general_purpose::STANDARD, Engine};
 use chacha20poly1305::{
     aead::{Aead, KeyInit},
     Key, XChaCha20Poly1305, XNonce,
@@ -28,7 +29,8 @@ impl AsymmetricKey {
     }
 
     pub fn from_base64(b64: &str) -> Result<Self> {
-        let bytes = base64::decode(b64)
+        let bytes = STANDARD
+            .decode(b64)
             .map_err(|_| crate::error::Error::generic("Failed parsing base64"))?;
 
         Self::from_slice(bytes.as_slice())
@@ -44,7 +46,7 @@ impl Debug for AsymmetricKey {
         write!(
             f,
             "<AsymmetricKey sk=*** pk={}>",
-            base64::encode(self.0.pk.as_slice())
+            STANDARD.encode(self.0.pk.as_slice())
         )
     }
 }

--- a/server/svix-server/src/core/idempotency.rs
+++ b/server/svix-server/src/core/idempotency.rs
@@ -293,7 +293,7 @@ async fn lock_loop(
             // Start value has expired
             Ok(None) => return Ok(None),
 
-            Err(e) => return Err(Error::database(format!("{e:?}"))),
+            Err(e) => return Err(Error::database(format_args!("{e:?}"))),
         }
     }
 }

--- a/server/svix-server/src/core/idempotency.rs
+++ b/server/svix-server/src/core/idempotency.rs
@@ -17,6 +17,7 @@ use axum::{
     http::{Request, StatusCode},
     response::{IntoResponse, Response},
 };
+use base64::{engine::general_purpose::STANDARD, Engine};
 use blake2::{Blake2b512, Digest};
 use http::request::Parts;
 use serde::{Deserialize, Serialize};
@@ -67,7 +68,7 @@ impl IdempotencyKey {
 
         let res = hasher.finalize();
         // FIXME: add (previously omitted) prefix: `SVIX_IDEMPOTENCY_CACHE`
-        IdempotencyKey(base64::encode(res))
+        IdempotencyKey(STANDARD.encode(res))
     }
 }
 

--- a/server/svix-server/src/core/message_app.rs
+++ b/server/svix-server/src/core/message_app.rs
@@ -215,6 +215,7 @@ impl AppEndpointKey {
 
 #[cfg(test)]
 mod tests {
+    use base64::{engine::general_purpose::STANDARD, Engine};
     use chrono::Utc;
 
     use super::CreateMessageEndpoint;
@@ -229,7 +230,7 @@ mod tests {
     #[test]
     fn test_valid_signing_keys() {
         let key = EndpointSecretInternal::from_endpoint_secret(
-            EndpointSecret::Symmetric(base64::decode("MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw").unwrap()),
+            EndpointSecret::Symmetric(STANDARD.decode("MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw").unwrap()),
             &Encryption::new_noop(),
         )
         .unwrap();

--- a/server/svix-server/src/core/webhook_http_client.rs
+++ b/server/svix-server/src/core/webhook_http_client.rs
@@ -383,15 +383,15 @@ impl RequestBuilder {
         let uri = self.uri.unwrap();
         let authority = uri.authority().expect("Missing authority");
         let host = match authority.port() {
-            Some(port) => format!("{}:{port}", authority.host()),
-            None => authority.host().to_string(),
-        };
+            Some(port) => HeaderValue::from_str(&format!("{}:{port}", authority.host())),
+            None => HeaderValue::from_str(authority.host()),
+        }.unwrap();
 
         let mut headers = HeaderMap::with_capacity(3 + custom_headers.len());
 
         // Ensure that host header is first -- even though this is technically
         // not required by HTTP spec, some clients fail if it's not first:
-        headers.insert(http::header::HOST, HeaderValue::from_str(&host).unwrap());
+        headers.insert(http::header::HOST, host);
         headers.insert(
             http::header::ACCEPT,
             self.accept.unwrap_or(HeaderValue::from_static("*/*")),

--- a/server/svix-server/src/core/webhook_http_client.rs
+++ b/server/svix-server/src/core/webhook_http_client.rs
@@ -220,14 +220,19 @@ pub struct RequestBuildError(pub Vec<BuildError>);
 
 impl std::fmt::Display for RequestBuildError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let err_str = self.0.iter().fold(String::default(), |acc, err| {
-            if acc.is_empty() {
-                format!("Build failed: {err}")
-            } else {
-                format!("{acc}; {err}")
+        let mut iter = self.0.iter();
+
+        f.write_str("Build failed")?;
+
+        if let Some(first) = iter.next() {
+            write!(f, ": {first}")?;
+
+            for err in iter {
+                write!(f, "; {err}")?;
             }
-        });
-        write!(f, "{err_str}")
+        }
+
+        Ok(())
     }
 }
 

--- a/server/svix-server/src/core/webhook_http_client.rs
+++ b/server/svix-server/src/core/webhook_http_client.rs
@@ -385,7 +385,8 @@ impl RequestBuilder {
         let host = match authority.port() {
             Some(port) => HeaderValue::from_str(&format!("{}:{port}", authority.host())),
             None => HeaderValue::from_str(authority.host()),
-        }.unwrap();
+        }
+        .unwrap();
 
         let mut headers = HeaderMap::with_capacity(3 + custom_headers.len());
 

--- a/server/svix-server/src/error.rs
+++ b/server/svix-server/src/error.rs
@@ -213,7 +213,7 @@ impl From<TransactionError<Error>> for Error {
 impl From<lapin::Error> for Error {
     #[track_caller]
     fn from(value: lapin::Error) -> Self {
-        Error::queue(format!("{value:?}"))
+        Error::queue(format_args!("{value:?}"))
     }
 }
 

--- a/server/svix-server/src/expired_message_cleaner.rs
+++ b/server/svix-server/src/expired_message_cleaner.rs
@@ -79,7 +79,7 @@ pub async fn clean_expired_messages(
         DELETE FROM messagecontent WHERE id = any(
             array(
                 SELECT id FROM messagecontent
-                WHERE 
+                WHERE
                     expiration <= now()
                 LIMIT $1
                 FOR UPDATE SKIP LOCKED
@@ -114,7 +114,7 @@ async fn has_message_payloads_pending_expiry(pool: &DatabaseConnection) -> Resul
     .await?
     .ok_or_else(|| Error::generic("failed to check for message payloads"))?
     .try_get_by_index(0)
-    .map_err(|e| Error::generic(format!("failed to check for message payloads: {e}")))
+    .map_err(|e| Error::generic(format_args!("failed to check for message payloads: {e}")))
 }
 
 /// Polls the database for expired messages to nullify payloads for.

--- a/server/svix-server/src/metrics/redis.rs
+++ b/server/svix-server/src/metrics/redis.rs
@@ -21,7 +21,7 @@ impl RedisQueueType<'_> {
             RedisQueueType::Stream(q) => conn
                 .xlen(q)
                 .await
-                .map_err(|e| Error::queue(format!("Failed to query queue depth: {e}"))),
+                .map_err(|e| Error::queue(format_args!("Failed to query queue depth: {e}"))),
             RedisQueueType::StreamPending { stream, group } => {
                 let reply: StreamPendingReply = conn.xpending(stream, group).await?;
                 Ok(reply.count() as _)
@@ -29,11 +29,11 @@ impl RedisQueueType<'_> {
             RedisQueueType::List(q) => conn
                 .llen(q)
                 .await
-                .map_err(|e| Error::queue(format!("Failed to query queue depth: {e}"))),
+                .map_err(|e| Error::queue(format_args!("Failed to query queue depth: {e}"))),
             RedisQueueType::SortedSet(q) => conn
                 .zcard(q)
                 .await
-                .map_err(|e| Error::queue(format!("Failed to query queue depth: {e}"))),
+                .map_err(|e| Error::queue(format_args!("Failed to query queue depth: {e}"))),
         }
     }
 }

--- a/server/svix-server/src/queue/mod.rs
+++ b/server/svix-server/src/queue/mod.rs
@@ -230,7 +230,7 @@ impl<T: OmniMessage> SvixOmniConsumer<T> {
                         acker
                             .payload_serde_json()
                             .map_err(|e| {
-                                Error::queue(format!("Failed to decode queue task: {e:?}"))
+                                Error::queue(format_args!("Failed to decode queue task: {e:?}"))
                             })?
                             .ok_or_else(|| Error::queue("Unexpected empty delivery"))?,
                     ),

--- a/server/svix-server/src/queue/redis.rs
+++ b/server/svix-server/src/queue/redis.rs
@@ -251,7 +251,7 @@ async fn new_pair_inner(
         payload_key: QUEUE_KV_KEY.to_owned(),
         ack_deadline_ms: pending_duration,
         dlq_config: Some(DeadLetterQueueConfig {
-            queue_key: dlq_name.to_string(),
+            queue_key: dlq_name,
             max_receives: 3,
         }),
         sentinel_config: cfg.redis_sentinel_cfg.clone().map(|c| c.into()),

--- a/server/svix-server/src/v1/endpoints/auth.rs
+++ b/server/svix-server/src/v1/endpoints/auth.rs
@@ -6,6 +6,7 @@ use axum::{
     extract::{Path, State},
     Json,
 };
+use base64::{engine::general_purpose::STANDARD, Engine};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use svix_server_derive::aide_annotate;
@@ -81,7 +82,7 @@ async fn app_portal_access(
     }))
     .map_err(|_| HttpError::internal_server_error(None, None))?;
 
-    let login_key = base64::encode(login_key);
+    let login_key = STANDARD.encode(login_key);
 
     // Included for API compatibility, but this URL will not be useful
     let url = format!("{}/login#key={login_key}", &cfg.internal.app_portal_url);

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -369,7 +369,7 @@ pub(crate) async fn create_message_inner(
     )
     .await?
     // Should never happen since you're giving it an existing Application, but just in case
-    .ok_or_else(|| Error::generic(format!("Application doesn't exist: {}", app.id)))?;
+    .ok_or_else(|| Error::generic(format_args!("Application doesn't exist: {}", app.id)))?;
 
     let payload = data.payload();
     let msg = message::ActiveModel {

--- a/server/svix-server/src/worker.rs
+++ b/server/svix-server/src/worker.rs
@@ -196,14 +196,14 @@ fn generate_msg_headers(
     let id_hdr = msg_id
         .0
         .parse()
-        .map_err(|e| Error::generic(format!("Error parsing message id: {e:?}")))?;
+        .map_err(|e| Error::generic(format_args!("Error parsing message id: {e:?}")))?;
     let timestamp = timestamp
         .to_string()
         .parse()
-        .map_err(|e| Error::generic(format!("Error parsing message timestamp: {e:?}")))?;
+        .map_err(|e| Error::generic(format_args!("Error parsing message timestamp: {e:?}")))?;
     let signatures_str = signatures
         .parse()
-        .map_err(|e| Error::generic(format!("Error parsing message signatures: {e:?}")))?;
+        .map_err(|e| Error::generic(format_args!("Error parsing message signatures: {e:?}")))?;
     if whitelabel_headers {
         headers.insert("webhook-id".to_owned(), id_hdr);
         headers.insert("webhook-timestamp".to_owned(), timestamp);
@@ -334,7 +334,7 @@ async fn make_http_call(
     let req = RequestBuilder::new()
         .method(method)
         .uri_str(&url)
-        .map_err(|e| Error::validation(format!("URL is invalid: {e:?}")))?
+        .map_err(|e| Error::validation(format_args!("URL is invalid: {e:?}")))?
         .headers(headers)
         .body(payload.into(), HeaderValue::from_static("application/json"))
         .version(Version::HTTP_11)
@@ -626,7 +626,7 @@ async fn handle_failed_dispatch(
                 .one(*db)
                 .await?
                 .ok_or_else(|| {
-                    Error::generic(format!(
+                    Error::generic(format_args!(
                         "Endpoint not found {app_id} {}",
                         &msg_task.endpoint_id
                     ))
@@ -772,7 +772,10 @@ async fn process_queue_task_inner(
                     .one(db)
                     .await?
                     .ok_or_else(|| {
-                        Error::generic(format!("Unexpected: message doesn't exist {}", task.msg_id))
+                        Error::generic(format_args!(
+                            "Unexpected: message doesn't exist {}",
+                            task.msg_id
+                        ))
                     })?;
 
                 let destination =
@@ -781,7 +784,7 @@ async fn process_queue_task_inner(
                         .one(db)
                         .await?
                         .ok_or_else(|| {
-                            Error::generic(format!(
+                            Error::generic(format_args!(
                                 "MessageDestination not found for message {}",
                                 &task.msg_id
                             ))
@@ -802,7 +805,10 @@ async fn process_queue_task_inner(
                     .one(db)
                     .await?
                     .ok_or_else(|| {
-                        Error::generic(format!("Unexpected: message doesn't exist {}", task.msg_id))
+                        Error::generic(format_args!(
+                            "Unexpected: message doesn't exist {}",
+                            task.msg_id
+                        ))
                     })?;
                 (
                     msg,
@@ -914,7 +920,7 @@ async fn process_queue_task_inner(
 
     let errs: Vec<_> = join.iter().filter(|x| x.is_err()).collect();
     if !errs.is_empty() {
-        return Err(Error::generic(format!(
+        return Err(Error::generic(format_args!(
             "Some dispatches failed unexpectedly: {errs:?}",
         )));
     }

--- a/server/svix-server/src/worker.rs
+++ b/server/svix-server/src/worker.rs
@@ -174,17 +174,14 @@ fn sign_msg(
 
     endpoint_signing_keys
         .iter()
-        .map(|x| {
+        .format_with(" ", |x, f| {
             let sig = x.sign(main_secret, to_sign.as_bytes());
             let version = match x.type_() {
                 EndpointSecretType::Hmac256 => "v1",
                 EndpointSecretType::Ed25519 => "v1a",
             };
 
-            (version, STANDARD.encode(sig))
-        })
-        .format_with(" ", |(version, sign), f| {
-            f(&format_args!("{version},{sign}"))
+            f(&format_args!("{version},{}", STANDARD.encode(sig)))
         })
         .to_string()
 }

--- a/server/svix-server_derive/src/aide.rs
+++ b/server/svix-server_derive/src/aide.rs
@@ -37,8 +37,10 @@ pub fn expand_aide_annotate(
             operation_summary = lit.value();
         } else {
             let path = arg.path.to_token_stream().to_string();
-            let msg = format!("Unknown argument `{path}`, expected `op_id` or `op_summary`");
-            return Err(syn::Error::new_spanned(arg.path, msg));
+            return Err(syn::Error::new_spanned(
+                arg.path,
+                format_args!("Unknown argument `{path}`, expected `op_id` or `op_summary`"),
+            ));
         }
     }
 


### PR DESCRIPTION
## Motivation

Closes https://github.com/svix/svix-webhooks/issues/258.

## Solution

I've gone over the server code and replaced the most obvious parts with unnecessary allocations with no or less allocating counterparts. I was really bothered with how signatures string are generated, so I payed more attention to their function, I think there's still a room for improvement, but it'll need more changes all over the server codebase. For now, let's start from this.

I've also updated `base64` to the latest version. The current version doesn't have needed for this PR function to calculate an encoded string length.

Review commit by commit.