### PR TITLE
gha: do not set file for server-release

### DIFF
--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -59,7 +59,6 @@ jobs:
       packages: write # to push to ghcr
     with:
       output: image
-      file: server/Dockerfile
       context: server
       push: true
       platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
[the most recent build failed](https://github.com/svix/svix-webhooks/actions/runs/24697073418/job/72232049371) with "failed to read dockerfile: open server/Dockerfile: no such file or directory"; I think the file is interpreted relative to the context by this action (although it doesn't document it so who knows!)

The default is documented as `{context}/Dockerfile`, so we should just be able to not pass it.