### PR TITLE
Update advisory-ignore list in deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -15,8 +15,6 @@ ignore = [
     "RUSTSEC-2023-0071",
     # TODO: Wait for dependencies to upgrade off of proc-macro-error
     "RUSTSEC-2024-0370",
-    # TODO: Wait for dependencies to upgrade off of paste
-    "RUSTSEC-2024-0436",
 ]
 
 [licenses]


### PR DESCRIPTION
We no longer have any dependencies on `paste`.