### PR TITLE
php: Fix bug causing `withTransformationsParams` to override `rawPaylaod`

### DIFF
--- a/codegen/templates/php/types/struct.php.jinja
+++ b/codegen/templates/php/types/struct.php.jinja
@@ -72,6 +72,13 @@ class {{ type.name | to_upper_camel_case }} implements \JsonSerializable
         {
             $setFields = $this->setFields;
             $setFields['{{ field.name | to_lower_camel_case }}'] = true;
+
+            {% if field.name == "transformationsParams" and type_name == "MessageIn" -%}
+            if ($transformationsParams !== null || $this->transformationsParams !== null) {
+                $transformationsParams = array_merge($this->transformationsParams ?? [], $transformationsParams ?? []);
+            }
+            {% endif -%}
+
             return new self(
                 {% for inner_field in type.fields -%}
                     {% if field.name != inner_field.name -%}

--- a/php/src/Models/MessageIn.php
+++ b/php/src/Models/MessageIn.php
@@ -210,6 +210,10 @@ class MessageIn implements \JsonSerializable
         $setFields = $this->setFields;
         $setFields['transformationsParams'] = true;
 
+        if (null !== $transformationsParams || null !== $this->transformationsParams) {
+            $transformationsParams = array_merge($this->transformationsParams ?? [], $transformationsParams ?? []);
+        }
+
         return new self(
             application: $this->application,
             channels: $this->channels,


### PR DESCRIPTION
The `rawPayload` is added to the `transformationsParams` in `createRaw`, and calling `withTransformationsParams` would delete the raw payload.