### PR TITLE
Remove stub for /event-type/schema/generate-example

### DIFF
--- a/server/openapi.json
+++ b/server/openapi.json
@@ -7037,30 +7037,6 @@
                 ]
             }
         },
-        "/api/v1/event-type/schema/generate-example": {
-            "post": {
-                "description": "Generates a fake example from the given JSONSchema",
-                "parameters": [
-                    {
-                        "description": "The request's idempotency key",
-                        "in": "header",
-                        "name": "idempotency-key",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "style": "simple"
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "no content"
-                    }
-                },
-                "tags": [
-                    "Event Type"
-                ]
-            }
-        },
         "/api/v1/event-type/{event_type_name}": {
             "delete": {
                 "description": "Archive an event type.\n\nEndpoints already configured to filter on an event type will continue to do so after archival.\nHowever, new messages can not be sent with it and endpoints can not filter on it.\nAn event type can be unarchived with the\n[create operation](#operation/create_event_type_api_v1_event_type__post).",

--- a/server/svix-server/src/v1/endpoints/event_type.rs
+++ b/server/svix-server/src/v1/endpoints/event_type.rs
@@ -24,7 +24,7 @@ use crate::{
     db::models::eventtype,
     error::{http_error_on_conflict, HttpError, Result},
     v1::utils::{
-        api_not_implemented, apply_pagination, openapi_desc, openapi_tag,
+        apply_pagination, openapi_tag,
         patch::{
             patch_field_non_nullable, patch_field_nullable, UnrequiredField,
             UnrequiredNullableField,
@@ -441,9 +441,6 @@ async fn delete_event_type(
     Ok(NoContent)
 }
 
-const GENERATE_SCHEMA_EXAMPLE_DESCRIPTION: &str =
-    "Generates a fake example from the given JSONSchema";
-
 pub fn router() -> ApiRouter<AppState> {
     let tag = openapi_tag("Event Type");
     ApiRouter::new()
@@ -461,19 +458,10 @@ pub fn router() -> ApiRouter<AppState> {
                 .delete_with(delete_event_type, delete_event_type_operation),
             &tag,
         )
-        .api_route_with(
-            "/event-type/schema/generate-example",
-            post_with(
-                api_not_implemented,
-                openapi_desc(GENERATE_SCHEMA_EXAMPLE_DESCRIPTION),
-            ),
-            tag,
-        )
 }
 
 #[cfg(test)]
 mod tests {
-
     use serde_json::json;
 
     use super::ListFetchQueryParams;


### PR DESCRIPTION
This is a route that exists in Svix cloud and is being removed. It's unclear to me why this stub was added here, as it was never exposed in our SDKs or otherwise used in client software that might work with the OSS backend rather than cloud, as far as I can tell.
