### PR TITLE
rust: Bump `hyper` dependencies

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,7 +9,12 @@ repository = "https://github.com/svix/svix-webhooks"
 readme = "../README.md"
 license = "MIT"
 keywords = ["svix", "webhooks", "diahook"]
-categories = ["development-tools", "asynchronous", "network-programming", "web-programming"]
+categories = [
+    "development-tools",
+    "asynchronous",
+    "network-programming",
+    "web-programming",
+]
 include = ["src/**/*", "README.md"]
 # bump .github/workflows/rust-link.yml when changing this
 rust-version = "1.85"
@@ -32,10 +37,14 @@ hmac-sha256 = "1"
 http02 = { package = "http", version = "0.2.0" }
 http1 = { package = "http", version = "1.0.0" }
 http-body-util = "0.1.0"
-hyper = "1.1.0"
-hyper-rustls = { version = "0.26.0", optional = true }
+hyper = "1.7.0"
+hyper-rustls = { version = "0.27.7", optional = true }
 hyper-tls = { version = "0.6.0", optional = true }
-hyper-util = { version = "0.1.16", features = ["client", "client-legacy", "tokio"] }
+hyper-util = { version = "0.1.16", features = [
+    "client",
+    "client-legacy",
+    "tokio",
+] }
 itertools = "0.14.0"
 js_option = "0.1.1"
 percent-encoding = "2.3.1"


### PR DESCRIPTION
## Motivation

Dependents of `svix` in Rust may use newer versions of `hyper` and `rustls` (a dependency in the chain). This helps the package keep up with the latest version so that older versions of these dependent libraries don't have to be compiled.

## Solution

Bumps `hyper` dependencies to the latest versions.
