### PR TITLE
Remove unused devDependency of javascript SDK

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -34,7 +34,6 @@
   "devDependencies": {
     "@biomejs/biome": "2.2.4",
     "@stablelib/utf8": "^2.0.0",
-    "@types/node": "^22.7.5",
     "@types/uuid": "^10.0.0",
     "mockttp": "^3.15.5",
     "typescript": "^4.0"


### PR DESCRIPTION
Pretty sure we have no node-specific code here. Let's see what CI says.