### PR TITLE
feat(gha): add `grype` scanning for OSS images

### DIFF
--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -63,6 +63,30 @@ jobs:
           echo "DOCKER_TAGS=${DOCKER_TAGS}" >> "$GITHUB_ENV"
           echo "Generated Tags: ${DOCKER_TAGS}"
 
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./server
+          file: ./server/Dockerfile
+          push: false
+          tags: ${{ env.DOCKER_TAGS }}
+          platforms: linux/amd64
+          load: true
+
+      - name: Scan image with Grype
+        id: scan
+        uses: anchore/scan-action@v6
+        with:
+          image: "${{ env.DOCKER_TAGS }}"
+          fail-build: true
+          severity-cutoff: high
+          only-fixed: true
+          output-file: grype.sarif
+
+      - name: Inspect action SARIF report
+        if: ${{ !cancelled() && hashFiles('grype.sarif') != '' }}
+        run: cat ${{ steps.scan.outputs.sarif }}
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
The server release build requires image scanning to detect the vulnerabilities in the image content
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
I am adding [grype](https://github.com/anchore/grype) image scanning for server release build.


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
This will
- scan images for fixable vulnerabilities of severity high and above
- fail the build if it detects above vulnerability
-  first build an amd64 image for this scan without the push
- push to registry only if the scan is okay