### PR TITLE
rust: Add support for retry schedule

### DIFF
--- a/rust/src/api/client.rs
+++ b/rust/src/api/client.rs
@@ -24,6 +24,12 @@ pub struct SvixOptions {
     ///
     /// Default: 2
     pub num_retries: Option<u32>,
+    /// Retry Schedule in milliseconds
+    ///
+    /// List of delays (in milliseconds) to wait before each retry attempt.
+    /// Takes precedence over numRetries.
+    ///
+    pub retry_schedule_in_ms: Option<Vec<u64>>,
 }
 
 impl Default for SvixOptions {
@@ -33,6 +39,7 @@ impl Default for SvixOptions {
             server_url: None,
             timeout: Some(std::time::Duration::from_secs(15)),
             num_retries: None,
+            retry_schedule_in_ms: None,
         }
     }
 }
@@ -55,7 +62,9 @@ impl Svix {
             // These fields will be set by `with_token` below
             base_path: String::new(),
             bearer_access_token: None,
-            num_retries: options.num_retries.unwrap_or(2),
+            // number of retries shouldn't include the initial request
+            num_retries: options.num_retries.unwrap_or(3) + 1,
+            retry_schedule_in_ms: options.retry_schedule_in_ms,
         });
         let svix = Self {
             cfg,
@@ -89,6 +98,7 @@ impl Svix {
             client: self.cfg.client.clone(),
             timeout: self.cfg.timeout,
             num_retries: self.cfg.num_retries,
+            retry_schedule_in_ms: self.cfg.retry_schedule_in_ms.clone(),
         });
 
         Self {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -27,6 +27,7 @@ pub struct Configuration {
     pub bearer_access_token: Option<String>,
     pub timeout: Option<Duration>,
     pub num_retries: u32,
+    pub retry_schedule_in_ms: Option<Vec<u64>>,
 }
 
 // If no TLS backend is enabled, use plain http connector.

--- a/rust/tests/it/utils/test_client.rs
+++ b/rust/tests/it/utils/test_client.rs
@@ -8,6 +8,7 @@ pub struct TestClientBuilder {
     token: Option<String>,
     url: Option<String>,
     retries: Option<u32>,
+    retry_schedule_in_ms: Option<Vec<u64>>,
 }
 
 impl TestClientBuilder {
@@ -16,6 +17,7 @@ impl TestClientBuilder {
             token: None,
             url: None,
             retries: None,
+            retry_schedule_in_ms: None,
         }
     }
 
@@ -35,6 +37,11 @@ impl TestClientBuilder {
         self
     }
 
+    pub fn retry_schedule_in_ms(mut self, retry_schedule_in_ms: Vec<u64>) -> Self {
+        self.retry_schedule_in_ms = Some(retry_schedule_in_ms);
+        self
+    }
+
     pub fn build(self) -> TestClient {
         let token = self.token.unwrap_or_else(|| {
             std::env::var("SVIX_TOKEN").expect("SVIX_TOKEN is required to run this test")
@@ -47,6 +54,7 @@ impl TestClientBuilder {
             Some(SvixOptions {
                 server_url: Some(url.clone()),
                 num_retries: self.retries,
+                retry_schedule_in_ms: self.retry_schedule_in_ms,
                 ..Default::default()
             }),
         );


### PR DESCRIPTION
Add support for retry schedule in the rust lib
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Work in progress for #782

Would be cool if one could specify an exact delay schedule for retries.
Currently, retry delays are hard coded.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Updated the number of retry logic. if user specifies num_retries = 3, we actually make 4 requests as we
shouldn't count the initial request.