### PR TITLE
Fix svix-cli/Cargo.lock

### DIFF
--- a/.github/workflows/cli-lint.yml
+++ b/.github/workflows/cli-lint.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: taiki-e/install-action@nextest
 
       - name: Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
         working-directory: svix-cli
 
       - name: Run tests

--- a/svix-cli/Cargo.lock
+++ b/svix-cli/Cargo.lock
@@ -1570,7 +1570,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svix"
-version = "1.75.0"
+version = "1.75.1"
 dependencies = [
  "base64 0.13.1",
  "hmac-sha256",
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "svix-cli"
-version = "1.75.0"
+version = "1.75.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",


### PR DESCRIPTION
It was out of sync with Cargo.toml (breaking the docker release for the CLI).

Update CI to check for this.