### PR TITLE
Github actions: add a CI check blocker that can be used for auto-merge.

### DIFF
--- a/.github/workflows/bridge-ci.yml
+++ b/.github/workflows/bridge-ci.yml
@@ -1,19 +1,7 @@
 name: Bridge CI
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'bridge/**'
-      - 'rust/**'
-      - '.github/workflows/bridge-ci.yml'
-  pull_request:
-    paths:
-      - 'bridge/**'
-      - '.github/workflows/bridge-ci.yml'
-      - 'rust/**'
-      - 'lib-openapi.json'
+  workflow_call:
 
 # When pushing to a PR, cancel any jobs still running for the previous head commit of the PR
 concurrency:

--- a/.github/workflows/bridge-ci.yml
+++ b/.github/workflows/bridge-ci.yml
@@ -3,13 +3,6 @@ name: Bridge CI
 on:
   workflow_call:
 
-# When pushing to a PR, cancel any jobs still running for the previous head commit of the PR
-concurrency:
-  # head_ref is only defined for pull requests, run_id is always unique and defined so if this
-  # workflow was not triggered by a pull request, nothing gets cancelled.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/ci-required-checks.yml
+++ b/.github/workflows/ci-required-checks.yml
@@ -1,0 +1,251 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+# Single workflow that gates all PR merges. Set "CI Required Checks / all-checks-passed"
+# as the required status check in branch protection rules.
+#
+# Each downstream workflow is called only when the same paths that would trigger
+# it directly have changed. When no relevant paths changed the job is skipped,
+# which counts as a pass for the final gate job.
+
+concurrency:
+  # head_ref is only defined for pull requests, run_id is always unique and defined so if this
+  # workflow was not triggered by a pull request, nothing gets cancelled.
+  group: ci-required-checks-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  checks: write
+  contents: read
+  issues: write
+  packages: write
+  pull-requests: write
+
+jobs:
+  filter:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      bridge-ci: ${{ steps.filter.outputs.bridge-ci }}
+      cli-lint: ${{ steps.filter.outputs.cli-lint }}
+      csharp-lint: ${{ steps.filter.outputs.csharp-lint }}
+      go-ci: ${{ steps.filter.outputs.go-ci }}
+      go-lint: ${{ steps.filter.outputs.go-lint }}
+      kotlin-lint: ${{ steps.filter.outputs.kotlin-lint }}
+      java-lint: ${{ steps.filter.outputs.java-lint }}
+      javascript-lint: ${{ steps.filter.outputs.javascript-lint }}
+      php-ci: ${{ steps.filter.outputs.php-ci }}
+      python-lint: ${{ steps.filter.outputs.python-lint }}
+      python-tests: ${{ steps.filter.outputs.python-tests }}
+      server-ci: ${{ steps.filter.outputs.server-ci }}
+      rust-lint: ${{ steps.filter.outputs.rust-lint }}
+      ruby-lint: ${{ steps.filter.outputs.ruby-lint }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            bridge-ci:
+              - 'bridge/**'
+              - 'rust/**'
+              - '.github/workflows/bridge-ci.yml'
+              - 'lib-openapi.json'
+            cli-lint:
+              - 'svix-cli/**'
+              - 'rust/**'
+              - '.github/workflows/cli-lint.yml'
+              - 'lib-openapi.json'
+            csharp-lint:
+              - 'csharp/**'
+              - 'codegen/lib-openapi.json'
+              - '.github/workflows/csharp-lint.yml'
+            go-ci:
+              - 'go/**'
+              - 'go.sum'
+              - 'go.mod'
+              - 'codegen/lib-openapi.json'
+              - '.github/workflows/go-ci.yml'
+            go-lint:
+              - 'go/**'
+              - 'go.sum'
+              - 'go.mod'
+              - 'codegen/lib-openapi.json'
+              - '.github/workflows/go-lint.yml'
+            kotlin-lint:
+              - 'kotlin/**'
+              - 'codegen/lib-openapi.json'
+              - '.github/workflows/kotlin-lint.yml'
+            java-lint:
+              - 'java/**'
+              - 'codegen/lib-openapi.json'
+              - '.github/workflows/java-lint.yml'
+            javascript-lint:
+              - 'javascript/**'
+              - 'codegen/lib-openapi.json'
+              - '.github/workflows/javascript-lint.yml'
+            php-ci:
+              - 'php/**'
+              - 'composer.json'
+              - '.github/workflows/php-ci.yml'
+            python-lint:
+              - 'python/**'
+              - 'codegen/lib-openapi.json'
+              - '.github/workflows/python-lint.yml'
+            python-tests:
+              - 'python/**'
+              - 'codegen/lib-openapi.json'
+              - 'server/**'
+              - '.github/workflows/python-tests.yml'
+            server-ci:
+              - 'server/**'
+              - '.github/workflows/server-ci.yml'
+            rust-lint:
+              - 'rust/**'
+              - 'codegen/lib-openapi.json'
+              - '.github/workflows/rust-lint.yml'
+            ruby-lint:
+              - 'ruby/**'
+              - 'codegen/lib-openapi.json'
+              - '.github/workflows/ruby-lint.yml'
+
+  bridge-ci:
+    needs: filter
+    if: needs.filter.outputs.bridge-ci == 'true'
+    uses: ./.github/workflows/bridge-ci.yml
+    secrets: inherit
+
+  cli-lint:
+    needs: filter
+    if: needs.filter.outputs.cli-lint == 'true'
+    uses: ./.github/workflows/cli-lint.yml
+    secrets: inherit
+
+  csharp-lint:
+    needs: filter
+    if: needs.filter.outputs.csharp-lint == 'true'
+    uses: ./.github/workflows/csharp-lint.yml
+    secrets: inherit
+
+  go-ci:
+    needs: filter
+    if: needs.filter.outputs.go-ci == 'true'
+    uses: ./.github/workflows/go-ci.yml
+    secrets: inherit
+
+  go-lint:
+    needs: filter
+    if: needs.filter.outputs.go-lint == 'true'
+    uses: ./.github/workflows/go-lint.yml
+    secrets: inherit
+
+  kotlin-lint:
+    needs: filter
+    if: needs.filter.outputs.kotlin-lint == 'true'
+    uses: ./.github/workflows/kotlin-lint.yml
+    secrets: inherit
+
+  java-lint:
+    needs: filter
+    if: needs.filter.outputs.java-lint == 'true'
+    uses: ./.github/workflows/java-lint.yml
+    secrets: inherit
+
+  javascript-lint:
+    needs: filter
+    if: needs.filter.outputs.javascript-lint == 'true'
+    uses: ./.github/workflows/javascript-lint.yml
+    secrets: inherit
+
+  php-ci:
+    needs: filter
+    if: needs.filter.outputs.php-ci == 'true'
+    uses: ./.github/workflows/php-ci.yml
+    secrets: inherit
+
+  python-lint:
+    needs: filter
+    if: needs.filter.outputs.python-lint == 'true'
+    uses: ./.github/workflows/python-lint.yml
+    secrets: inherit
+
+  python-tests:
+    needs: filter
+    if: needs.filter.outputs.python-tests == 'true'
+    uses: ./.github/workflows/python-tests.yml
+    secrets: inherit
+
+  server-ci:
+    needs: filter
+    if: needs.filter.outputs.server-ci == 'true'
+    uses: ./.github/workflows/server-ci.yml
+    secrets: inherit
+
+  rust-lint:
+    needs: filter
+    if: needs.filter.outputs.rust-lint == 'true'
+    uses: ./.github/workflows/rust-lint.yml
+    secrets: inherit
+
+  ruby-lint:
+    needs: filter
+    if: needs.filter.outputs.ruby-lint == 'true'
+    uses: ./.github/workflows/ruby-lint.yml
+    secrets: inherit
+
+  # pre-commit, typos, and codegen have no path filter — always run them.
+  pre-commit:
+    uses: ./.github/workflows/pre-commit.yml
+    secrets: inherit
+
+  typos:
+    uses: ./.github/workflows/typos.yml
+    secrets: inherit
+
+  codegen:
+    uses: ./.github/workflows/codegen.yml
+    secrets: inherit
+
+  ci-required-checks:
+    name: CI Required Checks
+    needs:
+      - bridge-ci
+      - cli-lint
+      - csharp-lint
+      - go-ci
+      - go-lint
+      - kotlin-lint
+      - java-lint
+      - javascript-lint
+      - php-ci
+      - python-lint
+      - python-tests
+      - server-ci
+      - rust-lint
+      - ruby-lint
+      - pre-commit
+      - typos
+      - codegen
+    if: always()
+    runs-on: ubuntu-24.04
+    # Always run so that this job is a stable required status check: if an
+    # upstream job is skipped (e.g. due to path filters) that is fine; we only
+    # fail if something actually failed or was cancelled.
+    steps:
+      - name: All checks passed
+        run: |
+          results="${{ join(needs.*.result, ' ') }}"
+          for result in $results; do
+            if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
+              echo "A required check failed or was cancelled (results: $results)"
+              exit 1
+            fi
+          done
+          echo "All required checks passed or were skipped (results: $results)"

--- a/.github/workflows/cli-lint.yml
+++ b/.github/workflows/cli-lint.yml
@@ -3,13 +3,6 @@ name: CLI Lint
 on:
   workflow_call:
 
-# When pushing to a PR, cancel any jobs still running for the previous head commit of the PR
-concurrency:
-  # head_ref is only defined for pull requests, run_id is always unique and defined so if this
-  # workflow was not triggered by a pull request, nothing gets cancelled.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/cli-lint.yml
+++ b/.github/workflows/cli-lint.yml
@@ -1,20 +1,7 @@
 name: CLI Lint
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'svix-cli/**'
-      - 'rust/**'
-      - '.github/workflows/cli-lint.yml'
-      - 'lib-openapi.json'
-  pull_request:
-    paths:
-      - 'svix-cli/**'
-      - 'rust/**'
-      - '.github/workflows/cli-lint.yml'
-      - 'lib-openapi.json'
+  workflow_call:
 
 # When pushing to a PR, cancel any jobs still running for the previous head commit of the PR
 concurrency:

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -3,13 +3,6 @@ name: Codegen
 on:
   workflow_call:
 
-# When pushing to a PR, cancel any jobs still running for the previous head commit of the PR
-concurrency:
-  # head_ref is only defined for pull requests, run_id is always unique and defined so if this
-  # workflow was not triggered by a pull request, nothing gets cancelled.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -1,12 +1,7 @@
 name: Codegen
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  workflow_call:
 
 # When pushing to a PR, cancel any jobs still running for the previous head commit of the PR
 concurrency:

--- a/.github/workflows/csharp-lint.yml
+++ b/.github/workflows/csharp-lint.yml
@@ -1,18 +1,7 @@
 name: C# Lint
 
 on:
-  pull_request:
-    paths:
-      - "csharp/**"
-      - "codegen/lib-openapi.json"
-      - '.github/workflows/csharp-lint.yml'
-  push:
-    branches:
-      - main
-    paths:
-      - "csharp/**"
-      - "codegen/lib-openapi.json"
-      - '.github/workflows/csharp-lint.yml'
+  workflow_call:
 
 jobs:
   dotnet:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -1,22 +1,7 @@
 name: Go CI
 
 on:
-  pull_request:
-    paths:
-      - "go/**"
-      - "go.sum"
-      - "go.mod"
-      - "codegen/lib-openapi.json"
-      - ".github/workflows/go-ci.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "go/**"
-      - "go.sum"
-      - "go.mod"
-      - "codegen/lib-openapi.json"
-      - ".github/workflows/go-ci.yml"
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -1,19 +1,6 @@
 name: Go Lint
 on:
-  pull_request:
-    paths:
-      - "go/**"
-      - "go.sum"
-      - "go.mod"
-      - "codegen/lib-openapi.json"
-  push:
-    branches:
-      - main
-    paths:
-      - "go/**"
-      - "go.sum"
-      - "go.mod"
-      - "codegen/lib-openapi.json"
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/java-lint.yml
+++ b/.github/workflows/java-lint.yml
@@ -1,15 +1,6 @@
 name: Java Lint
 on:
-  pull_request:
-    paths:
-      - "java/**"
-      - "codegen/lib-openapi.json"
-  push:
-    branches:
-      - main
-    paths:
-      - "java/**"
-      - "codegen/lib-openapi.json"
+  workflow_call:
 
 jobs:
   dotnet:

--- a/.github/workflows/javascript-lint.yml
+++ b/.github/workflows/javascript-lint.yml
@@ -1,18 +1,7 @@
 name: JavaScript Lint
 
 on:
-  pull_request:
-    paths:
-      - "javascript/**"
-      - "codegen/lib-openapi.json"
-      - '.github/workflows/javascript-lint.yml'
-  push:
-    branches:
-      - main
-    paths:
-      - "javascript/**"
-      - "codegen/lib-openapi.json"
-      - '.github/workflows/javascript-lint.yml'
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/kotlin-lint.yml
+++ b/.github/workflows/kotlin-lint.yml
@@ -1,18 +1,7 @@
 name: Kotlin Lint
 
 on:
-  pull_request:
-    paths:
-      - "kotlin/**"
-      - "codegen/lib-openapi.json"
-      - '.github/workflows/kotlin-lint.yml'
-  push:
-    branches:
-      - main
-    paths:
-      - "javascript/**"
-      - "codegen/lib-openapi.json"
-      - '.github/workflows/javascript-lint.yml'
+  workflow_call:
 
 jobs:
   kotlin:

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -1,18 +1,7 @@
 name: PHP CI
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'php/**'
-      - 'composer.json'
-      - '.github/workflows/php-ci.yml'
-  pull_request:
-    paths:
-      - 'composer.json'
-      - 'php/**'
-      - '.github/workflows/php-ci.yml'
+  workflow_call:
 jobs:
   build-test:
     strategy:

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1', '8.2', '8.3', '8.4']
+        php-versions: ['8.3', '8.4', '8.5']
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,10 +1,7 @@
 name: pre-commit
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_call:
 
 jobs:
   typos:

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,17 +1,6 @@
 name: Python Lint
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "python/**"
-      - "codegen/lib-openapi.json"
-      - ".github/workflows/python-lint.yml"
-  pull_request:
-    paths:
-      - "python/**"
-      - "codegen/lib-openapi.json"
-      - ".github/workflows/python-lint.yml"
+  workflow_call:
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,19 +1,6 @@
 name: Python Tests
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "python/**"
-      - "codegen/lib-openapi.json"
-      - "server/**"
-      - ".github/workflows/python-tests.yml"
-  pull_request:
-    paths:
-      - "python/**"
-      - "codegen/lib-openapi.json"
-      - "server/**"
-      - ".github/workflows/python-tests.yml"
+  workflow_call:
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ruby-lint.yml
+++ b/.github/workflows/ruby-lint.yml
@@ -1,18 +1,7 @@
 name: Ruby Lint
 
 on:
-  pull_request:
-    paths:
-      - "ruby/**"
-      - "codegen/lib-openapi.json"
-      - '.github/workflows/ruby-lint.yml'
-  push:
-    branches:
-      - main
-    paths:
-      - "ruby/**"
-      - "codegen/lib-openapi.json"
-      - '.github/workflows/ruby-lint.yml'
+  workflow_call:
 
 jobs:
   ruby:

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -1,18 +1,7 @@
 name: Rust Lint
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'rust/**'
-      - '.github/workflows/rust-lint.yml'
-      - "codegen/lib-openapi.json"
-  pull_request:
-    paths:
-      - 'rust/**'
-      - '.github/workflows/rust-lint.yml'
-      - "codegen/lib-openapi.json"
+  workflow_call:
 
 # When pushing to a PR, cancel any jobs still running for the previous head commit of the PR
 concurrency:

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -3,13 +3,6 @@ name: Rust Lint
 on:
   workflow_call:
 
-# When pushing to a PR, cancel any jobs still running for the previous head commit of the PR
-concurrency:
-  # head_ref is only defined for pull requests, run_id is always unique and defined so if this
-  # workflow was not triggered by a pull request, nothing gets cancelled.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -3,13 +3,6 @@ name: Server CI
 on:
   workflow_call:
 
-# When pushing to a PR, cancel any jobs still running for the previous head commit of the PR
-concurrency:
-  # head_ref is only defined for pull requests, run_id is always unique and defined so if this
-  # workflow was not triggered by a pull request, nothing gets cancelled.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -1,16 +1,7 @@
 name: Server CI
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'server/**'
-      - '.github/workflows/server-ci.yml'
-  pull_request:
-    paths:
-      - 'server/**'
-      - '.github/workflows/server-ci.yml'
+  workflow_call:
 
 # When pushing to a PR, cancel any jobs still running for the previous head commit of the PR
 concurrency:

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,10 +1,7 @@
 name: Typos
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_call:
 
 jobs:
   typos:


### PR DESCRIPTION
Auto-merge requires to manually select the required checks from the UI. Apparently this is how you're supposed to do it without manually updating the list in the UI every time.

It's a bit horrid and centralized, because that's the only way to do it with path filters (which we use). So damn you Github, what can I say.