### PR TITLE
get cargo-deny to be quiet

### DIFF
--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -14,6 +14,7 @@ members = [
 
 [workspace.package]
 version = "1.91.0"
+license = "MIT"
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "warn", priority = -1 }

--- a/bridge/svix-bridge-plugin-kafka/Cargo.toml
+++ b/bridge/svix-bridge-plugin-kafka/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition = "2021"
 rust-version = "1.91"
 publish = false
+license.workspace = true
 
 [dependencies]
 rdkafka = { version = "0.38.0", features = ["cmake-build", "ssl", "tracing"] }

--- a/bridge/svix-bridge-plugin-queue/Cargo.toml
+++ b/bridge/svix-bridge-plugin-queue/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition = "2021"
 rust-version = "1.91"
 publish = false
+license.workspace = true
 
 [dependencies]
 serde.workspace = true

--- a/bridge/svix-bridge-types/Cargo.toml
+++ b/bridge/svix-bridge-types/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition = "2021"
 rust-version = "1.91"
 publish = false
+license.workspace = true
 
 [dependencies]
 async-trait = "0.1"

--- a/bridge/svix-bridge/Cargo.toml
+++ b/bridge/svix-bridge/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition = "2021"
 rust-version = "1.91"
 publish = false
+license.workspace = true
 
 [dependencies]
 anyhow = "1"

--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,8 @@ targets = [
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
+# there are multiple projects in here
+unused-ignored-advisory = "allow"
 ignore = [
     # TODO: Update dependencies that use rsa crate
     "RUSTSEC-2023-0071",
@@ -23,12 +25,6 @@ ignore = [
     "RUSTSEC-2025-0134",
     # bincode (depended on by deno) is unmaintained
     "RUSTSEC-2025-0141",
-    # rustls-webpki incorrectly handles CRLs for certificates with multiple distributionPoints;
-    # the old versions are used in smithy and we can't upgrade them right now. this will be fixed
-    # when smithy drops hyper 0.x support
-    "RUSTSEC-2026-0049",
-    # can't upgrade rand until some dependencies support 0.10
-    "RUSTSEC-2026-0097",
 ]
 
 [licenses]
@@ -48,26 +44,11 @@ allow = [
     "CC0-1.0",
     "Zlib",
 ]
+unused-allowed-license = "allow"
+unused-license-exception = "allow"
 confidence-threshold = 0.8
 exceptions = [
-    #{ allow = ["Zlib"], name = "adler32", version = "*" },
     { allow = ["EPL-2.0"], name = "colored_json", version = "*" }
-]
-
-[[licenses.clarify]]
-name = "ring"
-version = "*"
-expression = "MIT AND ISC AND OpenSSL"
-license-files = [
-    { path = "LICENSE", hash = 0xbd0eed23 }
-]
-
-[[licenses.clarify]]
-name = "encoding_rs"
-version = "0.8.30"
-expression = "MIT OR Apache-2.0"
-license-files = [
-    { path = "COPYRIGHT", hash = 0x39f8ad31 }
 ]
 
 # TODO: Include internal crates
@@ -76,7 +57,7 @@ ignore = false
 registries = []
 
 [bans]
-multiple-versions = "warn"
+multiple-versions = "allow"
 wildcards = "allow"
 highlight = "all"
 allow = []
@@ -90,7 +71,13 @@ skip = []
 skip-tree = []
 
 [sources]
-unknown-registry = "warn"
-unknown-git = "warn"
+unknown-registry = "deny"
+unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
+allow-git = [
+    "https://github.com/svix/hyper.git",
+    "https://github.com/svix/omniqueue-rs.git",
+    "https://github.com/svix/validator.git",
+]
+# there are several projects in here, so it's okay if we don't use them all
+unused-allowed-source = "allow"

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1988,7 +1988,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
@@ -2010,7 +2010,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.18",
@@ -2498,7 +2498,7 @@ dependencies = [
  "k256",
  "p256",
  "p384",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa 0.7.2",
  "serde",
  "serde_json",
@@ -2826,7 +2826,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -3264,7 +3264,7 @@ dependencies = [
  "glob",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -3342,7 +3342,7 @@ dependencies = [
  "hmac",
  "pkcs12",
  "pkcs5",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rc2",
  "sha1",
  "sha2",
@@ -3791,7 +3791,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3840,9 +3840,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3851,9 +3851,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3861,9 +3861,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
@@ -3968,7 +3968,7 @@ dependencies = [
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ryu",
  "sha1_smol",
  "socket2 0.6.2",
@@ -4555,7 +4555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161283cfe8e99c8f6f236a402b9ccf726b201f365988b5bb637ebca0abbd4a30"
 dependencies = [
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sentry-types",
  "serde",
  "serde_json",
@@ -4602,7 +4602,7 @@ checksum = "5d68cdf6bc41b8ff3ae2a9c4671e97426dcdd154cc1d4b6b72813f285d6b163f"
 dependencies = [
  "debugid",
  "hex",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -4987,7 +4987,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa 0.9.10",
  "serde",
  "sha1",
@@ -5026,7 +5026,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",
@@ -5115,7 +5115,7 @@ dependencies = [
  "itertools",
  "js_option",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustls",
  "serde",
  "serde_json",
@@ -5203,7 +5203,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "rand 0.8.5",
+ "rand 0.8.6",
  "redis",
  "regex",
  "reqwest",
@@ -5312,7 +5312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -5624,7 +5624,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "slab",
  "tokio",
  "tokio-util",


### PR DESCRIPTION
Changes:

 - remove now-unused advisory about `rustls-webpki`
 - upgrade `rand` to deal with RUSTSEC-2026-0097 and remove that from the list
 - add `unused-ignored-advisory`, `unused-allowed-license`, `unused-license-exception`, and `unused-allowed-source` so cargo-deny doesn't warn us about things that only apply to one subproject
 - fill in the `allow-git` key
 - remove unused license clarifications
 - fill in the license field for bridge

after this change:

```
$ for dir in bridge server svix-cli rust ; cd $dir ; cargo deny check -c ../deny.toml ; cd .. ; end
advisories ok, bans ok, licenses ok, sources ok
advisories ok, bans ok, licenses ok, sources ok
advisories ok, bans ok, licenses ok, sources ok
advisories ok, bans ok, licenses ok, sources ok
```

:feelsgood: 