### PR TITLE
go: Send eventType on messages created with `NewMessageInRaw`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* Libs/Go: Fix bug causing 422 errors on `message.create` with messages created using the `NewMessageInRaw` helper
+
 ## Version 1.76.0
 * Libs/PHP: Added support for the full Svix SDK!
 

--- a/go/message_ext.go
+++ b/go/message_ext.go
@@ -20,7 +20,10 @@ func NewMessageInRaw(
 	payload string,
 	contentType *string,
 ) *models.MessageIn {
-	msgIn := models.MessageIn{}
+	msgIn := models.MessageIn{
+		EventType: eventType,
+		Payload:   map[string]any{},
+	}
 
 	transformationsParams := map[string]interface{}{
 		"rawPayload": payload,


### PR DESCRIPTION
Fixes issue raised in slack
