### PR TITLE
Silence clippy lint in generated code

### DIFF
--- a/codegen/templates/rust/types/struct_enum.rs.jinja
+++ b/codegen/templates/rust/types/struct_enum.rs.jinja
@@ -44,6 +44,7 @@ pub enum {{ enum_type_name }} {
     which then carries over to the enum type
 -#}
 {% set first_variant = type.variants[0] -%}
+#[allow(clippy::derivable_impls)]
 impl Default for {{ enum_type_name }} {
     fn default() -> Self {
         Self::{{ first_variant.name | to_upper_camel_case }}

--- a/rust/src/models/ingest_source_in.rs
+++ b/rust/src/models/ingest_source_in.rs
@@ -106,6 +106,7 @@ pub enum IngestSourceInConfig {
     Airwallex(AirwallexConfig),
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for IngestSourceInConfig {
     fn default() -> Self {
         Self::GenericWebhook

--- a/rust/src/models/ingest_source_out.rs
+++ b/rust/src/models/ingest_source_out.rs
@@ -121,6 +121,7 @@ pub enum IngestSourceOutConfig {
     Airwallex(AirwallexConfigOut),
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for IngestSourceOutConfig {
     fn default() -> Self {
         Self::GenericWebhook


### PR DESCRIPTION
## Motivation

New clippy lint on beta is making CI unhappy.

## Solution

Silence the lint, it's not worth following for generated code (we'd have to add couple extra template conditionals).