### PR TITLE
Clean up some codegen templates

### DIFF
--- a/codegen/templates/go/component_type_summary.go.jinja
+++ b/codegen/templates/go/component_type_summary.go.jinja
@@ -5,6 +5,6 @@ import "github.com/svix/svix-webhooks/go/models"
 
 type (
 {% for type in api.types -%}
-	{{ type | to_upper_camel_case }} =  models.{{ type | to_upper_camel_case }}
+	{{ type | to_upper_camel_case }} = models.{{ type | to_upper_camel_case }}
 {% endfor %}
 )

--- a/codegen/templates/go/types/integer_enum.go.jinja
+++ b/codegen/templates/go/types/integer_enum.go.jinja
@@ -1,4 +1,4 @@
-{% set ty_name =  type.name | to_upper_camel_case -%}
+{% set ty_name = type.name | to_upper_camel_case -%}
 // Package svix this file is @generated DO NOT EDIT
 package models
 

--- a/codegen/templates/go/types/string_enum.go.jinja
+++ b/codegen/templates/go/types/string_enum.go.jinja
@@ -1,4 +1,4 @@
-{% set ty_name =  type.name | to_upper_camel_case -%}
+{% set ty_name = type.name | to_upper_camel_case -%}
 // Package svix this file is @generated DO NOT EDIT
 package models
 

--- a/codegen/templates/go/types/struct_enum.go.jinja
+++ b/codegen/templates/go/types/struct_enum.go.jinja
@@ -1,6 +1,6 @@
-{% set ty_name =  type.name | to_upper_camel_case -%}
-{% set discriminator_field =  type.discriminator_field | to_upper_camel_case -%}
-{% set content_field =  type.content_field | to_upper_camel_case -%}
+{% set ty_name = type.name | to_upper_camel_case -%}
+{% set discriminator_field = type.discriminator_field | to_upper_camel_case -%}
+{% set content_field = type.content_field | to_upper_camel_case -%}
 {% set has_variant_with_no_schema_ref = type.variants | selectattr("schema_ref") | length != type.variants | length -%}
 // Package svix this file is @generated DO NOT EDIT
 package models
@@ -63,7 +63,7 @@ func (i *{{ ty_name }}) UnmarshalJSON(data []byte) error {
 	}
 
 	var err error
-	switch i.Type {
+	switch i.{{ discriminator_field }} {
 	{% for schema_ref, vars in type.variants | groupby("schema_ref") -%}
 		case {% for v in vars %}"{{ v.name }}"{%if not loop.last%},{% endif %}{% endfor %}:
 			{% if schema_ref is defined -%}
@@ -74,7 +74,7 @@ func (i *{{ ty_name }}) UnmarshalJSON(data []byte) error {
 	{% endfor -%}
 	default:
 		// should be unreachable
-		return fmt.Errorf("unexpected type %s", i.Type)
+		return fmt.Errorf("unexpected type %s", i.{{ discriminator_field }})
 	}
 	return err
 }

--- a/codegen/templates/java/api_resource.java.jinja
+++ b/codegen/templates/java/api_resource.java.jinja
@@ -112,7 +112,7 @@ public class {{ resource_type_name }} {
     ) {{ throws }}  {
         {# path params -#}
         {% if op.path_params | length > 0 -%}
-        HttpUrl.Builder url =  this.client.newUrlBuilder().encodedPath(String.format("{{ op.path | generate_java_path_str(op.path_params) }}"
+        HttpUrl.Builder url = this.client.newUrlBuilder().encodedPath(String.format("{{ op.path | generate_java_path_str(op.path_params) }}"
             {%- for p in op.path_params -%}
             ,{{ p | to_lower_camel_case }}
             {%- endfor -%}


### PR DESCRIPTION
- Remove double spaces
- Fix hardcoded name of discriminator in Go struct_enum template