### PR TITLE
go: Add a test for NewMessageInRaw return value serialization

### DIFF
--- a/go/message_ext_test.go
+++ b/go/message_ext_test.go
@@ -1,0 +1,19 @@
+package svix_test
+
+import (
+	"encoding/json"
+	"testing"
+	svix "github.com/svix/svix-webhooks/go"
+)
+
+func TestMessageInRawSerialization(t *testing.T) {
+	msgIn := svix.NewMessageInRaw("bar.foo", "{}", nil)
+	msgInJsonBytes, _ := json.Marshal(msgIn)
+	msgInJson := string(msgInJsonBytes)
+
+	expectedJson := `{"eventType":"bar.foo","payload":{},"transformationsParams":{"rawPayload":"{}"}}`
+
+	if msgInJson != expectedJson {
+		t.Errorf("Wrong serialization: %s", msgInJson)
+	}
+}


### PR DESCRIPTION
There's a report of this method not doing what it's supposed to do. Here's a test for the JSON form of its output. Looks fine to me, but I'm probably missing something.
