### PR TITLE
tools: Use generate-lockfile instead of update for bump-version

### DIFF
--- a/tools/bump_version.py
+++ b/tools/bump_version.py
@@ -34,9 +34,9 @@ class VersionFile:
 
 POST_BUMP_COMMANDS = [
     # Rust
-    "cargo update --workspace --manifest-path server/Cargo.toml",
-    "cargo update --workspace --manifest-path bridge/Cargo.toml",
-    "cargo update --workspace --manifest-path svix-cli/Cargo.toml",
+    "cargo generate-lockfile --offline --manifest-path=server/Cargo.toml",
+    "cargo generate-lockfile --offline --manifest-path=bridge/Cargo.toml",
+    "cargo generate-lockfile --offline --manifest-path=svix-cli/Cargo.toml",
     # JavaScript
     "cd javascript && npm i --package-lock-only",
 ]


### PR DESCRIPTION
Same thing as https://github.com/svix/diom/pull/1097.

Unfortunately still updates a bunch of unrelated things in `Cargo.lock`s in local testing, but should be better than the current thing at least.