### PR TITLE
Remove `rm` commands from codegen. use the builtin `--exclude-op-id`

### DIFF
--- a/codegen/codegen.toml
+++ b/codegen/codegen.toml
@@ -3,7 +3,7 @@ input_files = ["lib-openapi.json", "api_extra.ron"]
 
 [rust]
 extra_mounts = { "rust/.rustfmt.toml" = "/app/.rustfmt.toml" }
-extra_shell_commands = ["rm rust/src/api/health.rs"]
+extra_codegen_args = ["-e=v1.health.get"]
 [[rust.task]]
 template = "templates/rust/api_resource.rs.jinja"
 output_dir = "rust/src/api"
@@ -35,8 +35,12 @@ output_dir = "javascript/src"
 
 [cli]
 extra_mounts = { "svix-cli/.rustfmt.toml" = "/app/.rustfmt.toml" }
-extra_shell_commands = [
-   "rm svix-cli/src/cmds/api/{background_task,health,statistics}.rs",
+extra_codegen_args = [
+   "-e=v1.background-task.list",
+   "-e=v1.background-task.get",
+   "-e=v1.health.get",
+   "-e=v1.statistics.aggregate-event-types",
+   "-e=v1.statistics.aggregate-app-stats",
 ]
 [[cli.task]]
 template = "templates/svix-cli/api_resource.rs.jinja"
@@ -44,9 +48,7 @@ output_dir = "svix-cli/src/cmds/api"
 
 
 [python]
-extra_shell_commands = [
-   "rm python/svix/api/health.py",
-]
+extra_codegen_args = ["-e=v1.health.get"]
 [[python.task]]
 template = "templates/python/api_resource.py.jinja"
 output_dir = "python/svix/api"
@@ -96,9 +98,9 @@ output_dir = "java/lib/src/main/java/com/svix/models"
 
 [go]
 extra_shell_commands = [
-   "rm go/health.go",
    "sed -i.bak 's/package svix/package internalapi/g' go/internalapi/management* && rm go/internalapi/management*.bak",
 ]
+extra_codegen_args = ["-e=v1.health.get"]
 [[go.task]]
 template = "templates/go/api_resource.go.jinja"
 output_dir = "go"
@@ -124,7 +126,7 @@ extra_codegen_args = [
    "--include-op-id=v1.management.environment-settings.update",
    "--include-op-id=v1.management.environment-settings.patch",
    "--include-op-id=v1.management.authentication.create-api-token",
-   "--include-op-id=v1.management.authentication.expire-api-token"
+   "--include-op-id=v1.management.authentication.expire-api-token",
 ]
 [[go.task]]
 template = "templates/go/component_type.go.jinja"
@@ -141,7 +143,7 @@ extra_codegen_args = [
    "--include-op-id=v1.management.environment-settings.update",
    "--include-op-id=v1.management.environment-settings.patch",
    "--include-op-id=v1.management.authentication.create-api-token",
-   "--include-op-id=v1.management.authentication.expire-api-token"
+   "--include-op-id=v1.management.authentication.expire-api-token",
 ]
 
 

--- a/regen_openapi.py
+++ b/regen_openapi.py
@@ -240,7 +240,10 @@ def parse_config():
                     "template": task["template"],
                     "output_dir": task["output_dir"],
                     "extra_mounts": language_config.get("extra_mounts", {}),
-                    "extra_codegen_args": task.get("extra_codegen_args", []),
+                    "extra_codegen_args": task.get(
+                        "extra_codegen_args",
+                        language_config.get("extra_codegen_args", []),
+                    ),
                 }
             )
     # the cli step depends on generated rust code.


### PR DESCRIPTION
Codegen used to not support excluding files from generation, so we had some `rm commands`. I am now replacing the `rm` commands with the codegen's builtin `--exclude-op-id`

Happy to discuses if we even want to remove these api endpoints