### PR TITLE
javascript: fix handling of optional nested enums and objects

### DIFF
--- a/codegen/templates/javascript/types/macros.ts.jinja
+++ b/codegen/templates/javascript/types/macros.ts.jinja
@@ -11,7 +11,7 @@
             {{ field_expr }}
         {% else -%}
             {%- if not field_required -%}
-                {{ field_expr }} ? {{ type.to_js() }}Serializer._fromJsonObject({{ field_expr }}): undefined
+                {{ field_expr }} != null ? {{ type.to_js() }}Serializer._fromJsonObject({{ field_expr }}): undefined
             {%- else -%}
                 {{ type.to_js() }}Serializer._fromJsonObject({{ field_expr }})
             {%- endif %}
@@ -52,7 +52,7 @@
             {{ field_expr }}
         {% else -%}
             {%- if not field_required -%}
-            {{ field_expr }} ? {{ type.to_js() }}Serializer._toJsonObject({{ field_expr }}) : undefined
+            {{ field_expr }} != null ? {{ type.to_js() }}Serializer._toJsonObject({{ field_expr }}) : undefined
             {%- else -%}
             {{ type.to_js() }}Serializer._toJsonObject({{ field_expr }})
             {%- endif -%}

--- a/javascript/src/models/appPortalAccessIn.ts
+++ b/javascript/src/models/appPortalAccessIn.ts
@@ -57,9 +57,10 @@ export interface AppPortalAccessIn {
 export const AppPortalAccessInSerializer = {
   _fromJsonObject(object: any): AppPortalAccessIn {
     return {
-      application: object["application"]
-        ? ApplicationInSerializer._fromJsonObject(object["application"])
-        : undefined,
+      application:
+        object["application"] != null
+          ? ApplicationInSerializer._fromJsonObject(object["application"])
+          : undefined,
       capabilities: object["capabilities"]?.map((item: AppPortalCapability) =>
         AppPortalCapabilitySerializer._fromJsonObject(item)
       ),
@@ -72,9 +73,10 @@ export const AppPortalAccessInSerializer = {
 
   _toJsonObject(self: AppPortalAccessIn): any {
     return {
-      application: self.application
-        ? ApplicationInSerializer._toJsonObject(self.application)
-        : undefined,
+      application:
+        self.application != null
+          ? ApplicationInSerializer._toJsonObject(self.application)
+          : undefined,
       capabilities: self.capabilities?.map((item) =>
         AppPortalCapabilitySerializer._toJsonObject(item)
       ),

--- a/javascript/src/models/connectorIn.ts
+++ b/javascript/src/models/connectorIn.ts
@@ -23,14 +23,16 @@ export const ConnectorInSerializer = {
       description: object["description"],
       featureFlags: object["featureFlags"],
       instructions: object["instructions"],
-      kind: object["kind"]
-        ? ConnectorKindSerializer._fromJsonObject(object["kind"])
-        : undefined,
+      kind:
+        object["kind"] != null
+          ? ConnectorKindSerializer._fromJsonObject(object["kind"])
+          : undefined,
       logo: object["logo"],
       name: object["name"],
-      productType: object["productType"]
-        ? ConnectorProductSerializer._fromJsonObject(object["productType"])
-        : undefined,
+      productType:
+        object["productType"] != null
+          ? ConnectorProductSerializer._fromJsonObject(object["productType"])
+          : undefined,
       transformation: object["transformation"],
       uid: object["uid"],
     };
@@ -42,12 +44,14 @@ export const ConnectorInSerializer = {
       description: self.description,
       featureFlags: self.featureFlags,
       instructions: self.instructions,
-      kind: self.kind ? ConnectorKindSerializer._toJsonObject(self.kind) : undefined,
+      kind:
+        self.kind != null ? ConnectorKindSerializer._toJsonObject(self.kind) : undefined,
       logo: self.logo,
       name: self.name,
-      productType: self.productType
-        ? ConnectorProductSerializer._toJsonObject(self.productType)
-        : undefined,
+      productType:
+        self.productType != null
+          ? ConnectorProductSerializer._toJsonObject(self.productType)
+          : undefined,
       transformation: self.transformation,
       uid: self.uid,
     };

--- a/javascript/src/models/connectorPatch.ts
+++ b/javascript/src/models/connectorPatch.ts
@@ -19,9 +19,10 @@ export const ConnectorPatchSerializer = {
       description: object["description"],
       featureFlags: object["featureFlags"],
       instructions: object["instructions"],
-      kind: object["kind"]
-        ? ConnectorKindSerializer._fromJsonObject(object["kind"])
-        : undefined,
+      kind:
+        object["kind"] != null
+          ? ConnectorKindSerializer._fromJsonObject(object["kind"])
+          : undefined,
       logo: object["logo"],
       name: object["name"],
       transformation: object["transformation"],
@@ -34,7 +35,8 @@ export const ConnectorPatchSerializer = {
       description: self.description,
       featureFlags: self.featureFlags,
       instructions: self.instructions,
-      kind: self.kind ? ConnectorKindSerializer._toJsonObject(self.kind) : undefined,
+      kind:
+        self.kind != null ? ConnectorKindSerializer._toJsonObject(self.kind) : undefined,
       logo: self.logo,
       name: self.name,
       transformation: self.transformation,

--- a/javascript/src/models/connectorUpdate.ts
+++ b/javascript/src/models/connectorUpdate.ts
@@ -19,9 +19,10 @@ export const ConnectorUpdateSerializer = {
       description: object["description"],
       featureFlags: object["featureFlags"],
       instructions: object["instructions"],
-      kind: object["kind"]
-        ? ConnectorKindSerializer._fromJsonObject(object["kind"])
-        : undefined,
+      kind:
+        object["kind"] != null
+          ? ConnectorKindSerializer._fromJsonObject(object["kind"])
+          : undefined,
       logo: object["logo"],
       name: object["name"],
       transformation: object["transformation"],
@@ -34,7 +35,8 @@ export const ConnectorUpdateSerializer = {
       description: self.description,
       featureFlags: self.featureFlags,
       instructions: self.instructions,
-      kind: self.kind ? ConnectorKindSerializer._toJsonObject(self.kind) : undefined,
+      kind:
+        self.kind != null ? ConnectorKindSerializer._toJsonObject(self.kind) : undefined,
       logo: self.logo,
       name: self.name,
       transformation: self.transformation,

--- a/javascript/src/models/createStreamEventsIn.ts
+++ b/javascript/src/models/createStreamEventsIn.ts
@@ -18,16 +18,18 @@ export const CreateStreamEventsInSerializer = {
       events: object["events"].map((item: EventIn) =>
         EventInSerializer._fromJsonObject(item)
       ),
-      stream: object["stream"]
-        ? StreamInSerializer._fromJsonObject(object["stream"])
-        : undefined,
+      stream:
+        object["stream"] != null
+          ? StreamInSerializer._fromJsonObject(object["stream"])
+          : undefined,
     };
   },
 
   _toJsonObject(self: CreateStreamEventsIn): any {
     return {
       events: self.events.map((item) => EventInSerializer._toJsonObject(item)),
-      stream: self.stream ? StreamInSerializer._toJsonObject(self.stream) : undefined,
+      stream:
+        self.stream != null ? StreamInSerializer._toJsonObject(self.stream) : undefined,
     };
   },
 };

--- a/javascript/src/models/endpointDisabledEventData.ts
+++ b/javascript/src/models/endpointDisabledEventData.ts
@@ -26,9 +26,10 @@ export const EndpointDisabledEventDataSerializer = {
       endpointId: object["endpointId"],
       endpointUid: object["endpointUid"],
       failSince: object["failSince"] ? new Date(object["failSince"]) : null,
-      trigger: object["trigger"]
-        ? EndpointDisabledTriggerSerializer._fromJsonObject(object["trigger"])
-        : undefined,
+      trigger:
+        object["trigger"] != null
+          ? EndpointDisabledTriggerSerializer._fromJsonObject(object["trigger"])
+          : undefined,
     };
   },
 
@@ -39,9 +40,10 @@ export const EndpointDisabledEventDataSerializer = {
       endpointId: self.endpointId,
       endpointUid: self.endpointUid,
       failSince: self.failSince,
-      trigger: self.trigger
-        ? EndpointDisabledTriggerSerializer._toJsonObject(self.trigger)
-        : undefined,
+      trigger:
+        self.trigger != null
+          ? EndpointDisabledTriggerSerializer._toJsonObject(self.trigger)
+          : undefined,
     };
   },
 };

--- a/javascript/src/models/ingestEndpointDisabledEventData.ts
+++ b/javascript/src/models/ingestEndpointDisabledEventData.ts
@@ -23,9 +23,10 @@ export const IngestEndpointDisabledEventDataSerializer = {
       endpointUid: object["endpointUid"],
       failSince: object["failSince"] ? new Date(object["failSince"]) : null,
       sourceId: object["sourceId"],
-      trigger: object["trigger"]
-        ? EndpointDisabledTriggerSerializer._fromJsonObject(object["trigger"])
-        : undefined,
+      trigger:
+        object["trigger"] != null
+          ? EndpointDisabledTriggerSerializer._fromJsonObject(object["trigger"])
+          : undefined,
     };
   },
 
@@ -35,9 +36,10 @@ export const IngestEndpointDisabledEventDataSerializer = {
       endpointUid: self.endpointUid,
       failSince: self.failSince,
       sourceId: self.sourceId,
-      trigger: self.trigger
-        ? EndpointDisabledTriggerSerializer._toJsonObject(self.trigger)
-        : undefined,
+      trigger:
+        self.trigger != null
+          ? EndpointDisabledTriggerSerializer._toJsonObject(self.trigger)
+          : undefined,
     };
   },
 };

--- a/javascript/src/models/messageAttemptLog.ts
+++ b/javascript/src/models/messageAttemptLog.ts
@@ -39,9 +39,10 @@ export const MessageAttemptLogSerializer = {
       attemptStart: new Date(object["attemptStart"]),
       endpointId: object["endpointId"],
       eventType: object["eventType"],
-      httpTimes: object["httpTimes"]
-        ? HttpAttemptTimesSerializer._fromJsonObject(object["httpTimes"])
-        : undefined,
+      httpTimes:
+        object["httpTimes"] != null
+          ? HttpAttemptTimesSerializer._fromJsonObject(object["httpTimes"])
+          : undefined,
       msgCreated: new Date(object["msgCreated"]),
       msgEventId: object["msgEventId"],
       msgId: object["msgId"],
@@ -61,9 +62,10 @@ export const MessageAttemptLogSerializer = {
       attemptStart: self.attemptStart,
       endpointId: self.endpointId,
       eventType: self.eventType,
-      httpTimes: self.httpTimes
-        ? HttpAttemptTimesSerializer._toJsonObject(self.httpTimes)
-        : undefined,
+      httpTimes:
+        self.httpTimes != null
+          ? HttpAttemptTimesSerializer._toJsonObject(self.httpTimes)
+          : undefined,
       msgCreated: self.msgCreated,
       msgEventId: self.msgEventId,
       msgId: self.msgId,

--- a/javascript/src/models/messageAttemptOut.ts
+++ b/javascript/src/models/messageAttemptOut.ts
@@ -31,9 +31,10 @@ export const MessageAttemptOutSerializer = {
     return {
       endpointId: object["endpointId"],
       id: object["id"],
-      msg: object["msg"]
-        ? MessageOutSerializer._fromJsonObject(object["msg"])
-        : undefined,
+      msg:
+        object["msg"] != null
+          ? MessageOutSerializer._fromJsonObject(object["msg"])
+          : undefined,
       msgId: object["msgId"],
       response: object["response"],
       responseDurationMs: object["responseDurationMs"],
@@ -52,7 +53,7 @@ export const MessageAttemptOutSerializer = {
     return {
       endpointId: self.endpointId,
       id: self.id,
-      msg: self.msg ? MessageOutSerializer._toJsonObject(self.msg) : undefined,
+      msg: self.msg != null ? MessageOutSerializer._toJsonObject(self.msg) : undefined,
       msgId: self.msgId,
       response: self.response,
       responseDurationMs: self.responseDurationMs,

--- a/javascript/src/models/messageIn.ts
+++ b/javascript/src/models/messageIn.ts
@@ -39,9 +39,10 @@ export interface MessageIn {
 export const MessageInSerializer = {
   _fromJsonObject(object: any): MessageIn {
     return {
-      application: object["application"]
-        ? ApplicationInSerializer._fromJsonObject(object["application"])
-        : undefined,
+      application:
+        object["application"] != null
+          ? ApplicationInSerializer._fromJsonObject(object["application"])
+          : undefined,
       channels: object["channels"],
       deliverAt: object["deliverAt"] ? new Date(object["deliverAt"]) : null,
       eventId: object["eventId"],
@@ -56,9 +57,10 @@ export const MessageInSerializer = {
 
   _toJsonObject(self: MessageIn): any {
     return {
-      application: self.application
-        ? ApplicationInSerializer._toJsonObject(self.application)
-        : undefined,
+      application:
+        self.application != null
+          ? ApplicationInSerializer._toJsonObject(self.application)
+          : undefined,
       channels: self.channels,
       deliverAt: self.deliverAt,
       eventId: self.eventId,

--- a/javascript/src/models/streamSinkIn.ts
+++ b/javascript/src/models/streamSinkIn.ts
@@ -109,9 +109,10 @@ export const StreamSinkInSerializer = {
       eventTypes: object["eventTypes"],
       maxWaitSecs: object["maxWaitSecs"],
       metadata: object["metadata"],
-      status: object["status"]
-        ? SinkStatusInSerializer._fromJsonObject(object["status"])
-        : undefined,
+      status:
+        object["status"] != null
+          ? SinkStatusInSerializer._fromJsonObject(object["status"])
+          : undefined,
       uid: object["uid"],
     };
   },
@@ -147,7 +148,10 @@ export const StreamSinkInSerializer = {
       eventTypes: self.eventTypes,
       maxWaitSecs: self.maxWaitSecs,
       metadata: self.metadata,
-      status: self.status ? SinkStatusInSerializer._toJsonObject(self.status) : undefined,
+      status:
+        self.status != null
+          ? SinkStatusInSerializer._toJsonObject(self.status)
+          : undefined,
       uid: self.uid,
     };
   },

--- a/javascript/src/models/streamSinkPatch.ts
+++ b/javascript/src/models/streamSinkPatch.ts
@@ -101,9 +101,10 @@ export const StreamSinkPatchSerializer = {
       eventTypes: object["eventTypes"],
       maxWaitSecs: object["maxWaitSecs"],
       metadata: object["metadata"],
-      status: object["status"]
-        ? SinkStatusInSerializer._fromJsonObject(object["status"])
-        : undefined,
+      status:
+        object["status"] != null
+          ? SinkStatusInSerializer._fromJsonObject(object["status"])
+          : undefined,
       uid: object["uid"],
     };
   },
@@ -139,7 +140,10 @@ export const StreamSinkPatchSerializer = {
       eventTypes: self.eventTypes,
       maxWaitSecs: self.maxWaitSecs,
       metadata: self.metadata,
-      status: self.status ? SinkStatusInSerializer._toJsonObject(self.status) : undefined,
+      status:
+        self.status != null
+          ? SinkStatusInSerializer._toJsonObject(self.status)
+          : undefined,
       uid: self.uid,
     };
   },


### PR DESCRIPTION
The current template generates code like this for optional fields:

```
object["foo"] ? FooSerializer._fromJsonObject(object["foo"]) : undefined
```

This has a bug where, if `object["foo"]` is `""` or `0`, it also gets evaluated to false and the field is skipped. This can happen with enums like `MessageStatus`. 

```
enum MessageStatus {
    Success = 0,
    Pending = 1,
    Fail = 2,
    Sending = 3
}
```

This updated the template to use `object["foo"] != null ?` instead, which only evaluates to false when object[foo] is `undefined` or `null`. So `""` and `0` are not discarded. 