### PR TITLE
ts: Fix all outstanding biome lint rules

### DIFF
--- a/codegen/templates/javascript/types/struct.ts.jinja
+++ b/codegen/templates/javascript/types/struct.ts.jinja
@@ -5,8 +5,9 @@ import {
     {{ c | to_upper_camel_case }}Serializer,
 } from './{{ c | to_lower_camel_case }}';
 {% endfor -%}
-
 {% set type_name = type.name | to_upper_camel_case %}
+
+{% if type.fields | length == 0 %}// biome-ignore-all lint/suspicious/noEmptyInterface: backwards compat{% endif %}
 
 {{ doc_comment }}
 export interface {{ type_name }} {

--- a/codegen/templates/javascript/types/struct.ts.jinja
+++ b/codegen/templates/javascript/types/struct.ts.jinja
@@ -14,7 +14,8 @@ export interface {{ type_name }} {
 }
 
 export const {{ type_name }}Serializer = {
-    _fromJsonObject(object: any): {{ type_name }} {
+    {% set underscore_prefix %}{% if type.fields | length == 0%}_{% endif %}{% endset -%}
+    _fromJsonObject({{ underscore_prefix }}object: any): {{ type_name }} {
         return {
             {% for field in type.fields -%}
                 {% set field_expr %}object['{{ field.name }}']{% endset -%}
@@ -23,7 +24,7 @@ export const {{ type_name }}Serializer = {
         };
     },
 
-    _toJsonObject(self: {{ type_name }}): any {
+    _toJsonObject({{ underscore_prefix }}self: {{ type_name }}): any {
         return {
             {% for field in type.fields -%}
                 {% set field_expr %}self.{{ field.name | to_lower_camel_case }}{% endset -%}

--- a/codegen/templates/javascript/types/struct_enum.ts.jinja
+++ b/codegen/templates/javascript/types/struct_enum.ts.jinja
@@ -72,6 +72,7 @@ export const {{ type.name | to_upper_camel_case }}Serializer = {
     },
 
     _toJsonObject(self: {{ type.name | to_upper_camel_case }}): any {
+        // biome-ignore lint/suspicious/noImplicitAnyLet: the return type needs to be any
         let {{ content_field_name }};
         switch (self.{{ disc_field_name }}) {
         {%- for variant in type.variants %}

--- a/codegen/templates/javascript/types/struct_enum.ts.jinja
+++ b/codegen/templates/javascript/types/struct_enum.ts.jinja
@@ -17,6 +17,7 @@ interface _{{ type_name }}Fields {
 {# export the types for enum variants without a config -#}
 {% for variant in type.variants %}
     {% if variant.schema_ref is not defined %}
+// biome-ignore lint/suspicious/noEmptyInterface: backwards compat
 interface {{ type_name }}{{ variant.name | to_upper_camel_case }}{{ type.content_field | to_upper_camel_case }} {}
     {% endif %}
 {% endfor %}

--- a/javascript/biome.jsonc
+++ b/javascript/biome.jsonc
@@ -26,9 +26,7 @@
             },
             "suspicious": {
                 // needs codegen fix
-                "noExplicitAny": "off",
-                // needs codegen fix
-                "noEmptyInterface": "off"
+                "noExplicitAny": "off"
             }
         }
     },

--- a/javascript/biome.jsonc
+++ b/javascript/biome.jsonc
@@ -28,9 +28,7 @@
                 // needs codegen fix
                 "noExplicitAny": "off",
                 // needs codegen fix
-                "noEmptyInterface": "off",
-                // needs codegen fix
-                "noImplicitAnyLet": "off"
+                "noEmptyInterface": "off"
             }
         }
     },

--- a/javascript/biome.jsonc
+++ b/javascript/biome.jsonc
@@ -18,12 +18,7 @@
         "rules": {
             "recommended": true,
             "complexity": {
-                // needs codegen fix
                 "useLiteralKeys": "off"
-            },
-            "correctness": {
-                // needs codegen fix
-                "noUnusedFunctionParameters": "off"
             },
             "style": {
                 // needs codegen fix

--- a/javascript/src/models/adobeSignConfigOut.ts
+++ b/javascript/src/models/adobeSignConfigOut.ts
@@ -3,11 +3,11 @@
 export interface AdobeSignConfigOut {}
 
 export const AdobeSignConfigOutSerializer = {
-  _fromJsonObject(object: any): AdobeSignConfigOut {
+  _fromJsonObject(_object: any): AdobeSignConfigOut {
     return {};
   },
 
-  _toJsonObject(self: AdobeSignConfigOut): any {
+  _toJsonObject(_self: AdobeSignConfigOut): any {
     return {};
   },
 };

--- a/javascript/src/models/adobeSignConfigOut.ts
+++ b/javascript/src/models/adobeSignConfigOut.ts
@@ -1,5 +1,7 @@
 // this file is @generated
 
+// biome-ignore-all lint/suspicious/noEmptyInterface: backwards compat
+
 export interface AdobeSignConfigOut {}
 
 export const AdobeSignConfigOutSerializer = {

--- a/javascript/src/models/airwallexConfigOut.ts
+++ b/javascript/src/models/airwallexConfigOut.ts
@@ -3,11 +3,11 @@
 export interface AirwallexConfigOut {}
 
 export const AirwallexConfigOutSerializer = {
-  _fromJsonObject(object: any): AirwallexConfigOut {
+  _fromJsonObject(_object: any): AirwallexConfigOut {
     return {};
   },
 
-  _toJsonObject(self: AirwallexConfigOut): any {
+  _toJsonObject(_self: AirwallexConfigOut): any {
     return {};
   },
 };

--- a/javascript/src/models/airwallexConfigOut.ts
+++ b/javascript/src/models/airwallexConfigOut.ts
@@ -1,5 +1,7 @@
 // this file is @generated
 
+// biome-ignore-all lint/suspicious/noEmptyInterface: backwards compat
+
 export interface AirwallexConfigOut {}
 
 export const AirwallexConfigOutSerializer = {

--- a/javascript/src/models/checkbookConfigOut.ts
+++ b/javascript/src/models/checkbookConfigOut.ts
@@ -3,11 +3,11 @@
 export interface CheckbookConfigOut {}
 
 export const CheckbookConfigOutSerializer = {
-  _fromJsonObject(object: any): CheckbookConfigOut {
+  _fromJsonObject(_object: any): CheckbookConfigOut {
     return {};
   },
 
-  _toJsonObject(self: CheckbookConfigOut): any {
+  _toJsonObject(_self: CheckbookConfigOut): any {
     return {};
   },
 };

--- a/javascript/src/models/checkbookConfigOut.ts
+++ b/javascript/src/models/checkbookConfigOut.ts
@@ -1,5 +1,7 @@
 // this file is @generated
 
+// biome-ignore-all lint/suspicious/noEmptyInterface: backwards compat
+
 export interface CheckbookConfigOut {}
 
 export const CheckbookConfigOutSerializer = {

--- a/javascript/src/models/docusignConfigOut.ts
+++ b/javascript/src/models/docusignConfigOut.ts
@@ -3,11 +3,11 @@
 export interface DocusignConfigOut {}
 
 export const DocusignConfigOutSerializer = {
-  _fromJsonObject(object: any): DocusignConfigOut {
+  _fromJsonObject(_object: any): DocusignConfigOut {
     return {};
   },
 
-  _toJsonObject(self: DocusignConfigOut): any {
+  _toJsonObject(_self: DocusignConfigOut): any {
     return {};
   },
 };

--- a/javascript/src/models/docusignConfigOut.ts
+++ b/javascript/src/models/docusignConfigOut.ts
@@ -1,5 +1,7 @@
 // this file is @generated
 
+// biome-ignore-all lint/suspicious/noEmptyInterface: backwards compat
+
 export interface DocusignConfigOut {}
 
 export const DocusignConfigOutSerializer = {

--- a/javascript/src/models/easypostConfigOut.ts
+++ b/javascript/src/models/easypostConfigOut.ts
@@ -3,11 +3,11 @@
 export interface EasypostConfigOut {}
 
 export const EasypostConfigOutSerializer = {
-  _fromJsonObject(object: any): EasypostConfigOut {
+  _fromJsonObject(_object: any): EasypostConfigOut {
     return {};
   },
 
-  _toJsonObject(self: EasypostConfigOut): any {
+  _toJsonObject(_self: EasypostConfigOut): any {
     return {};
   },
 };

--- a/javascript/src/models/easypostConfigOut.ts
+++ b/javascript/src/models/easypostConfigOut.ts
@@ -1,5 +1,7 @@
 // this file is @generated
 
+// biome-ignore-all lint/suspicious/noEmptyInterface: backwards compat
+
 export interface EasypostConfigOut {}
 
 export const EasypostConfigOutSerializer = {

--- a/javascript/src/models/githubConfigOut.ts
+++ b/javascript/src/models/githubConfigOut.ts
@@ -3,11 +3,11 @@
 export interface GithubConfigOut {}
 
 export const GithubConfigOutSerializer = {
-  _fromJsonObject(object: any): GithubConfigOut {
+  _fromJsonObject(_object: any): GithubConfigOut {
     return {};
   },
 
-  _toJsonObject(self: GithubConfigOut): any {
+  _toJsonObject(_self: GithubConfigOut): any {
     return {};
   },
 };

--- a/javascript/src/models/githubConfigOut.ts
+++ b/javascript/src/models/githubConfigOut.ts
@@ -1,5 +1,7 @@
 // this file is @generated
 
+// biome-ignore-all lint/suspicious/noEmptyInterface: backwards compat
+
 export interface GithubConfigOut {}
 
 export const GithubConfigOutSerializer = {

--- a/javascript/src/models/hubspotConfigOut.ts
+++ b/javascript/src/models/hubspotConfigOut.ts
@@ -3,11 +3,11 @@
 export interface HubspotConfigOut {}
 
 export const HubspotConfigOutSerializer = {
-  _fromJsonObject(object: any): HubspotConfigOut {
+  _fromJsonObject(_object: any): HubspotConfigOut {
     return {};
   },
 
-  _toJsonObject(self: HubspotConfigOut): any {
+  _toJsonObject(_self: HubspotConfigOut): any {
     return {};
   },
 };

--- a/javascript/src/models/hubspotConfigOut.ts
+++ b/javascript/src/models/hubspotConfigOut.ts
@@ -1,5 +1,7 @@
 // this file is @generated
 
+// biome-ignore-all lint/suspicious/noEmptyInterface: backwards compat
+
 export interface HubspotConfigOut {}
 
 export const HubspotConfigOutSerializer = {

--- a/javascript/src/models/ingestSourceIn.ts
+++ b/javascript/src/models/ingestSourceIn.ts
@@ -27,6 +27,7 @@ interface _IngestSourceInFields {
   uid?: string | null;
 }
 
+// biome-ignore lint/suspicious/noEmptyInterface: backwards compat
 interface IngestSourceInGenericWebhookConfig {}
 
 interface IngestSourceInGenericWebhook {

--- a/javascript/src/models/ingestSourceIn.ts
+++ b/javascript/src/models/ingestSourceIn.ts
@@ -349,6 +349,7 @@ export const IngestSourceInSerializer = {
   },
 
   _toJsonObject(self: IngestSourceIn): any {
+    // biome-ignore lint/suspicious/noImplicitAnyLet: the return type needs to be any
     let config;
     switch (self.type) {
       case "generic-webhook":

--- a/javascript/src/models/ingestSourceOut.ts
+++ b/javascript/src/models/ingestSourceOut.ts
@@ -41,6 +41,7 @@ interface _IngestSourceOutFields {
   updatedAt: Date;
 }
 
+// biome-ignore lint/suspicious/noEmptyInterface: backwards compat
 interface IngestSourceOutGenericWebhookConfig {}
 
 interface IngestSourceOutGenericWebhook {

--- a/javascript/src/models/ingestSourceOut.ts
+++ b/javascript/src/models/ingestSourceOut.ts
@@ -367,6 +367,7 @@ export const IngestSourceOutSerializer = {
   },
 
   _toJsonObject(self: IngestSourceOut): any {
+    // biome-ignore lint/suspicious/noImplicitAnyLet: the return type needs to be any
     let config;
     switch (self.type) {
       case "generic-webhook":

--- a/javascript/src/models/pandaDocConfigOut.ts
+++ b/javascript/src/models/pandaDocConfigOut.ts
@@ -3,11 +3,11 @@
 export interface PandaDocConfigOut {}
 
 export const PandaDocConfigOutSerializer = {
-  _fromJsonObject(object: any): PandaDocConfigOut {
+  _fromJsonObject(_object: any): PandaDocConfigOut {
     return {};
   },
 
-  _toJsonObject(self: PandaDocConfigOut): any {
+  _toJsonObject(_self: PandaDocConfigOut): any {
     return {};
   },
 };

--- a/javascript/src/models/pandaDocConfigOut.ts
+++ b/javascript/src/models/pandaDocConfigOut.ts
@@ -1,5 +1,7 @@
 // this file is @generated
 
+// biome-ignore-all lint/suspicious/noEmptyInterface: backwards compat
+
 export interface PandaDocConfigOut {}
 
 export const PandaDocConfigOutSerializer = {

--- a/javascript/src/models/portIoConfigOut.ts
+++ b/javascript/src/models/portIoConfigOut.ts
@@ -1,5 +1,7 @@
 // this file is @generated
 
+// biome-ignore-all lint/suspicious/noEmptyInterface: backwards compat
+
 export interface PortIoConfigOut {}
 
 export const PortIoConfigOutSerializer = {

--- a/javascript/src/models/portIoConfigOut.ts
+++ b/javascript/src/models/portIoConfigOut.ts
@@ -3,11 +3,11 @@
 export interface PortIoConfigOut {}
 
 export const PortIoConfigOutSerializer = {
-  _fromJsonObject(object: any): PortIoConfigOut {
+  _fromJsonObject(_object: any): PortIoConfigOut {
     return {};
   },
 
-  _toJsonObject(self: PortIoConfigOut): any {
+  _toJsonObject(_self: PortIoConfigOut): any {
     return {};
   },
 };

--- a/javascript/src/models/rutterConfigOut.ts
+++ b/javascript/src/models/rutterConfigOut.ts
@@ -1,5 +1,7 @@
 // this file is @generated
 
+// biome-ignore-all lint/suspicious/noEmptyInterface: backwards compat
+
 export interface RutterConfigOut {}
 
 export const RutterConfigOutSerializer = {

--- a/javascript/src/models/rutterConfigOut.ts
+++ b/javascript/src/models/rutterConfigOut.ts
@@ -3,11 +3,11 @@
 export interface RutterConfigOut {}
 
 export const RutterConfigOutSerializer = {
-  _fromJsonObject(object: any): RutterConfigOut {
+  _fromJsonObject(_object: any): RutterConfigOut {
     return {};
   },
 
-  _toJsonObject(self: RutterConfigOut): any {
+  _toJsonObject(_self: RutterConfigOut): any {
     return {};
   },
 };

--- a/javascript/src/models/segmentConfigOut.ts
+++ b/javascript/src/models/segmentConfigOut.ts
@@ -1,5 +1,7 @@
 // this file is @generated
 
+// biome-ignore-all lint/suspicious/noEmptyInterface: backwards compat
+
 export interface SegmentConfigOut {}
 
 export const SegmentConfigOutSerializer = {

--- a/javascript/src/models/segmentConfigOut.ts
+++ b/javascript/src/models/segmentConfigOut.ts
@@ -3,11 +3,11 @@
 export interface SegmentConfigOut {}
 
 export const SegmentConfigOutSerializer = {
-  _fromJsonObject(object: any): SegmentConfigOut {
+  _fromJsonObject(_object: any): SegmentConfigOut {
     return {};
   },
 
-  _toJsonObject(self: SegmentConfigOut): any {
+  _toJsonObject(_self: SegmentConfigOut): any {
     return {};
   },
 };

--- a/javascript/src/models/shopifyConfigOut.ts
+++ b/javascript/src/models/shopifyConfigOut.ts
@@ -3,11 +3,11 @@
 export interface ShopifyConfigOut {}
 
 export const ShopifyConfigOutSerializer = {
-  _fromJsonObject(object: any): ShopifyConfigOut {
+  _fromJsonObject(_object: any): ShopifyConfigOut {
     return {};
   },
 
-  _toJsonObject(self: ShopifyConfigOut): any {
+  _toJsonObject(_self: ShopifyConfigOut): any {
     return {};
   },
 };

--- a/javascript/src/models/shopifyConfigOut.ts
+++ b/javascript/src/models/shopifyConfigOut.ts
@@ -1,5 +1,7 @@
 // this file is @generated
 
+// biome-ignore-all lint/suspicious/noEmptyInterface: backwards compat
+
 export interface ShopifyConfigOut {}
 
 export const ShopifyConfigOutSerializer = {

--- a/javascript/src/models/slackConfigOut.ts
+++ b/javascript/src/models/slackConfigOut.ts
@@ -1,5 +1,7 @@
 // this file is @generated
 
+// biome-ignore-all lint/suspicious/noEmptyInterface: backwards compat
+
 export interface SlackConfigOut {}
 
 export const SlackConfigOutSerializer = {

--- a/javascript/src/models/slackConfigOut.ts
+++ b/javascript/src/models/slackConfigOut.ts
@@ -3,11 +3,11 @@
 export interface SlackConfigOut {}
 
 export const SlackConfigOutSerializer = {
-  _fromJsonObject(object: any): SlackConfigOut {
+  _fromJsonObject(_object: any): SlackConfigOut {
     return {};
   },
 
-  _toJsonObject(self: SlackConfigOut): any {
+  _toJsonObject(_self: SlackConfigOut): any {
     return {};
   },
 };

--- a/javascript/src/models/stripeConfigOut.ts
+++ b/javascript/src/models/stripeConfigOut.ts
@@ -3,11 +3,11 @@
 export interface StripeConfigOut {}
 
 export const StripeConfigOutSerializer = {
-  _fromJsonObject(object: any): StripeConfigOut {
+  _fromJsonObject(_object: any): StripeConfigOut {
     return {};
   },
 
-  _toJsonObject(self: StripeConfigOut): any {
+  _toJsonObject(_self: StripeConfigOut): any {
     return {};
   },
 };

--- a/javascript/src/models/stripeConfigOut.ts
+++ b/javascript/src/models/stripeConfigOut.ts
@@ -1,5 +1,7 @@
 // this file is @generated
 
+// biome-ignore-all lint/suspicious/noEmptyInterface: backwards compat
+
 export interface StripeConfigOut {}
 
 export const StripeConfigOutSerializer = {

--- a/javascript/src/models/svixConfigOut.ts
+++ b/javascript/src/models/svixConfigOut.ts
@@ -3,11 +3,11 @@
 export interface SvixConfigOut {}
 
 export const SvixConfigOutSerializer = {
-  _fromJsonObject(object: any): SvixConfigOut {
+  _fromJsonObject(_object: any): SvixConfigOut {
     return {};
   },
 
-  _toJsonObject(self: SvixConfigOut): any {
+  _toJsonObject(_self: SvixConfigOut): any {
     return {};
   },
 };

--- a/javascript/src/models/svixConfigOut.ts
+++ b/javascript/src/models/svixConfigOut.ts
@@ -1,5 +1,7 @@
 // this file is @generated
 
+// biome-ignore-all lint/suspicious/noEmptyInterface: backwards compat
+
 export interface SvixConfigOut {}
 
 export const SvixConfigOutSerializer = {

--- a/javascript/src/models/vapiConfigOut.ts
+++ b/javascript/src/models/vapiConfigOut.ts
@@ -1,5 +1,7 @@
 // this file is @generated
 
+// biome-ignore-all lint/suspicious/noEmptyInterface: backwards compat
+
 export interface VapiConfigOut {}
 
 export const VapiConfigOutSerializer = {

--- a/javascript/src/models/vapiConfigOut.ts
+++ b/javascript/src/models/vapiConfigOut.ts
@@ -3,11 +3,11 @@
 export interface VapiConfigOut {}
 
 export const VapiConfigOutSerializer = {
-  _fromJsonObject(object: any): VapiConfigOut {
+  _fromJsonObject(_object: any): VapiConfigOut {
     return {};
   },
 
-  _toJsonObject(self: VapiConfigOut): any {
+  _toJsonObject(_self: VapiConfigOut): any {
     return {};
   },
 };

--- a/javascript/src/models/veriffConfigOut.ts
+++ b/javascript/src/models/veriffConfigOut.ts
@@ -1,5 +1,7 @@
 // this file is @generated
 
+// biome-ignore-all lint/suspicious/noEmptyInterface: backwards compat
+
 export interface VeriffConfigOut {}
 
 export const VeriffConfigOutSerializer = {

--- a/javascript/src/models/veriffConfigOut.ts
+++ b/javascript/src/models/veriffConfigOut.ts
@@ -3,11 +3,11 @@
 export interface VeriffConfigOut {}
 
 export const VeriffConfigOutSerializer = {
-  _fromJsonObject(object: any): VeriffConfigOut {
+  _fromJsonObject(_object: any): VeriffConfigOut {
     return {};
   },
 
-  _toJsonObject(self: VeriffConfigOut): any {
+  _toJsonObject(_self: VeriffConfigOut): any {
     return {};
   },
 };

--- a/javascript/src/models/zoomConfigOut.ts
+++ b/javascript/src/models/zoomConfigOut.ts
@@ -3,11 +3,11 @@
 export interface ZoomConfigOut {}
 
 export const ZoomConfigOutSerializer = {
-  _fromJsonObject(object: any): ZoomConfigOut {
+  _fromJsonObject(_object: any): ZoomConfigOut {
     return {};
   },
 
-  _toJsonObject(self: ZoomConfigOut): any {
+  _toJsonObject(_self: ZoomConfigOut): any {
     return {};
   },
 };

--- a/javascript/src/models/zoomConfigOut.ts
+++ b/javascript/src/models/zoomConfigOut.ts
@@ -1,5 +1,7 @@
 // this file is @generated
 
+// biome-ignore-all lint/suspicious/noEmptyInterface: backwards compat
+
 export interface ZoomConfigOut {}
 
 export const ZoomConfigOutSerializer = {


### PR DESCRIPTION
Review this PR commit by commit. each commits fixes a different rule 


2. [Fix `lint/correctness/noUnusedFunctionParameters`](https://github.com/svix/svix-webhooks/pull/2072/commits/0fd10198caff546cda41486f31785eeb17adc9cc), renamed params from `<param>` to `_<param>`  
3. [Fix `lint/style/noNonNullAssertion`](https://github.com/svix/svix-webhooks/pull/2072/commits/b0b86dabb550fea74b50fe7dff94264351bf02d0), Remove some not null assertions from the tests
4. [Fix(ignore) `lint/suspicious/noImplicitAnyLet`](https://github.com/svix/svix-webhooks/pull/2072/commits/c71fb196ccd7cd9a69c80fee8b0cb1f3fc6d11a9): Ignore this warning (since this code is generated, I am comfortable with ignoring the type system) 
5. [Fix(ignore) `lint/suspicious/noEmptyInterface`](https://github.com/svix/svix-webhooks/pull/2072/commits/52bceca38d7cc7ee237fdd916ba2253dc218138c), we could technically export these as  types instead of interfaces, but that would be a breaking change  
