### PR TITLE
Remove outdated section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,10 +173,6 @@ docker run \
   svix/svix-server
 ```
 
-### Pre-compiled binaries
-
-Pre-compiled binaries are available for released versions in the [releases section](https://github.com/svix/svix-webhooks/releases).
-
 ### Building from source
 
 The Svix server is written in Rust 🦀 and requires a Rust build environment.


### PR DESCRIPTION
We no longer provide server binaries.

Had this commit lying around locally, no idea why it never became a PR.