### PR TITLE
codegen: Clean up api_resource.ts.jinja

### DIFF
--- a/codegen/templates/javascript/api_resource.ts.jinja
+++ b/codegen/templates/javascript/api_resource.ts.jinja
@@ -11,8 +11,8 @@ import {
 {# HACK: can't easily do this with api_extra files -#}
 {% if resource.name == "authentication" -%}
 import {
-  DashboardAccessOut,
-  DashboardAccessOutSerializer,
+    type DashboardAccessOut,
+    DashboardAccessOutSerializer,
 } from "../models/dashboardAccessOut";
 {% endif -%}
 {% for _, sub in resource.subresources | items -%}
@@ -49,7 +49,7 @@ import { MessageIn, MessageInSerializer } from "../models/messageIn";
 {% if resource.name == "authentication" %}
 /** @deprecated */
 export interface AuthenticationDashboardAccessOptions {
-  idempotencyKey?: string;
+    idempotencyKey?: string;
 }
 
 {% endif -%}

--- a/codegen/templates/javascript/api_resource.ts.jinja
+++ b/codegen/templates/javascript/api_resource.ts.jinja
@@ -4,7 +4,7 @@
 
 {% for c in referenced_components -%}
 import {
-    {{ c | to_upper_camel_case }},
+    type {{ c | to_upper_camel_case }},
     {{ c | to_upper_camel_case }}Serializer,
 } from '../models/{{ c | to_lower_camel_case }}';
 {% endfor -%}
@@ -20,7 +20,7 @@ import { {{ sub.name | to_upper_camel_case}} } from './{{ sub.name | to_lower_ca
 {% endfor -%}
 import { HttpMethod, SvixRequest, SvixRequestContext } from "../request";
 {# HACK: api_internal/message.ts generates the `messageInRaw` function that requires `MessageIn` -#}
-import { MessageIn, MessageInSerializer } from "../models/messageIn";
+import { type MessageIn, MessageInSerializer } from "../models/messageIn";
 
 {% for op in resource.operations -%}
     {% if op | has_query_or_header_params -%}


### PR DESCRIPTION
Fix some easily fixable things in the codegen template so we're less dependent on postprocessing.