### PR TITLE
 Pin latest ca-certificates and fix the bridge/cli dockerfile 

### DIFF
--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -58,9 +58,9 @@ RUN set -ex ; \
         mkdir -p /home/appuser ;\
         chown -R appuser: /home/appuser
 
-RUN apt-get update ;\
-    apt-get install --no-install-recommends -y ca-certificates=20230311+deb12u1; \
-    update-ca-certificates; \
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y ca-certificates=20250419 && \
+    update-ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 USER appuser

--- a/svix-cli/Dockerfile
+++ b/svix-cli/Dockerfile
@@ -46,9 +46,9 @@ RUN set -ex ; \
         mkdir -p /home/appuser ;\
         chown -R appuser: /home/appuser
 
-RUN apt-get update ;\
-    apt-get install --no-install-recommends -y ca-certificates=20230311+deb12u1; \
-    update-ca-certificates; \
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y ca-certificates=20250419 && \
+    update-ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 USER appuser


### PR DESCRIPTION
This PR pins `ca-certificates` to latest version and fixes the bridge/cli dockerfiles
I will open another PR to replace all of the `;` with `&&`