### PR TITLE
docker: convert bridge dockerfile to use v1 syntax

### DIFF
--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -1,22 +1,33 @@
+# syntax=docker/dockerfile:1
+
+# NOTE: this should be built from the root of `svix-webhooks`
+# with `docker build -f bridge/Dockerfile .`
+
 # Base build
 FROM rust:1.89-slim-trixie AS build
 
-RUN apt-get update && apt-get install -y \
-    build-essential=12.* \
-    checkinstall=1.* \
-    curl=8.* \
-    libssl-dev=* \
-    pkg-config=1.8.* \
-    zlib1g-dev=1:* \
-    cmake=3.* \
-    --no-install-recommends
+SHELL ["/bin/bash", "-eux", "-o", "pipefail", "-c"]
+RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked --mount=target=/var/cache/apt,type=cache,sharing=locked <<EOF
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -q
+    apt-get install -y \
+        build-essential=12.* \
+        checkinstall=1.* \
+        curl=8.* \
+        libssl-dev=* \
+        pkg-config=1.8.* \
+        zlib1g-dev=1:* \
+        cmake=3.* \
+        --no-install-recommends
+EOF
 
-RUN set -ex && \
-        mkdir -p /app && \
-        useradd appuser && \
-        chown -R appuser: /app && \
-        mkdir -p /home/appuser && \
-        chown -R appuser: /home/appuser
+RUN <<EOF
+    mkdir -p /app
+    useradd appuser
+    chown -R appuser: /app
+    mkdir -p /home/appuser
+    chown -R appuser: /home/appuser
+EOF
 
 WORKDIR /app/bridge
 
@@ -28,20 +39,22 @@ COPY bridge/svix-bridge-types/Cargo.toml svix-bridge-types/
 COPY bridge/svix-bridge-plugin-kafka/Cargo.toml svix-bridge-plugin-kafka/
 COPY bridge/svix-bridge-plugin-queue/Cargo.toml svix-bridge-plugin-queue/
 COPY bridge/svix-bridge/Cargo.toml svix-bridge/
-RUN set -ex && \
-        mkdir svix-bridge-plugin-kafka/src && \
-        mkdir svix-bridge-plugin-queue/src && \
-        mkdir svix-bridge-types/src && \
-        mkdir svix-bridge/src && \
-        echo '' > svix-bridge-plugin-kafka/src/lib.rs && \
-        echo '' > svix-bridge-plugin-queue/src/lib.rs && \
-        echo '' > svix-bridge-types/src/lib.rs && \
-        echo 'fn main() { println!("Dummy!"); }' > svix-bridge/src/main.rs && \
-        cargo build --release && \
-        rm -rf \
-          svix-bridge-plugin-queue/src \
-          svix-bridge-types/src \
-          svix-bridge/src
+
+RUN <<EOF
+    mkdir svix-bridge-plugin-kafka/src
+    mkdir svix-bridge-plugin-queue/src
+    mkdir svix-bridge-types/src
+    mkdir svix-bridge/src
+    echo '' > svix-bridge-plugin-kafka/src/lib.rs
+    echo '' > svix-bridge-plugin-queue/src/lib.rs
+    echo '' > svix-bridge-types/src/lib.rs
+    echo 'fn main() { println!("Dummy!"); }' > svix-bridge/src/main.rs
+    cargo build --release
+    rm -rf \
+        svix-bridge-plugin-queue/src \
+        svix-bridge-types/src \
+        svix-bridge/src
+EOF
 
 COPY bridge /app/bridge
 # touching the lib.rs/main.rs ensures cargo rebuilds them instead of considering them already built.
@@ -51,17 +64,21 @@ RUN cargo build --release --frozen
 # Production
 FROM debian:trixie-slim AS prod
 
-RUN set -ex && \
-        mkdir -p /app && \
-        useradd appuser && \
-        chown -R appuser: /app && \
-        mkdir -p /home/appuser && \
-        chown -R appuser: /home/appuser
+SHELL ["/bin/bash", "-eux", "-o", "pipefail", "-c"]
+RUN <<EOF
+    mkdir -p /app
+    useradd appuser
+    chown -R appuser: /app
+    mkdir -p /home/appuser
+    chown -R appuser: /home/appuser
+EOF
 
-RUN apt-get update && \
-    apt-get install --no-install-recommends -y ca-certificates=20250419 && \
-    update-ca-certificates && \
-    rm -rf /var/lib/apt/lists/*
+RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked --mount=target=/var/cache/apt,type=cache,sharing=locked <<EOF
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -q
+    apt-get install --no-install-recommends -y ca-certificates=20250419
+    update-ca-certificates
+EOF
 
 USER appuser
 


### PR DESCRIPTION
This converts the `bridge/` Dockerfile to use the newer Dockerfile v1 features (specifically, requiring at least Docker 1.2, introduced in 2020), with things like heredocs and cache mounts.

Some improvements:

 - Sets `SHELL` to include `-e` and `-u` and `-o pipefail` so we don't need to do that in each `RUN` and instead get sane default behavior
 - Uses heredocs for multi-line `RUN` invocations instead of ` && \`
 - Uses bind-mounts for apt cache to improve performance
 - Sets `DEBIAN_FRONTEND=noninteractive` to silence the noisy warning on every build

Once this is approved, I'll make the same change to the other Dockerfiles.