### PR TITLE
use docker/github-builder for building docker images

### DIFF
--- a/.github/workflows/bridge-release.yml
+++ b/.github/workflows/bridge-release.yml
@@ -7,6 +7,11 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
 jobs:
   release:
     name: release x86_64-unknown-linux-gnu
@@ -41,40 +46,88 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  docker:
-    name: release docker
+  get-version:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           filter: tree:0
+      - id: get-version-number
+        run: |
+          echo "tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
+    outputs:
+      version: steps.get-version-number.outputs.tag
 
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
+  build:
+    needs: [get-version]
+    uses: docker/github-builder/.github/workflows/build.yml@v1
+    permissions:
+      contents: read # to fetch the repository content
+      id-token: write # for signing attestation(s) with GitHub OIDC Token
+      packages: write # to push to ghcr
+    with:
+      output: image
+      file: bridge/Dockerfile
+      context: ./
+      push: true
+      platforms: linux/amd64,linux/arm64
+      cache: true
+      cache-scope: svix-bridge-release
+      cache-mode: max
+      meta-images: ghcr.io/svix/svix-bridge-staging
+      meta-flavor: |
+        latest=true
+      meta-tags: |
+        type=semver,pattern={{version}},prefix=v,value=${{needs.get-version.outputs.version}}
+        type=semver,pattern={{major}}.{{minor}},prefix=v,value=${{needs.get-version.outputs.version}}
+        type=semver,pattern={{major}},prefix=v,value=${{needs.get-version.outputs.version}}
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login Docker
+  release-to-dockerhub:
+    environment: release
+    needs: [get-version, build]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install regctl
+        uses: iarekylew00t/regctl-installer@v4
+      - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Derive Version Numbers
-        run: |
-          export REPO="${{ secrets.DOCKERHUB_USERNAME }}/svix-bridge"
-          export GIT_TAG="$(git describe --tags --abbrev=0)"
-          export DOCKER_TAGS=$(echo "${GIT_TAG}" | sed -E "s#v([0-9]+)\.([0-9]+)\.([0-9]+)#${REPO}:latest,${REPO}:v\1.\2.\3,${REPO}:v\1.\2,${REPO}:v\1#")
-          echo "DOCKER_TAGS=${DOCKER_TAGS}" >> "$GITHUB_ENV"
-          echo "Generated Tags: ${DOCKER_TAGS}"
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+      - name: Recompute meta tags
+        id: meta
+        uses: docker/metadata-action@v6
         with:
-          context: ./
-          file: ./bridge/Dockerfile
-          push: true
-          tags: ${{ env.DOCKER_TAGS }}
-          platforms: linux/amd64,linux/arm64
+          images: ghcr.io/svix/svix-bridge-staging
+          sep-tags: " "
+          flavor: |
+            latest=true
+          tags: |
+            type=semver,pattern={{version}},prefix=v,value=${{needs.get-version.outputs.version}}
+            type=semver,pattern={{major}}.{{minor}},prefix=v,value=${{needs.get-version.outputs.version}}
+            type=semver,pattern={{major}},prefix=v,value=${{needs.get-version.outputs.version}}
+      - name: "Copy images"
+        run: |
+          for source in ${{ steps.meta.outputs.tags }}; do
+            # shellcheck disable=SC2001
+            dest="$(echo "$source" | sed -e 's,ghcr.io/svix/svix-bridge-staging,docker.io/svix/svix-bridge,')"
+            echo "Copying $source to $dest"
+            regctl image copy "$source" "$dest"
+          done

--- a/.github/workflows/cli-docker-release.yml
+++ b/.github/workflows/cli-docker-release.yml
@@ -7,41 +7,92 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
 jobs:
-  docker:
-    name: release docker
+  get-version:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           filter: tree:0
-
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Login Docker
+      - id: get-version-number
+        run: |
+          echo "tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
+    outputs:
+      version: steps.get-version-number.outputs.tag
+  build:
+    needs: [get-version]
+    uses: docker/github-builder/.github/workflows/build.yml@v1
+    permissions:
+      contents: read # to fetch the repository content
+      id-token: write # for signing attestation(s) with GitHub OIDC Token
+      packages: write # to push to ghcr
+    with:
+      output: image
+      file: svix-cli/Dockerfile
+      context: ./
+      push: true
+      platforms: linux/amd64,linux/arm64
+      cache: true
+      cache-scope: svix-cli-release
+      cache-mode: max
+      meta-images: ghcr.io/svix/svix-cli-staging
+      meta-flavor: |
+        latest=true
+      meta-tags: |
+        type=semver,pattern={{version}},prefix=v,value=${{needs.get-version.outputs.version}}
+        type=semver,pattern={{major}}.{{minor}},prefix=v,value=${{needs.get-version.outputs.version}}
+        type=semver,pattern={{major}},prefix=v,value=${{needs.get-version.outputs.version}}
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+  release-to-dockerhub:
+    environment: release
+    needs: [get-version, build]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install regctl
+        uses: iarekylew00t/regctl-installer@v4
+      - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Derive Version Numbers
-        run: |
-          export REPO="${{ secrets.DOCKERHUB_USERNAME }}/svix-cli"
-          export GIT_TAG="$(git describe --tags --abbrev=0)"
-          export DOCKER_TAGS=$(echo "${GIT_TAG}" | sed -E "s#v([0-9]+)\.([0-9]+)\.([0-9]+)#${REPO}:latest,${REPO}:v\1.\2.\3,${REPO}:v\1.\2,${REPO}:v\1#")
-          echo "DOCKER_TAGS=${DOCKER_TAGS}" >> "$GITHUB_ENV"
-          echo "Generated Tags: ${DOCKER_TAGS}"
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+      - name: Recompute meta tags
+        id: meta
+        uses: docker/metadata-action@v6
         with:
-          context: ./
-          file: ./svix-cli/Dockerfile
-          push: true
-          tags: ${{ env.DOCKER_TAGS }}
-          platforms: linux/amd64,linux/arm64
+          images: ghcr.io/svix/svix-cli-staging
+          sep-tags: " "
+          flavor: |
+            latest=true
+          tags: |
+            type=semver,pattern={{version}},prefix=v,value=${{needs.get-version.outputs.version}}
+            type=semver,pattern={{major}}.{{minor}},prefix=v,value=${{needs.get-version.outputs.version}}
+            type=semver,pattern={{major}},prefix=v,value=${{needs.get-version.outputs.version}}
+      - name: "Copy images"
+        run: |
+          for source in ${{ steps.meta.outputs.tags }}; do
+            # shellcheck disable=SC2001
+            dest="$(echo "$source" | sed -e 's,ghcr.io/svix/svix-cli-staging,docker.io/svix/svix-cli,')"
+            echo "Copying $source to $dest"
+            regctl image copy "$source" "$dest"
+          done

--- a/.github/workflows/mega-releaser.yml
+++ b/.github/workflows/mega-releaser.yml
@@ -5,6 +5,7 @@ on: workflow_dispatch
 permissions:
   id-token: write
   contents: read
+  packages: write
 
 jobs:
   bridge:

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -7,6 +7,11 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
 jobs:
   release:
     name: release x86_64-unknown-linux-gnu
@@ -30,66 +35,88 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  docker:
-    name: release docker
+  get-version:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           filter: tree:0
+      - id: get-version-number
+        run: |
+          echo "tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
+    outputs:
+      version: steps.get-version-number.outputs.tag
 
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
+  build:
+    needs: [get-version]
+    uses: docker/github-builder/.github/workflows/build.yml@v1
+    permissions:
+      contents: read # to fetch the repository content
+      id-token: write # for signing attestation(s) with GitHub OIDC Token
+      packages: write # to push to ghcr
+    with:
+      output: image
+      file: server/Dockerfile
+      context: server
+      push: true
+      platforms: linux/amd64,linux/arm64
+      cache: true
+      cache-scope: svix-server-release
+      cache-mode: max
+      meta-images: ghcr.io/svix/svix-server-staging
+      meta-flavor: |
+        latest=true
+      meta-tags: |
+        type=semver,pattern={{version}},prefix=v,value=${{needs.get-version.outputs.version}}
+        type=semver,pattern={{major}}.{{minor}},prefix=v,value=${{needs.get-version.outputs.version}}
+        type=semver,pattern={{major}},prefix=v,value=${{needs.get-version.outputs.version}}
+    secrets:
+      registry-auths: |
+        - registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login Docker
+  release-to-dockerhub:
+    environment: release
+    needs: [get-version, build]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install regctl
+        uses: iarekylew00t/regctl-installer@v4
+      - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Derive Version Numbers
-        id: gen_docker_tags
+      - name: Recompute meta tags
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/svix/svix-server-staging
+          sep-tags: " "
+          flavor: |
+            latest=true
+          tags: |
+            type=semver,pattern={{version}},prefix=v,value=${{needs.get-version.outputs.version}}
+            type=semver,pattern={{major}}.{{minor}},prefix=v,value=${{needs.get-version.outputs.version}}
+            type=semver,pattern={{major}},prefix=v,value=${{needs.get-version.outputs.version}}
+      - name: "Copy images"
         run: |
-          export REPO="${{ secrets.DOCKERHUB_USERNAME }}/svix-server"
-          export GIT_TAG="$(git describe --tags --abbrev=0)"
-          export DOCKER_TAGS=$(echo "${GIT_TAG}" | sed -E "s#v([0-9]+)\.([0-9]+)\.([0-9]+)#${REPO}:latest,${REPO}:v\1.\2.\3,${REPO}:v\1.\2,${REPO}:v\1#")
-          echo "latest_tag=${REPO}:latest" >> "$GITHUB_OUTPUT"
-          echo "docker_tags=${DOCKER_TAGS}" >> "$GITHUB_OUTPUT"
-          echo "Generated Tags: ${DOCKER_TAGS}"
-
-      - name: Build Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: ./server
-          file: ./server/Dockerfile
-          push: false
-          tags: ${{ steps.gen_docker_tags.outputs.docker_tags }}
-          platforms: linux/amd64
-          load: true
-
-      - name: Scan image with Grype
-        id: scan
-        uses: anchore/scan-action@v6
-        with:
-          image: "${{ steps.gen_docker_tags.outputs.latest_tag }}"
-          fail-build: true
-          severity-cutoff: high
-          only-fixed: true
-          output-file: grype.sarif
-
-      - name: Inspect action SARIF report
-        if: ${{ !cancelled() && hashFiles('grype.sarif') != '' }}
-        run: cat ${{ steps.scan.outputs.sarif }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: ./server
-          file: ./server/Dockerfile
-          push: true
-          tags: ${{ steps.gen_docker_tags.outputs.docker_tags }}
-          platforms: linux/amd64,linux/arm64
+          for source in ${{ steps.meta.outputs.tags }}; do
+            # shellcheck disable=SC2001
+            dest="$(echo "$source" | sed -e 's,ghcr.io/svix/svix-server-staging,docker.io/svix/svix-server,')"
+            echo "Copying $source to $dest"
+            regctl image copy "$source" "$dest"
+          done


### PR DESCRIPTION
This is similar to what we do in https://github.com/svix/diom

We use `docker/github-builder` to do native multiarch builds into GHCR (because `docker/github-builder` doesn't support release environments), and then we run a separate job to copy from GHCR to DockerHub in the release environment.

Not sure if there's a good way to test this other than running it...