### PR TITLE
cli: Fix rustls crypto provider error

### DIFF
--- a/svix-cli/Cargo.lock
+++ b/svix-cli/Cargo.lock
@@ -1482,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "6a9586e9ee2b4f8fab52a0048ca7334d7024eef48e2cb9407e3497bb7cab7fa7"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -1758,6 +1758,7 @@ dependencies = [
  "open",
  "rand 0.8.5",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "svix",

--- a/svix-cli/Cargo.toml
+++ b/svix-cli/Cargo.toml
@@ -46,6 +46,7 @@ indoc = "2.0.5"
 open = "5.3.1"
 rand = "0.8.5"
 reqwest = { version = "0.12.9", features = ["rustls-tls", "json", "charset", "http2", "macos-system-configuration"], default-features = false }
+rustls = "0.23.34"
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
 svix = { path = "../rust" }

--- a/svix-cli/src/main.rs
+++ b/svix-cli/src/main.rs
@@ -99,6 +99,12 @@ enum RootCommands {
 async fn main() -> Result<()> {
     let cli = Cli::parse();
     let color_mode = cli.color_mode();
+
+    // rustls requires a crypto backend ("provider") choice to be made explicitly
+    // The Svix SDK uses the default provider if a default is not installed, but
+    // we use reqwest directly in some code paths, which does not do this.
+    _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     // XXX: cfg can give an Err in certain situations.
     // Assigning the variable here since several match arms need a `&Config` but the rest of them
     // won't care/are still usable if the config doesn't exist.


### PR DESCRIPTION
## Motivation

`svix listen` has been broken since v1.77.0 (the same may be true for `svix login`), panicking because current `rustls` requires a crypto provider to be explicitly configured, and we didn't do so.

## Solution

Put the default rustls crypto provider (aws-lc) as the process-wide default.