### PR TITLE
docker: convert server dockerfile to use v1 syntax

### DIFF
--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -17,3 +17,4 @@ tmp/
 
 ## Docker-specific ignores
 Dockerfile
+.dockerignore

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,3 +1,8 @@
+# syntax=docker/dockerfile:1
+#
+# NOTE: this should be built from the server/ subdirectory of `svix-webhooks`
+# with `docker build .`
+
 # Using https://github.com/LukeMathWalker/cargo-chef for better layer caching
 
 # Base image for planner and build - keep in sync with .github/workflows/server-ci.yml
@@ -13,20 +18,26 @@ RUN cargo chef prepare --recipe-path recipe.json
 # Build environment
 FROM chef AS build
 
-RUN apt-get update && apt-get install -y \
+SHELL ["/bin/bash", "-eux", "-o", "pipefail", "-c"]
+RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked --mount=target=/var/cache/apt,type=cache,sharing=locked <<EOF
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -q
+    apt-get install -y \
         build-essential=12.* \
         checkinstall=1.* \
         zlib1g-dev=1:* \
         pkg-config=1.8.* \
         libssl-dev=* \
         --no-install-recommends
+EOF
 
-RUN set -ex && \
-        mkdir -p /app && \
-        useradd appuser && \
-        chown -R appuser: /app && \
-        mkdir -p /home/appuser && \
-        chown -R appuser: /home/appuser
+RUN <<EOF
+    mkdir -p /app
+    useradd appuser
+    chown -R appuser: /app
+    mkdir -p /home/appuser
+    chown -R appuser: /home/appuser
+EOF
 
 COPY --from=planner /app/recipe.json recipe.json
 
@@ -40,30 +51,28 @@ RUN cargo build --release --package svix-server --bin svix-server --frozen
 # Production
 FROM docker.io/debian:trixie-slim AS prod
 
-RUN set -ex && \
-        mkdir -p /app && \
-        useradd appuser && \
-        chown -R appuser: /app && \
-        mkdir -p /home/appuser && \
-        chown -R appuser: /home/appuser
+SHELL ["/bin/bash", "-eux", "-o", "pipefail", "-c"]
+RUN <<EOF
+    mkdir -p /app
+    useradd appuser
+    chown -R appuser: /app
+    mkdir -p /home/appuser
+    chown -R appuser: /home/appuser
+EOF
 
-RUN apt-get update && apt-get install -y \
+RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked --mount=target=/var/cache/apt,type=cache,sharing=locked <<EOF
+    apt-get update -q
+    apt-get install -y \
         ca-certificates=20250419 \
         libssl3t64=3.* \
-        --no-install-recommends && \
-        update-ca-certificates && \
-        rm -rf /var/lib/apt/lists/*
+        --no-install-recommends
+    update-ca-certificates
+EOF
 
 USER appuser
 EXPOSE 8071
 
-COPY --from=build /app/target/release/svix-server /usr/local/bin/svix-server
+COPY --chown=root:root --chmod=755 --from=build /app/target/release/svix-server /usr/local/bin/svix-server
+COPY --chown=root:root --chmod=755 ./scripts/launch-svix-server /usr/local/bin/launch-svix-server
 
-# Ignoring this lint, because it's an embedded shell script
-# hadolint ignore=DL3025
-CMD \
-    set -ex ; \
-    if [ ! -z "$WAIT_FOR" ]; then \
-        WAIT_FOR_ARG="--wait-for 15"; \
-    fi ; \
-    exec svix-server --run-migrations $WAIT_FOR_ARG
+CMD ["/usr/local/bin/launch-svix-server"]

--- a/server/scripts/launch-svix-server
+++ b/server/scripts/launch-svix-server
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# this is a helper file for launching the server in the Docker image
+
+set -xeuo pipefail
+
+args=("--run-migrations")
+if [[ -n "${WAIT_FOR:-}" ]]; then
+    args+=("--wait-for" "15")
+fi
+
+exec svix-server "${args[@]}"


### PR DESCRIPTION
This converts the `server/` Dockerfile to use the newer Dockerfile v1 features (specifically, requiring at least Docker 1.2, introduced in 2020), with things like heredocs and cache mounts. This is the same as svix/svix-webhooks#2023, but for `server`.

In addition to the aforementioned changes, this also makes `CMD` a separate bash script instead of a multiline heredoc; this doesn't make that much of a difference in OSS (`ps` is less ugly, but whatever) but will let us greatly clean up the private version.