### PR TITLE
codegen: Remove usage of `cargo fix` from the `extra_shell_commands` …

### DIFF
--- a/codegen/codegen.toml
+++ b/codegen/codegen.toml
@@ -36,8 +36,6 @@ output_dir = "javascript/src"
 [cli]
 extra_mounts = { "svix-cli/.rustfmt.toml" = "/app/.rustfmt.toml" }
 extra_shell_commands = [
-   "cargo fix --all-targets --all-features --manifest-path svix-cli/Cargo.toml --allow-dirty --allow-staged",
-   "cargo fmt --manifest-path svix-cli/Cargo.toml",
    "rm svix-cli/src/cmds/api/{background_task,health,statistics}.rs",
 ]
 [[cli.task]]

--- a/codegen/templates/svix-cli/api_resource.rs.jinja
+++ b/codegen/templates/svix-cli/api_resource.rs.jinja
@@ -4,11 +4,9 @@
 {% if resource.name == "message" %}{% set resource_id_name = "msg_id" %}{% endif -%}
 {% if resource.name == "integration" %}{% set resource_id_name = "integ_id" %}{% endif -%}
 
-use chrono::{DateTime, Utc};
 use clap::{Args, Subcommand};
 use svix::api::*;
 
-use crate::json::JsonOf;
 {% for _, sub in resource.subresources | items -%}
 use super::{{ sub.name | to_snake_case }}::{{ sub.name | to_upper_camel_case }}Args;
 {% endfor %}
@@ -23,6 +21,9 @@ use super::{{ sub.name | to_snake_case }}::{{ sub.name | to_upper_camel_case }}A
         pub struct {{ param_struct_type_name }} {
             {% for p in op.query_params -%}
                 {% set ty = p.type.to_rust() -%}
+                {% if ty == "DateTime<Utc>" -%}
+                    {% set ty = "chrono::DateTime<chrono::Utc>" -%}
+                {% endif -%}
                 {% if not p.required %}{% set ty %}Option<{{ ty }}>{% endset %}{% endif -%}
                 {% if p.description is defined -%}
                     {{ p.description | to_doc_comment(style="rust") }}
@@ -108,9 +109,9 @@ pub enum {{ resource_type_name }}Commands {
             {% if op.request_body_schema_name is defined -%}
                 {{ op.request_body_schema_name | to_snake_case }}:
                 {% if op.request_body_all_optional %}
-                Option<JsonOf<{{ op.request_body_schema_name }}>>
+                Option<crate::json::JsonOf<{{ op.request_body_schema_name }}>>
                 {% else %}
-                JsonOf<{{ op.request_body_schema_name }}>
+                crate::json::JsonOf<{{ op.request_body_schema_name }}>
                 {% endif %}
                 ,
             {% endif -%}

--- a/codegen/templates/svix-cli/api_resource.rs.jinja
+++ b/codegen/templates/svix-cli/api_resource.rs.jinja
@@ -1,3 +1,4 @@
+// this file is @generated
 {% set resource_type_name = resource.name | to_upper_camel_case -%}
 {% set resource_id_name %}{{ resource.name | to_snake_case }}_id{% endset -%}
 {% if resource.name == "application" %}{% set resource_id_name = "app_id" %}{% endif -%}

--- a/svix-cli/src/cmds/api/application.rs
+++ b/svix-cli/src/cmds/api/application.rs
@@ -1,8 +1,6 @@
 use clap::{Args, Subcommand};
 use svix::api::*;
 
-use crate::json::JsonOf;
-
 #[derive(Args, Clone)]
 pub struct ApplicationListOptions {
     /// Limit the number of returned items
@@ -60,7 +58,7 @@ pub enum ApplicationCommands {
     },
     /// Create a new application.
     Create {
-        application_in: JsonOf<ApplicationIn>,
+        application_in: crate::json::JsonOf<ApplicationIn>,
         #[clap(flatten)]
         options: ApplicationCreateOptions,
     },
@@ -69,14 +67,14 @@ pub enum ApplicationCommands {
     /// Update an application.
     Update {
         id: String,
-        application_in: JsonOf<ApplicationIn>,
+        application_in: crate::json::JsonOf<ApplicationIn>,
     },
     /// Delete an application.
     Delete { id: String },
     /// Partially update an application.
     Patch {
         id: String,
-        application_patch: Option<JsonOf<ApplicationPatch>>,
+        application_patch: Option<crate::json::JsonOf<ApplicationPatch>>,
     },
 }
 

--- a/svix-cli/src/cmds/api/application.rs
+++ b/svix-cli/src/cmds/api/application.rs
@@ -1,3 +1,4 @@
+// this file is @generated
 use clap::{Args, Subcommand};
 use svix::api::*;
 

--- a/svix-cli/src/cmds/api/authentication.rs
+++ b/svix-cli/src/cmds/api/authentication.rs
@@ -1,8 +1,6 @@
 use clap::{Args, Subcommand};
 use svix::api::*;
 
-use crate::json::JsonOf;
-
 #[derive(Args, Clone)]
 pub struct AuthenticationAppPortalAccessOptions {
     #[arg(long)]
@@ -56,14 +54,14 @@ pub enum AuthenticationCommands {
     /// Use this function to get magic links (and authentication codes) for connecting your users to the Consumer Application Portal.
     AppPortalAccess {
         app_id: String,
-        app_portal_access_in: Option<JsonOf<AppPortalAccessIn>>,
+        app_portal_access_in: Option<crate::json::JsonOf<AppPortalAccessIn>>,
         #[clap(flatten)]
         options: AuthenticationAppPortalAccessOptions,
     },
     /// Expire all of the tokens associated with a specific application.
     ExpireAll {
         app_id: String,
-        application_token_expire_in: Option<JsonOf<ApplicationTokenExpireIn>>,
+        application_token_expire_in: Option<crate::json::JsonOf<ApplicationTokenExpireIn>>,
         #[clap(flatten)]
         options: AuthenticationExpireAllOptions,
     },

--- a/svix-cli/src/cmds/api/authentication.rs
+++ b/svix-cli/src/cmds/api/authentication.rs
@@ -1,3 +1,4 @@
+// this file is @generated
 use clap::{Args, Subcommand};
 use svix::api::*;
 

--- a/svix-cli/src/cmds/api/endpoint.rs
+++ b/svix-cli/src/cmds/api/endpoint.rs
@@ -1,8 +1,5 @@
-use chrono::{DateTime, Utc};
 use clap::{Args, Subcommand};
 use svix::api::*;
-
-use crate::json::JsonOf;
 
 #[derive(Args, Clone)]
 pub struct EndpointListOptions {
@@ -101,10 +98,10 @@ impl From<EndpointSendExampleOptions> for svix::api::EndpointSendExampleOptions 
 pub struct EndpointGetStatsOptions {
     /// Filter the range to data starting from this date.
     #[arg(long)]
-    pub since: Option<DateTime<Utc>>,
+    pub since: Option<chrono::DateTime<chrono::Utc>>,
     /// Filter the range to data ending by this date.
     #[arg(long)]
-    pub until: Option<DateTime<Utc>>,
+    pub until: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 impl From<EndpointGetStatsOptions> for svix::api::EndpointGetStatsOptions {
@@ -137,7 +134,7 @@ pub enum EndpointCommands {
     /// When `secret` is `null` the secret is automatically generated (recommended).
     Create {
         app_id: String,
-        endpoint_in: JsonOf<EndpointIn>,
+        endpoint_in: crate::json::JsonOf<EndpointIn>,
         #[clap(flatten)]
         options: EndpointCreateOptions,
     },
@@ -147,7 +144,7 @@ pub enum EndpointCommands {
     Update {
         app_id: String,
         id: String,
-        endpoint_update: JsonOf<EndpointUpdate>,
+        endpoint_update: crate::json::JsonOf<EndpointUpdate>,
     },
     /// Delete an endpoint.
     Delete { app_id: String, id: String },
@@ -155,7 +152,7 @@ pub enum EndpointCommands {
     Patch {
         app_id: String,
         id: String,
-        endpoint_patch: Option<JsonOf<EndpointPatch>>,
+        endpoint_patch: Option<crate::json::JsonOf<EndpointPatch>>,
     },
     /// Get the additional headers to be sent with the webhook.
     GetHeaders { app_id: String, id: String },
@@ -163,13 +160,13 @@ pub enum EndpointCommands {
     UpdateHeaders {
         app_id: String,
         id: String,
-        endpoint_headers_in: JsonOf<EndpointHeadersIn>,
+        endpoint_headers_in: crate::json::JsonOf<EndpointHeadersIn>,
     },
     /// Partially set the additional headers to be sent with the webhook.
     PatchHeaders {
         app_id: String,
         id: String,
-        endpoint_headers_patch_in: JsonOf<EndpointHeadersPatchIn>,
+        endpoint_headers_patch_in: crate::json::JsonOf<EndpointHeadersPatchIn>,
     },
     /// Resend all failed messages since a given time.
     ///
@@ -177,7 +174,7 @@ pub enum EndpointCommands {
     Recover {
         app_id: String,
         id: String,
-        recover_in: JsonOf<RecoverIn>,
+        recover_in: crate::json::JsonOf<RecoverIn>,
         #[clap(flatten)]
         options: EndpointRecoverOptions,
     },
@@ -188,7 +185,7 @@ pub enum EndpointCommands {
     ReplayMissing {
         app_id: String,
         id: String,
-        replay_in: JsonOf<ReplayIn>,
+        replay_in: crate::json::JsonOf<ReplayIn>,
         #[clap(flatten)]
         options: EndpointReplayMissingOptions,
     },
@@ -203,7 +200,7 @@ pub enum EndpointCommands {
     RotateSecret {
         app_id: String,
         id: String,
-        endpoint_secret_rotate_in: Option<JsonOf<EndpointSecretRotateIn>>,
+        endpoint_secret_rotate_in: Option<crate::json::JsonOf<EndpointSecretRotateIn>>,
         #[clap(flatten)]
         options: EndpointRotateSecretOptions,
     },
@@ -211,7 +208,7 @@ pub enum EndpointCommands {
     SendExample {
         app_id: String,
         id: String,
-        event_example_in: JsonOf<EventExampleIn>,
+        event_example_in: crate::json::JsonOf<EventExampleIn>,
         #[clap(flatten)]
         options: EndpointSendExampleOptions,
     },
@@ -228,7 +225,7 @@ pub enum EndpointCommands {
     PatchTransformation {
         app_id: String,
         id: String,
-        endpoint_transformation_patch: Option<JsonOf<EndpointTransformationPatch>>,
+        endpoint_transformation_patch: Option<crate::json::JsonOf<EndpointTransformationPatch>>,
     },
 }
 

--- a/svix-cli/src/cmds/api/endpoint.rs
+++ b/svix-cli/src/cmds/api/endpoint.rs
@@ -1,3 +1,4 @@
+// this file is @generated
 use clap::{Args, Subcommand};
 use svix::api::*;
 

--- a/svix-cli/src/cmds/api/environment.rs
+++ b/svix-cli/src/cmds/api/environment.rs
@@ -1,8 +1,6 @@
 use clap::{Args, Subcommand};
 use svix::api::*;
 
-use crate::json::JsonOf;
-
 #[derive(Args, Clone)]
 pub struct EnvironmentExportOptions {
     #[arg(long)]
@@ -47,7 +45,7 @@ pub enum EnvironmentCommands {
     ///
     /// It doesn't delete anything, only adds / updates what was passed to it.
     Import {
-        environment_in: Option<JsonOf<EnvironmentIn>>,
+        environment_in: Option<crate::json::JsonOf<EnvironmentIn>>,
         #[clap(flatten)]
         options: EnvironmentImportOptions,
     },

--- a/svix-cli/src/cmds/api/environment.rs
+++ b/svix-cli/src/cmds/api/environment.rs
@@ -1,3 +1,4 @@
+// this file is @generated
 use clap::{Args, Subcommand};
 use svix::api::*;
 

--- a/svix-cli/src/cmds/api/event_type.rs
+++ b/svix-cli/src/cmds/api/event_type.rs
@@ -1,3 +1,4 @@
+// this file is @generated
 use clap::{Args, Subcommand};
 use svix::api::*;
 

--- a/svix-cli/src/cmds/api/event_type.rs
+++ b/svix-cli/src/cmds/api/event_type.rs
@@ -1,8 +1,6 @@
 use clap::{Args, Subcommand};
 use svix::api::*;
 
-use crate::json::JsonOf;
-
 #[derive(Args, Clone)]
 pub struct EventTypeListOptions {
     /// Limit the number of returned items
@@ -101,7 +99,7 @@ pub enum EventTypeCommands {
     /// Endpoints filtering on the event type before archival will continue to filter on it.
     /// This operation does not preserve the description and schemas.
     Create {
-        event_type_in: JsonOf<EventTypeIn>,
+        event_type_in: crate::json::JsonOf<EventTypeIn>,
         #[clap(flatten)]
         options: EventTypeCreateOptions,
     },
@@ -111,7 +109,7 @@ pub enum EventTypeCommands {
     /// The importer will convert all webhooks found in the either the `webhooks` or `x-webhooks`
     /// top-level.
     ImportOpenapi {
-        event_type_import_open_api_in: Option<JsonOf<EventTypeImportOpenApiIn>>,
+        event_type_import_open_api_in: Option<crate::json::JsonOf<EventTypeImportOpenApiIn>>,
         #[clap(flatten)]
         options: EventTypeImportOpenapiOptions,
     },
@@ -120,7 +118,7 @@ pub enum EventTypeCommands {
     /// Update an event type.
     Update {
         event_type_name: String,
-        event_type_update: JsonOf<EventTypeUpdate>,
+        event_type_update: crate::json::JsonOf<EventTypeUpdate>,
     },
     /// Archive an event type.
     ///
@@ -136,7 +134,7 @@ pub enum EventTypeCommands {
     /// Partially update an event type.
     Patch {
         event_type_name: String,
-        event_type_patch: Option<JsonOf<EventTypePatch>>,
+        event_type_patch: Option<crate::json::JsonOf<EventTypePatch>>,
     },
 }
 

--- a/svix-cli/src/cmds/api/ingest.rs
+++ b/svix-cli/src/cmds/api/ingest.rs
@@ -2,7 +2,6 @@ use clap::{Args, Subcommand};
 use svix::api::*;
 
 use super::{ingest_endpoint::IngestEndpointArgs, ingest_source::IngestSourceArgs};
-use crate::json::JsonOf;
 
 #[derive(Args, Clone)]
 pub struct IngestDashboardOptions {
@@ -31,7 +30,8 @@ pub enum IngestCommands {
     /// Get access to the Ingest Source Consumer Portal.
     Dashboard {
         source_id: String,
-        ingest_source_consumer_portal_access_in: Option<JsonOf<IngestSourceConsumerPortalAccessIn>>,
+        ingest_source_consumer_portal_access_in:
+            Option<crate::json::JsonOf<IngestSourceConsumerPortalAccessIn>>,
         #[clap(flatten)]
         options: IngestDashboardOptions,
     },

--- a/svix-cli/src/cmds/api/ingest.rs
+++ b/svix-cli/src/cmds/api/ingest.rs
@@ -1,3 +1,4 @@
+// this file is @generated
 use clap::{Args, Subcommand};
 use svix::api::*;
 

--- a/svix-cli/src/cmds/api/ingest_endpoint.rs
+++ b/svix-cli/src/cmds/api/ingest_endpoint.rs
@@ -1,8 +1,6 @@
 use clap::{Args, Subcommand};
 use svix::api::*;
 
-use crate::json::JsonOf;
-
 #[derive(Args, Clone)]
 pub struct IngestEndpointListOptions {
     /// Limit the number of returned items
@@ -75,7 +73,7 @@ pub enum IngestEndpointCommands {
     /// Create an ingest endpoint.
     Create {
         source_id: String,
-        ingest_endpoint_in: JsonOf<IngestEndpointIn>,
+        ingest_endpoint_in: crate::json::JsonOf<IngestEndpointIn>,
         #[clap(flatten)]
         options: IngestEndpointCreateOptions,
     },
@@ -88,7 +86,7 @@ pub enum IngestEndpointCommands {
     Update {
         source_id: String,
         endpoint_id: String,
-        ingest_endpoint_update: JsonOf<IngestEndpointUpdate>,
+        ingest_endpoint_update: crate::json::JsonOf<IngestEndpointUpdate>,
     },
     /// Delete an ingest endpoint.
     Delete {
@@ -104,7 +102,7 @@ pub enum IngestEndpointCommands {
     UpdateHeaders {
         source_id: String,
         endpoint_id: String,
-        ingest_endpoint_headers_in: JsonOf<IngestEndpointHeadersIn>,
+        ingest_endpoint_headers_in: crate::json::JsonOf<IngestEndpointHeadersIn>,
     },
     /// Get an ingest endpoint's signing secret.
     ///
@@ -120,7 +118,7 @@ pub enum IngestEndpointCommands {
     RotateSecret {
         source_id: String,
         endpoint_id: String,
-        ingest_endpoint_secret_in: Option<JsonOf<IngestEndpointSecretIn>>,
+        ingest_endpoint_secret_in: Option<crate::json::JsonOf<IngestEndpointSecretIn>>,
         #[clap(flatten)]
         options: IngestEndpointRotateSecretOptions,
     },

--- a/svix-cli/src/cmds/api/ingest_endpoint.rs
+++ b/svix-cli/src/cmds/api/ingest_endpoint.rs
@@ -1,3 +1,4 @@
+// this file is @generated
 use clap::{Args, Subcommand};
 use svix::api::*;
 

--- a/svix-cli/src/cmds/api/ingest_source.rs
+++ b/svix-cli/src/cmds/api/ingest_source.rs
@@ -1,8 +1,6 @@
 use clap::{Args, Subcommand};
 use svix::api::*;
 
-use crate::json::JsonOf;
-
 #[derive(Args, Clone)]
 pub struct IngestSourceListOptions {
     /// Limit the number of returned items
@@ -73,7 +71,7 @@ pub enum IngestSourceCommands {
     },
     /// Create Ingest Source.
     Create {
-        ingest_source_in: JsonOf<IngestSourceIn>,
+        ingest_source_in: crate::json::JsonOf<IngestSourceIn>,
         #[clap(flatten)]
         options: IngestSourceCreateOptions,
     },
@@ -82,7 +80,7 @@ pub enum IngestSourceCommands {
     /// Update an Ingest Source.
     Update {
         source_id: String,
-        ingest_source_in: JsonOf<IngestSourceIn>,
+        ingest_source_in: crate::json::JsonOf<IngestSourceIn>,
     },
     /// Delete an Ingest Source.
     Delete { source_id: String },

--- a/svix-cli/src/cmds/api/ingest_source.rs
+++ b/svix-cli/src/cmds/api/ingest_source.rs
@@ -1,3 +1,4 @@
+// this file is @generated
 use clap::{Args, Subcommand};
 use svix::api::*;
 

--- a/svix-cli/src/cmds/api/integration.rs
+++ b/svix-cli/src/cmds/api/integration.rs
@@ -1,8 +1,6 @@
 use clap::{Args, Subcommand};
 use svix::api::*;
 
-use crate::json::JsonOf;
-
 #[derive(Args, Clone)]
 pub struct IntegrationListOptions {
     /// Limit the number of returned items
@@ -75,7 +73,7 @@ pub enum IntegrationCommands {
     /// Create an integration.
     Create {
         app_id: String,
-        integration_in: JsonOf<IntegrationIn>,
+        integration_in: crate::json::JsonOf<IntegrationIn>,
         #[clap(flatten)]
         options: IntegrationCreateOptions,
     },
@@ -85,7 +83,7 @@ pub enum IntegrationCommands {
     Update {
         app_id: String,
         id: String,
-        integration_update: JsonOf<IntegrationUpdate>,
+        integration_update: crate::json::JsonOf<IntegrationUpdate>,
     },
     /// Delete an integration.
     Delete { app_id: String, id: String },

--- a/svix-cli/src/cmds/api/integration.rs
+++ b/svix-cli/src/cmds/api/integration.rs
@@ -1,3 +1,4 @@
+// this file is @generated
 use clap::{Args, Subcommand};
 use svix::api::*;
 

--- a/svix-cli/src/cmds/api/message.rs
+++ b/svix-cli/src/cmds/api/message.rs
@@ -1,3 +1,4 @@
+// this file is @generated
 use clap::{Args, Subcommand};
 use svix::api::*;
 

--- a/svix-cli/src/cmds/api/message.rs
+++ b/svix-cli/src/cmds/api/message.rs
@@ -1,9 +1,7 @@
-use chrono::{DateTime, Utc};
 use clap::{Args, Subcommand};
 use svix::api::*;
 
 use super::message_poller::MessagePollerArgs;
-use crate::json::JsonOf;
 
 #[derive(Args, Clone)]
 pub struct MessageListOptions {
@@ -18,10 +16,10 @@ pub struct MessageListOptions {
     pub channel: Option<String>,
     /// Only include items created before a certain date.
     #[arg(long)]
-    pub before: Option<DateTime<Utc>>,
+    pub before: Option<chrono::DateTime<chrono::Utc>>,
     /// Only include items created after a certain date.
     #[arg(long)]
-    pub after: Option<DateTime<Utc>>,
+    pub after: Option<chrono::DateTime<chrono::Utc>>,
     /// When `true` message payloads are included in the response.
     #[arg(long)]
     pub with_content: Option<bool>,
@@ -143,7 +141,7 @@ pub enum MessageCommands {
     /// The `payload` property is the webhook's body (the actual webhook message). Svix supports payload sizes of up to 1MiB, though it's generally a good idea to keep webhook payloads small, probably no larger than 40kb.
     Create {
         app_id: String,
-        message_in: JsonOf<MessageIn>,
+        message_in: crate::json::JsonOf<MessageIn>,
         #[clap(flatten)]
         options: MessageCreateOptions,
     },

--- a/svix-cli/src/cmds/api/message_attempt.rs
+++ b/svix-cli/src/cmds/api/message_attempt.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use clap::{Args, Subcommand};
 use svix::api::*;
 
@@ -24,10 +23,10 @@ pub struct MessageAttemptListByEndpointOptions {
     pub tag: Option<String>,
     /// Only include items created before a certain date
     #[arg(long)]
-    pub before: Option<DateTime<Utc>>,
+    pub before: Option<chrono::DateTime<chrono::Utc>>,
     /// Only include items created after a certain date
     #[arg(long)]
-    pub after: Option<DateTime<Utc>>,
+    pub after: Option<chrono::DateTime<chrono::Utc>>,
     /// When `true` attempt content is included in the response
     #[arg(long)]
     pub with_content: Option<bool>,
@@ -95,10 +94,10 @@ pub struct MessageAttemptListByMsgOptions {
     pub endpoint_id: Option<String>,
     /// Only include items created before a certain date
     #[arg(long)]
-    pub before: Option<DateTime<Utc>>,
+    pub before: Option<chrono::DateTime<chrono::Utc>>,
     /// Only include items created after a certain date
     #[arg(long)]
-    pub after: Option<DateTime<Utc>>,
+    pub after: Option<chrono::DateTime<chrono::Utc>>,
     /// When `true` attempt content is included in the response
     #[arg(long)]
     pub with_content: Option<bool>,
@@ -157,10 +156,10 @@ pub struct MessageAttemptListAttemptedMessagesOptions {
     pub status: Option<MessageStatus>,
     /// Only include items created before a certain date
     #[arg(long)]
-    pub before: Option<DateTime<Utc>>,
+    pub before: Option<chrono::DateTime<chrono::Utc>>,
     /// Only include items created after a certain date
     #[arg(long)]
-    pub after: Option<DateTime<Utc>>,
+    pub after: Option<chrono::DateTime<chrono::Utc>>,
     /// When `true` message payloads are included in the response
     #[arg(long)]
     pub with_content: Option<bool>,

--- a/svix-cli/src/cmds/api/message_attempt.rs
+++ b/svix-cli/src/cmds/api/message_attempt.rs
@@ -1,3 +1,4 @@
+// this file is @generated
 use clap::{Args, Subcommand};
 use svix::api::*;
 

--- a/svix-cli/src/cmds/api/message_poller.rs
+++ b/svix-cli/src/cmds/api/message_poller.rs
@@ -1,8 +1,5 @@
-use chrono::{DateTime, Utc};
 use clap::{Args, Subcommand};
 use svix::api::*;
-
-use crate::json::JsonOf;
 
 #[derive(Args, Clone)]
 pub struct MessagePollerPollOptions {
@@ -19,7 +16,7 @@ pub struct MessagePollerPollOptions {
     #[arg(long)]
     pub channel: Option<String>,
     #[arg(long)]
-    pub after: Option<DateTime<Utc>>,
+    pub after: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 impl From<MessagePollerPollOptions> for svix::api::MessagePollerPollOptions {
@@ -101,7 +98,7 @@ pub enum MessagePollerCommands {
         app_id: String,
         sink_id: String,
         consumer_id: String,
-        polling_endpoint_consumer_seek_in: JsonOf<PollingEndpointConsumerSeekIn>,
+        polling_endpoint_consumer_seek_in: crate::json::JsonOf<PollingEndpointConsumerSeekIn>,
         #[clap(flatten)]
         options: MessagePollerConsumerSeekOptions,
     },

--- a/svix-cli/src/cmds/api/message_poller.rs
+++ b/svix-cli/src/cmds/api/message_poller.rs
@@ -1,3 +1,4 @@
+// this file is @generated
 use clap::{Args, Subcommand};
 use svix::api::*;
 

--- a/svix-cli/src/cmds/api/operational_webhook.rs
+++ b/svix-cli/src/cmds/api/operational_webhook.rs
@@ -1,3 +1,4 @@
+// this file is @generated
 use clap::{Args, Subcommand};
 use svix::api::*;
 

--- a/svix-cli/src/cmds/api/operational_webhook_endpoint.rs
+++ b/svix-cli/src/cmds/api/operational_webhook_endpoint.rs
@@ -1,8 +1,6 @@
 use clap::{Args, Subcommand};
 use svix::api::*;
 
-use crate::json::JsonOf;
-
 #[derive(Args, Clone)]
 pub struct OperationalWebhookEndpointListOptions {
     /// Limit the number of returned items
@@ -79,7 +77,7 @@ pub enum OperationalWebhookEndpointCommands {
     },
     /// Create an operational webhook endpoint.
     Create {
-        operational_webhook_endpoint_in: JsonOf<OperationalWebhookEndpointIn>,
+        operational_webhook_endpoint_in: crate::json::JsonOf<OperationalWebhookEndpointIn>,
         #[clap(flatten)]
         options: OperationalWebhookEndpointCreateOptions,
     },
@@ -88,7 +86,7 @@ pub enum OperationalWebhookEndpointCommands {
     /// Update an operational webhook endpoint.
     Update {
         endpoint_id: String,
-        operational_webhook_endpoint_update: JsonOf<OperationalWebhookEndpointUpdate>,
+        operational_webhook_endpoint_update: crate::json::JsonOf<OperationalWebhookEndpointUpdate>,
     },
     /// Delete an operational webhook endpoint.
     Delete { endpoint_id: String },
@@ -97,7 +95,8 @@ pub enum OperationalWebhookEndpointCommands {
     /// Set the additional headers to be sent with the operational webhook.
     UpdateHeaders {
         endpoint_id: String,
-        operational_webhook_endpoint_headers_in: JsonOf<OperationalWebhookEndpointHeadersIn>,
+        operational_webhook_endpoint_headers_in:
+            crate::json::JsonOf<OperationalWebhookEndpointHeadersIn>,
     },
     /// Get an operational webhook endpoint's signing secret.
     ///
@@ -109,7 +108,8 @@ pub enum OperationalWebhookEndpointCommands {
     /// The previous secret will remain valid for the next 24 hours.
     RotateSecret {
         endpoint_id: String,
-        operational_webhook_endpoint_secret_in: Option<JsonOf<OperationalWebhookEndpointSecretIn>>,
+        operational_webhook_endpoint_secret_in:
+            Option<crate::json::JsonOf<OperationalWebhookEndpointSecretIn>>,
         #[clap(flatten)]
         options: OperationalWebhookEndpointRotateSecretOptions,
     },

--- a/svix-cli/src/cmds/api/operational_webhook_endpoint.rs
+++ b/svix-cli/src/cmds/api/operational_webhook_endpoint.rs
@@ -1,3 +1,4 @@
+// this file is @generated
 use clap::{Args, Subcommand};
 use svix::api::*;
 


### PR DESCRIPTION
This speeds up the `regen_openapi.py` by a bunch.
Now we don't need to wait for `cargo fix`