### PR TITLE
Svix CLI: support disabling TLS verification when relaying requests.

### DIFF
--- a/svix-cli/src/cmds/listen.rs
+++ b/svix-cli/src/cmds/listen.rs
@@ -7,6 +7,9 @@ use crate::config::{get_config_file_path, Config};
 pub struct ListenArgs {
     /// The local URL to forward webhooks to
     url: url::Url,
+    /// Disable TLS certificate verification when connecting to the local URL
+    #[arg(long)]
+    disable_tls_verification: bool,
 }
 
 impl ListenArgs {
@@ -33,6 +36,7 @@ impl ListenArgs {
             token,
             cfg.relay_debug_hostname.as_deref(),
             cfg.relay_disable_security.unwrap_or_default(),
+            self.disable_tls_verification,
         )
         .await?;
         Ok(())

--- a/svix-cli/src/relay/mod.rs
+++ b/svix-cli/src/relay/mod.rs
@@ -215,6 +215,7 @@ pub async fn listen(
     relay_token: String,
     relay_debug_url: Option<&str>,
     relay_disable_security: bool,
+    disable_tls_verification: bool,
 ) -> Result<()> {
     let scheme = if relay_disable_security { "ws" } else { "wss" };
     let api_host = relay_debug_url.unwrap_or(DEFAULT_API_HOST);
@@ -222,11 +223,15 @@ pub async fn listen(
 
     let websocket_url = format!("{scheme}://{api_host}/{API_PREFIX}/listen/").parse()?;
 
+    let http_client = HttpClient::builder()
+        .danger_accept_invalid_certs(disable_tls_verification)
+        .build()?;
+
     let mut client = Client {
         token,
         websocket_url,
         local_url,
-        http_client: HttpClient::new(),
+        http_client,
     };
 
     const MAX_BACKOFF: Duration = Duration::from_millis(5000);


### PR DESCRIPTION
Makes local debugging easier when you're already using self-signed TLS certs.