### PR TITLE
chore: remove obsolete docker-compose version field

### DIFF
--- a/server/docker-compose.override.yml
+++ b/server/docker-compose.override.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   backend:
     environment:

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   backend:
     build:


### PR DESCRIPTION
Docker Compose v2 prints a warning on startup indicating that the `version` field is obsolete and ignored.

This removes the `version` attribute from the compose files to eliminate the warning and reduce startup noise, with no behavior change.


