### PR TITLE
feat: adding configurable deployment.name in otel

### DIFF
--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -149,6 +149,8 @@ pub struct ConfigurationInner {
     pub opentelemetry_sample_ratio: Option<f64>,
     /// The service name to use for OpenTelemetry. If not provided, it defaults to "svix_server".
     pub opentelemetry_service_name: String,
+    /// The deployment environment to use for OpenTelemetry. It will be translated to "deployment.environment" resource if provided
+    pub opentelemetry_deployment_env: Option<String>,
     /// Whether to enable the logging of the databases at the configured log level. This may be
     /// useful for analyzing their response times.
     pub db_tracing: bool,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Adding configuration to tag otel trace and metrics with `deployment.environment` attribute. Supporting signoz environment
https://signoz.io/docs/faqs/general/#q-how-to-setup-signoz-across-different-environments

## Solution

As above

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
