### PR TITLE
fix(go): fix execute with retry empty body bug

### DIFF
--- a/go/internal/svix_http_client.go
+++ b/go/internal/svix_http_client.go
@@ -128,7 +128,6 @@ func ExecuteRequest[ReqBody any, ResBody any](
 }
 
 func executeRequestWithRetries(client *SvixHttpClient, request *http.Request) (*http.Response, error) {
-
 	var bodyBytes []byte
 	if request.Body != nil {
 		var err error
@@ -136,7 +135,10 @@ func executeRequestWithRetries(client *SvixHttpClient, request *http.Request) (*
 		if err != nil {
 			return nil, err
 		}
-		request.Body.Close()
+		err = request.Body.Close()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if bodyBytes != nil {

--- a/go/internal/svix_http_client.go
+++ b/go/internal/svix_http_client.go
@@ -128,6 +128,21 @@ func ExecuteRequest[ReqBody any, ResBody any](
 }
 
 func executeRequestWithRetries(client *SvixHttpClient, request *http.Request) (*http.Response, error) {
+
+	var bodyBytes []byte
+	if request.Body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(request.Body)
+		if err != nil {
+			return nil, err
+		}
+		request.Body.Close()
+	}
+
+	if bodyBytes != nil {
+		request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	}
+
 	if client.Debug {
 		log.Printf("URL: %s", request.URL)
 		dump, err := httputil.DumpRequestOut(request, true)
@@ -141,6 +156,9 @@ func executeRequestWithRetries(client *SvixHttpClient, request *http.Request) (*
 	for try := 0; try < len(client.RetrySchedule); try++ {
 		if err == nil && resp.StatusCode < 500 {
 			break
+		}
+		if bodyBytes != nil {
+			request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 		}
 		request.Header.Set("svix-retry-count", strconv.Itoa(try+1))
 		sleepTime := client.RetrySchedule[try]

--- a/go/internal/svix_http_client_test.go
+++ b/go/internal/svix_http_client_test.go
@@ -1,0 +1,161 @@
+package internal
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/svix/svix-webhooks/go/models"
+)
+
+func Test_executeRequestWithRetries(t *testing.T) {
+	tests := []struct {
+		name           string
+		failFirst      bool
+		expectedCalls  int32
+		expectedStatus int
+	}{
+		{
+			name:           "request succeeds with retry after initial failure",
+			failFirst:      true,
+			expectedCalls:  2,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "request succeeds immediately without retry",
+			failFirst:      false,
+			expectedCalls:  1,
+			expectedStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given ... we have a test server
+			var requestCount int32
+			var receivedBodies []string
+
+			// And ... we have a test payload
+			payload := map[string]any{
+				"test": "test",
+				"blah": "blah",
+			}
+
+			// And ... we have an event type and message id
+			eventType := "someEvent"
+			msgId := "msg_123"
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				count := atomic.AddInt32(&requestCount, 1)
+
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Errorf("Failed to read request body: %v", err)
+					return
+				}
+				receivedBodies = append(receivedBodies, string(body))
+
+				t.Logf("Request %d: Content-Length=%s, Body-Length=%d",
+					count, r.Header.Get("Content-Length"), len(body))
+				t.Logf("Request %d body: %s", count, string(body))
+
+				if tt.failFirst && count == 1 {
+					w.WriteHeader(http.StatusInternalServerError)
+					w.Write([]byte(`{"error": "server error"}`))
+					return
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.expectedStatus)
+				response := models.MessageOut{
+					Id:        msgId,
+					EventType: eventType,
+					Payload:   payload,
+				}
+				json.NewEncoder(w).Encode(response)
+			}))
+			defer server.Close()
+
+			// And ... we have a svix http client
+			client := &SvixHttpClient{
+				HTTPClient:     &http.Client{},
+				BaseURL:        server.URL,
+				RetrySchedule:  []time.Duration{10 * time.Millisecond}, // Quick retry for test
+				DefaultHeaders: map[string]string{},
+				Debug:          true,
+			}
+
+			// And ... a test message in
+			messageIn := models.MessageIn{
+				EventType: eventType,
+				Payload:   payload,
+			}
+
+			// When ... we execute the request
+			jsonBody, err := json.Marshal(messageIn)
+			if err != nil {
+				t.Fatalf("Failed to marshal request body: %v", err)
+			}
+
+			req, err := http.NewRequest("POST", server.URL+"/api/v1/app/test_app/msg", bytes.NewBuffer(jsonBody))
+			if err != nil {
+				t.Fatalf("Failed to create request: %v", err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := executeRequestWithRetries(client, req)
+			if err != nil {
+				t.Fatalf("Request failed: %v", err)
+			}
+			defer resp.Body.Close()
+
+			// Then ... the response should be decoded without error
+			var result models.MessageOut
+			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+				t.Fatalf("Failed to decode response: %v", err)
+			}
+
+			// And ... our request count should match the expected number of calls
+			if requestCount != tt.expectedCalls {
+				t.Errorf("Expected %d requests, got %d", tt.expectedCalls, requestCount)
+			}
+
+			// And ... we should have the same number of request bodies
+			if len(receivedBodies) != int(tt.expectedCalls) {
+				t.Fatalf("Expected %d request bodies, got %d", tt.expectedCalls, len(receivedBodies))
+			}
+
+			// And ... the bodies should be set as expected
+			for i, body := range receivedBodies {
+				if len(body) == 0 {
+					t.Errorf("Request body %d is empty", i+1)
+				}
+
+				var receivedMsg models.MessageIn
+				if err := json.Unmarshal([]byte(body), &receivedMsg); err != nil {
+					t.Errorf("Failed to unmarshal request body %d: %v", i+1, err)
+				}
+				if receivedMsg.EventType != messageIn.EventType {
+					t.Errorf("Request body %d mismatch: expected %s, got %s",
+						i+1, messageIn.EventType, receivedMsg.EventType)
+				}
+			}
+
+			// And ... if there are multiple calls then the bodies should match
+			if tt.expectedCalls > 1 {
+				if receivedBodies[0] != receivedBodies[1] {
+					t.Error("Request bodies don't match between retries")
+					t.Errorf("First body length: %d, Second body length: %d",
+						len(receivedBodies[0]), len(receivedBodies[1]))
+					t.Errorf("First body: %s", receivedBodies[0])
+					t.Errorf("Second body: %s", receivedBodies[1])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

- I am occasionally seeing the Sentry error 

```
Post "<svix-server-url>": http: ContentLength=2461 with Body length 0
```

in our Sentry as a result of an error with the Golang Svix Client.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

When reading through the code it seems like this behaviour is caused when calling executeRequestWithRetries when a retry occurs and the body, which is a ReadCloser is read once on the initial call, there's nothing left in the stream, and then a retry results in the above error.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- preserve the request body at the start of executeRequestWithRetries
- set it on initial try and on subsequent retries

You can verify this behaviour by running the tests against the current code and observing the failure as below, and then applying the changes and checking the tests pass.

<img width="1796" alt="Screenshot 2025-07-06 at 19 57 15" src="https://github.com/user-attachments/assets/dff6a3cd-5809-4935-8e13-97b6accf7f28" />


