### PR TITLE
Upgrade to a supported runner for Windows releases

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -29,5 +29,6 @@ allow-dirty = ["ci"]
 [dist.github-custom-runners]
 x86_64-unknown-linux-musl = "ubuntu-22.04"
 x86_64-unknown-linux-gnu = "ubuntu-22.04"
+x86_64-pc-windows-msvc = "windows-2022"
 aarch64-unknown-linux-gnu = "ubuntu-22.04"
 global = "ubuntu-22.04"


### PR DESCRIPTION
The one dist is trying to use was just removed: https://github.com/actions/runner-images/issues/12045