### PR TITLE
Clean up double spaces within jinja tags

### DIFF
--- a/codegen/templates/csharp/api_resource.cs.jinja
+++ b/codegen/templates/csharp/api_resource.cs.jinja
@@ -77,7 +77,7 @@ namespace Svix
             {%- set ret_ty = op.response_body_schema_name | to_upper_camel_case %}
         {%- endif %}
         {%- if async %}
-            {%- set ret_ty_sig  %}Task<{{ ret_ty }}>{% endset %}
+            {%- set ret_ty_sig%}Task<{{ ret_ty }}>{% endset %}
         {%- else %}
             {%- set ret_ty_sig = ret_ty %}
         {%- endif %}

--- a/codegen/templates/csharp/types/struct_enum.cs.jinja
+++ b/codegen/templates/csharp/types/struct_enum.cs.jinja
@@ -24,7 +24,7 @@ namespace Svix.Models {
         [JsonProperty("{{ type.discriminator_field }}")]
         private string {{ discriminator_field_name }} => Config.GetDiscriminator();
 
-        [JsonProperty("{{ type.content_field  }}")]
+        [JsonProperty("{{ type.content_field }}")]
         private object real{{ content_field_name }} { get => Config.GetContent(); set => Config.SetContent(value); }
 
 

--- a/codegen/templates/go/api_resource.go.jinja
+++ b/codegen/templates/go/api_resource.go.jinja
@@ -166,7 +166,7 @@ func ({{ resource_self_name }} *{{ resource_type_name }}) {{ op.name | to_upper_
 		{% endif -%}
 
 		{#- query params -#}
-		{% if op.query_params | length > 0 or op.id == "v1.application.create"  -%}
+		{% if op.query_params | length > 0 or op.id == "v1.application.create" -%}
 		queryMap,
 		{% else -%}
 		nil,

--- a/codegen/templates/go/types/integer_enum.go.jinja
+++ b/codegen/templates/go/types/integer_enum.go.jinja
@@ -15,7 +15,7 @@ type {{ ty_name }} int64
 
 const (
 {% for varname, val in type.variants -%}
-	{{ type.name |  to_upper_snake_case | replace("_", "") }}_{{ varname | to_upper_snake_case }}  {{ ty_name }} = {{ val }}
+	{{ type.name | to_upper_snake_case | replace("_", "") }}_{{ varname | to_upper_snake_case }}  {{ ty_name }} = {{ val }}
 {% endfor -%}
 )
 
@@ -43,6 +43,6 @@ func (v *{{ ty_name }}) UnmarshalJSON(src []byte) error {
 
 var {{ ty_name }}FromInt64 = map[int64]{{ ty_name }}{
 	{% for varname, val in type.variants -%}
-	{{ val }} : {{ type.name |  to_upper_snake_case | replace("_", "") }}_{{ varname | to_upper_snake_case }},
+	{{ val }} : {{ type.name | to_upper_snake_case | replace("_", "") }}_{{ varname | to_upper_snake_case }},
 	{% endfor -%}
 }

--- a/codegen/templates/go/types/string_enum.go.jinja
+++ b/codegen/templates/go/types/string_enum.go.jinja
@@ -15,7 +15,7 @@ type {{ ty_name }} string
 
 const (
 {% for value in type.values -%}
-	{{ type.name |  to_upper_snake_case | replace("_", "") }}_{{ value | to_upper_snake_case }} {{ ty_name }} = "{{ value }}"
+	{{ type.name | to_upper_snake_case | replace("_", "") }}_{{ value | to_upper_snake_case }} {{ ty_name }} = "{{ value }}"
 {% endfor -%}
 )
 
@@ -43,6 +43,6 @@ func (v *{{ ty_name }}) UnmarshalJSON(src []byte) error {
 
 var {{ ty_name }}FromString = map[string]{{ ty_name }}{
 	{% for value in type.values -%}
-	"{{ value }}" : {{ type.name |  to_upper_snake_case | replace("_", "") }}_{{ value | to_upper_snake_case }},
+	"{{ value }}" : {{ type.name | to_upper_snake_case | replace("_", "") }}_{{ value | to_upper_snake_case }},
 	{% endfor -%}
 }

--- a/codegen/templates/java/types/struct.java.jinja
+++ b/codegen/templates/java/types/struct.java.jinja
@@ -1,5 +1,5 @@
 // This file is @generated
-{% set class_ty = type.name | to_upper_camel_case  -%}
+{% set class_ty = type.name | to_upper_camel_case -%}
 package com.svix.models;
 
 import com.svix.MaybeUnset;
@@ -84,7 +84,7 @@ public class {{ type.name | to_upper_camel_case }} {
     }
 
     {% if field.type.is_set() or  field.type.is_list() -%}
-    {{ f_deprecated }} public {{ class_ty }} add{{ f_varname | to_upper_camel_case }}Item ({{ field.type.inner_type().to_java() }} {{ f_varname  }}Item) {
+    {{ f_deprecated }} public {{ class_ty }} add{{ f_varname | to_upper_camel_case }}Item ({{ field.type.inner_type().to_java() }} {{ f_varname }}Item) {
         if (this.{{ f_varname }} == null) {
             {% if field.type.is_set() -%}
                 {% if type.name is endingwith "Patch" and field.nullable -%}
@@ -101,14 +101,14 @@ public class {{ type.name | to_upper_camel_case }} {
             {% endif -%}
         }
         {% if type.name is endingwith "Patch" and field.nullable -%}
-        this.{{ f_varname }}.getValue().add({{ f_varname  }}Item);
+        this.{{ f_varname }}.getValue().add({{ f_varname }}Item);
         {% else -%}
-        this.{{ f_varname }}.add({{ f_varname  }}Item);
+        this.{{ f_varname }}.add({{ f_varname }}Item);
         {% endif %}
         return this;
     }
     {% elif field.type.is_map() -%}
-    {{ f_deprecated }} public {{ class_ty }} put{{ f_varname | to_upper_camel_case  }}Item(String key, String {{ f_varname }}Item) {
+    {{ f_deprecated }} public {{ class_ty }} put{{ f_varname | to_upper_camel_case }}Item(String key, String {{ f_varname }}Item) {
         if (this.{{ f_varname }} == null) {
             {% if type.name is endingwith "Patch" and field.nullable -%}
             this.{{ f_varname }} = new MaybeUnset<>(new HashMap<>());
@@ -132,7 +132,7 @@ public class {{ type.name | to_upper_camel_case }} {
      * Get {{ f_varname }}
     {% endif -%}
      *
-     * @return {{ f_varname  }}
+     * @return {{ f_varname }}
      */
     {% if field.nullable or not field.required -%}
     @javax.annotation.Nullable

--- a/codegen/templates/java/types/struct_enum.java.jinja
+++ b/codegen/templates/java/types/struct_enum.java.jinja
@@ -53,7 +53,7 @@ public class {{ type_name }} {
     private {{ enum_type_name }} {{ content_field_name }};
 
     {% for f in type.fields -%}
-    public {{ type_name }} {{ f.name | to_lower_camel_case  }}({{ f.type.to_java() }} {{ f.name | to_lower_camel_case }}) {
+    public {{ type_name }} {{ f.name | to_lower_camel_case }}({{ f.type.to_java() }} {{ f.name | to_lower_camel_case }}) {
         this.{{ f.name | to_lower_camel_case }} = {{ f.name | to_lower_camel_case }};
         return this;
     }
@@ -103,7 +103,7 @@ class {{ type_name }}Serializer extends StdSerializer<{{ type_name }}> {
 
     @Override
     public void serialize({{ type_name }} value, JsonGenerator gen, SerializerProvider provider) throws IOException {
-        {{ type_name }}Surrogate surrogate = new {{ type_name }}Surrogate(value,value.get{{ content_field_name | to_upper_camel_case }}().getVariantName(),value.get{{ content_field_name | to_upper_camel_case  }}().toJsonNode());
+        {{ type_name }}Surrogate surrogate = new {{ type_name }}Surrogate(value,value.get{{ content_field_name | to_upper_camel_case }}().getVariantName(),value.get{{ content_field_name | to_upper_camel_case }}().toJsonNode());
         gen.writeObject(surrogate);
     }
 }

--- a/codegen/templates/php/operation_options.php.jinja
+++ b/codegen/templates/php/operation_options.php.jinja
@@ -14,10 +14,10 @@ use Svix\Models\{{ c | to_upper_camel_case }};
 class {{ resource_type_name }}{{ operation.name | to_upper_camel_case }}Options {
     public function __construct(
     {% for p in operation.query_params -%}
-        public readonly ?{{ p.type.to_php() }} ${{ p.name | to_lower_camel_case  }} = null,
+        public readonly ?{{ p.type.to_php() }} ${{ p.name | to_lower_camel_case }} = null,
     {% endfor -%}
     {% for p in operation.header_params -%}
-        public readonly ?string ${{ p.name | to_lower_camel_case  }} = null,
+        public readonly ?string ${{ p.name | to_lower_camel_case }} = null,
     {% endfor -%}
     ) {}
 }

--- a/codegen/templates/php/types/struct.php.jinja
+++ b/codegen/templates/php/types/struct.php.jinja
@@ -71,7 +71,7 @@ class {{ type.name | to_upper_camel_case }} implements \JsonSerializable
     public function with{{ field.name | to_upper_camel_case }}(?{{ field.type.to_php() }} ${{ field.name | to_lower_camel_case }}): self
         {
             $setFields = $this->setFields;
-            $setFields['{{  field.name | to_lower_camel_case }}'] = true;
+            $setFields['{{ field.name | to_lower_camel_case }}'] = true;
             return new self(
                 {% for inner_field in type.fields -%}
                     {% if field.name != inner_field.name -%}

--- a/codegen/templates/ruby/types/integer_enum.rb.jinja
+++ b/codegen/templates/ruby/types/integer_enum.rb.jinja
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 # This file is @generated
-{% set class_ty = type.name | to_upper_camel_case  -%}
+{% set class_ty = type.name | to_upper_camel_case -%}
 
 module Svix
   {% if type.description is defined -%}

--- a/codegen/templates/ruby/types/string_enum.rb.jinja
+++ b/codegen/templates/ruby/types/string_enum.rb.jinja
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 # This file is @generated
-{% set class_ty = type.name | to_upper_camel_case  -%}
+{% set class_ty = type.name | to_upper_camel_case -%}
 
 module Svix
   {% if type.description is defined -%}

--- a/codegen/templates/ruby/types/struct.rb.jinja
+++ b/codegen/templates/ruby/types/struct.rb.jinja
@@ -1,5 +1,5 @@
 {% from "types/macros.rb.jinja" import deserialize_field, serialize_field -%}
-{% set class_ty = type.name | to_upper_camel_case  -%}
+{% set class_ty = type.name | to_upper_camel_case -%}
 # frozen_string_literal: true
 # This file is @generated
 require 'json'

--- a/codegen/templates/ruby/types/struct_enum.rb.jinja
+++ b/codegen/templates/ruby/types/struct_enum.rb.jinja
@@ -1,5 +1,5 @@
 {% from "types/macros.rb.jinja" import deserialize_field, serialize_field -%}
-{% set class_ty = type.name | to_upper_camel_case  -%}
+{% set class_ty = type.name | to_upper_camel_case -%}
 {% set enum_type_name %}{{ class_ty }}{{ type.content_field | to_upper_camel_case }}{% endset-%}
 # frozen_string_literal: true
 # This file is @generated
@@ -69,7 +69,7 @@ module Svix
         unless ALL_FIELD.include?(k.to_s)
           fail(ArgumentError, "The field #{k} is not part of Svix::{{ class_ty }}")
         end
-        if k == "{{type.content_field | to_snake_case  }}"
+        if k == "{{type.content_field | to_snake_case }}"
           unless TYPE_TO_NAME.key?(v.class)
             fail(ArgumentError, "The field #{k} can't be a `#{v.class}` expected one of #{TYPE_TO_NAME.keys}")
           end
@@ -95,7 +95,7 @@ module Svix
       unless attributes.key? "{{ type.content_field }}"
         fail(ArgumentError, "Missing required field {{ type.content_field }}")
       end
-      attrs["{{ type.content_field  }}"] = NAME_TO_TYPE[attributes["{{ type.discriminator_field }}"]].deserialize(attributes["{{ type.content_field }}"])
+      attrs["{{ type.content_field }}"] = NAME_TO_TYPE[attributes["{{ type.discriminator_field }}"]].deserialize(attributes["{{ type.content_field }}"])
       new(attrs)
     end
 


### PR DESCRIPTION
Noticed that we had some weird double spaces within jinja tags while working on another template thing.