### PR TITLE
Replace the `TWINE_PASSWORD` with trusted publishing

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      id-token: write
     name: Build distributions
     runs-on: ubuntu-24.04
     environment: release
@@ -40,5 +42,4 @@ jobs:
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.TWINE_PASSWORD }}
           packages_dir: python/dist


### PR DESCRIPTION
Instead of using the `TWINE_PASSWORD`, Tom added support for oidc/trusted publishing.

The `TWINE_PASSWORD` was also removed. So this is now the only way to publish to our pypi package.

