### PR TITLE
rust, bridge: Clean up manual retry schedule

### DIFF
--- a/bridge/svix-bridge-types/src/lib.rs
+++ b/bridge/svix-bridge-types/src/lib.rs
@@ -202,7 +202,7 @@ pub struct SvixOptions {
     pub server_url: Option<String>,
     pub timeout_secs: Option<u64>,
     pub num_retries: Option<u32>,
-    pub retry_schedule_in_ms: Option<Vec<u64>>,
+    pub retry_schedule_ms: Option<Vec<u64>>,
     pub proxy_address: Option<String>,
 }
 
@@ -213,7 +213,7 @@ impl From<SvixOptions> for _SvixOptions {
             server_url,
             timeout_secs,
             num_retries,
-            retry_schedule_in_ms,
+            retry_schedule_ms,
             proxy_address,
         }: SvixOptions,
     ) -> Self {
@@ -222,7 +222,8 @@ impl From<SvixOptions> for _SvixOptions {
             server_url,
             timeout: timeout_secs.map(Duration::from_secs),
             num_retries,
-            retry_schedule_in_ms,
+            retry_schedule: retry_schedule_ms
+                .map(|sched| sched.into_iter().map(Duration::from_millis).collect()),
             proxy_address,
         }
     }

--- a/rust/src/api/client.rs
+++ b/rust/src/api/client.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use hyper_util::{client::legacy::Client as HyperClient, rt::TokioExecutor};
 
@@ -18,7 +18,7 @@ pub struct SvixOptions {
     /// out.
     ///
     /// Default: 15 seconds.
-    pub timeout: Option<std::time::Duration>,
+    pub timeout: Option<Duration>,
 
     /// Number of retries
     ///
@@ -30,9 +30,9 @@ pub struct SvixOptions {
 
     /// Retry Schedule in milliseconds
     ///
-    /// List of delays (in milliseconds) to wait before each retry attempt.
-    /// Takes precedence over numRetries.
-    pub retry_schedule_in_ms: Option<Vec<u64>>,
+    /// List of delays to wait before each retry attempt.
+    /// Takes precedence over `num_retries`.
+    pub retry_schedule: Option<Vec<Duration>>,
 
     /// Proxy address.
     ///
@@ -48,9 +48,9 @@ impl Default for SvixOptions {
         Self {
             debug: false,
             server_url: None,
-            timeout: Some(std::time::Duration::from_secs(15)),
+            timeout: Some(Duration::from_secs(15)),
             num_retries: None,
-            retry_schedule_in_ms: None,
+            retry_schedule: None,
             proxy_address: None,
         }
     }
@@ -76,7 +76,7 @@ impl Svix {
             base_path: String::new(),
             bearer_access_token: None,
             num_retries: options.num_retries.unwrap_or(2),
-            retry_schedule_in_ms: options.retry_schedule_in_ms,
+            retry_schedule: options.retry_schedule,
         });
         let svix = Self {
             cfg,
@@ -110,7 +110,7 @@ impl Svix {
             client: self.cfg.client.clone(),
             timeout: self.cfg.timeout,
             num_retries: self.cfg.num_retries,
-            retry_schedule_in_ms: self.cfg.retry_schedule_in_ms.clone(),
+            retry_schedule: self.cfg.retry_schedule.clone(),
         });
 
         Self {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -29,7 +29,7 @@ pub struct Configuration {
     pub bearer_access_token: Option<String>,
     pub timeout: Option<Duration>,
     pub num_retries: u32,
-    pub retry_schedule_in_ms: Option<Vec<u64>>,
+    pub retry_schedule: Option<Vec<Duration>>,
 
     client: HyperClient<Connector, http_body_util::Full<Bytes>>,
 }

--- a/rust/tests/it/kitchen_sink.rs
+++ b/rust/tests/it/kitchen_sink.rs
@@ -1,5 +1,5 @@
 use js_option::JsOption;
-use std::collections::HashSet;
+use std::{collections::HashSet, time::Duration};
 use svix::{
     api::{ApplicationIn, EndpointIn, EndpointPatch, EventTypeIn},
     error::Error,
@@ -242,7 +242,8 @@ async fn test_custom_retries() {
 #[tokio::test]
 async fn test_custom_retry_schedule() {
     let mock_server: MockServer = MockServer::start().await;
-    let retry_schedule_in_ms = vec![50, 100, 200, 400];
+    let retry_schedule_in_ms = [50, 100, 200, 400];
+    let retry_schedule = retry_schedule_in_ms.map(Duration::from_millis).into();
 
     Mock::given(wiremock::matchers::method("POST"))
         .and(wiremock::matchers::path("/api/v1/app"))
@@ -267,7 +268,7 @@ async fn test_custom_retry_schedule() {
     let client = TestClientBuilder::new()
         .url(mock_server.uri())
         .token("test".to_string())
-        .retry_schedule_in_ms(retry_schedule_in_ms.clone())
+        .retry_schedule(retry_schedule)
         .build()
         .client;
 

--- a/rust/tests/it/utils/test_client.rs
+++ b/rust/tests/it/utils/test_client.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use svix::api::{Svix, SvixOptions};
 
 pub struct TestClient {
@@ -8,7 +10,7 @@ pub struct TestClientBuilder {
     token: Option<String>,
     url: Option<String>,
     retries: Option<u32>,
-    retry_schedule_in_ms: Option<Vec<u64>>,
+    retry_schedule: Option<Vec<Duration>>,
 }
 
 impl TestClientBuilder {
@@ -17,7 +19,7 @@ impl TestClientBuilder {
             token: None,
             url: None,
             retries: None,
-            retry_schedule_in_ms: None,
+            retry_schedule: None,
         }
     }
 
@@ -37,8 +39,8 @@ impl TestClientBuilder {
         self
     }
 
-    pub fn retry_schedule_in_ms(mut self, retry_schedule_in_ms: Vec<u64>) -> Self {
-        self.retry_schedule_in_ms = Some(retry_schedule_in_ms);
+    pub fn retry_schedule(mut self, retry_schedule: Vec<Duration>) -> Self {
+        self.retry_schedule = Some(retry_schedule);
         self
     }
 
@@ -54,7 +56,7 @@ impl TestClientBuilder {
             Some(SvixOptions {
                 server_url: Some(url.clone()),
                 num_retries: self.retries,
-                retry_schedule_in_ms: self.retry_schedule_in_ms,
+                retry_schedule: self.retry_schedule,
                 ..Default::default()
             }),
         );


### PR DESCRIPTION
I noticed some oddities in the new retry schedule implementation from #1975 when working on #2015. This should make the API nicer:

- Use `std::time::Duration` instead of `u64` milliseconds
- Use `_ms` suffix instead of `_in_ms` in bridge, where we also have `timeout_secs` (not `timeout_in_secs`)

This is not a breaking change because #1975 hasn't been released yet.