### PR TITLE
ci: Fix GHA output references

### DIFF
--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -71,7 +71,7 @@ jobs:
           context: ./server
           file: ./server/Dockerfile
           push: false
-          tags: ${{ steps.gen_docker_tags.docker_tags }}
+          tags: ${{ steps.gen_docker_tags.outputs.docker_tags }}
           platforms: linux/amd64
           load: true
 
@@ -79,7 +79,7 @@ jobs:
         id: scan
         uses: anchore/scan-action@v6
         with:
-          image: "${{ steps.gen_docker_tags.latest_tag }}"
+          image: "${{ steps.gen_docker_tags.outputs.latest_tag }}"
           fail-build: true
           severity-cutoff: high
           only-fixed: true
@@ -95,5 +95,5 @@ jobs:
           context: ./server
           file: ./server/Dockerfile
           push: true
-          tags: ${{ steps.gen_docker_tags.docker_tags }}
+          tags: ${{ steps.gen_docker_tags.outputs.docker_tags }}
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Follow-up to https://github.com/svix/svix-webhooks/pull/2194.