### PR TITLE
ruby: Return nil if payload does is empty

### DIFF
--- a/ruby/lib/svix/webhook.rb
+++ b/ruby/lib/svix/webhook.rb
@@ -40,7 +40,7 @@ module Svix
         end
 
         if ::Svix::secure_compare(signature, expectedSignature)
-          return {} if payload.empty?
+          return nil if payload.empty?
           return JSON.parse(payload, symbolize_names: true)
         end
       end

--- a/ruby/spec/webhook_spec.rb
+++ b/ruby/spec/webhook_spec.rb
@@ -167,6 +167,6 @@ describe Svix::Webhook do
     wh = Svix::Webhook.new(testPayload.secret)
 
     json = wh.verify(testPayload.payload, testPayload.headers)
-    expect(json).to(eq({}))
+    expect(json).to(eq(nil))
   end
 end


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

I'm using the Svix gem in Ruby to verify a `GET` request using the `verify` method. The payload of this request is empty so when calling `verify`, I pass in an empty string as the `payload`. Tracing the code, it looks like it's able to verify the request correctly but an error gets throw when returning the empty payload: `return JSON.parse(payload, symbolize_names: true)`


## Solution

The problem is that calling `JSON.parse` on an empty string throws an error: `unexpected end of input at line 1 column 1 (JSON::ParserError)`. The solution is to just return `nil` if the `payload` is empty.