### PR TITLE
js: Add option to configure the fetch method

### DIFF
--- a/codegen/templates/javascript/summary.ts.jinja
+++ b/codegen/templates/javascript/summary.ts.jinja
@@ -27,6 +27,11 @@ export type SvixOptions = {
   serverUrl?: string;
   /** Time in milliseconds to wait for requests to get a response. */
   requestTimeout?: number;
+  /**
+   * Custom fetch implementation to use for HTTP requests.
+   * Useful for testing, adding custom middleware, or running in non-standard environments.
+   */
+  fetch?: typeof fetch;
 } & XOR<
   {
     /** List of delays (in milliseconds) to wait before each retry attempt.*/
@@ -63,6 +68,7 @@ export class Svix {
         token,
         timeout: options.requestTimeout,
         retryScheduleInMs: options.retryScheduleInMs,
+        fetch: options.fetch,
       };
       return;
     }
@@ -72,6 +78,7 @@ export class Svix {
         token,
         timeout: options.requestTimeout,
         numRetries: options.numRetries,
+        fetch: options.fetch,
       };
       return;
     }
@@ -79,6 +86,7 @@ export class Svix {
       baseUrl,
       token,
       timeout: options.requestTimeout,
+      fetch: options.fetch,
     };
   }
 

--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -36,6 +36,11 @@ export type SvixOptions = {
   serverUrl?: string;
   /** Time in milliseconds to wait for requests to get a response. */
   requestTimeout?: number;
+  /**
+   * Custom fetch implementation to use for HTTP requests.
+   * Useful for testing, adding custom middleware, or running in non-standard environments.
+   */
+  fetch?: typeof fetch;
 } & XOR<
   {
     /** List of delays (in milliseconds) to wait before each retry attempt.*/
@@ -71,6 +76,7 @@ export class Svix {
         token,
         timeout: options.requestTimeout,
         retryScheduleInMs: options.retryScheduleInMs,
+        fetch: options.fetch,
       };
       return;
     }
@@ -80,6 +86,7 @@ export class Svix {
         token,
         timeout: options.requestTimeout,
         numRetries: options.numRetries,
+        fetch: options.fetch,
       };
       return;
     }
@@ -87,6 +94,7 @@ export class Svix {
       baseUrl,
       token,
       timeout: options.requestTimeout,
+      fetch: options.fetch,
     };
   }
 

--- a/javascript/src/mockttp.test.ts
+++ b/javascript/src/mockttp.test.ts
@@ -500,4 +500,22 @@ test("mockttp tests", async (t) => {
     const requests = await endpointMock.getSeenRequests();
     assert.equal(requests.length, 1);
   });
+
+  await t.test("should use custom fetch implementation", async () => {
+    let customFetchCalled = false;
+    const mockFetch: typeof fetch = async (_input, _init) => {
+      customFetchCalled = true;
+      return new Response(ListResponseApplicationOut, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    await mockServer
+      .forGet(/\/api\/v1\/app.*/)
+      .thenReply(200, ListResponseApplicationOut);
+    const svx = new Svix("token", { serverUrl: mockServer.url, fetch: mockFetch });
+    await svx.application.list({ order: Ordering.Ascending });
+    assert(customFetchCalled);
+  });
 });


### PR DESCRIPTION
Add new option in the js `SvixOptions`. `fetch`.
Allows user to override the fetch impl, while still keeping the default retry/idempotency headers behavior. 


This came from a community slack request. https://svixcommunity.slack.com/archives/C022BJ2EBHV/p1760452704322919