### PR TITLE
Fix: Handle trailing slashes in server URLs across all libraries

### DIFF
--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -49,7 +49,11 @@ export class Svix {
 
   public constructor(token: string, options: SvixOptions = {}) {
     const regionalUrl = REGIONS.find((x) => x.region === token.split(".")[1])?.url;
-    const baseUrl: string = options.serverUrl ?? regionalUrl ?? "https://api.svix.com";
+    const baseUrl: string = (
+      options.serverUrl ??
+      regionalUrl ??
+      "https://api.svix.com"
+    ).replace(/\/+$/, "");
 
     this.requestCtx = { baseUrl, token, timeout: options.requestTimeout };
   }

--- a/javascript/src/request.ts
+++ b/javascript/src/request.ts
@@ -109,7 +109,10 @@ export class SvixRequest {
   }
 
   private async sendInner(ctx: SvixRequestContext): Promise<Response> {
-    const url = new URL(ctx.baseUrl + this.path);
+    // Ensure path always starts with a single slash
+    const normalizedPath = this.path.replace(/^\/+/, "/");
+    // Combine normalized base URL and path
+    const url = new URL(ctx.baseUrl + normalizedPath);
     for (const [name, value] of Object.entries(this.queryParams)) {
       url.searchParams.set(name, value);
     }

--- a/javascript/src/trailing-slash.test.ts
+++ b/javascript/src/trailing-slash.test.ts
@@ -1,0 +1,64 @@
+import { Svix } from "./index";
+import * as mockttp from "mockttp";
+
+const mockServer = mockttp.getLocal();
+
+describe("Trailing Slash Handling", () => {
+  beforeEach(async () => await mockServer.start(0));
+  afterEach(async () => await mockServer.stop());
+
+  const testEndpoints = [
+    "/api/v1/app",
+    "/api/v1/app/app_id/endpoint",
+    "/ingest/api/v1/source/source_id",
+    "/api/v1/operational-webhook/endpoint",
+  ];
+
+  test.each(testEndpoints)("should handle trailing slash variations for %s", async () => {
+    // Test with trailing slash in base URL
+    const clientWithSlash = new Svix("token", { serverUrl: mockServer.url + "/" });
+
+    // Test without trailing slash in base URL
+    const clientWithoutSlash = new Svix("token", { serverUrl: mockServer.url });
+
+    // Make requests using internal request context
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const reqCtx1 = (clientWithSlash as any).requestCtx;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const reqCtx2 = (clientWithoutSlash as any).requestCtx;
+
+    // Verify both clients have normalized base URLs (no trailing slash)
+    expect(reqCtx1.baseUrl).not.toMatch(/\/$/);
+    expect(reqCtx2.baseUrl).not.toMatch(/\/$/);
+    expect(reqCtx1.baseUrl).toBe(reqCtx2.baseUrl);
+  });
+
+  test("should handle multiple trailing slashes", () => {
+    const client = new Svix("token", { serverUrl: "https://api.svix.com///" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const reqCtx = (client as any).requestCtx;
+    expect(reqCtx.baseUrl).toBe("https://api.svix.com");
+  });
+
+  test("should handle single trailing slash", () => {
+    const client = new Svix("token", { serverUrl: "https://api.svix.com/" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const reqCtx = (client as any).requestCtx;
+    expect(reqCtx.baseUrl).toBe("https://api.svix.com");
+  });
+
+  test("should preserve URLs without trailing slashes", () => {
+    const client = new Svix("token", { serverUrl: "https://api.svix.com" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const reqCtx = (client as any).requestCtx;
+    expect(reqCtx.baseUrl).toBe("https://api.svix.com");
+  });
+
+  test("should handle regional URLs with trailing slashes", () => {
+    // Mock a token with EU region
+    const client = new Svix("test.eu.token");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const reqCtx = (client as any).requestCtx;
+    expect(reqCtx.baseUrl).toBe("https://api.eu.svix.com");
+  });
+});

--- a/python/svix/api/svix.py
+++ b/python/svix/api/svix.py
@@ -69,7 +69,7 @@ class ClientBase:
         elif region == "au":
             regional_url = "https://api.au.svix.com"
 
-        host = options.server_url or regional_url or DEFAULT_SERVER_URL
+        host = (options.server_url or regional_url or DEFAULT_SERVER_URL).rstrip('/')
         client = AuthenticatedClient(
             base_url=host,
             token=auth_token,

--- a/python/tests/test_trailing_slash.py
+++ b/python/tests/test_trailing_slash.py
@@ -1,0 +1,37 @@
+import pytest
+from svix.api import Svix, SvixOptions
+
+
+def test_trailing_slash_handling():
+    """Test that trailing slashes are properly removed from server URLs."""
+    
+    # Test with trailing slash
+    svix_with_slash = Svix("key", SvixOptions(server_url="http://localhost:8000/"))
+    assert svix_with_slash._client.base_url == "http://localhost:8000"
+    
+    # Test without trailing slash
+    svix_without_slash = Svix("key", SvixOptions(server_url="http://localhost:8000"))
+    assert svix_without_slash._client.base_url == "http://localhost:8000"
+    
+    # Test with multiple trailing slashes
+    svix_multiple_slashes = Svix("key", SvixOptions(server_url="http://localhost:8000///"))
+    assert svix_multiple_slashes._client.base_url == "http://localhost:8000"
+
+
+def test_regional_url_trailing_slash():
+    """Test that regional URLs are handled correctly."""
+    
+    # Test EU region token (regional URL should not have trailing slash)
+    svix_eu = Svix("test.eu.token")
+    assert svix_eu._client.base_url == "https://api.eu.svix.com"
+    
+    # Test US region token
+    svix_us = Svix("test.us.token") 
+    assert svix_us._client.base_url == "https://api.us.svix.com"
+
+
+def test_default_url_no_trailing_slash():
+    """Test that default URL doesn't have trailing slash."""
+    
+    svix_default = Svix("key")
+    assert svix_default._client.base_url == "https://api.svix.com"

--- a/ruby/lib/svix/svix.rb
+++ b/ruby/lib/svix/svix.rb
@@ -43,7 +43,8 @@ module Svix
         regional_url = "https://api.svix.com"
       end
 
-      uri = URI(options.server_url || regional_url)
+      server_url = (options.server_url || regional_url).sub(/\/+$/, '')
+      uri = URI(server_url)
       api_client = SvixHttpClient.new(auth_token, uri)
 
       @application = Application.new(api_client)

--- a/ruby/spec/trailing_slash_spec.rb
+++ b/ruby/spec/trailing_slash_spec.rb
@@ -1,0 +1,40 @@
+require "svix"
+
+RSpec.describe "Trailing Slash Handling" do
+  it "removes trailing slash from server URL" do
+    client = Svix::Client.new("key", Svix::SvixOptions.new(false, "http://localhost:8000/"))
+    uri = client.instance_variable_get(:@application)
+                .instance_variable_get(:@api_client)
+                .instance_variable_get(:@uri)
+    
+    expect(uri.to_s).to eq("http://localhost:8000/api/v1")
+  end
+
+  it "handles URL without trailing slash" do
+    client = Svix::Client.new("key", Svix::SvixOptions.new(false, "http://localhost:8000"))
+    uri = client.instance_variable_get(:@application)
+                .instance_variable_get(:@api_client)
+                .instance_variable_get(:@uri)
+    
+    expect(uri.to_s).to eq("http://localhost:8000/api/v1")
+  end
+
+  it "handles multiple trailing slashes" do
+    client = Svix::Client.new("key", Svix::SvixOptions.new(false, "http://localhost:8000///"))
+    uri = client.instance_variable_get(:@application)
+                .instance_variable_get(:@api_client)
+                .instance_variable_get(:@uri)
+    
+    expect(uri.to_s).to eq("http://localhost:8000/api/v1")
+  end
+
+  it "handles regional URLs correctly" do
+    # Test with EU region (should use regional URL)
+    client_eu = Svix::Client.new("test.eu.token")
+    uri_eu = client_eu.instance_variable_get(:@application)
+                     .instance_variable_get(:@api_client)
+                     .instance_variable_get(:@uri)
+    
+    expect(uri_eu.to_s).to eq("https://api.eu.svix.com/api/v1")
+  end
+end

--- a/rust/src/api/client.rs
+++ b/rust/src/api/client.rs
@@ -71,7 +71,7 @@ impl Svix {
     /// This can be used to change the token without incurring
     /// the cost of TLS initialization.
     pub fn with_token(&self, token: String) -> Self {
-        let base_path = self.server_url.clone().unwrap_or_else(|| {
+        let mut base_path = self.server_url.clone().unwrap_or_else(|| {
             match token.split('.').next_back() {
                 Some("us") => "https://api.us.svix.com",
                 Some("eu") => "https://api.eu.svix.com",
@@ -82,6 +82,10 @@ impl Svix {
             }
             .to_string()
         });
+        // Remove trailing slashes
+        while base_path.ends_with('/') {
+            base_path.pop();
+        }
         let cfg = Arc::new(Configuration {
             base_path,
             user_agent: self.cfg.user_agent.clone(),

--- a/rust/tests/trailing_slash_test.rs
+++ b/rust/tests/trailing_slash_test.rs
@@ -1,0 +1,54 @@
+use svix::api::{Svix, SvixOptions};
+
+#[test]
+fn test_trailing_slash_removal() {
+    let svix = Svix::new(
+        "key".to_string(),
+        Some(SvixOptions {
+            server_url: Some("http://localhost:8000/".to_string()),
+            ..Default::default()
+        }),
+    );
+    assert_eq!(svix.cfg.base_path, "http://localhost:8000");
+}
+
+#[test] 
+fn test_no_trailing_slash() {
+    let svix = Svix::new(
+        "key".to_string(),
+        Some(SvixOptions {
+            server_url: Some("http://localhost:8000".to_string()),
+            ..Default::default()
+        }),
+    );
+    assert_eq!(svix.cfg.base_path, "http://localhost:8000");
+}
+
+#[test]
+fn test_multiple_trailing_slashes() {
+    let svix = Svix::new(
+        "key".to_string(),
+        Some(SvixOptions {
+            server_url: Some("http://localhost:8000///".to_string()),
+            ..Default::default()
+        }),
+    );
+    assert_eq!(svix.cfg.base_path, "http://localhost:8000");
+}
+
+#[test]
+fn test_regional_url_handling() {
+    // Test EU region token
+    let svix_eu = Svix::new("test.eu.token".to_string(), None);
+    assert_eq!(svix_eu.cfg.base_path, "https://api.eu.svix.com");
+    
+    // Test US region token
+    let svix_us = Svix::new("test.us.token".to_string(), None);
+    assert_eq!(svix_us.cfg.base_path, "https://api.us.svix.com");
+}
+
+#[test]
+fn test_default_url() {
+    let svix = Svix::new("key".to_string(), None);
+    assert_eq!(svix.cfg.base_path, "https://api.svix.com");
+}


### PR DESCRIPTION
  PR Summary

  ## Summary
  • Implements consistent trailing slash handling across JavaScript, Python, Ruby, and Rust libraries
  • Adds robust URL normalization to prevent double slashes in API requests
  • Maintains backward compatibility while fixing edge cases with multiple trailing slashes
  • Ensures uniform behavior across all SDK languages for better developer experience


Implementation details 
  - Add consistent trailing slash normalization in JavaScript, Python, Ruby, and Rust
  - JavaScript: Implement regex-based URL and path normalization
  - Python: Use rstrip('/') for clean URL handling
  - Ruby: Apply regex substitution for multiple slash removal
  - Rust: Loop-based trailing slash elimination
  - Add comprehensive test suites for all libraries
  - Ensure backward compatibility and consistent behavior

Closes
Issue - https://github.com/svix/svix-webhooks/issues/1154
