### PR TITLE
Fix `repository` url in js package.json

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -3,7 +3,7 @@
   "version": "1.84.0",
   "description": "Svix webhooks API client and webhook verification library",
   "author": "svix",
-  "repository": "https://github.com/svix/svix-libs",
+  "repository": "https://github.com/svix/svix-webhooks",
   "type": "commonjs",
   "keywords": [
     "svix",


### PR DESCRIPTION
The provenance verification fails due to the incorrect url

See logs here: https://github.com/svix/svix-webhooks/actions/runs/20583273320/job/59115024859