### PR TITLE
js: Set query parameters in bulk

### DIFF
--- a/codegen/templates/javascript/api_resource.ts.jinja
+++ b/codegen/templates/javascript/api_resource.ts.jinja
@@ -96,9 +96,13 @@ export class {{ resource_type_name }} {
             {% endfor -%}
 
             {# query parameters -#}
-            {% for p in op.query_params -%}
-                request.setQueryParam("{{ p.name }}", options{% if not p.required %}?{% endif %}.{{ p.name | to_lower_camel_case }});
-            {% endfor -%}
+            {% if op.query_params | length > 0 -%}
+            request.setQueryParams({
+                {% for p in op.query_params -%}
+                "{{ p.name }}": options{% if not p.required %}?{% endif %}.{{ p.name | to_lower_camel_case }},
+                {% endfor -%}
+            });
+            {% endif -%}
 
             {# header parameters -#}
             {% for p in op.header_params -%}

--- a/javascript/src/api/application.ts
+++ b/javascript/src/api/application.ts
@@ -37,17 +37,13 @@ export class Application {
   public list(options?: ApplicationListOptions): Promise<ListResponseApplicationOut> {
     const request = new SvixRequest(HttpMethod.GET, "/api/v1/app");
 
-    request.setQueryParam(
-      "exclude_apps_with_no_endpoints",
-      options?.excludeAppsWithNoEndpoints
-    );
-    request.setQueryParam(
-      "exclude_apps_with_disabled_endpoints",
-      options?.excludeAppsWithDisabledEndpoints
-    );
-    request.setQueryParam("limit", options?.limit);
-    request.setQueryParam("iterator", options?.iterator);
-    request.setQueryParam("order", options?.order);
+    request.setQueryParams({
+      exclude_apps_with_no_endpoints: options?.excludeAppsWithNoEndpoints,
+      exclude_apps_with_disabled_endpoints: options?.excludeAppsWithDisabledEndpoints,
+      limit: options?.limit,
+      iterator: options?.iterator,
+      order: options?.order,
+    });
 
     return request.send(
       this.requestCtx,

--- a/javascript/src/api/backgroundTask.ts
+++ b/javascript/src/api/backgroundTask.ts
@@ -35,11 +35,13 @@ export class BackgroundTask {
   ): Promise<ListResponseBackgroundTaskOut> {
     const request = new SvixRequest(HttpMethod.GET, "/api/v1/background-task");
 
-    request.setQueryParam("status", options?.status);
-    request.setQueryParam("task", options?.task);
-    request.setQueryParam("limit", options?.limit);
-    request.setQueryParam("iterator", options?.iterator);
-    request.setQueryParam("order", options?.order);
+    request.setQueryParams({
+      status: options?.status,
+      task: options?.task,
+      limit: options?.limit,
+      iterator: options?.iterator,
+      order: options?.order,
+    });
 
     return request.send(
       this.requestCtx,

--- a/javascript/src/api/connector.ts
+++ b/javascript/src/api/connector.ts
@@ -36,10 +36,12 @@ export class Connector {
   public list(options?: ConnectorListOptions): Promise<ListResponseConnectorOut> {
     const request = new SvixRequest(HttpMethod.GET, "/api/v1/connector");
 
-    request.setQueryParam("limit", options?.limit);
-    request.setQueryParam("iterator", options?.iterator);
-    request.setQueryParam("order", options?.order);
-    request.setQueryParam("product_type", options?.productType);
+    request.setQueryParams({
+      limit: options?.limit,
+      iterator: options?.iterator,
+      order: options?.order,
+      product_type: options?.productType,
+    });
 
     return request.send(
       this.requestCtx,

--- a/javascript/src/api/endpoint.ts
+++ b/javascript/src/api/endpoint.ts
@@ -97,9 +97,11 @@ export class Endpoint {
     const request = new SvixRequest(HttpMethod.GET, "/api/v1/app/{app_id}/endpoint");
 
     request.setPathParam("app_id", appId);
-    request.setQueryParam("limit", options?.limit);
-    request.setQueryParam("iterator", options?.iterator);
-    request.setQueryParam("order", options?.order);
+    request.setQueryParams({
+      limit: options?.limit,
+      iterator: options?.iterator,
+      order: options?.order,
+    });
 
     return request.send(
       this.requestCtx,
@@ -405,8 +407,10 @@ export class Endpoint {
 
     request.setPathParam("app_id", appId);
     request.setPathParam("endpoint_id", endpointId);
-    request.setQueryParam("since", options?.since);
-    request.setQueryParam("until", options?.until);
+    request.setQueryParams({
+      since: options?.since,
+      until: options?.until,
+    });
 
     return request.send(this.requestCtx, EndpointStatsSerializer._fromJsonObject);
   }

--- a/javascript/src/api/eventType.ts
+++ b/javascript/src/api/eventType.ts
@@ -55,11 +55,13 @@ export class EventType {
   public list(options?: EventTypeListOptions): Promise<ListResponseEventTypeOut> {
     const request = new SvixRequest(HttpMethod.GET, "/api/v1/event-type");
 
-    request.setQueryParam("limit", options?.limit);
-    request.setQueryParam("iterator", options?.iterator);
-    request.setQueryParam("order", options?.order);
-    request.setQueryParam("include_archived", options?.includeArchived);
-    request.setQueryParam("with_content", options?.withContent);
+    request.setQueryParams({
+      limit: options?.limit,
+      iterator: options?.iterator,
+      order: options?.order,
+      include_archived: options?.includeArchived,
+      with_content: options?.withContent,
+    });
 
     return request.send(
       this.requestCtx,
@@ -153,7 +155,9 @@ export class EventType {
     );
 
     request.setPathParam("event_type_name", eventTypeName);
-    request.setQueryParam("expunge", options?.expunge);
+    request.setQueryParams({
+      expunge: options?.expunge,
+    });
 
     return request.sendNoResponseBody(this.requestCtx);
   }

--- a/javascript/src/api/ingestEndpoint.ts
+++ b/javascript/src/api/ingestEndpoint.ts
@@ -74,9 +74,11 @@ export class IngestEndpoint {
     );
 
     request.setPathParam("source_id", sourceId);
-    request.setQueryParam("limit", options?.limit);
-    request.setQueryParam("iterator", options?.iterator);
-    request.setQueryParam("order", options?.order);
+    request.setQueryParams({
+      limit: options?.limit,
+      iterator: options?.iterator,
+      order: options?.order,
+    });
 
     return request.send(
       this.requestCtx,

--- a/javascript/src/api/ingestSource.ts
+++ b/javascript/src/api/ingestSource.ts
@@ -37,9 +37,11 @@ export class IngestSource {
   public list(options?: IngestSourceListOptions): Promise<ListResponseIngestSourceOut> {
     const request = new SvixRequest(HttpMethod.GET, "/ingest/api/v1/source");
 
-    request.setQueryParam("limit", options?.limit);
-    request.setQueryParam("iterator", options?.iterator);
-    request.setQueryParam("order", options?.order);
+    request.setQueryParams({
+      limit: options?.limit,
+      iterator: options?.iterator,
+      order: options?.order,
+    });
 
     return request.send(
       this.requestCtx,

--- a/javascript/src/api/integration.ts
+++ b/javascript/src/api/integration.ts
@@ -45,9 +45,11 @@ export class Integration {
     const request = new SvixRequest(HttpMethod.GET, "/api/v1/app/{app_id}/integration");
 
     request.setPathParam("app_id", appId);
-    request.setQueryParam("limit", options?.limit);
-    request.setQueryParam("iterator", options?.iterator);
-    request.setQueryParam("order", options?.order);
+    request.setQueryParams({
+      limit: options?.limit,
+      iterator: options?.iterator,
+      order: options?.order,
+    });
 
     return request.send(
       this.requestCtx,

--- a/javascript/src/api/message.ts
+++ b/javascript/src/api/message.ts
@@ -72,14 +72,16 @@ export class Message {
     const request = new SvixRequest(HttpMethod.GET, "/api/v1/app/{app_id}/msg");
 
     request.setPathParam("app_id", appId);
-    request.setQueryParam("limit", options?.limit);
-    request.setQueryParam("iterator", options?.iterator);
-    request.setQueryParam("channel", options?.channel);
-    request.setQueryParam("before", options?.before);
-    request.setQueryParam("after", options?.after);
-    request.setQueryParam("with_content", options?.withContent);
-    request.setQueryParam("tag", options?.tag);
-    request.setQueryParam("event_types", options?.eventTypes);
+    request.setQueryParams({
+      limit: options?.limit,
+      iterator: options?.iterator,
+      channel: options?.channel,
+      before: options?.before,
+      after: options?.after,
+      with_content: options?.withContent,
+      tag: options?.tag,
+      event_types: options?.eventTypes,
+    });
 
     return request.send(
       this.requestCtx,
@@ -106,7 +108,9 @@ export class Message {
     const request = new SvixRequest(HttpMethod.POST, "/api/v1/app/{app_id}/msg");
 
     request.setPathParam("app_id", appId);
-    request.setQueryParam("with_content", options?.withContent);
+    request.setQueryParams({
+      with_content: options?.withContent,
+    });
     request.setHeaderParam("idempotency-key", options?.idempotencyKey);
     request.setBody(MessageInSerializer._toJsonObject(messageIn));
 
@@ -155,7 +159,9 @@ export class Message {
 
     request.setPathParam("app_id", appId);
     request.setPathParam("msg_id", msgId);
-    request.setQueryParam("with_content", options?.withContent);
+    request.setQueryParams({
+      with_content: options?.withContent,
+    });
 
     return request.send(this.requestCtx, MessageOutSerializer._fromJsonObject);
   }

--- a/javascript/src/api/messageAttempt.ts
+++ b/javascript/src/api/messageAttempt.ts
@@ -126,17 +126,19 @@ export class MessageAttempt {
 
     request.setPathParam("app_id", appId);
     request.setPathParam("endpoint_id", endpointId);
-    request.setQueryParam("limit", options?.limit);
-    request.setQueryParam("iterator", options?.iterator);
-    request.setQueryParam("status", options?.status);
-    request.setQueryParam("status_code_class", options?.statusCodeClass);
-    request.setQueryParam("channel", options?.channel);
-    request.setQueryParam("tag", options?.tag);
-    request.setQueryParam("before", options?.before);
-    request.setQueryParam("after", options?.after);
-    request.setQueryParam("with_content", options?.withContent);
-    request.setQueryParam("with_msg", options?.withMsg);
-    request.setQueryParam("event_types", options?.eventTypes);
+    request.setQueryParams({
+      limit: options?.limit,
+      iterator: options?.iterator,
+      status: options?.status,
+      status_code_class: options?.statusCodeClass,
+      channel: options?.channel,
+      tag: options?.tag,
+      before: options?.before,
+      after: options?.after,
+      with_content: options?.withContent,
+      with_msg: options?.withMsg,
+      event_types: options?.eventTypes,
+    });
 
     return request.send(
       this.requestCtx,
@@ -164,17 +166,19 @@ export class MessageAttempt {
 
     request.setPathParam("app_id", appId);
     request.setPathParam("msg_id", msgId);
-    request.setQueryParam("limit", options?.limit);
-    request.setQueryParam("iterator", options?.iterator);
-    request.setQueryParam("status", options?.status);
-    request.setQueryParam("status_code_class", options?.statusCodeClass);
-    request.setQueryParam("channel", options?.channel);
-    request.setQueryParam("tag", options?.tag);
-    request.setQueryParam("endpoint_id", options?.endpointId);
-    request.setQueryParam("before", options?.before);
-    request.setQueryParam("after", options?.after);
-    request.setQueryParam("with_content", options?.withContent);
-    request.setQueryParam("event_types", options?.eventTypes);
+    request.setQueryParams({
+      limit: options?.limit,
+      iterator: options?.iterator,
+      status: options?.status,
+      status_code_class: options?.statusCodeClass,
+      channel: options?.channel,
+      tag: options?.tag,
+      endpoint_id: options?.endpointId,
+      before: options?.before,
+      after: options?.after,
+      with_content: options?.withContent,
+      event_types: options?.eventTypes,
+    });
 
     return request.send(
       this.requestCtx,
@@ -204,15 +208,17 @@ export class MessageAttempt {
 
     request.setPathParam("app_id", appId);
     request.setPathParam("endpoint_id", endpointId);
-    request.setQueryParam("limit", options?.limit);
-    request.setQueryParam("iterator", options?.iterator);
-    request.setQueryParam("channel", options?.channel);
-    request.setQueryParam("tag", options?.tag);
-    request.setQueryParam("status", options?.status);
-    request.setQueryParam("before", options?.before);
-    request.setQueryParam("after", options?.after);
-    request.setQueryParam("with_content", options?.withContent);
-    request.setQueryParam("event_types", options?.eventTypes);
+    request.setQueryParams({
+      limit: options?.limit,
+      iterator: options?.iterator,
+      channel: options?.channel,
+      tag: options?.tag,
+      status: options?.status,
+      before: options?.before,
+      after: options?.after,
+      with_content: options?.withContent,
+      event_types: options?.eventTypes,
+    });
 
     return request.send(
       this.requestCtx,
@@ -275,8 +281,10 @@ export class MessageAttempt {
 
     request.setPathParam("app_id", appId);
     request.setPathParam("msg_id", msgId);
-    request.setQueryParam("limit", options?.limit);
-    request.setQueryParam("iterator", options?.iterator);
+    request.setQueryParams({
+      limit: options?.limit,
+      iterator: options?.iterator,
+    });
 
     return request.send(
       this.requestCtx,

--- a/javascript/src/api/messagePoller.ts
+++ b/javascript/src/api/messagePoller.ts
@@ -53,11 +53,13 @@ export class MessagePoller {
 
     request.setPathParam("app_id", appId);
     request.setPathParam("sink_id", sinkId);
-    request.setQueryParam("limit", options?.limit);
-    request.setQueryParam("iterator", options?.iterator);
-    request.setQueryParam("event_type", options?.eventType);
-    request.setQueryParam("channel", options?.channel);
-    request.setQueryParam("after", options?.after);
+    request.setQueryParams({
+      limit: options?.limit,
+      iterator: options?.iterator,
+      event_type: options?.eventType,
+      channel: options?.channel,
+      after: options?.after,
+    });
 
     return request.send(this.requestCtx, PollingEndpointOutSerializer._fromJsonObject);
   }
@@ -80,8 +82,10 @@ export class MessagePoller {
     request.setPathParam("app_id", appId);
     request.setPathParam("sink_id", sinkId);
     request.setPathParam("consumer_id", consumerId);
-    request.setQueryParam("limit", options?.limit);
-    request.setQueryParam("iterator", options?.iterator);
+    request.setQueryParams({
+      limit: options?.limit,
+      iterator: options?.iterator,
+    });
 
     return request.send(this.requestCtx, PollingEndpointOutSerializer._fromJsonObject);
   }

--- a/javascript/src/api/operationalWebhookEndpoint.ts
+++ b/javascript/src/api/operationalWebhookEndpoint.ts
@@ -64,9 +64,11 @@ export class OperationalWebhookEndpoint {
       "/api/v1/operational-webhook/endpoint"
     );
 
-    request.setQueryParam("limit", options?.limit);
-    request.setQueryParam("iterator", options?.iterator);
-    request.setQueryParam("order", options?.order);
+    request.setQueryParams({
+      limit: options?.limit,
+      iterator: options?.iterator,
+      order: options?.order,
+    });
 
     return request.send(
       this.requestCtx,

--- a/javascript/src/api/streamingEventType.ts
+++ b/javascript/src/api/streamingEventType.ts
@@ -48,10 +48,12 @@ export class StreamingEventType {
   ): Promise<ListResponseStreamEventTypeOut> {
     const request = new SvixRequest(HttpMethod.GET, "/api/v1/stream/event-type");
 
-    request.setQueryParam("limit", options?.limit);
-    request.setQueryParam("iterator", options?.iterator);
-    request.setQueryParam("order", options?.order);
-    request.setQueryParam("include_archived", options?.includeArchived);
+    request.setQueryParams({
+      limit: options?.limit,
+      iterator: options?.iterator,
+      order: options?.order,
+      include_archived: options?.includeArchived,
+    });
 
     return request.send(
       this.requestCtx,
@@ -102,7 +104,9 @@ export class StreamingEventType {
     );
 
     request.setPathParam("name", name);
-    request.setQueryParam("expunge", options?.expunge);
+    request.setQueryParams({
+      expunge: options?.expunge,
+    });
 
     return request.sendNoResponseBody(this.requestCtx);
   }

--- a/javascript/src/api/streamingEvents.ts
+++ b/javascript/src/api/streamingEvents.ts
@@ -58,9 +58,11 @@ export class StreamingEvents {
 
     request.setPathParam("stream_id", streamId);
     request.setPathParam("sink_id", sinkId);
-    request.setQueryParam("limit", options?.limit);
-    request.setQueryParam("iterator", options?.iterator);
-    request.setQueryParam("after", options?.after);
+    request.setQueryParams({
+      limit: options?.limit,
+      iterator: options?.iterator,
+      after: options?.after,
+    });
 
     return request.send(this.requestCtx, EventStreamOutSerializer._fromJsonObject);
   }

--- a/javascript/src/api/streamingSink.ts
+++ b/javascript/src/api/streamingSink.ts
@@ -51,9 +51,11 @@ export class StreamingSink {
     const request = new SvixRequest(HttpMethod.GET, "/api/v1/stream/{stream_id}/sink");
 
     request.setPathParam("stream_id", streamId);
-    request.setQueryParam("limit", options?.limit);
-    request.setQueryParam("iterator", options?.iterator);
-    request.setQueryParam("order", options?.order);
+    request.setQueryParams({
+      limit: options?.limit,
+      iterator: options?.iterator,
+      order: options?.order,
+    });
 
     return request.send(
       this.requestCtx,

--- a/javascript/src/api/streamingStream.ts
+++ b/javascript/src/api/streamingStream.ts
@@ -30,9 +30,11 @@ export class StreamingStream {
   public list(options?: StreamingStreamListOptions): Promise<ListResponseStreamOut> {
     const request = new SvixRequest(HttpMethod.GET, "/api/v1/stream");
 
-    request.setQueryParam("limit", options?.limit);
-    request.setQueryParam("iterator", options?.iterator);
-    request.setQueryParam("order", options?.order);
+    request.setQueryParams({
+      limit: options?.limit,
+      iterator: options?.iterator,
+      order: options?.order,
+    });
 
     return request.send(this.requestCtx, ListResponseStreamOutSerializer._fromJsonObject);
   }

--- a/javascript/src/request.ts
+++ b/javascript/src/request.ts
@@ -63,6 +63,12 @@ export class SvixRequest {
     this.path = newPath;
   }
 
+  public setQueryParams(params: { [name: string]: QueryParameter }) {
+    for (const [name, value] of Object.entries(params)) {
+      this.setQueryParam(name, value);
+    }
+  }
+
   public setQueryParam(name: string, value: QueryParameter) {
     if (value === undefined || value === null) {
       return;


### PR DESCRIPTION
Makes it easier to patch in extra query parameters for our internal JS lib derived from this one.
Also makes the generated code look a little bit nicer.

(internal ref: https://github.com/svix/monorepo-private/issues/12097)