### PR TITLE
svix-cli: allow reading JSON bodies from stdin

### DIFF
--- a/svix-cli/src/json.rs
+++ b/svix-cli/src/json.rs
@@ -1,6 +1,6 @@
-use std::str::FromStr;
+use std::{io::Read, str::FromStr};
 
-use anyhow::{Error, Result};
+use anyhow::{Context, Error, Result};
 use colored_json::{Color, ColorMode, ToColoredJson};
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -11,7 +11,16 @@ impl<T: DeserializeOwned> FromStr for JsonOf<T> {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(JsonOf(serde_json::from_str(s)?))
+        if s == "-" {
+            let mut stdin = std::io::stdin().lock();
+            let mut input = String::new();
+            stdin
+                .read_to_string(&mut input)
+                .context("Error reading stdin for '-' argument")?;
+            Ok(JsonOf(serde_json::from_str(&input)?))
+        } else {
+            Ok(JsonOf(serde_json::from_str(s)?))
+        }
     }
 }
 


### PR DESCRIPTION
Right now, all of the JSON bodies for `svix-cli` actions (some of which can be quite large) need to be specified as command-line arguments. This is sort of annoying for testing.

This allows you to specify any of the JSON types as the string "-", in which case it will be read from stdin. Obviously you can only do this once per command line, because there's only one stdin.

This is fairly typical behavior of a UNIX command.