### PR TITLE
fix postman CI: install openapi-to-postmanv2 before running script

### DIFF
--- a/.github/workflows/update-postman.yml
+++ b/.github/workflows/update-postman.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Update Postman Collection
-        run: npx --yes -p openapi-to-postmanv2 node tools/update_postman.js
+        run: npm install openapi-to-postmanv2 && node tools/update_postman.js
         env:
           POSTMAN_API_KEY: ${{ secrets.POSTMAN_API_KEY }}


### PR DESCRIPTION
It worked locally before because I haven't wiped my `node_modules` so I had this installed without realizing.