### PR TITLE
python: update wheel from 0.44.0 to 0.46.3

### DIFF
--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -40,6 +40,7 @@ packaging==24.1
     # via
     #   build
     #   pytest
+    #   wheel
 pip==25.3
     # via pip-tools
 pip-tools==7.4.1
@@ -78,5 +79,5 @@ werkzeug==3.1.5
     # via
     #   -r requirements.in/development.txt
     #   pytest-httpserver
-wheel==0.44.0
+wheel==0.46.3
     # via pip-tools


### PR DESCRIPTION
Dependabot wasn't able to do this, so I had to do it by hand.

Fixes CVE-2026-24049.