### PR TITLE
Remove double space in PHP tests

### DIFF
--- a/php/tests/TestPayload.php
+++ b/php/tests/TestPayload.php
@@ -23,7 +23,7 @@ final class TestPayload
         $this->secret = self::DEFAULT_SECRET;
 
         $toSign = "{$this->id}.{$this->timestamp}.{$this->payload}";
-        $signature =  base64_encode(pack('H*', hash_hmac('sha256', $toSign, base64_decode($this->secret))));
+        $signature = base64_encode(pack('H*', hash_hmac('sha256', $toSign, base64_decode($this->secret))));
 
         $this->header = array(
             "svix-id" => $this->id,


### PR DESCRIPTION
We should probably auto-format the PHP stuff. Found this at the same time as #2185 but it didn't fit that PR.