### PR TITLE
fix(tf): grype scanner image ref

### DIFF
--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -63,6 +63,11 @@ jobs:
           echo "DOCKER_TAGS=${DOCKER_TAGS}" >> "$GITHUB_ENV"
           echo "Generated Tags: ${DOCKER_TAGS}"
 
+      - name: Extract first tag
+        id: extract
+        run: |
+          echo "SVIX_TAG=${DOCKER_TAGS%%,*}" >> "$GITHUB_OUTPUT"
+
       - name: Build Docker image
         uses: docker/build-push-action@v6
         with:
@@ -77,7 +82,7 @@ jobs:
         id: scan
         uses: anchore/scan-action@v6
         with:
-          image: "${{ env.DOCKER_TAGS }}"
+          image: "${{ steps.extract.outputs.SVIX_TAG }}"
           fail-build: true
           severity-cutoff: high
           only-fixed: true


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Came across an error while building image for the svix webhooks OSS

```
   [0028] ERROR failed to catalog: errors occurred attempting to resolve '***/***-server:latest,***/***-server:v1.85.0,***/***-server:v1.85,***/***-server:v1':
55
    - snap: snap file "***/***-server:latest,***/***-server:v1.85.0,***/***-server:v1.85,***/***-server:v1" does not exist
56
    - docker: could not parse reference: ***/***-server:latest,***/***-server:v1.85.0,***/***-server:v1.85,***/***-server:v1
57
    - podman: podman not available: no host address
58
    - containerd: containerd not available: failed to dial "/run/containerd/containerd.sock": connection error: desc = "transport: error while dialing: dial unix /run/containerd/containerd.sock: connect: permission denied"
59
    - oci-registry: unable to parse registry reference="***/***-server:latest,***/***-server:v1.85.0,***/***-server:v1.85,***/***-server:v1": could not parse reference: ***/***-server:latest,***/***-server:v1.85.0,***/***-server:v1.85,***/***-server:v1
60
    - snap: no snap found with name '***/***-server:latest,***/***-server:v1.85.0,***/***-server:v1.85,***/***-server:v1'
61
    - additionally, the following providers failed with file does not exist: docker-archive, oci-archive, oci-dir, singularity, oci-dir, local-file, local-directory
62
  ```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
The error is because of the multple comma separated image tags. Usually grype github action expects a single image tag instead of a string of comma separated image tags.

## Solution
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Solution is to extract the a single tag from the comma separated list and pass it to the grype github action step.
