### PR TITLE
Respect Retry-After on error responses

### DIFF
--- a/server/svix-server/src/worker.rs
+++ b/server/svix-server/src/worker.rs
@@ -383,20 +383,12 @@ async fn make_http_call(
                 MessageStatus::Fail
             };
 
-            let retry_after = if matches!(
-                res.status(),
-                StatusCode::TOO_MANY_REQUESTS | StatusCode::SERVICE_UNAVAILABLE
-            ) {
-                retry_after(res.headers())
-            } else {
-                None
-            };
-
             let http_error = if !res.status().is_success() {
                 Some(WebhookClientError::FailureStatus(res.status()))
             } else {
                 None
             };
+            let response_headers = res.headers().clone();
 
             let body = match res.into_body().collect().await {
                 Ok(collected) => {
@@ -419,11 +411,14 @@ async fn make_http_call(
             };
 
             match http_error {
-                Some(err) => Ok(CompletedDispatch::Failed(FailedDispatch(
-                    attempt,
-                    Error::generic(err),
-                    retry_after,
-                ))),
+                Some(err) => {
+                    let retry_after = retry_after(&response_headers);
+                    Ok(CompletedDispatch::Failed(FailedDispatch(
+                        attempt,
+                        Error::generic(err),
+                        retry_after,
+                    )))
+                }
                 None => Ok(CompletedDispatch::Successful(SuccessfulDispatch(attempt))),
             }
         }
@@ -517,8 +512,7 @@ fn retry_after(hdr_map: &HeaderMap) -> Option<DateTime<Utc>> {
 }
 
 fn limit_retry_delay(base: Duration, retry_after: Duration) -> Duration {
-    let cap = base.saturating_add(Duration::from_secs(2 * 60 * 60));
-    std::cmp::min(std::cmp::max(base, retry_after), cap)
+    retry_after.clamp(base, base * 2)
 }
 
 fn calculate_retry_delay(


### PR DESCRIPTION

This adds Retry-After handling as discussed in #2200 

If a destination responds with 429 or 503 and includes a Retry-After header, we now incorporate it into retry scheduling. The effective delay becomes max(internal_backoff, retry_after) and is capped at internal_backoff + 2h (using saturating_add) to avoid very large values causing excessive sleep.

Retry-After is honored for both 429 and 503 responses.

Existing overload penalty and jitter behavior remain unchanged. Invalid Retry-After headers are logged and ignored, falling back to the normal backoff logic. Unit tests are included for both seconds and HTTP-date formats.

Based on the Cloud implementation shared by @svix-jplatte 


Closes #2200 