### PR TITLE
deps(dev): pin wiremock < 0.6.5

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -53,7 +53,7 @@ uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 tokio = { version = "1.41.0", features = ["macros"] }
-wiremock = "0.6.2"
+wiremock = "0.6.2, <0.6.5"
 
 [package.metadata.cargo-public-api-crates]
 allowed = [


### PR DESCRIPTION
wiremock 0.6.5 was released yesterday; it bumps its MSRV to 1.88.0 (without setting the `rust-version` key in Cargo.toml). I don't really want to bump our MSRV to 1.88.0, so pin `< 0.6.5` for now.

I sent https://github.com/LukeMathWalker/wiremock-rs/pull/172 upstream to fix that issue.