### PR TITLE
server: Port to hyper 1.0

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -24,6 +24,7 @@ allow = [
     "Apache-2.0",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "CDLA-Permissive-2.0",
     "ISC",
     "MIT",
     "MPL-2.0",
@@ -68,7 +69,8 @@ allow = []
 deny = [
     # Versions containing the binary blob
     # See: https://github.com/serde-rs/serde/issues/2538
-    { name = "serde_derive", version = ">1.0.171, <1.0.184"}
+    { name = "serde_derive", version = ">1.0.171, <1.0.184"},
+    { name = "axum", version = "<0.7" },
 ]
 skip = []
 skip-tree = []

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -63,17 +63,17 @@ dependencies = [
 
 [[package]]
 name = "aide"
-version = "0.12.0"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b9ab2c8531a5ac6bcc579cc4c308d1b4bd5b9910a0f08bf4e65b3452407400"
+checksum = "5678d2978845ddb4bd736a026f467dd652d831e9e6254b0e41b07f7ee7523309"
 dependencies = [
  "aide-macros",
  "axum",
+ "axum-extra",
  "bytes",
  "cfg-if",
- "derive_more",
- "http 0.2.12",
- "indexmap 1.9.3",
+ "http 1.2.0",
+ "indexmap 2.7.1",
  "schemars",
  "serde",
  "serde_json",
@@ -406,17 +406,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-socks5"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f634add2445eb2c1f785642a67ca1073fedd71e73dc3ca69435ef9b9bdedc7"
-dependencies = [
- "async-trait",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,19 +476,19 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.6.20"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "headers",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.28",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -511,41 +500,72 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 0.1.2",
+ "sync_wrapper 1.0.2",
  "tokio",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.3.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
 dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
  "mime",
+ "pin-project-lite",
  "rustversion",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-extra"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c794b30c904f0a1c2fb7740f7df7f7972dfaa14ef6f57cb6178dc63e5dca2f04"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "fastrand 2.3.0",
+ "futures-util",
+ "headers",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "multer",
+ "pin-project-lite",
+ "serde",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-server"
-version = "0.5.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447f28c85900215cc1bea282f32d4a2f22d55c5a300afdfbc661c8d6a632e063"
+checksum = "495c05f60d6df0093e8fb6e74aa5846a0ad06abaf96d76166283720bf740f8ab"
 dependencies = [
+ "arc-swap",
  "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.28",
+ "fs-err",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "hyper 1.7.0",
+ "hyper-util",
  "openssl",
  "pin-project-lite",
  "tokio",
@@ -785,6 +805,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,12 +957,6 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cookie-factory"
@@ -1152,19 +1172,6 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
  "serde",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 2.0.99",
 ]
 
 [[package]]
@@ -1494,6 +1501,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d7be93788013f265201256d58f04936a8079ad5dc898743aa20525f503b683"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1652,8 +1669,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -1700,6 +1719,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.2.0",
+ "indexmap 2.7.1",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1727,14 +1765,14 @@ dependencies = [
 
 [[package]]
 name = "headers"
-version = "0.3.9"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
- "http 0.2.12",
+ "http 1.2.0",
  "httpdate",
  "mime",
  "sha1",
@@ -1742,11 +1780,11 @@ dependencies = [
 
 [[package]]
 name = "headers-core"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 0.2.12",
+ "http 1.2.0",
 ]
 
 [[package]]
@@ -1954,12 +1992,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-range-header"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
-
-[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1973,21 +2005,22 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
-source = "git+https://github.com/svix/hyper/?rev=63efac5a6719937359d61a1bb1b93d9ce88f0e3d#63efac5a6719937359d61a1bb1b93d9ce88f0e3d"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -1996,18 +2029,21 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+version = "1.7.0"
+source = "git+https://github.com/svix/hyper.git?rev=18c04c321e1a9a4958ad14b880f7403acbe1c914#18c04c321e1a9a4958ad14b880f7403acbe1c914"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
+ "h2 0.4.12",
  "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2015,51 +2051,21 @@ dependencies = [
 
 [[package]]
 name = "hyper-openssl"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ee5d7a8f718585d1c3c61dfde28ef5b0bb14734b4db13f5ada856cdc6c612b"
+checksum = "527d4d619ca2c2aafa31ec139a3d1d60bf557bf7578a1f20f743637eccd9ca19"
 dependencies = [
- "http 0.2.12",
- "hyper 0.14.28",
+ "http 1.2.0",
+ "hyper 1.7.0",
+ "hyper-util",
  "linked_hash_set",
  "once_cell",
  "openssl",
  "openssl-sys",
  "parking_lot",
- "tokio",
- "tokio-openssl",
+ "pin-project",
  "tower-layer",
-]
-
-[[package]]
-name = "hyper-proxy"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca815a891b24fdfb243fa3239c86154392b0953ee584aa1a2a1f66d20cbe75cc"
-dependencies = [
- "bytes",
- "futures",
- "headers",
- "http 0.2.12",
- "hyper 0.14.28",
- "openssl",
- "tokio",
- "tokio-openssl",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.28",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -2070,7 +2076,7 @@ checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
 dependencies = [
  "futures-util",
  "http 1.2.0",
- "hyper 1.6.0",
+ "hyper 1.7.0",
  "hyper-util",
  "log",
  "rustls 0.22.4",
@@ -2082,43 +2088,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-socks2"
-version = "0.8.0"
+name = "hyper-rustls"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc38166fc2732d450e9372388d269eb38ff0b75a3cfb4c542e65b2f6893629c4"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "async-socks5",
- "futures",
- "http 0.2.12",
- "hyper 0.14.28",
- "hyper-tls 0.5.0",
- "thiserror 1.0.69",
+ "http 1.2.0",
+ "hyper 1.7.0",
+ "hyper-util",
+ "rustls 0.23.23",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls 0.26.2",
+ "tower-service",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
 name = "hyper-timeout"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
 dependencies = [
- "hyper 0.14.28",
+ "hyper 1.7.0",
+ "hyper-util",
  "pin-project-lite",
  "tokio",
- "tokio-io-timeout",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.28",
- "native-tls",
- "tokio",
- "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -2129,7 +2125,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper 1.7.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2139,18 +2135,23 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http 1.2.0",
  "http-body 1.0.1",
- "hyper 1.6.0",
+ "hyper 1.7.0",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.8",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -2241,6 +2242,7 @@ checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
+ "serde",
 ]
 
 [[package]]
@@ -2324,15 +2326,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "924e5d73ea28f59011fec52a0d12185d496a9b075d360657aed2a5707f701153"
 dependencies = [
  "nom",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -2472,9 +2465,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libm"
@@ -2545,6 +2538,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2611,6 +2610,23 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.2.0",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -2871,9 +2887,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.23.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
+checksum = "570074cc999d1a58184080966e5bd3bf3a9a4af650c3b05047c2621e7405cd17"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2885,25 +2901,25 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.12.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0ba633e55c5ea6f431875ba55e71664f2fa5d3a90bd34ec9302eecc41c865dd"
+checksum = "6351496aeaa49d7c267fb480678d85d1cd30c5edb20b497c48c56f62a8c14b99"
 dependencies = [
  "async-trait",
  "bytes",
- "http 0.2.12",
+ "http 1.2.0",
  "opentelemetry",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.16.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a94c69209c05319cdf7460c6d4c055ed102be242a0a6245835d7bc42c6ec7f54"
+checksum = "29e1f9c8b032d4f635c730c0efcf731d5e2530ea13fa8bef7939ddc8420696bd"
 dependencies = [
  "async-trait",
  "futures-core",
- "http 0.2.12",
+ "http 1.2.0",
  "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry_sdk",
@@ -2915,9 +2931,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.6.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984806e6cf27f2b49282e2a05e288f30594f3dbc74eb7a6e99422bc48ed78162"
+checksum = "c9d3968ce3aefdcca5c27e3c4ea4391b37547726a70893aab52d3de95d5f8b34"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -2926,22 +2942,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry_sdk"
-version = "0.23.0"
+name = "opentelemetry-semantic-conventions"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae312d58eaa90a82d2e627fd86e075cf5230b3f11794e2ed74199ebbe572d4fd"
+checksum = "db945c1eaea8ac6a9677185357480d215bb6999faa9f691d0c4d4d641eab7a09"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c627d9f4c9cdc1f21a29ee4bfbd6028fcb8bcf2a857b43f3abdf72c9c862f3"
 dependencies = [
  "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "glob",
- "lazy_static",
  "once_cell",
  "opentelemetry",
- "ordered-float 4.6.0",
  "percent-encoding",
  "rand 0.8.5",
+ "serde_json",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -2952,15 +2973,6 @@ name = "ordered-float"
 version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "ordered-float"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
 ]
@@ -3426,9 +3438,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3436,12 +3448,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.99",
@@ -3452,6 +3464,61 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quinn"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.23",
+ "socket2 0.5.8",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.1",
+ "lru-slab",
+ "rand 0.9.0",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.23",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.12",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.5.8",
+ "tracing",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "quote"
@@ -3636,12 +3703,10 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "hickory-resolver",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
- "hyper-rustls 0.24.2",
+ "hyper 0.14.32",
  "ipnet",
  "js-sys",
  "log",
@@ -3649,40 +3714,38 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
- "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.25.4",
  "winreg",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
+ "hickory-resolver",
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.6.0",
- "hyper-tls 0.6.0",
+ "hyper 1.7.0",
+ "hyper-rustls 0.27.7",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -3692,19 +3755,23 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile 2.2.0",
+ "quinn",
+ "rustls 0.23.23",
+ "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
- "tower 0.5.2",
+ "tokio-rustls 0.26.2",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 0.26.8",
  "windows-registry",
 ]
 
@@ -3801,6 +3868,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3847,18 +3920,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
@@ -3866,7 +3927,7 @@ dependencies = [
  "log",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -3880,7 +3941,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -3895,7 +3956,7 @@ dependencies = [
  "rustls 0.23.23",
  "rustls-native-certs",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
 ]
 
 [[package]]
@@ -3905,19 +3966,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -3934,15 +3986,8 @@ name = "rustls-pki-types"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring",
- "untrusted",
+ "web-time",
 ]
 
 [[package]]
@@ -3995,6 +4040,7 @@ dependencies = [
  "chrono",
  "dyn-clone",
  "indexmap 1.9.3",
+ "indexmap 2.7.1",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -4028,16 +4074,6 @@ dependencies = [
  "pbkdf2",
  "salsa20",
  "sha2",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -4104,7 +4140,7 @@ checksum = "b731192738ebf56d20580fc8ba2d23940333befe900b04dd08a26a77cd056f02"
 dependencies = [
  "chrono",
  "inherent",
- "ordered-float 3.9.2",
+ "ordered-float",
  "serde_json",
 ]
 
@@ -4165,13 +4201,13 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "sentry"
-version = "0.32.3"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00421ed8fa0c995f07cde48ba6c89e80f2b312f74ff637326f392fbfd23abe02"
+checksum = "5484316556650182f03b43d4c746ce0e3e48074a21e2f51244b648b6542e1066"
 dependencies = [
  "httpdate",
  "native-tls",
- "reqwest 0.12.12",
+ "reqwest 0.12.9",
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
@@ -4184,9 +4220,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.32.3"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a79194074f34b0cbe5dd33896e5928bbc6ab63a889bd9df2264af5acb186921e"
+checksum = "40aa225bb41e2ec9d7c90886834367f560efc1af028f1c5478a6cce6a59c463a"
 dependencies = [
  "backtrace",
  "once_cell",
@@ -4196,9 +4232,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.32.3"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba8870c5dba2bfd9db25c75574a11429f6b95957b0a78ac02e2970dd7a5249a"
+checksum = "1a8dd746da3d16cb8c39751619cefd4fcdbd6df9610f3310fd646b55f6e39910"
 dependencies = [
  "hostname 0.4.0",
  "libc",
@@ -4210,9 +4246,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.32.3"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a75011ea1c0d5c46e9e57df03ce81f5c7f0a9e199086334a1f9c0a541e0826"
+checksum = "161283cfe8e99c8f6f236a402b9ccf726b201f365988b5bb637ebca0abbd4a30"
 dependencies = [
  "once_cell",
  "rand 0.8.5",
@@ -4223,9 +4259,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.32.3"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec2a486336559414ab66548da610da5e9626863c3c4ffca07d88f7dc71c8de8"
+checksum = "8fc6b25e945fcaa5e97c43faee0267eebda9f18d4b09a251775d8fef1086238a"
 dependencies = [
  "findshlibs",
  "once_cell",
@@ -4234,9 +4270,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.32.3"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eaa3ecfa3c8750c78dcfd4637cfa2598b95b52897ed184b4dc77fcf7d95060d"
+checksum = "bc74f229c7186dd971a9491ffcbe7883544aa064d1589bd30b83fb856cd22d63"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -4244,9 +4280,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.32.3"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f715932bf369a61b7256687c6f0554141b7ce097287e30e3f7ed6e9de82498fe"
+checksum = "cd3c5faf2103cd01eeda779ea439b68c4ee15adcdb16600836e97feafab362ec"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -4256,9 +4292,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.32.3"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4519c900ce734f7a0eb7aba0869dfb225a7af8820634a7dd51449e3b093cfb7c"
+checksum = "5d68cdf6bc41b8ff3ae2a9c4671e97426dcdd154cc1d4b6b72813f285d6b163f"
 dependencies = [
  "debugid",
  "hex",
@@ -4326,9 +4362,9 @@ dependencies = [
 
 [[package]]
 name = "serde_qs"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0431a35568651e363364210c91983c1da5eb29404d9f0928b67d4ebcfa7d330c"
+checksum = "cd34f36fe4c5ba9654417139a9b3a20d2e1de6012ee678ad14d240c22c78d8d6"
 dependencies = [
  "axum",
  "futures",
@@ -4480,6 +4516,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4545,7 +4591,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rustls 0.23.23",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "sha2",
@@ -4748,10 +4794,10 @@ dependencies = [
  "http 0.2.12",
  "http 1.2.0",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper 1.7.0",
  "hyper-rustls 0.26.0",
  "hyper-util",
- "itertools 0.14.0",
+ "itertools",
  "js_option",
  "rand 0.9.0",
  "serde",
@@ -4795,6 +4841,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "axum",
+ "axum-extra",
  "axum-server",
  "base64 0.22.1",
  "bb8",
@@ -4815,14 +4862,15 @@ dependencies = [
  "hickory-resolver",
  "hmac-sha256",
  "http 0.2.12",
- "hyper 0.14.28",
+ "http 1.2.0",
+ "http-body-util",
+ "hyper 1.7.0",
  "hyper-openssl",
- "hyper-proxy",
- "hyper-socks2",
+ "hyper-util",
  "idna_adapter",
- "indexmap 1.9.3",
+ "indexmap 2.7.1",
  "ipnet",
- "itertools 0.14.0",
+ "itertools",
  "jsonschema",
  "jwt-simple",
  "lapin",
@@ -4832,11 +4880,12 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "rand 0.8.5",
  "redis",
  "regex",
- "reqwest 0.11.27",
+ "reqwest 0.12.9",
  "schemars",
  "sea-orm",
  "sentry",
@@ -4851,7 +4900,7 @@ dependencies = [
  "tikv-jemallocator",
  "time",
  "tokio",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tower-http",
  "tracing",
  "tracing-opentelemetry",
@@ -4948,7 +4997,7 @@ dependencies = [
  "cfg-if",
  "p12-keystore",
  "rustls-connector",
- "rustls-pemfile 2.2.0",
+ "rustls-pemfile",
 ]
 
 [[package]]
@@ -5100,16 +5149,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5143,22 +5182,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
  "rustls 0.22.4",
  "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+dependencies = [
+ "rustls 0.23.23",
  "tokio",
 ]
 
@@ -5222,23 +5261,26 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.11.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.28",
+ "h2 0.4.12",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.7.0",
  "hyper-timeout",
+ "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost",
+ "socket2 0.5.8",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
@@ -5280,21 +5322,19 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "tower-http"
-version = "0.4.4"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "bitflags 2.9.0",
  "bytes",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "http-range-header",
+ "http 1.2.0",
+ "http-body 1.0.1",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
@@ -5360,9 +5400,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.24.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68803492bf28ab40aeccaecc7021096bd256baf7ca77c3d425d89b35a7be4e4"
+checksum = "dc58af5d3f6c5811462cabb3289aec0093f7338e367e5a33d28c0433b3c7360b"
 dependencies = [
  "js-sys",
  "once_cell",
@@ -5735,15 +5775,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
-name = "webpki-roots"
 version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -33,4 +33,4 @@ build-override.opt-level = 2
 svix-server_derive = { opt-level = 0 }
 
 [patch.crates-io]
-hyper = { git = "https://github.com/svix/hyper/", rev = "63efac5a6719937359d61a1bb1b93d9ce88f0e3d" }
+hyper = { git = "https://github.com/svix/hyper.git", rev = "18c04c321e1a9a4958ad14b880f7403acbe1c914" }

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -2153,6 +2153,13 @@
                 ],
                 "type": "object"
             }
+        },
+        "securitySchemes": {
+            "HTTPBearer": {
+                "description": "HTTP Bearer token passed in the `Authorization` header",
+                "scheme": "bearer",
+                "type": "http"
+            }
         }
     },
     "info": {

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -22,18 +22,19 @@ svix-ksuid = "^0.5.1"
 dotenvy = "0.15.7"
 hmac-sha256 = "1"
 clap = { version = "4.1.8", features = ["derive"] }
-axum = { version = "0.6.1", features = ["headers"] }
+axum = "0.7.9"
+axum-extra = { version = "0.9.3", features = ["typed-header"] }
 base64 = "0.22"
-hyper = { version = "=0.14.28", features = ["full"] }
-hyper-openssl = "0.9.2"
-hyper-socks2 = "0.8.0"
+hyper = { version = "=1.7.0", features = ["full"] }
+hyper-openssl = { version = "0.10.2", features = ["client-legacy", "tokio"] }
+hyper-util = { version = "0.1.16", features = ["client-legacy", "client-proxy", "tokio"] }
 # Reduce compile times for idna (we don't need the fastest possible impl of UTS 46)
 # As per https://github.com/hsivonen/idna_adapter?tab=readme-ov-file#opting-to-use-unicode-rs
 idna_adapter = "=1.1.0"
 openssl = "0.10.72"
 tokio = { version = "1.24.2", features = ["full"] }
-tower = "0.4.11"
-tower-http = { version = "0.4.4", features = ["trace", "cors", "normalize-path", "request-id"] }
+tower = "0.5.1"
+tower-http = { version = "0.6.1", features = ["trace", "cors", "normalize-path", "request-id"] }
 serde = { version = "1.0.184", features = ["derive"] }
 serde_json = { version = "1.0.74", features = ["arbitrary_precision", "raw_value"] }
 serde_path_to_error = "0.1.7"
@@ -43,11 +44,12 @@ regex = "1.5.5"
 figment = { version = "0.10", features = ["toml", "env", "test"] }
 tracing = "0.1.35"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-tracing-opentelemetry = "0.24.0"
-opentelemetry = { version = "0.23.0", features = ["metrics"] }
-opentelemetry_sdk = { version = "0.23.0", features = ["rt-tokio"] }
-opentelemetry-http = "0.12.0"
-opentelemetry-otlp = { version = "0.16.0", features = ["metrics"] }
+tracing-opentelemetry = "0.27.0"
+opentelemetry = { version = "0.26.0", features = ["metrics"] }
+opentelemetry_sdk = { version = "0.26.0", features = ["rt-tokio"] }
+opentelemetry-http = "0.26.0"
+opentelemetry-otlp = { version = "0.26.0", features = ["metrics"] }
+opentelemetry-semantic-conventions = "0.26.0"
 # Forked version of 0.16 with a small fix and dependency upgrades, since we
 # haven't gotten around to doing a proper upgrade yet (0.17 is a large
 # rewrite with a barely-useful changelog)
@@ -55,7 +57,7 @@ validator = { git = "https://github.com/svix/validator.git", rev = "aebdc34a4ed7
 jwt-simple = "0.11.6"
 ed25519-compact = "2.1.1"
 chrono = { version="0.4.26", features = ["serde"] }
-reqwest = { version = "0.11.27", features = ["json", "rustls-tls", "hickory-resolver"], default-features = false }
+reqwest = { version = "0.12.7", default-features = false, features = ["json", "rustls-tls", "hickory-dns"] }
 bb8 = "0.9.0"
 bb8-redis = "0.20.0"
 redis = { version = "0.28.2", features = ["tokio-comp", "tokio-native-tls-comp", "streams", "cluster-async", "tcp_nodelay", "connection-manager", "sentinel"] }
@@ -64,27 +66,26 @@ bytes = "1.1.0"
 blake2 = "0.10.4"
 chacha20poly1305 = "0.10.1"
 # sea orm
-sea-orm = { version = "1.1.0", features = [ "sqlx-postgres", "runtime-tokio-rustls", "macros", "with-chrono", "with-json" ], default-features = false }
+sea-orm = { version = "1.1.1", features = [ "sqlx-postgres", "runtime-tokio-rustls", "macros", "with-chrono", "with-json" ], default-features = false }
 sqlx = { version = "0.8.2", features = [ "runtime-tokio-rustls", "postgres", "migrate" ] }
-http = "0.2"
+http = "1.1.0"
+http02 = { package = "http", version = "0.2.12" }
+http-body-util = "0.1.2"
 time = { version = "0.3.9", features = [ "std" ]}
 futures = "0.3"
 url = { version = "2.2.2", features = ["serde"] }
 rand = "0.8.5"
 jsonschema = "0.17.1"
-aide = { version = "0.12.0", features = ["axum", "redoc", "macros", "axum-headers"] }
+aide = { version = "0.13.4", features = ["axum", "redoc", "macros", "axum-headers"] }
 schemars = { version = "0.8.11", features = ["chrono", "url", "preserve_order"] }
-indexmap = "1.9.2"
+indexmap = "2.6.0"
 hickory-resolver = "0.24.0"
 ipnet = { version = "2.5", features = ["serde"] }
 urlencoding = "2.1.2"
 form_urlencoded = "1.1.0"
 lapin = "2.1.1"
-sentry = { version = "0.32.2", features = ["tracing"] }
+sentry = { version = "0.34.0", features = ["tracing"] }
 omniqueue = { git = "https://github.com/svix/omniqueue-rs", rev = "63fe1f303c547e218f44890245a6dada6054931f", default-features = false, features = ["in_memory", "rabbitmq-with-message-ids", "redis_cluster", "redis_sentinel", "beta"] }
-# Not a well-known author, and no longer gets updates => pinned.
-# Switch to hyper-http-proxy when upgrading hyper to 1.0.
-hyper-proxy = { version = "=0.9.1", default-features = false, features = ["openssl-tls"] }
 hex = "0.4.3"
 anyhow = "1.0.56"
 itertools = "0.14"
@@ -94,8 +95,7 @@ tikv-jemallocator = { version = "0.5", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-# NOTE: Purposely not the latest version such as not to mess up the `hyper` fork patch
-axum-server = { version = "0.5", features = ["tls-openssl"] }
+axum-server = { version = "0.7.1", features = ["tls-openssl"] }
 ctor = "0.2.7"
 
 [features]

--- a/server/svix-server/src/core/idempotency.rs
+++ b/server/svix-server/src/core/idempotency.rs
@@ -13,13 +13,15 @@
 use std::{collections::HashMap, convert::Infallible, future::Future, pin::Pin, time::Duration};
 
 use axum::{
-    body::{Body, HttpBody},
-    http::{Request, StatusCode},
+    body::Body,
+    extract::Request,
+    http::StatusCode,
     response::{IntoResponse, Response},
 };
 use base64::{engine::general_purpose::STANDARD, Engine};
 use blake2::{Blake2b512, Digest};
 use http::request::Parts;
+use http_body_util::BodyExt as _;
 use serde::{Deserialize, Serialize};
 use tower::Service;
 
@@ -106,9 +108,9 @@ fn finished_serialized_response_to_response(
     Ok(out)
 }
 
-async fn resolve_service<S>(mut service: S, req: Request<Body>) -> Response
+async fn resolve_service<S>(mut service: S, req: Request) -> Response
 where
-    S: Service<Request<Body>, Error = Infallible> + Clone + Send + 'static,
+    S: Service<Request, Error = Infallible> + Clone + Send + 'static,
     S::Response: IntoResponse,
     S::Future: Send + 'static,
 {
@@ -125,9 +127,9 @@ pub struct IdempotencyService<S: Clone> {
     pub service: S,
 }
 
-impl<S> Service<Request<Body>> for IdempotencyService<S>
+impl<S> Service<Request> for IdempotencyService<S>
 where
-    S: Service<Request<Body>, Error = Infallible> + Clone + Send + 'static,
+    S: Service<Request, Error = Infallible> + Clone + Send + 'static,
     S::Response: IntoResponse,
     S::Future: Send + 'static,
 {
@@ -142,7 +144,7 @@ where
         self.service.poll_ready(cx)
     }
 
-    fn call(&mut self, req: Request<Body>) -> Self::Future {
+    fn call(&mut self, req: Request) -> Self::Future {
         let mut service = self.service.clone();
         let cache = self.cache.clone();
 
@@ -304,10 +306,10 @@ async fn resolve_and_cache_response<S>(
     cache: &Cache,
     key: &IdempotencyKey,
     service: S,
-    request: Request<Body>,
+    request: Request,
 ) -> Response
 where
-    S: Service<Request<Body>, Error = Infallible> + Clone + Send + 'static,
+    S: Service<Request, Error = Infallible> + Clone + Send + 'static,
     S::Response: IntoResponse,
     S::Future: Send + 'static,
 {
@@ -350,12 +352,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{net::TcpListener, sync::Arc};
+    use std::sync::Arc;
 
-    use axum::{extract::State, routing::post, Router, Server};
+    use axum::{extract::State, routing::post, serve, Router};
     use http::StatusCode;
     use reqwest::Client;
-    use tokio::{sync::Mutex, task::JoinHandle};
+    use tokio::{net::TcpListener, sync::Mutex, task::JoinHandle};
     use tower::ServiceBuilder;
 
     use super::IdempotencyService;
@@ -389,28 +391,23 @@ mod tests {
 
         let count = Arc::new(Mutex::new(0));
 
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let endpoint = format!("http://{}/", listener.local_addr().unwrap());
 
         let jh = tokio::spawn({
             let count = count.clone();
             async move {
-                Server::from_tcp(listener)
-                    .unwrap()
-                    .serve(
-                        Router::new()
-                            .route("/", post(service_endpoint).get(service_endpoint))
-                            .layer(ServiceBuilder::new().layer_fn(move |service| {
-                                IdempotencyService {
-                                    cache: cache.clone(),
-                                    service,
-                                }
-                            }))
-                            .with_state(TestAppState { count, wait })
-                            .into_make_service(),
+                let svc = Router::new()
+                    .route("/", post(service_endpoint).get(service_endpoint))
+                    .layer(
+                        ServiceBuilder::new().layer_fn(move |service| IdempotencyService {
+                            cache: cache.clone(),
+                            service,
+                        }),
                     )
-                    .await
-                    .unwrap();
+                    .with_state(TestAppState { count, wait })
+                    .into_make_service();
+                serve(listener, svc).await.unwrap();
             }
         });
 
@@ -588,28 +585,23 @@ mod tests {
 
         let count = Arc::new(Mutex::new(199));
 
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let endpoint = format!("http://{}/", listener.local_addr().unwrap());
 
         let jh = tokio::spawn({
             let count = count.clone();
             async move {
-                Server::from_tcp(listener)
-                    .unwrap()
-                    .serve(
-                        Router::new()
-                            .route("/", post(empty_service_endpoint))
-                            .layer(ServiceBuilder::new().layer_fn(move |service| {
-                                IdempotencyService {
-                                    cache: cache.clone(),
-                                    service,
-                                }
-                            }))
-                            .with_state(TestAppState { count, wait: None })
-                            .into_make_service(),
+                let svc = Router::new()
+                    .route("/", post(empty_service_endpoint))
+                    .layer(
+                        ServiceBuilder::new().layer_fn(move |service| IdempotencyService {
+                            cache: cache.clone(),
+                            service,
+                        }),
                     )
-                    .await
-                    .unwrap();
+                    .with_state(TestAppState { count, wait: None })
+                    .into_make_service();
+                serve(listener, svc).await.unwrap();
             }
         });
 

--- a/server/svix-server/src/core/operational_webhooks.rs
+++ b/server/svix-server/src/core/operational_webhooks.rs
@@ -6,7 +6,6 @@
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
-use http::StatusCode;
 use schemars::JsonSchema;
 use serde::Serialize;
 use svix::api::{MessageIn, Svix, SvixOptions};
@@ -181,7 +180,7 @@ impl OperationalWebhookSenderInner {
                 Ok(_) => {}
                 // Ignore 404s because not every org will have an associated application
                 Err(svix::error::Error::Http(svix::error::HttpErrorContent {
-                    status: StatusCode::NOT_FOUND,
+                    status: http02::StatusCode::NOT_FOUND,
                     ..
                 })) => {
                     tracing::warn!(

--- a/server/svix-server/src/core/security.rs
+++ b/server/svix-server/src/core/security.rs
@@ -3,9 +3,10 @@
 
 use std::fmt::{Debug, Formatter};
 
-use axum::{
-    extract::{FromRequestParts, TypedHeader},
+use axum::extract::FromRequestParts;
+use axum_extra::{
     headers::{authorization::Bearer, Authorization},
+    TypedHeader,
 };
 use http::request::Parts;
 use jwt_simple::prelude::*;

--- a/server/svix-server/src/core/types/mod.rs
+++ b/server/svix-server/src/core/types/mod.rs
@@ -1301,9 +1301,9 @@ macro_rules! jsonschema_for_repr_enum {
                     })),
                     instance_type: Some(SingleOrVec::Single(Box::new(InstanceType::Integer))),
                     enum_values: Some(values),
-                    extensions: indexmap::indexmap!{
-                        "x-enum-varnames".to_string() => serde_json::Value::Array(variant_names),
-                    },
+                    extensions: FromIterator::from_iter([
+                        ("x-enum-varnames".to_string(), serde_json::Value::Array(variant_names)),
+                    ]),
                     ..Default::default()
                 })
             }

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -213,7 +213,7 @@ async fn main() -> anyhow::Result<()> {
             let router = svix_server::v1::router();
             _ = aide::axum::ApiRouter::new()
                 .nest("/api/v1", router)
-                .finish_api(&mut openapi);
+                .finish_api_with(&mut openapi, svix_server::openapi::add_security_scheme);
 
             svix_server::openapi::postprocess_spec(&mut openapi);
             println!(

--- a/server/svix-server/src/openapi.rs
+++ b/server/svix-server/src/openapi.rs
@@ -229,6 +229,20 @@ fn replace_multiple_examples(openapi: &mut OpenApi) {
     }
 }
 
+pub fn add_security_scheme(
+    api: aide::transform::TransformOpenApi<'_>,
+) -> aide::transform::TransformOpenApi<'_> {
+    api.security_scheme(
+        "HTTPBearer",
+        aide::openapi::SecurityScheme::Http {
+            scheme: "bearer".to_string(),
+            bearer_format: None,
+            description: Some("HTTP Bearer token passed in the `Authorization` header".into()),
+            extensions: Default::default(),
+        },
+    )
+}
+
 /// Applies a list of hacks to the finished OpenAPI spec to make it usable with
 /// our tooling.
 pub fn postprocess_spec(openapi: &mut OpenApi) {

--- a/server/svix-server/src/worker.rs
+++ b/server/svix-server/src/worker.rs
@@ -10,11 +10,11 @@ use std::{
     time::Duration,
 };
 
-use axum::body::HttpBody as _;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use chrono::Utc;
 use futures::future;
 use http::{HeaderValue, StatusCode, Version};
+use http_body_util::BodyExt as _;
 use itertools::Itertools;
 use rand::Rng;
 use sea_orm::{

--- a/server/svix-server/tests/it/e2e_proxy.rs
+++ b/server/svix-server/tests/it/e2e_proxy.rs
@@ -10,8 +10,7 @@ use crate::utils::{
     get_default_test_config, TestClient, TestReceiver,
 };
 
-// I could not get it to work with a dockerized socks5 proxy yet
-#[ignore]
+#[ignore] // works with microsocks running at the specified address
 #[tokio::test]
 async fn test_message_delivery_via_socks5() {
     use crate::utils::start_svix_server_with_cfg;
@@ -28,7 +27,7 @@ fn socks_proxy_config() -> ProxyConfig {
     }
 }
 
-#[ignore] // requires an http proxy to be running
+#[ignore] // works with tinyproxy running at the specified address
 #[tokio::test]
 async fn test_message_delivery_via_http_proxy() {
     use crate::utils::start_svix_server_with_cfg;


### PR DESCRIPTION
## Motivation

Hyper 0.14 is no longer getting patches, and the only reason we were still on it was the proxy stuff (which was fortunately easy to figure out with the new `hyper-util` proxy support).

## Solution

Upgrade to hyper 1.0 and axum 0.7. Further upgrades (axum 0.8, maybe otel crates) to follow.

Closes https://github.com/svix/monorepo-private/issues/11082.