### PR TITLE
Bump version of `ca-certificates`

### DIFF
--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -59,7 +59,7 @@ RUN set -ex ; \
         chown -R appuser: /home/appuser
 
 RUN apt-get update ;\
-    apt-get install --no-install-recommends -y ca-certificates=20230311; \
+    apt-get install --no-install-recommends -y ca-certificates=20230311+deb12u1; \
     update-ca-certificates; \
     rm -rf /var/lib/apt/lists/*
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -48,7 +48,7 @@ RUN set -ex ; \
         chown -R appuser: /home/appuser
 
 RUN apt-get update && apt-get install -y \
-        ca-certificates=20230311 \
+        ca-certificates=20230311+deb12u1 \
         libssl3=3.* \
         --no-install-recommends && \
         update-ca-certificates && \

--- a/svix-cli/Dockerfile
+++ b/svix-cli/Dockerfile
@@ -47,7 +47,7 @@ RUN set -ex ; \
         chown -R appuser: /home/appuser
 
 RUN apt-get update ;\
-    apt-get install --no-install-recommends -y ca-certificates=20230311; \
+    apt-get install --no-install-recommends -y ca-certificates=20230311+deb12u1; \
     update-ca-certificates; \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fixes issue where user had endpoint with certificate signed by a CA that was missing

This was the missing CA [crt.sh?q=4267304690](https://crt.sh/?q=4267304690)