### PR TITLE
codegen: Fix field_to_json when reading reading a dictionary of arrays

### DIFF
--- a/codegen/templates/javascript/types/macros.ts.jinja
+++ b/codegen/templates/javascript/types/macros.ts.jinja
@@ -34,8 +34,8 @@
             or value_t.is_list()
             or value_t.is_set()
             or value_t.is_map() -%}
-            Object.fromEntries(Object.entries({{ field_expr }}).map(
-                (item : {{ inner_t.to_js() }}) => [item[0], {{ field_from_json("item[1]", value_t, true) }}]
+            Object.fromEntries(Object.entries<{{ value_t.to_js() }}>({{ field_expr }}).map(
+                (item : [string, {{ value_t.to_js() }}]) => [item[0], {{ field_from_json("item[1]", value_t, true) }}]
             ))
         {%- else -%}
             {{ field_expr }}


### PR DESCRIPTION
This was mapping over the elements of a dictionary, so map([key, value] => ...) is the expected type. Also, `inner_t` is not defined here, it was a typo, `value_t` is the correct variable.
