### PR TITLE
Use `bitnamilegacy` images instead of my backup images 

### DIFF
--- a/bridge/testing-docker-compose.yml
+++ b/bridge/testing-docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - "0.0.0.0:8085"
 
   kafka:
-    image: "ghcr.io/svix-mman/docker.io/bitnami/kafka:3.5.1"
+    image: "docker.io/bitnamilegacy/kafka:3.5.1"
     ports:
       - "9092:9092"
       - "9094:9094"

--- a/server/testing-docker-compose.yml
+++ b/server/testing-docker-compose.yml
@@ -17,7 +17,7 @@ services:
 
   # Redis cluster
   redis-cluster:
-    image: "ghcr.io/svix-mman/docker.io/bitnami/redis-cluster:7.0.10"
+    image: "docker.io/bitnamilegacy/redis-cluster:7.0.10"
     environment:
       ALLOW_EMPTY_PASSWORD: "yes"
       REDIS_NODES: "redis-cluster redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4"
@@ -33,7 +33,7 @@ services:
       - redis-cluster-node-4
 
   redis-cluster-node-0:
-    image: "ghcr.io/svix-mman/docker.io/bitnami/redis-cluster:7.0.10"
+    image: "docker.io/bitnamilegacy/redis-cluster:7.0.10"
     ports:
       - "6381:6379"
     environment:
@@ -41,7 +41,7 @@ services:
       REDIS_NODES: "redis-cluster redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4"
 
   redis-cluster-node-1:
-    image: "ghcr.io/svix-mman/docker.io/bitnami/redis-cluster:7.0.10"
+    image: "docker.io/bitnamilegacy/redis-cluster:7.0.10"
     ports:
       - "6382:6379"
     environment:
@@ -49,7 +49,7 @@ services:
       REDIS_NODES: "redis-cluster redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4"
 
   redis-cluster-node-2:
-    image: "ghcr.io/svix-mman/docker.io/bitnami/redis-cluster:7.0.10"
+    image: "docker.io/bitnamilegacy/redis-cluster:7.0.10"
     ports:
       - "6383:6379"
     environment:
@@ -57,7 +57,7 @@ services:
       REDIS_NODES: "redis-cluster redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4"
 
   redis-cluster-node-3:
-    image: "ghcr.io/svix-mman/docker.io/bitnami/redis-cluster:7.0.10"
+    image: "docker.io/bitnamilegacy/redis-cluster:7.0.10"
     ports:
       - "6384:6379"
     environment:
@@ -65,7 +65,7 @@ services:
       REDIS_NODES: "redis-cluster redis-cluster-node-0 redis-cluster-node-1 redis-cluster-node-2 redis-cluster-node-3 redis-cluster-node-4"
 
   redis-cluster-node-4:
-    image: "ghcr.io/svix-mman/docker.io/bitnami/redis-cluster:7.0.10"
+    image: "docker.io/bitnamilegacy/redis-cluster:7.0.10"
     ports:
       - "6385:6379"
     environment:


### PR DESCRIPTION
When bitnami announced they would remove all of the `bitnami` images, I copied the images we used and uploaded them to `ghcr.io/svix-mman/docker.io/bitnami/*`, we no longer need to use my images, we can just use `bitnamilegacy` (this is where all of the images ended up)