### PR TITLE
Use fully-qualified image names in bridge/Dockerfile, svix-cli/Dockerfile

### DIFF
--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -1,5 +1,5 @@
 # Base build
-FROM rust:1.89-slim-trixie AS build
+FROM docker.io/rust:1.89-slim-trixie AS build
 
 RUN apt-get update && apt-get install -y \
     build-essential=12.* \
@@ -49,7 +49,7 @@ RUN touch */src/lib.rs && touch */src/main.rs
 RUN cargo build --release --frozen
 
 # Production
-FROM debian:trixie-slim AS prod
+FROM docker.io/debian:trixie-slim AS prod
 
 RUN set -ex && \
         mkdir -p /app && \

--- a/svix-cli/Dockerfile
+++ b/svix-cli/Dockerfile
@@ -1,5 +1,5 @@
 # Base build
-FROM rust:1.89-slim-trixie AS build
+FROM docker.io/rust:1.89-slim-trixie AS build
 
 RUN apt-get update && apt-get install -y \
     build-essential=12.* \
@@ -37,7 +37,7 @@ RUN touch src/main.rs
 RUN cargo build --release --frozen
 
 # Production
-FROM debian:trixie-slim AS prod
+FROM docker.io/debian:trixie-slim AS prod
 
 RUN set -ex && \
         mkdir -p /app && \


### PR DESCRIPTION
Just like we do everywhere else.
