### PR TITLE
server: Allow creating an application in app-portal-access

### DIFF
--- a/server/openapi.json
+++ b/server/openapi.json
@@ -3,6 +3,11 @@
         "schemas": {
             "AppPortalAccessIn": {
                 "properties": {
+                    "application": {
+                        "$ref": "#/components/schemas/ApplicationIn",
+                        "description": "Optionally creates a new application alongside the message.\n\nIf the application id or uid that is used in the path already exists, this argument is ignored.",
+                        "nullable": true
+                    },
                     "featureFlags": {
                         "description": "The set of feature flags the created token will have access to.",
                         "example": [],

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -460,7 +460,10 @@ pub(crate) async fn create_message_inner(
     Ok(msg_out)
 }
 
-fn validate_create_app_uid(app_id_or_uid: &ApplicationIdOrUid, data: &ApplicationIn) -> Result<()> {
+pub fn validate_create_app_uid(
+    app_id_or_uid: &ApplicationIdOrUid,
+    data: &ApplicationIn,
+) -> Result<()> {
     // If implicit app creation is requested then the UID must be set
     // in the request body, and it must match the UID given in the path
     if let Some(uid) = &data.uid {

--- a/server/svix-server/tests/it/utils/common_calls.rs
+++ b/server/svix-server/tests/it/utils/common_calls.rs
@@ -416,7 +416,10 @@ pub async fn app_portal_access(
     let resp: DashboardAccessOut = org_client
         .post(
             &format!("api/v1/auth/app-portal-access/{application_id}/"),
-            AppPortalAccessIn { feature_flags },
+            AppPortalAccessIn {
+                feature_flags,
+                application: None,
+            },
             StatusCode::OK,
         )
         .await


### PR DESCRIPTION
Add support for creating apps in app-portal-access

part of: https://github.com/svix/monorepo-private/issues/11626