### PR TITLE
Bump openapi-codegen image

### DIFF
--- a/regen_openapi.py
+++ b/regen_openapi.py
@@ -17,7 +17,7 @@ except ImportError:
     print("Python 3.11 or greater is required to run the codegen")
     exit(1)
 
-OPENAPI_CODEGEN_IMAGE = "ghcr.io/svix/openapi-codegen:20250929-329"
+OPENAPI_CODEGEN_IMAGE = "ghcr.io/svix/openapi-codegen:20251007-338"
 DEBUG = os.getenv("DEBUG") is not None
 GREEN = "\033[92m"
 BLUE = "\033[94m"


### PR DESCRIPTION
We're planning to drop `x-hidden` in favor of `x-internal`. This new version of `openapi-codegen` is equipped to deal with it.

