### PR TITLE
Remove old endpoint secrets on rotation

### DIFF
--- a/server/svix-server/src/core/types/mod.rs
+++ b/server/svix-server/src/core/types/mod.rs
@@ -643,6 +643,11 @@ json_wrapper!(ExpiringSigningKeys);
 impl ExpiringSigningKeys {
     pub const MAX_OLD_KEYS: usize = 10;
     pub const OLD_KEY_EXPIRY_HOURS: i64 = 24;
+
+    pub fn unexpired_keys(&self) -> impl Iterator<Item = &ExpiringSigningKey> {
+        let now = Utc::now();
+        self.0.iter().filter(move |x| x.expiration > now)
+    }
 }
 
 /// The type of encryption key

--- a/server/svix-server/src/v1/endpoints/endpoint/secrets.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/secrets.rs
@@ -1,5 +1,3 @@
-use std::iter;
-
 use axum::{
     Json,
     extract::{Path, State},
@@ -11,12 +9,14 @@ use svix_server_derive::aide_annotate;
 use super::{EndpointSecretOut, EndpointSecretRotateIn};
 use crate::{
     AppState,
-    cfg::DefaultSignatureType,
+    cfg::{ConfigurationInner, DefaultSignatureType},
     core::{
+        can_fail::CanFail,
         cryptography::Encryption,
+        message_app::CreateMessageApp,
         operational_webhooks::{EndpointEvent, OperationalWebhook},
         permissions,
-        types::{EndpointSecretInternal, ExpiringSigningKey, ExpiringSigningKeys},
+        types::{EndpointSecret, EndpointSecretInternal, ExpiringSigningKey, ExpiringSigningKeys},
     },
     db::models::endpoint,
     error::{HttpError, Result},
@@ -31,6 +31,63 @@ pub(super) fn generate_secret(
         DefaultSignatureType::Hmac256 => EndpointSecretInternal::generate_symmetric(encryption),
         DefaultSignatureType::Ed25519 => EndpointSecretInternal::generate_asymmetric(encryption),
     }
+}
+
+pub struct SigningKeysData {
+    pub current_key: Option<EndpointSecretInternal>,
+    pub old_keys: Option<ExpiringSigningKeys>,
+}
+
+/// Takes in a `SigningKeysData` corresponding to the latest 'current_key / old_keys' for the endpoint/sink,
+/// and produces a new `SigningKeysData` by performing a key rotation.
+///
+/// The new key is taken from the input `EndpointSecretRotateIn`, or generated if not provided.
+pub fn rotate_key(
+    current_data: SigningKeysData,
+    new_key: Option<EndpointSecret>,
+    cfg: &ConfigurationInner,
+) -> Result<SigningKeysData> {
+    let now = Utc::now();
+    let last_key = current_data
+        .current_key
+        .clone()
+        .map(|current_key| ExpiringSigningKey {
+            key: current_key,
+            expiration: now + Duration::hours(ExpiringSigningKeys::OLD_KEY_EXPIRY_HOURS),
+        });
+
+    let unexpired_old_keys = current_data
+        .old_keys
+        .as_ref()
+        .map(|k| k.unexpired_keys().cloned().collect::<Vec<_>>());
+
+    if let Some(old_keys) = &unexpired_old_keys {
+        if old_keys.len() + 1 > ExpiringSigningKeys::MAX_OLD_KEYS {
+            return Err(HttpError::bad_request(
+                Some("limit_reached".to_owned()),
+                Some(format!(
+                    "You can only rotate a key {} times within the last {} hours.",
+                    ExpiringSigningKeys::MAX_OLD_KEYS,
+                    ExpiringSigningKeys::OLD_KEY_EXPIRY_HOURS
+                )),
+            )
+            .into());
+        }
+    }
+
+    Ok(SigningKeysData {
+        current_key: Some(if let Some(key) = new_key {
+            EndpointSecretInternal::from_endpoint_secret(key, &cfg.encryption)?
+        } else {
+            generate_secret(&cfg.encryption, &cfg.default_signature_type)?
+        }),
+        old_keys: Some(ExpiringSigningKeys(
+            last_key
+                .into_iter()
+                .chain(unexpired_old_keys.unwrap_or_default())
+                .collect(),
+        )),
+    })
 }
 
 /// Get the endpoint's signing secret.
@@ -59,58 +116,37 @@ pub(super) async fn rotate_endpoint_secret(
         ref db,
         cfg,
         ref op_webhooks,
+        ref cache,
         ..
     }): State<AppState>,
     Path(ApplicationEndpointPath { endpoint_id, .. }): Path<ApplicationEndpointPath>,
     permissions::Application { app }: permissions::Application,
     ValidatedJson(data): ValidatedJson<EndpointSecretRotateIn>,
 ) -> Result<NoContent> {
-    let mut endp = endpoint::Entity::secure_find_by_id_or_uid(app.id, endpoint_id)
+    let endp = endpoint::Entity::secure_find_by_id_or_uid(app.id.clone(), endpoint_id)
         .one(db)
         .await?
         .ok_or_else(|| HttpError::not_found(None, None))?;
 
-    let now = Utc::now();
-    let last_key = ExpiringSigningKey {
-        key: endp.key.clone(),
-        expiration: now + Duration::hours(ExpiringSigningKeys::OLD_KEY_EXPIRY_HOURS),
-    };
-
-    if let Some(ref old_keys) = endp.old_keys {
-        if old_keys.0.len() + 1 > ExpiringSigningKeys::MAX_OLD_KEYS {
-            return Err(HttpError::bad_request(
-                Some("limit_reached".to_owned()),
-                Some(format!(
-                    "You can only rotate a key {} times within the last {}.",
-                    ExpiringSigningKeys::MAX_OLD_KEYS,
-                    ExpiringSigningKeys::OLD_KEY_EXPIRY_HOURS
-                )),
-            )
-            .into());
-        }
-    }
-
-    let old_keys = endp.old_keys.take();
+    let new_data = rotate_key(
+        SigningKeysData {
+            current_key: Some(endp.key.clone()),
+            old_keys: endp.old_keys.clone(),
+        },
+        data.key,
+        &cfg,
+    )?;
 
     let endp = endpoint::ActiveModel {
-        key: Set(if let Some(key) = data.key {
-            EndpointSecretInternal::from_endpoint_secret(key, &cfg.encryption)?
-        } else {
-            generate_secret(&cfg.encryption, &cfg.default_signature_type)?
-        }),
-
-        old_keys: Set(Some(ExpiringSigningKeys(
-            iter::once(last_key)
-                .chain(
-                    old_keys
-                        .map(|x| x.0.into_iter())
-                        .unwrap_or_else(|| vec![].into_iter()),
-                )
-                .collect(),
-        ))),
+        key: Set(new_data.current_key.unwrap()),
+        old_keys: Set(new_data.old_keys),
         ..endp.into()
     };
     let endp = endp.update(db).await?;
+
+    CreateMessageApp::invalidate(cache, &app.id, &app.org_id)
+        .await
+        .can_fail("invalidating CMA cache");
 
     op_webhooks
         .send_operational_webhook(

--- a/server/svix-server/tests/it/e2e_endpoint.rs
+++ b/server/svix-server/tests/it/e2e_endpoint.rs
@@ -13,8 +13,8 @@ use chrono::{DateTime, Utc};
 use ed25519_compact::Signature;
 use reqwest::{StatusCode, Url};
 use sea_orm::{
-    ActiveModelBehavior, ActiveModelTrait, ConnectionTrait, DatabaseBackend, QueryResult, Set,
-    Statement,
+    ActiveModelBehavior, ActiveModelTrait, ConnectionTrait, DatabaseBackend, IntoActiveModel,
+    QueryResult, Set, Statement,
 };
 use serde::{Deserialize, de::IgnoredAny};
 use serde_json::json;
@@ -30,7 +30,7 @@ use svix_server::{
             MessageAttemptTriggerType, MessageId, MessageStatus, OrganizationId,
         },
     },
-    db::models::{message, messageattempt},
+    db::models::{endpoint, message, messageattempt},
     v1::{
         endpoints::{
             endpoint::{
@@ -993,6 +993,9 @@ async fn test_recovery_expected_retry_counts() {
 #[tokio::test]
 async fn test_endpoint_rotate_max() {
     let (client, _jh) = start_svix_server().await;
+    let cfg = get_default_test_config();
+    let db = Arc::new(cfg);
+    let db = svix_server::db::init_db(&db).await;
 
     let app_id = create_test_app(&client, "app1").await.unwrap().id;
 
@@ -1012,6 +1015,7 @@ async fn test_endpoint_rotate_max() {
             .unwrap();
     }
 
+    // We now have MAX_OLD_KEYS unexpired keys, so we should be unable to perform a rotation
     let _: IgnoredAny = client
         .post(
             &format!("api/v1/app/{app_id}/endpoint/{endp_id}/secret/rotate/"),
@@ -1020,6 +1024,51 @@ async fn test_endpoint_rotate_max() {
         )
         .await
         .unwrap();
+
+    // Manually expire a key, and verify that we can now perform a rotation
+    let mut endpoint = endpoint::Entity::secure_find_by_id(app_id.clone(), endp_id.clone())
+        .one(&db)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let mut modified_keys = endpoint.old_keys.take();
+    modified_keys
+        .as_mut()
+        .unwrap()
+        .0
+        .last_mut()
+        .unwrap()
+        .expiration = Utc::now() - Duration::from_secs(1);
+    let mut updated_endpoint = endpoint.into_active_model();
+
+    updated_endpoint.old_keys = Set(modified_keys);
+    updated_endpoint.update(&db).await.unwrap();
+
+    // Check that the rotation actually worked
+    let new_secret = EndpointSecretInternal::generate_symmetric(&Encryption::new_noop())
+        .unwrap()
+        .into_endpoint_secret(&Encryption::new_noop())
+        .unwrap();
+
+    client
+        .post_without_response(
+            &format!("api/v1/app/{app_id}/endpoint/{endp_id}/secret/rotate/"),
+            json!({ "key": new_secret }),
+            StatusCode::NO_CONTENT,
+        )
+        .await
+        .unwrap();
+
+    let actual_secret: EndpointSecretOut = client
+        .get(
+            &format!("api/v1/app/{app_id}/endpoint/{endp_id}/secret/"),
+            StatusCode::OK,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(new_secret, actual_secret.key);
 }
 
 #[tokio::test]


### PR DESCRIPTION
When rotating secrets, remove secrets whose expiration has passed the retention period. Based on existing downstream logic.
