### PR TITLE
Ignore User-Agent overrides in configured headers

### DIFF
--- a/server/svix-server/src/worker.rs
+++ b/server/svix-server/src/worker.rs
@@ -1174,7 +1174,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(expected.get("user-agent"), actual.get("user-agent"));
-        assert!(actual.get("User-Agent").is_none());
+        assert!(!actual.contains_key("User-Agent"));
     }
 
     // Tests endpoint signing keys -- expected values are fetched from the Svix documentation for a


### PR DESCRIPTION
Motivation
The OSS worker builds headers in a case‑sensitive HashMap, so both user-agent (default) and User-Agent (from transformations) can exist simultaneously. When converted into a case‑insensitive HeaderMap, only one survives, and the winner depends on HashMap iteration order. This causes nondeterministic User‑Agent values, matching the “flip‑flop” behavior reported in Slack.

Solution
Ignore User-Agent overrides in configured headers (per product intent), and remove any existing case‑insensitive match before inserting a configured header. This guarantees a single, deterministic User‑Agent value. Added a unit test to ensure overrides are ignored.
