### PR TITLE
Remove EndpointPatch#secret

### DIFF
--- a/server/openapi.json
+++ b/server/openapi.json
@@ -732,13 +732,6 @@
                         "nullable": true,
                         "type": "integer"
                     },
-                    "secret": {
-                        "description": "The endpoint's verification secret. If `null` is passed, a secret is automatically generated. Format: `base64` encoded random bytes optionally prefixed with `whsec_`. Recommended size: 24.",
-                        "example": "whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD",
-                        "nullable": true,
-                        "pattern": "^(whsec_)?[a-zA-Z0-9+/=]{32,100}$",
-                        "type": "string"
-                    },
                     "uid": {
                         "example": "unique-ep-identifier",
                         "maxLength": 256,

--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -384,12 +384,6 @@ pub struct EndpointPatch {
     #[serde(default, skip_serializing_if = "UnrequiredNullableField::is_absent")]
     pub channels: UnrequiredNullableField<EventChannelSet>,
 
-    #[validate]
-    #[serde(default)]
-    #[serde(rename = "secret")]
-    #[serde(skip_serializing_if = "UnrequiredNullableField::is_absent")]
-    pub key: UnrequiredNullableField<EndpointSecret>,
-
     #[serde(default)]
     #[serde(skip_serializing_if = "UnrequiredField::is_absent")]
     pub metadata: UnrequiredField<Metadata>,
@@ -409,7 +403,6 @@ impl ModelIn for EndpointPatch {
             disabled,
             event_types_ids,
             channels,
-            key: _,
             metadata: _,
         } = self;
 


### PR DESCRIPTION
It is being deprecated in the cloud API which we use for generating the SDKs. It never did anything and was added by mistake (the corresponding `PUT` route doesn't have it).