### PR TITLE
go: Fix `time.time` is query params

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* Libs/Go: Fix bug preventing `time.time` query params from serializing correctly
+
 ## Version 1.75.0
 * Bridge, CLI, Server: Modify Dockerfiles to use cache mounts for improved build time; these now require Docker 1.2 or later to build
 * Libs/JS: Add support for custom retry schedule (thanks @KranzAklilu)

--- a/go/internal/svix_http_client.go
+++ b/go/internal/svix_http_client.go
@@ -261,7 +261,14 @@ func serializeQueryOrHeaderParam(val interface{}, key string) (string, error) {
 			serializedValues[i] = serializedVal
 		}
 		value = strings.Join(serializedValues, ",")
+	case reflect.Struct:
+		// if it's a time.time
+		if t, ok := v.Interface().(time.Time); ok {
+			return t.Format(time.RFC3339), nil
+		}
 
+		// else fallthrough
+		fallthrough
 	default:
 		return "", fmt.Errorf("can't serialize %s as a query param, key: %s", v.Kind().String(), key)
 


### PR DESCRIPTION
We were not serializing `time.time` at all, rather we returned a error `can't serialize struct as a query param, key: before`

We now correctly serialize it with RFC3339 

fixes: https://github.com/svix/svix-webhooks/issues/2042