### PR TITLE
sec: ignore RUSTSEC-2026-0097 for now

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -26,7 +26,9 @@ ignore = [
     # rustls-webpki incorrectly handles CRLs for certificates with multiple distributionPoints;
     # the old versions are used in smithy and we can't upgrade them right now. this will be fixed
     # when smithy drops hyper 0.x support
-    "RUSTSEC-2026-0049"
+    "RUSTSEC-2026-0049",
+    # can't upgrade rand until some dependencies support 0.10
+    "RUSTSEC-2026-0097",
 ]
 
 [licenses]


### PR DESCRIPTION
[RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097) is a somewhat subtle bug in `rand`; there isn't a fix available for 0.8.x., but several of our dependencies (including [sqlx](https://github.com/launchbadge/sqlx/pull/3946) and [num-bigint](https://github.com/rust-num/num-bigint/pull/338)) don't support 0.9/0.10 yet.

We don't configure a logger that uses `rand::thread_rng` anyway.
