### PR TITLE
ci: Use correct path for `lib-openapi.json` trigger

### DIFF
--- a/.github/workflows/csharp-lint.yml
+++ b/.github/workflows/csharp-lint.yml
@@ -4,14 +4,14 @@ on:
   pull_request:
     paths:
       - "csharp/**"
-      - "lib-openapi.json"
+      - "codegen/lib-openapi.json"
       - '.github/workflows/csharp-lint.yml'
   push:
     branches:
       - main
     paths:
       - "csharp/**"
-      - "lib-openapi.json"
+      - "codegen/lib-openapi.json"
       - '.github/workflows/csharp-lint.yml'
 
 jobs:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -6,7 +6,7 @@ on:
       - "go/**"
       - "go.sum"
       - "go.mod"
-      - "lib-openapi.json"
+      - "codegen/lib-openapi.json"
       - ".github/workflows/go-ci.yml"
   push:
     branches:
@@ -15,7 +15,7 @@ on:
       - "go/**"
       - "go.sum"
       - "go.mod"
-      - "lib-openapi.json"
+      - "codegen/lib-openapi.json"
       - ".github/workflows/go-ci.yml"
 
 jobs:

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -5,7 +5,7 @@ on:
       - "go/**"
       - "go.sum"
       - "go.mod"
-      - "lib-openapi.json"
+      - "codegen/lib-openapi.json"
   push:
     branches:
       - main
@@ -13,7 +13,7 @@ on:
       - "go/**"
       - "go.sum"
       - "go.mod"
-      - "lib-openapi.json"
+      - "codegen/lib-openapi.json"
 
 jobs:
   build:

--- a/.github/workflows/java-lint.yml
+++ b/.github/workflows/java-lint.yml
@@ -3,13 +3,13 @@ on:
   pull_request:
     paths:
       - "java/**"
-      - "lib-openapi.json"
+      - "codegen/lib-openapi.json"
   push:
     branches:
       - main
     paths:
       - "java/**"
-      - "lib-openapi.json"
+      - "codegen/lib-openapi.json"
 
 jobs:
   dotnet:

--- a/.github/workflows/javascript-lint.yml
+++ b/.github/workflows/javascript-lint.yml
@@ -4,14 +4,14 @@ on:
   pull_request:
     paths:
       - "javascript/**"
-      - "lib-openapi.json"
+      - "codegen/lib-openapi.json"
       - '.github/workflows/javascript-lint.yml'
   push:
     branches:
       - main
     paths:
       - "javascript/**"
-      - "lib-openapi.json"
+      - "codegen/lib-openapi.json"
       - '.github/workflows/javascript-lint.yml'
 
 jobs:

--- a/.github/workflows/kotlin-lint.yml
+++ b/.github/workflows/kotlin-lint.yml
@@ -4,14 +4,14 @@ on:
   pull_request:
     paths:
       - "kotlin/**"
-      - "lib-openapi.json"
+      - "codegen/lib-openapi.json"
       - '.github/workflows/kotlin-lint.yml'
   push:
     branches:
       - main
     paths:
       - "javascript/**"
-      - "lib-openapi.json"
+      - "codegen/lib-openapi.json"
       - '.github/workflows/javascript-lint.yml'
 
 jobs:

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -5,12 +5,12 @@ on:
       - main
     paths:
       - "python/**"
-      - "lib-openapi.json"
+      - "codegen/lib-openapi.json"
       - ".github/workflows/python-lint.yml"
   pull_request:
     paths:
       - "python/**"
-      - "lib-openapi.json"
+      - "codegen/lib-openapi.json"
       - ".github/workflows/python-lint.yml"
 jobs:
   build:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -5,13 +5,13 @@ on:
       - main
     paths:
       - "python/**"
-      - "lib-openapi.json"
+      - "codegen/lib-openapi.json"
       - "server/**"
       - ".github/workflows/python-tests.yml"
   pull_request:
     paths:
       - "python/**"
-      - "lib-openapi.json"
+      - "codegen/lib-openapi.json"
       - "server/**"
       - ".github/workflows/python-tests.yml"
 jobs:

--- a/.github/workflows/ruby-lint.yml
+++ b/.github/workflows/ruby-lint.yml
@@ -4,14 +4,14 @@ on:
   pull_request:
     paths:
       - "ruby/**"
-      - "lib-openapi.json"
+      - "codegen/lib-openapi.json"
       - '.github/workflows/ruby-lint.yml'
   push:
     branches:
       - main
     paths:
       - "ruby/**"
-      - "lib-openapi.json"
+      - "codegen/lib-openapi.json"
       - '.github/workflows/ruby-lint.yml'
 
 jobs:

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -7,12 +7,12 @@ on:
     paths:
       - 'rust/**'
       - '.github/workflows/rust-lint.yml'
-      - "lib-openapi.json"
+      - "codegen/lib-openapi.json"
   pull_request:
     paths:
       - 'rust/**'
       - '.github/workflows/rust-lint.yml'
-      - "lib-openapi.json"
+      - "codegen/lib-openapi.json"
 
 # When pushing to a PR, cancel any jobs still running for the previous head commit of the PR
 concurrency:


### PR DESCRIPTION
We moved the `lib-openapi.json` to `codegen/lib-openapi.json`