### PR TITLE
Mega releaser: make explicit rather than implicit.

### DIFF
--- a/.github/workflows/bridge-release.yml
+++ b/.github/workflows/bridge-release.yml
@@ -2,11 +2,7 @@ name: Bridge Release
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      - Mega Releaser
-    types:
-      - completed
+  workflow_call:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/cli-docker-release.yml
+++ b/.github/workflows/cli-docker-release.yml
@@ -2,11 +2,7 @@ name: CLI Docker Release
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      - Mega Releaser
-    types:
-      - completed
+  workflow_call:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/csharp-release.yml
+++ b/.github/workflows/csharp-release.yml
@@ -2,11 +2,7 @@ name: C# Release
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      - Mega Releaser
-    types:
-      - completed
+  workflow_call:
 
 jobs:
   dotnet:

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -2,11 +2,7 @@ name: Java Release
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      - Mega Releaser
-    types:
-      - completed
+  workflow_call:
 
 jobs:
   dotnet:

--- a/.github/workflows/javascript-release.yml
+++ b/.github/workflows/javascript-release.yml
@@ -9,11 +9,7 @@ on:
       - 'javascript/**'
       - '.github/workflows/javascript-release.yml'
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      - Mega Releaser
-    types:
-      - completed
+  workflow_call:
 
 permissions:
   id-token: write

--- a/.github/workflows/kotlin-release.yml
+++ b/.github/workflows/kotlin-release.yml
@@ -2,11 +2,7 @@ name: Kotlin Release
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      - Mega Releaser
-    types:
-      - completed
+  workflow_call:
 
 jobs:
   kotlin:

--- a/.github/workflows/mega-releaser.yml
+++ b/.github/workflows/mega-releaser.yml
@@ -2,9 +2,54 @@ name: Mega Releaser
 
 on: workflow_dispatch
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
-  kick-off:
-    name: Kick-off Releases
-    runs-on: ubuntu-latest
-    steps:
-      - run: /bin/true
+  bridge:
+    uses: ./.github/workflows/bridge-release.yml
+    secrets: inherit
+
+  cli-docker:
+    uses: ./.github/workflows/cli-docker-release.yml
+    secrets: inherit
+
+  csharp:
+    uses: ./.github/workflows/csharp-release.yml
+    secrets: inherit
+
+  java:
+    uses: ./.github/workflows/java-release.yml
+    secrets: inherit
+
+  javascript:
+    uses: ./.github/workflows/javascript-release.yml
+    secrets: inherit
+
+  kotlin:
+    uses: ./.github/workflows/kotlin-release.yml
+    secrets: inherit
+
+  php:
+    uses: ./.github/workflows/php-release.yml
+    secrets: inherit
+
+  python:
+    uses: ./.github/workflows/python-release.yml
+
+  ruby:
+    uses: ./.github/workflows/ruby-release.yml
+    secrets: inherit
+
+  rust:
+    uses: ./.github/workflows/rust-release.yml
+    secrets: inherit
+
+  server:
+    uses: ./.github/workflows/server-release.yml
+    secrets: inherit
+
+  postman:
+    uses: ./.github/workflows/update-postman.yml
+    secrets: inherit

--- a/.github/workflows/php-release.yml
+++ b/.github/workflows/php-release.yml
@@ -2,11 +2,7 @@ name: PHP Release
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      - Mega Releaser
-    types:
-      - completed
+  workflow_call:
 
 jobs:
   packagist:

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -2,11 +2,7 @@ name: Python Release
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      - Mega Releaser
-    types:
-      - completed
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/ruby-release.yml
+++ b/.github/workflows/ruby-release.yml
@@ -2,11 +2,7 @@ name: Ruby Release
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      - Mega Releaser
-    types:
-      - completed
+  workflow_call:
 
 jobs:
   dotnet:

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -2,11 +2,7 @@ name: Rust Release
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      - Mega Releaser
-    types:
-      - completed
+  workflow_call:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -2,11 +2,7 @@ name: Server Release
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      - Mega Releaser
-    types:
-      - completed
+  workflow_call:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/update-postman.yml
+++ b/.github/workflows/update-postman.yml
@@ -2,11 +2,7 @@ name: Update Postman Collection
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      - Mega Releaser
-    types:
-      - completed
+  workflow_call:
 
 jobs:
   postman:


### PR DESCRIPTION
First of all, it's cleaner, we don't want mega to succeed if the rest fail.
Second of all, it means that we only need to approve the workflow once instead of once per library.