### PR TITLE
js: Clean up includes and excludes in tsconfigs

### DIFF
--- a/javascript/tsconfig.json
+++ b/javascript/tsconfig.json
@@ -20,14 +20,10 @@
     "noLib": false,
     "lib": ["es6", "dom"]
   },
-  "exclude": [
-    "dist",
-    "test_build",
-    "node_modules",
-    "templates",
-    "jest.config.js",
-    "src/**/*.test.ts",
-    "eslint.config.mjs"
+  "include": [
+    "src/**/*.ts"
   ],
-  "filesGlob": ["./src/**/*.ts"]
+  "exclude": [
+    "src/**/*.test.ts"
+  ],
 }

--- a/javascript/tsconfig.test.json
+++ b/javascript/tsconfig.test.json
@@ -12,11 +12,6 @@
         "sourceMap": true
     },
     "include": [
-        "**/*.test.ts",
-        "**/*.ts"
-    ],
-    "exclude": [
-        "node_modules",
-        "dist"
+        "src/**/*.ts"
     ]
 }


### PR DESCRIPTION
We had a lot of excludes that were no-ops because the files matched by them were never included in the first place.
