### PR TITLE
bridge: Add default user-agent to http output

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Libs/JavaScript: Use native `fetch` API
+* Bridge: Add a default `user-agent` to requests made by the new `http` output
 
 ## Version 1.71.0
 * Bridge: Add `http` output to `receivers`


### PR DESCRIPTION
It is a good practice to include a user-agent. Some services even block requests without a user-agent.