### PR TITLE
Warn when Redis pending timeout is shorter than worker request timeout (+buffer)

### DIFF
--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -111,7 +111,7 @@ pub async fn run(cfg: Configuration) {
 fn warn_if_risky_redis_pending_timeout(cfg: &Configuration) {
     const BUFFER_SECS: u64 = 5;
 
-    if !matches(cfg.queue_type, QueueType::Redis | QueueType::RedisCluster | QueueType::RedisSentinel) {
+    if !matches!(cfg.queue_type, QueueType::Redis | QueueType::RedisCluster | QueueType::RedisSentinel) {
       return;
     }
 

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -111,9 +111,13 @@ pub async fn run(cfg: Configuration) {
 fn warn_if_risky_redis_pending_timeout(cfg: &Configuration) {
     const BUFFER_SECS: u64 = 5;
 
-    if !matches!(cfg.queue_type, QueueType::Redis | QueueType::RedisCluster | QueueType::RedisSentinel) {
-      return;
-    }
+    if !matches!(
+    cfg.queue_type,
+    QueueType::Redis | QueueType::RedisCluster | QueueType::RedisSentinel
+) {
+    return;
+}
+
 
     let http_timeout = cfg.worker_request_timeout as u64;
     let pending = cfg.redis_pending_duration_secs;

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -111,9 +111,8 @@ pub async fn run(cfg: Configuration) {
 fn warn_if_risky_redis_pending_timeout(cfg: &Configuration) {
     const BUFFER_SECS: u64 = 5;
 
-    match cfg.queue_type {
-        QueueType::Redis | QueueType::RedisCluster | QueueType::RedisSentinel => {}
-        _ => return,
+    if !matches(cfg.queue_type, QueueType::Redis | QueueType::RedisCluster | QueueType::RedisSentinel) {
+      return;
     }
 
     let http_timeout = cfg.worker_request_timeout as u64;

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -112,12 +112,11 @@ fn warn_if_risky_redis_pending_timeout(cfg: &Configuration) {
     const BUFFER_SECS: u64 = 5;
 
     if !matches!(
-    cfg.queue_type,
-    QueueType::Redis | QueueType::RedisCluster | QueueType::RedisSentinel
-) {
-    return;
-}
-
+        cfg.queue_type,
+        QueueType::Redis | QueueType::RedisCluster | QueueType::RedisSentinel
+    ) {
+        return;
+    }
 
     let http_timeout = cfg.worker_request_timeout as u64;
     let pending = cfg.redis_pending_duration_secs;

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -130,8 +130,6 @@ fn warn_if_risky_redis_pending_timeout(cfg: &Configuration) {
         );
     }
 }
-
-
 #[derive(Clone)]
 pub struct AppState {
     db: DatabaseConnection,

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -30,7 +30,7 @@ use tower_http::{
 use tracing_subscriber::{Layer as _, layer::SubscriberExt as _};
 
 use crate::{
-    cfg::{CacheBackend, Configuration},
+    cfg::{CacheBackend, Configuration, QueueType},
     core::{
         cache,
         cache::Cache,
@@ -108,6 +108,30 @@ pub async fn run(cfg: Configuration) {
     run_with_prefix(cfg.queue_prefix.clone(), cfg, None).await
 }
 
+fn warn_if_risky_redis_pending_timeout(cfg: &Configuration) {
+    const BUFFER_SECS: u64 = 5;
+
+    match cfg.queue_type {
+        QueueType::Redis | QueueType::RedisCluster | QueueType::RedisSentinel => {}
+        _ => return,
+    }
+
+    let http_timeout = cfg.worker_request_timeout as u64;
+    let pending = cfg.redis_pending_duration_secs;
+
+    if pending < http_timeout + BUFFER_SECS {
+        tracing::warn!(
+            redis_pending_duration_secs = pending,
+            worker_request_timeout = http_timeout,
+            buffer_secs = BUFFER_SECS,
+            "redis_pending_duration_secs is shorter than worker_request_timeout \
+             (plus safety buffer); slow deliveries may be re-queued while still in-flight, \
+             causing overlapping webhook deliveries for the same message."
+        );
+    }
+}
+
+
 #[derive(Clone)]
 pub struct AppState {
     db: DatabaseConnection,
@@ -124,6 +148,8 @@ pub async fn run_with_prefix(
     cfg: Configuration,
     listener: Option<TcpListener>,
 ) {
+    warn_if_risky_redis_pending_timeout(&cfg);
+
     tracing::debug!("DB: Initializing pool");
     let pool = init_db(&cfg).await;
     tracing::debug!("DB: Started");


### PR DESCRIPTION
## Context

In OSS/self-hosted setups, operators sometimes increase
`worker_request_timeout` to accommodate slow endpoints.

The Redis visibility timeout (`redis_pending_duration_secs`) is configured
separately and remains global.

If `worker_request_timeout` is increased for slow deliveries but
`redis_pending_duration_secs` is not adjusted accordingly, Redis may
re-queue a task while the original worker is still processing it.

That can result in overlapping deliveries of the same message.

## Change

This PR adds a startup guardrail:

If using a Redis-based queue and:

    redis_pending_duration_secs < worker_request_timeout + 5s

a `tracing::warn!` is emitted during startup.

## Why a Warning (Not a Hard Error)

The configuration is technically valid and may be intentional.
This change does not modify runtime behavior.

It simply highlights a potentially unsafe configuration
that could lead to duplicate in-flight deliveries when
handling slow endpoints.

## Scope

- Applies only to Redis-based queue types
- No behavior change
- OSS/self-hosted safeguard only
