### PR TITLE
feat(cli): show command examples on --help

### DIFF
--- a/codegen/templates/svix-cli/api_resource.rs.jinja
+++ b/codegen/templates/svix-cli/api_resource.rs.jinja
@@ -24,7 +24,7 @@ use svix::api::*;
 use super::{{ sub.name | to_snake_case }}::{{ sub.name | to_upper_camel_case }}Args;
 {% endfor %}
 
-{%- macro get_type_example(field, api) -%}
+{%- macro get_type_example(field, api, indent) -%}
     {%- if field.type.is_string_const() -%}
         \"{{ field.type.string_const_val() }}\"
     {%- elif field.type.is_unix_timestamp_ms() -%}
@@ -40,9 +40,9 @@ use super::{{ sub.name | to_snake_case }}::{{ sub.name | to_upper_camel_case }}A
     {%- elif field.type.is_int_or_uint() -%}
         123
     {%- elif field.type.is_list() or field.type.is_set() -%}
-        [{{ get_type_example({"type": field.type.inner_type()}, api) }}]
+        [{{ get_type_example({"type": field.type.inner_type()}, api, indent) }}]
     {%- elif field.type.is_map() -%}
-        {\"key\": {{ get_type_example({"type": field.type.value_type()}, api) }}}
+        {\"key\": {{ get_type_example({"type": field.type.value_type()}, api, indent) }}}
     {%- elif field.type.is_json_object() -%}
         {\"key\": \"...\"}
     {%- elif field.type.is_schema_ref() -%}
@@ -52,7 +52,7 @@ use super::{{ sub.name | to_snake_case }}::{{ sub.name | to_upper_camel_case }}A
         {%- elif ref_type is defined and ref_type.kind == "integer_enum" -%}
             {{ ref_type.variants[0][1] }}
         {%- elif ref_type is defined and ref_type.kind == "struct" -%}
-            {{ render_inline_object(ref_type, api) }}
+            {{ render_inline_object(ref_type, api, indent) }}
         {%- else -%}
             {\"...\": \"...\"}
         {%- endif -%}
@@ -61,19 +61,19 @@ use super::{{ sub.name | to_snake_case }}::{{ sub.name | to_upper_camel_case }}A
     {%- endif -%}
 {%- endmacro -%}
 
-{%- macro render_inline_object(schema, api) -%}
-    {
-    {%- for f in schema.fields -%}
-        \"{{ f.name }}\": {% if f.example is defined %}{{ f.example | tojson | replace('\\', '\\\\') | replace('"', '\\"') }}{% else %}{{ get_type_example(f, api) }}{% endif %}{{ ", " if not loop.last else "" }}
-    {%- endfor -%}
-    }
+{%- macro render_inline_object(schema, api, indent) -%}
+{
+{%- for f in schema.fields %}
+{{ indent }}  \"{{ f.name }}\": {% if f.example is defined %}{{ f.example | tojson | replace('\\', '\\\\') | replace('"', '\\"') }}{% else %}{{ get_type_example(f, api, indent + "  ") }}{% endif %}{{ "," if not loop.last else "" }}
+{%- endfor %}
+{{ indent }}}
 {%- endmacro -%}
 
 {%- macro render_schema_example(title, schema, api) -%}
 \x1b[1;4m{{ title }}:\x1b[0m
 {
 {%- for field in schema.fields | selectattr("positional", "false") %}
-  \"{{ field.name }}\": {% if field.example is defined %}{{ field.example | tojson | replace('\\', '\\\\') | replace('"', '\\"') }}{% else %}{{ get_type_example(field, api) }}{% endif %}{{ "," if not loop.last else "" }}
+  \"{{ field.name }}\": {% if field.example is defined %}{{ field.example | tojson | replace('\\', '\\\\') | replace('"', '\\"') }}{% else %}{{ get_type_example(field, api, "  ") }}{% endif %}{{ "," if not loop.last else "" }}
 {%- endfor %}
 }
 {%- endmacro -%}

--- a/codegen/templates/svix-cli/api_resource.rs.jinja
+++ b/codegen/templates/svix-cli/api_resource.rs.jinja
@@ -4,6 +4,18 @@
 {% if resource.name == "application" %}{% set resource_id_name = "app_id" %}{% endif -%}
 {% if resource.name == "message" %}{% set resource_id_name = "msg_id" %}{% endif -%}
 {% if resource.name == "integration" %}{% set resource_id_name = "integ_id" %}{% endif -%}
+{% set path_param_examples = {
+    "app_id": "app_000000000000000000000000000",
+    "msg_id": "msg_000000000000000000000000000",
+    "endpoint_id": "ep_000000000000000000000000000",
+    "integ_id": "integ_000000000000000000000000000",
+    "attempt_id": "atmpt_000000000000000000000000000",
+    "stream_id": "strm_000000000000000000000",
+    "sink_id": "sink_000000000000000000000",
+    "source_id": "src_000000000000000000000",
+    "task_id": "qtask_000000000000000000000000000",
+    "event_type_name": "example.event",
+} -%}
 
 use clap::{Args, Subcommand};
 use svix::api::*;
@@ -96,6 +108,13 @@ pub enum {{ resource_type_name }}Commands {
         {% if op.description is defined -%}
             {{ op.description | to_doc_comment(style="rust") }}
         {% endif -%}
+        #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix {{ resource.name | replace(".", " ") }} {{ op.name }}{% for p in op.path_params %} {{ path_param_examples[p] | default(p | upper) }}{% endfor %}\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
         {{ op.name | to_upper_camel_case }} {
             {# path parameters -#}
             {% for p in op.path_params -%}

--- a/codegen/templates/svix-cli/api_resource.rs.jinja
+++ b/codegen/templates/svix-cli/api_resource.rs.jinja
@@ -82,7 +82,7 @@ use super::{{ sub.name | to_snake_case }}::{{ sub.name | to_upper_camel_case }}A
 {%- endmacro -%}
 
 {%- macro render_schema_example(title, schema, api) -%}
-\x1b[1;4m{{ title }}:\x1b[0m
+{{ title }}:
 {
 {%- for field in schema.fields | selectattr("positional", "false") %}
   \"{{ field.name }}\": {% if field.example is defined %}{{ render_example_value(field.example, "  ") }}{% else %}{{ get_type_example(field, api, "  ") }}{% endif %}{{ "," if not loop.last else "" }}

--- a/codegen/templates/svix-cli/api_resource.rs.jinja
+++ b/codegen/templates/svix-cli/api_resource.rs.jinja
@@ -24,6 +24,60 @@ use svix::api::*;
 use super::{{ sub.name | to_snake_case }}::{{ sub.name | to_upper_camel_case }}Args;
 {% endfor %}
 
+{%- macro get_type_example(field, api) -%}
+    {%- if field.type.is_string_const() -%}
+        \"{{ field.type.string_const_val() }}\"
+    {%- elif field.type.is_unix_timestamp_ms() -%}
+        1234567890123
+    {%- elif field.type.is_duration_ms() -%}
+        60000
+    {%- elif field.type.is_datetime() -%}
+        \"2030-01-01T00:00:00Z\"
+    {%- elif field.type.is_u64() -%}
+        123
+    {%- elif field.type.is_bool() -%}
+        true
+    {%- elif field.type.is_int_or_uint() -%}
+        123
+    {%- elif field.type.is_list() or field.type.is_set() -%}
+        [{{ get_type_example({"type": field.type.inner_type()}, api) }}]
+    {%- elif field.type.is_map() -%}
+        {\"key\": {{ get_type_example({"type": field.type.value_type()}, api) }}}
+    {%- elif field.type.is_json_object() -%}
+        {\"key\": \"...\"}
+    {%- elif field.type.is_schema_ref() -%}
+        {%- set ref_type = api.types[field.type.to_rust()] -%}
+        {%- if ref_type is defined and ref_type.kind == "string_enum" -%}
+            \"{{ ref_type.values[0] }}\"
+        {%- elif ref_type is defined and ref_type.kind == "integer_enum" -%}
+            {{ ref_type.variants[0][1] }}
+        {%- elif ref_type is defined and ref_type.kind == "struct" -%}
+            {{ render_inline_object(ref_type, api) }}
+        {%- else -%}
+            {\"...\": \"...\"}
+        {%- endif -%}
+    {%- else -%}
+        \"...\"
+    {%- endif -%}
+{%- endmacro -%}
+
+{%- macro render_inline_object(schema, api) -%}
+    {
+    {%- for f in schema.fields -%}
+        \"{{ f.name }}\": {% if f.example is defined %}{{ f.example | tojson | replace('\\', '\\\\') | replace('"', '\\"') }}{% else %}{{ get_type_example(f, api) }}{% endif %}{{ ", " if not loop.last else "" }}
+    {%- endfor -%}
+    }
+{%- endmacro -%}
+
+{%- macro render_schema_example(title, schema, api) -%}
+\x1b[1;4m{{ title }}:\x1b[0m
+{
+{%- for field in schema.fields | selectattr("positional", "false") %}
+  \"{{ field.name }}\": {% if field.example is defined %}{{ field.example | tojson | replace('\\', '\\\\') | replace('"', '\\"') }}{% else %}{{ get_type_example(field, api) }}{% endif %}{{ "," if not loop.last else "" }}
+{%- endfor %}
+}
+{%- endmacro -%}
+
 {% for op in resource.operations -%}
     {% if (op.query_params | length > 0) or (op.header_params | length > 0) -%}
         {% set param_struct_type_name -%}
@@ -112,9 +166,23 @@ pub enum {{ resource_type_name }}Commands {
             "{about-with-newline}\n",
             "{usage-heading} {usage}\n",
             "Example:   svix {{ resource.name | replace(".", " ") }} {{ op.name }}{% for p in op.path_params %} {{ path_param_examples[p] | default(p | upper) }}{% endfor %}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+        {% if op.request_body_schema_name is defined or op.response_body_schema_name is defined -%}
+        #[command(after_long_help = "\n
+        {%- if op.request_body_schema_name is defined -%}
+            {{- render_schema_example("Example body", api.types[op.request_body_schema_name], api) -}}
+        {%- endif -%}
+        {%- if op.request_body_schema_name is defined and op.response_body_schema_name is defined -%}
+\n\n
+        {%- endif -%}
+        {%- if op.response_body_schema_name is defined -%}
+            {{- render_schema_example("Example response", api.types[op.response_body_schema_name], api) -}}
+        {%- endif -%}
+\n")]
+        {% endif -%}
         {{ op.name | to_upper_camel_case }} {
             {# path parameters -#}
             {% for p in op.path_params -%}

--- a/codegen/templates/svix-cli/api_resource.rs.jinja
+++ b/codegen/templates/svix-cli/api_resource.rs.jinja
@@ -5,15 +5,15 @@
 {% if resource.name == "message" %}{% set resource_id_name = "msg_id" %}{% endif -%}
 {% if resource.name == "integration" %}{% set resource_id_name = "integ_id" %}{% endif -%}
 {% set path_param_examples = {
-    "app_id": "app_000000000000000000000000000",
-    "msg_id": "msg_000000000000000000000000000",
-    "endpoint_id": "ep_000000000000000000000000000",
-    "integ_id": "integ_000000000000000000000000000",
-    "attempt_id": "atmpt_000000000000000000000000000",
-    "stream_id": "strm_000000000000000000000",
-    "sink_id": "sink_000000000000000000000",
-    "source_id": "src_000000000000000000000",
-    "task_id": "qtask_000000000000000000000000000",
+    "app_id": "app_abc000000000000000000000000",
+    "msg_id": "msg_abc000000000000000000000000",
+    "endpoint_id": "ep_abc000000000000000000000000",
+    "integ_id": "integ_abc000000000000000000000000",
+    "attempt_id": "atmpt_abc000000000000000000000000",
+    "stream_id": "strm_abc000000000000000000",
+    "sink_id": "sink_abc000000000000000000",
+    "source_id": "src_abc000000000000000000",
+    "task_id": "qtask_abc000000000000000000000000",
     "event_type_name": "example.event",
 } -%}
 
@@ -61,10 +61,22 @@ use super::{{ sub.name | to_snake_case }}::{{ sub.name | to_upper_camel_case }}A
     {%- endif -%}
 {%- endmacro -%}
 
+{%- macro render_example_value(value, indent) -%}
+{%- if value is mapping -%}
+{
+{%- for k, v in value | items %}
+{{ indent }}  \"{{ k }}\": {{ render_example_value(v, indent + "  ") }}{{ "," if not loop.last else "" }}
+{%- endfor %}
+{{ indent }}}
+{%- else -%}
+{{ value | tojson | replace('\\', '\\\\') | replace('"', '\\"') }}
+{%- endif -%}
+{%- endmacro -%}
+
 {%- macro render_inline_object(schema, api, indent) -%}
 {
 {%- for f in schema.fields %}
-{{ indent }}  \"{{ f.name }}\": {% if f.example is defined %}{{ f.example | tojson | replace('\\', '\\\\') | replace('"', '\\"') }}{% else %}{{ get_type_example(f, api, indent + "  ") }}{% endif %}{{ "," if not loop.last else "" }}
+{{ indent }}  \"{{ f.name }}\": {% if f.example is defined %}{{ render_example_value(f.example, indent + "  ") }}{% else %}{{ get_type_example(f, api, indent + "  ") }}{% endif %}{{ "," if not loop.last else "" }}
 {%- endfor %}
 {{ indent }}}
 {%- endmacro -%}
@@ -73,7 +85,7 @@ use super::{{ sub.name | to_snake_case }}::{{ sub.name | to_upper_camel_case }}A
 \x1b[1;4m{{ title }}:\x1b[0m
 {
 {%- for field in schema.fields | selectattr("positional", "false") %}
-  \"{{ field.name }}\": {% if field.example is defined %}{{ field.example | tojson | replace('\\', '\\\\') | replace('"', '\\"') }}{% else %}{{ get_type_example(field, api, "  ") }}{% endif %}{{ "," if not loop.last else "" }}
+  \"{{ field.name }}\": {% if field.example is defined %}{{ render_example_value(field.example, "  ") }}{% else %}{{ get_type_example(field, api, "  ") }}{% endif %}{{ "," if not loop.last else "" }}
 {%- endfor %}
 }
 {%- endmacro -%}
@@ -164,14 +176,14 @@ pub enum {{ resource_type_name }}Commands {
         {% endif -%}
         #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix {{ resource.name | replace(".", " ") }} {{ op.name }}{% for p in op.path_params %} {{ path_param_examples[p] | default(p | upper) }}{% endfor %}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix {{ resource.name | replace(".", " ") }} {{ op.name }}{% for p in op.path_params %} {{ path_param_examples[p] | default(p | upper) }}{% endfor %}{% if op.request_body_schema_name is defined %} {...}{% endif %}\n",
             "{after-help}",
             "\n",
             "{all-args}",
         ))]
         {% if op.request_body_schema_name is defined or op.response_body_schema_name is defined -%}
-        #[command(after_long_help = "\n
+        #[command(after_help = "
         {%- if op.request_body_schema_name is defined -%}
             {{- render_schema_example("Example body", api.types[op.request_body_schema_name], api) -}}
         {%- endif -%}

--- a/regen_openapi.py
+++ b/regen_openapi.py
@@ -18,7 +18,7 @@ except ImportError:
     print("Python 3.11 or greater is required to run the codegen")
     exit(1)
 
-OPENAPI_CODEGEN_IMAGE = "ghcr.io/svix/openapi-codegen:20260105-347"
+OPENAPI_CODEGEN_IMAGE = "ghcr.io/svix/openapi-codegen:20260423-356"
 DEBUG = os.getenv("DEBUG") is not None
 GREEN = "\033[92m"
 BLUE = "\033[94m"

--- a/svix-cli/src/cmds/api/application.rs
+++ b/svix-cli/src/cmds/api/application.rs
@@ -67,26 +67,68 @@ pub struct ApplicationArgs {
 #[derive(Subcommand)]
 pub enum ApplicationCommands {
     /// List of all the organization's applications.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix application list\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     List {
         #[clap(flatten)]
         options: ApplicationListOptions,
     },
     /// Create a new application.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix application create\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Create {
         application_in: crate::json::JsonOf<ApplicationIn>,
         #[clap(flatten)]
         options: ApplicationCreateOptions,
     },
     /// Get an application.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix application get app_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Get { id: String },
     /// Update an application.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix application update app_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Update {
         id: String,
         application_in: crate::json::JsonOf<ApplicationIn>,
     },
     /// Delete an application.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix application delete app_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Delete { id: String },
     /// Partially update an application.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix application patch app_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Patch {
         id: String,
         application_patch: Option<crate::json::JsonOf<ApplicationPatch>>,

--- a/svix-cli/src/cmds/api/application.rs
+++ b/svix-cli/src/cmds/api/application.rs
@@ -69,11 +69,28 @@ pub enum ApplicationCommands {
     /// List of all the organization's applications.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix application list\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix application list\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"data\": [{
+    \"createdAt\": \"2030-01-01T00:00:00Z\",
+    \"id\": \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+    \"metadata\": {\"key\": \"...\"},
+    \"name\": \"My first application\",
+    \"rateLimit\": 123,
+    \"throttleRate\": 123,
+    \"uid\": \"unique-identifier\",
+    \"updatedAt\": \"2030-01-01T00:00:00Z\"
+  }],
+  \"done\": true,
+  \"iterator\": \"iterator\",
+  \"prevIterator\": \"-iterator\"
+}\n")]
     List {
         #[clap(flatten)]
         options: ApplicationListOptions,
@@ -81,11 +98,30 @@ pub enum ApplicationCommands {
     /// Create a new application.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix application create\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix application create {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"metadata\": {\"key\": \"...\"},
+  \"name\": \"My first application\",
+  \"rateLimit\": 123,
+  \"throttleRate\": 123,
+  \"uid\": \"unique-identifier\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"id\": \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"metadata\": {\"key\": \"...\"},
+  \"name\": \"My first application\",
+  \"rateLimit\": 123,
+  \"throttleRate\": 123,
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Create {
         application_in: crate::json::JsonOf<ApplicationIn>,
         #[clap(flatten)]
@@ -94,20 +130,51 @@ pub enum ApplicationCommands {
     /// Get an application.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix application get app_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix application get app_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"id\": \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"metadata\": {\"key\": \"...\"},
+  \"name\": \"My first application\",
+  \"rateLimit\": 123,
+  \"throttleRate\": 123,
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Get { id: String },
     /// Update an application.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix application update app_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix application update app_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"metadata\": {\"key\": \"...\"},
+  \"name\": \"My first application\",
+  \"rateLimit\": 123,
+  \"throttleRate\": 123,
+  \"uid\": \"unique-identifier\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"id\": \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"metadata\": {\"key\": \"...\"},
+  \"name\": \"My first application\",
+  \"rateLimit\": 123,
+  \"throttleRate\": 123,
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Update {
         id: String,
         application_in: crate::json::JsonOf<ApplicationIn>,
@@ -115,20 +182,39 @@ pub enum ApplicationCommands {
     /// Delete an application.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix application delete app_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix application delete app_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
     Delete { id: String },
     /// Partially update an application.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix application patch app_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix application patch app_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"metadata\": {\"key\": \"...\"},
+  \"name\": \"...\",
+  \"rateLimit\": 123,
+  \"uid\": \"unique-identifier\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"id\": \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"metadata\": {\"key\": \"...\"},
+  \"name\": \"My first application\",
+  \"rateLimit\": 123,
+  \"throttleRate\": 123,
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Patch {
         id: String,
         application_patch: Option<crate::json::JsonOf<ApplicationPatch>>,

--- a/svix-cli/src/cmds/api/application.rs
+++ b/svix-cli/src/cmds/api/application.rs
@@ -75,7 +75,7 @@ pub enum ApplicationCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"data\": [{
     \"createdAt\": \"2030-01-01T00:00:00Z\",
@@ -104,14 +104,14 @@ pub enum ApplicationCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"metadata\": {\"key\": \"...\"},
   \"name\": \"My first application\",
   \"rateLimit\": 123,
   \"throttleRate\": 123,
   \"uid\": \"unique-identifier\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"createdAt\": \"2030-01-01T00:00:00Z\",
   \"id\": \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
@@ -136,7 +136,7 @@ pub enum ApplicationCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"createdAt\": \"2030-01-01T00:00:00Z\",
   \"id\": \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
@@ -157,14 +157,14 @@ pub enum ApplicationCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"metadata\": {\"key\": \"...\"},
   \"name\": \"My first application\",
   \"rateLimit\": 123,
   \"throttleRate\": 123,
   \"uid\": \"unique-identifier\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"createdAt\": \"2030-01-01T00:00:00Z\",
   \"id\": \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
@@ -198,13 +198,13 @@ pub enum ApplicationCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"metadata\": {\"key\": \"...\"},
   \"name\": \"...\",
   \"rateLimit\": 123,
   \"uid\": \"unique-identifier\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"createdAt\": \"2030-01-01T00:00:00Z\",
   \"id\": \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",

--- a/svix-cli/src/cmds/api/authentication.rs
+++ b/svix-cli/src/cmds/api/authentication.rs
@@ -111,6 +111,13 @@ pub struct AuthenticationArgs {
 #[derive(Subcommand)]
 pub enum AuthenticationCommands {
     /// Use this function to get magic links (and authentication codes) for connecting your users to the Consumer Application Portal.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix authentication app-portal-access app_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     AppPortalAccess {
         app_id: String,
         app_portal_access_in: Option<crate::json::JsonOf<AppPortalAccessIn>>,
@@ -118,6 +125,13 @@ pub enum AuthenticationCommands {
         options: AuthenticationAppPortalAccessOptions,
     },
     /// Expire all of the tokens associated with a specific application.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix authentication expire-all app_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     ExpireAll {
         app_id: String,
         application_token_expire_in: Option<crate::json::JsonOf<ApplicationTokenExpireIn>>,
@@ -127,6 +141,13 @@ pub enum AuthenticationCommands {
     /// Logout an app token.
     ///
     /// Trying to log out other tokens will fail.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix authentication logout\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Logout {
         #[clap(flatten)]
         options: AuthenticationLogoutOptions,
@@ -134,11 +155,25 @@ pub enum AuthenticationCommands {
     /// Logout a stream token.
     ///
     /// Trying to log out other tokens will fail.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix authentication stream-logout\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     StreamLogout {
         #[clap(flatten)]
         options: AuthenticationStreamLogoutOptions,
     },
     /// Use this function to get magic links (and authentication codes) for connecting your users to the Stream Consumer Portal.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix authentication stream-portal-access strm_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     StreamPortalAccess {
         stream_id: String,
         stream_portal_access_in: Option<crate::json::JsonOf<StreamPortalAccessIn>>,
@@ -146,6 +181,13 @@ pub enum AuthenticationCommands {
         options: AuthenticationStreamPortalAccessOptions,
     },
     /// Expire all of the tokens associated with a specific stream.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix authentication stream-expire-all strm_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     StreamExpireAll {
         stream_id: String,
         stream_token_expire_in: Option<crate::json::JsonOf<StreamTokenExpireIn>>,
@@ -153,8 +195,22 @@ pub enum AuthenticationCommands {
         options: AuthenticationStreamExpireAllOptions,
     },
     /// Get the current auth token for the stream poller.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix authentication get-stream-poller-token strm_000000000000000000000 sink_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     GetStreamPollerToken { stream_id: String, sink_id: String },
     /// Create a new auth token for the stream poller API.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix authentication rotate-stream-poller-token strm_000000000000000000000 sink_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     RotateStreamPollerToken {
         stream_id: String,
         sink_id: String,

--- a/svix-cli/src/cmds/api/authentication.rs
+++ b/svix-cli/src/cmds/api/authentication.rs
@@ -119,7 +119,7 @@ pub enum AuthenticationCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"application\": {
     \"metadata\": {\"key\": \"...\"},
@@ -133,7 +133,7 @@ pub enum AuthenticationCommands {
   \"featureFlags\": [],
   \"readOnly\": true,
   \"sessionId\": \"user_1FB8\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"token\": \"appsk_kV3ts5tKPNJN4Dl25cMTfUNdmabxbX0O\",
   \"url\": \"https://app.svix.com/login#key=eyJhcHBJZCI6ICJhcHBfMXRSdFl\"
@@ -153,7 +153,7 @@ pub enum AuthenticationCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"expiry\": 60,
   \"sessionIds\": [\"...\"]
@@ -203,12 +203,12 @@ pub enum AuthenticationCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"expiry\": 123,
   \"featureFlags\": [],
   \"sessionId\": \"user_1FB8\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"token\": \"appsk_kV3ts5tKPNJN4Dl25cMTfUNdmabxbX0O\",
   \"url\": \"https://app.svix.com/login#key=eyJhcHBJZCI6ICJhcHBfMXRSdFl\"
@@ -228,7 +228,7 @@ pub enum AuthenticationCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"expiry\": 60,
   \"sessionIds\": [\"...\"]
@@ -248,7 +248,7 @@ pub enum AuthenticationCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"createdAt\": \"2030-01-01T00:00:00Z\",
   \"expiresAt\": \"2030-01-01T00:00:00Z\",
@@ -267,11 +267,11 @@ pub enum AuthenticationCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"expiry\": 123,
   \"oldTokenExpiry\": 123
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"createdAt\": \"2030-01-01T00:00:00Z\",
   \"expiresAt\": \"2030-01-01T00:00:00Z\",

--- a/svix-cli/src/cmds/api/authentication.rs
+++ b/svix-cli/src/cmds/api/authentication.rs
@@ -113,11 +113,31 @@ pub enum AuthenticationCommands {
     /// Use this function to get magic links (and authentication codes) for connecting your users to the Consumer Application Portal.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix authentication app-portal-access app_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix authentication app-portal-access app_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"application\": {
+    \"metadata\": {\"key\": \"...\"},
+    \"name\": \"My first application\",
+    \"rateLimit\": 123,
+    \"throttleRate\": 123,
+    \"uid\": \"unique-identifier\"
+  },
+  \"capabilities\": [\"ViewBase\",\"ViewEndpointSecret\"],
+  \"expiry\": 123,
+  \"featureFlags\": [],
+  \"readOnly\": true,
+  \"sessionId\": \"user_1FB8\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"token\": \"appsk_kV3ts5tKPNJN4Dl25cMTfUNdmabxbX0O\",
+  \"url\": \"https://app.svix.com/login#key=eyJhcHBJZCI6ICJhcHBfMXRSdFl\"
+}\n")]
     AppPortalAccess {
         app_id: String,
         app_portal_access_in: Option<crate::json::JsonOf<AppPortalAccessIn>>,
@@ -127,11 +147,17 @@ pub enum AuthenticationCommands {
     /// Expire all of the tokens associated with a specific application.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix authentication expire-all app_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix authentication expire-all app_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"expiry\": 60,
+  \"sessionIds\": [\"...\"]
+}\n")]
     ExpireAll {
         app_id: String,
         application_token_expire_in: Option<crate::json::JsonOf<ApplicationTokenExpireIn>>,
@@ -143,10 +169,11 @@ pub enum AuthenticationCommands {
     /// Trying to log out other tokens will fail.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix authentication logout\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix authentication logout\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
     Logout {
         #[clap(flatten)]
@@ -157,10 +184,11 @@ pub enum AuthenticationCommands {
     /// Trying to log out other tokens will fail.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix authentication stream-logout\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix authentication stream-logout\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
     StreamLogout {
         #[clap(flatten)]
@@ -169,11 +197,22 @@ pub enum AuthenticationCommands {
     /// Use this function to get magic links (and authentication codes) for connecting your users to the Stream Consumer Portal.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix authentication stream-portal-access strm_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix authentication stream-portal-access strm_abc000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"expiry\": 123,
+  \"featureFlags\": [],
+  \"sessionId\": \"user_1FB8\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"token\": \"appsk_kV3ts5tKPNJN4Dl25cMTfUNdmabxbX0O\",
+  \"url\": \"https://app.svix.com/login#key=eyJhcHBJZCI6ICJhcHBfMXRSdFl\"
+}\n")]
     StreamPortalAccess {
         stream_id: String,
         stream_portal_access_in: Option<crate::json::JsonOf<StreamPortalAccessIn>>,
@@ -183,11 +222,17 @@ pub enum AuthenticationCommands {
     /// Expire all of the tokens associated with a specific stream.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix authentication stream-expire-all strm_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix authentication stream-expire-all strm_abc000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"expiry\": 60,
+  \"sessionIds\": [\"...\"]
+}\n")]
     StreamExpireAll {
         stream_id: String,
         stream_token_expire_in: Option<crate::json::JsonOf<StreamTokenExpireIn>>,
@@ -197,20 +242,44 @@ pub enum AuthenticationCommands {
     /// Get the current auth token for the stream poller.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix authentication get-stream-poller-token strm_000000000000000000000 sink_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix authentication get-stream-poller-token strm_abc000000000000000000 sink_abc000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"expiresAt\": \"2030-01-01T00:00:00Z\",
+  \"id\": \"...\",
+  \"name\": \"...\",
+  \"scopes\": [\"...\"],
+  \"token\": \"...\"
+}\n")]
     GetStreamPollerToken { stream_id: String, sink_id: String },
     /// Create a new auth token for the stream poller API.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix authentication rotate-stream-poller-token strm_000000000000000000000 sink_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix authentication rotate-stream-poller-token strm_abc000000000000000000 sink_abc000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"expiry\": 123,
+  \"oldTokenExpiry\": 123
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"expiresAt\": \"2030-01-01T00:00:00Z\",
+  \"id\": \"...\",
+  \"name\": \"...\",
+  \"scopes\": [\"...\"],
+  \"token\": \"...\"
+}\n")]
     RotateStreamPollerToken {
         stream_id: String,
         sink_id: String,

--- a/svix-cli/src/cmds/api/connector.rs
+++ b/svix-cli/src/cmds/api/connector.rs
@@ -57,26 +57,68 @@ pub struct ConnectorArgs {
 #[derive(Subcommand)]
 pub enum ConnectorCommands {
     /// List all connectors for an application.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix connector list\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     List {
         #[clap(flatten)]
         options: ConnectorListOptions,
     },
     /// Create a new connector.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix connector create\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Create {
         connector_in: crate::json::JsonOf<ConnectorIn>,
         #[clap(flatten)]
         options: ConnectorCreateOptions,
     },
     /// Get a connector.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix connector get CONNECTOR_ID\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Get { id: String },
     /// Update a connector.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix connector update CONNECTOR_ID\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Update {
         id: String,
         connector_update: crate::json::JsonOf<ConnectorUpdate>,
     },
     /// Delete a connector.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix connector delete CONNECTOR_ID\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Delete { id: String },
     /// Partially update a connector.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix connector patch CONNECTOR_ID\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Patch {
         id: String,
         connector_patch: Option<crate::json::JsonOf<ConnectorPatch>>,

--- a/svix-cli/src/cmds/api/connector.rs
+++ b/svix-cli/src/cmds/api/connector.rs
@@ -65,7 +65,7 @@ pub enum ConnectorCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"data\": [{
     \"allowedEventTypes\": [\"user.signup\",\"user.deleted\"],
@@ -101,7 +101,7 @@ pub enum ConnectorCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"allowedEventTypes\": [\"user.signup\",\"user.deleted\"],
   \"description\": \"Example connector description\",
@@ -113,7 +113,7 @@ pub enum ConnectorCommands {
   \"productType\": \"Dispatch\",
   \"transformation\": \"function handler(webhook) { /* ... */ }\",
   \"uid\": \"unique-identifier\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"allowedEventTypes\": [\"user.signup\",\"user.deleted\"],
   \"createdAt\": \"2030-01-01T00:00:00Z\",
@@ -145,7 +145,7 @@ pub enum ConnectorCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"allowedEventTypes\": [\"user.signup\",\"user.deleted\"],
   \"createdAt\": \"2030-01-01T00:00:00Z\",
@@ -173,7 +173,7 @@ pub enum ConnectorCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"allowedEventTypes\": [\"user.signup\",\"user.deleted\"],
   \"description\": \"Example connector description\",
@@ -183,7 +183,7 @@ pub enum ConnectorCommands {
   \"logo\": \"https://example.com/logo.png\",
   \"name\": \"My first connector\",
   \"transformation\": \"function handler(webhook) { /* ... */ }\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"allowedEventTypes\": [\"user.signup\",\"user.deleted\"],
   \"createdAt\": \"2030-01-01T00:00:00Z\",
@@ -224,7 +224,7 @@ pub enum ConnectorCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"allowedEventTypes\": [\"user.signup\",\"user.deleted\"],
   \"description\": \"...\",
@@ -234,7 +234,7 @@ pub enum ConnectorCommands {
   \"logo\": \"...\",
   \"name\": \"...\",
   \"transformation\": \"...\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"allowedEventTypes\": [\"user.signup\",\"user.deleted\"],
   \"createdAt\": \"2030-01-01T00:00:00Z\",

--- a/svix-cli/src/cmds/api/connector.rs
+++ b/svix-cli/src/cmds/api/connector.rs
@@ -59,11 +59,35 @@ pub enum ConnectorCommands {
     /// List all connectors for an application.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix connector list\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix connector list\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"data\": [{
+    \"allowedEventTypes\": [\"user.signup\",\"user.deleted\"],
+    \"createdAt\": \"2030-01-01T00:00:00Z\",
+    \"description\": \"...\",
+    \"featureFlags\": [\"cool-new-feature\"],
+    \"id\": \"trtmpl_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+    \"instructions\": \"...\",
+    \"kind\": \"Custom\",
+    \"logo\": \"...\",
+    \"name\": \"...\",
+    \"orgId\": \"org_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+    \"productType\": \"Dispatch\",
+    \"transformation\": \"...\",
+    \"transformationUpdatedAt\": \"2030-01-01T00:00:00Z\",
+    \"uid\": \"unique-identifier\",
+    \"updatedAt\": \"2030-01-01T00:00:00Z\"
+  }],
+  \"done\": true,
+  \"iterator\": \"iterator\",
+  \"prevIterator\": \"-iterator\"
+}\n")]
     List {
         #[clap(flatten)]
         options: ConnectorListOptions,
@@ -71,11 +95,42 @@ pub enum ConnectorCommands {
     /// Create a new connector.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix connector create\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix connector create {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"allowedEventTypes\": [\"user.signup\",\"user.deleted\"],
+  \"description\": \"Example connector description\",
+  \"featureFlags\": [\"...\"],
+  \"instructions\": \"Markdown-formatted instructions\",
+  \"kind\": \"Slack\",
+  \"logo\": \"https://example.com/logo.png\",
+  \"name\": \"My first connector\",
+  \"productType\": \"Dispatch\",
+  \"transformation\": \"function handler(webhook) { /* ... */ }\",
+  \"uid\": \"unique-identifier\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"allowedEventTypes\": [\"user.signup\",\"user.deleted\"],
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"description\": \"...\",
+  \"featureFlags\": [\"cool-new-feature\"],
+  \"id\": \"trtmpl_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"instructions\": \"...\",
+  \"kind\": \"Custom\",
+  \"logo\": \"...\",
+  \"name\": \"...\",
+  \"orgId\": \"org_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"productType\": \"Dispatch\",
+  \"transformation\": \"...\",
+  \"transformationUpdatedAt\": \"2030-01-01T00:00:00Z\",
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Create {
         connector_in: crate::json::JsonOf<ConnectorIn>,
         #[clap(flatten)]
@@ -84,20 +139,68 @@ pub enum ConnectorCommands {
     /// Get a connector.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix connector get CONNECTOR_ID\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix connector get CONNECTOR_ID\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"allowedEventTypes\": [\"user.signup\",\"user.deleted\"],
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"description\": \"...\",
+  \"featureFlags\": [\"cool-new-feature\"],
+  \"id\": \"trtmpl_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"instructions\": \"...\",
+  \"kind\": \"Custom\",
+  \"logo\": \"...\",
+  \"name\": \"...\",
+  \"orgId\": \"org_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"productType\": \"Dispatch\",
+  \"transformation\": \"...\",
+  \"transformationUpdatedAt\": \"2030-01-01T00:00:00Z\",
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Get { id: String },
     /// Update a connector.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix connector update CONNECTOR_ID\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix connector update CONNECTOR_ID {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"allowedEventTypes\": [\"user.signup\",\"user.deleted\"],
+  \"description\": \"Example connector description\",
+  \"featureFlags\": [\"cool-new-feature\"],
+  \"instructions\": \"Markdown-formatted instructions\",
+  \"kind\": \"Slack\",
+  \"logo\": \"https://example.com/logo.png\",
+  \"name\": \"My first connector\",
+  \"transformation\": \"function handler(webhook) { /* ... */ }\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"allowedEventTypes\": [\"user.signup\",\"user.deleted\"],
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"description\": \"...\",
+  \"featureFlags\": [\"cool-new-feature\"],
+  \"id\": \"trtmpl_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"instructions\": \"...\",
+  \"kind\": \"Custom\",
+  \"logo\": \"...\",
+  \"name\": \"...\",
+  \"orgId\": \"org_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"productType\": \"Dispatch\",
+  \"transformation\": \"...\",
+  \"transformationUpdatedAt\": \"2030-01-01T00:00:00Z\",
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Update {
         id: String,
         connector_update: crate::json::JsonOf<ConnectorUpdate>,
@@ -105,20 +208,50 @@ pub enum ConnectorCommands {
     /// Delete a connector.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix connector delete CONNECTOR_ID\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix connector delete CONNECTOR_ID\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
     Delete { id: String },
     /// Partially update a connector.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix connector patch CONNECTOR_ID\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix connector patch CONNECTOR_ID {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"allowedEventTypes\": [\"user.signup\",\"user.deleted\"],
+  \"description\": \"...\",
+  \"featureFlags\": [\"cool-new-feature\"],
+  \"instructions\": \"...\",
+  \"kind\": \"Custom\",
+  \"logo\": \"...\",
+  \"name\": \"...\",
+  \"transformation\": \"...\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"allowedEventTypes\": [\"user.signup\",\"user.deleted\"],
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"description\": \"...\",
+  \"featureFlags\": [\"cool-new-feature\"],
+  \"id\": \"trtmpl_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"instructions\": \"...\",
+  \"kind\": \"Custom\",
+  \"logo\": \"...\",
+  \"name\": \"...\",
+  \"orgId\": \"org_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"productType\": \"Dispatch\",
+  \"transformation\": \"...\",
+  \"transformationUpdatedAt\": \"2030-01-01T00:00:00Z\",
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Patch {
         id: String,
         connector_patch: Option<crate::json::JsonOf<ConnectorPatch>>,

--- a/svix-cli/src/cmds/api/endpoint.rs
+++ b/svix-cli/src/cmds/api/endpoint.rs
@@ -140,11 +140,33 @@ pub enum EndpointCommands {
     /// List the application's endpoints.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix endpoint list app_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix endpoint list app_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"data\": [{
+    \"channels\": [\"project_123\",\"group_2\"],
+    \"createdAt\": \"2030-01-01T00:00:00Z\",
+    \"description\": \"...\",
+    \"disabled\": false,
+    \"filterTypes\": [\"user.signup\",\"user.deleted\"],
+    \"id\": \"ep_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+    \"metadata\": {\"key\": \"...\"},
+    \"rateLimit\": 123,
+    \"throttleRate\": 123,
+    \"uid\": \"unique-identifier\",
+    \"updatedAt\": \"2030-01-01T00:00:00Z\",
+    \"url\": \"https://example.com/webhook/\",
+    \"version\": 1
+  }],
+  \"done\": true,
+  \"iterator\": \"iterator\",
+  \"prevIterator\": \"-iterator\"
+}\n")]
     List {
         app_id: String,
         #[clap(flatten)]
@@ -155,11 +177,45 @@ pub enum EndpointCommands {
     /// When `secret` is `null` the secret is automatically generated (recommended).
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix endpoint create app_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix endpoint create app_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"channels\": [\"project_123\",\"group_2\"],
+  \"description\": \"An example endpoint name\",
+  \"disabled\": false,
+  \"filterTypes\": [\"user.signup\",\"user.deleted\"],
+  \"headers\": {
+    \"X-Example\": \"123\",
+    \"X-Foobar\": \"Bar\"
+  },
+  \"metadata\": {\"key\": \"...\"},
+  \"rateLimit\": 123,
+  \"secret\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",
+  \"throttleRate\": 123,
+  \"uid\": \"unique-identifier\",
+  \"url\": \"https://example.com/webhook/\",
+  \"version\": 1
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"channels\": [\"project_123\",\"group_2\"],
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"description\": \"...\",
+  \"disabled\": false,
+  \"filterTypes\": [\"user.signup\",\"user.deleted\"],
+  \"id\": \"ep_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"metadata\": {\"key\": \"...\"},
+  \"rateLimit\": 123,
+  \"throttleRate\": 123,
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\",
+  \"url\": \"https://example.com/webhook/\",
+  \"version\": 1
+}\n")]
     Create {
         app_id: String,
         endpoint_in: crate::json::JsonOf<EndpointIn>,
@@ -169,20 +225,66 @@ pub enum EndpointCommands {
     /// Get an endpoint.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix endpoint get app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix endpoint get app_abc000000000000000000000000 ep_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"channels\": [\"project_123\",\"group_2\"],
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"description\": \"...\",
+  \"disabled\": false,
+  \"filterTypes\": [\"user.signup\",\"user.deleted\"],
+  \"id\": \"ep_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"metadata\": {\"key\": \"...\"},
+  \"rateLimit\": 123,
+  \"throttleRate\": 123,
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\",
+  \"url\": \"https://example.com/webhook/\",
+  \"version\": 1
+}\n")]
     Get { app_id: String, id: String },
     /// Update an endpoint.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix endpoint update app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix endpoint update app_abc000000000000000000000000 ep_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"channels\": [\"project_123\",\"group_2\"],
+  \"description\": \"An example endpoint name\",
+  \"disabled\": false,
+  \"filterTypes\": [\"user.signup\",\"user.deleted\"],
+  \"metadata\": {\"key\": \"...\"},
+  \"rateLimit\": 123,
+  \"throttleRate\": 123,
+  \"uid\": \"unique-identifier\",
+  \"url\": \"https://example.com/webhook/\",
+  \"version\": 1
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"channels\": [\"project_123\",\"group_2\"],
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"description\": \"...\",
+  \"disabled\": false,
+  \"filterTypes\": [\"user.signup\",\"user.deleted\"],
+  \"id\": \"ep_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"metadata\": {\"key\": \"...\"},
+  \"rateLimit\": 123,
+  \"throttleRate\": 123,
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\",
+  \"url\": \"https://example.com/webhook/\",
+  \"version\": 1
+}\n")]
     Update {
         app_id: String,
         id: String,
@@ -191,20 +293,51 @@ pub enum EndpointCommands {
     /// Delete an endpoint.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix endpoint delete app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix endpoint delete app_abc000000000000000000000000 ep_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
     Delete { app_id: String, id: String },
     /// Partially update an endpoint.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix endpoint patch app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix endpoint patch app_abc000000000000000000000000 ep_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"channels\": [\"...\"],
+  \"description\": \"...\",
+  \"disabled\": true,
+  \"filterTypes\": [\"...\"],
+  \"metadata\": {\"key\": \"...\"},
+  \"rateLimit\": 123,
+  \"secret\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",
+  \"throttleRate\": 123,
+  \"uid\": \"unique-identifier\",
+  \"url\": \"...\",
+  \"version\": 1
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"channels\": [\"project_123\",\"group_2\"],
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"description\": \"...\",
+  \"disabled\": false,
+  \"filterTypes\": [\"user.signup\",\"user.deleted\"],
+  \"id\": \"ep_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"metadata\": {\"key\": \"...\"},
+  \"rateLimit\": 123,
+  \"throttleRate\": 123,
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\",
+  \"url\": \"https://example.com/webhook/\",
+  \"version\": 1
+}\n")]
     Patch {
         app_id: String,
         id: String,
@@ -228,11 +361,28 @@ pub enum EndpointCommands {
     /// ```
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix endpoint bulk-replay app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix endpoint bulk-replay app_abc000000000000000000000000 ep_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"channel\": \"project_1337\",
+  \"eventTypes\": [\"...\"],
+  \"since\": \"2030-01-01T00:00:00Z\",
+  \"status\": 0,
+  \"statusCodeClass\": 0,
+  \"tag\": \"project_1337\",
+  \"until\": \"2030-01-01T00:00:00Z\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"id\": \"qtask_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"status\": \"running\",
+  \"task\": \"endpoint.replay\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     BulkReplay {
         app_id: String,
         id: String,
@@ -243,20 +393,37 @@ pub enum EndpointCommands {
     /// Get the additional headers to be sent with the webhook.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix endpoint get-headers app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix endpoint get-headers app_abc000000000000000000000000 ep_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"headers\": {
+    \"X-Example\": \"123\",
+    \"X-Foobar\": \"Bar\"
+  },
+  \"sensitive\": [\"Authorization\"]
+}\n")]
     GetHeaders { app_id: String, id: String },
     /// Set the additional headers to be sent with the webhook.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix endpoint update-headers app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix endpoint update-headers app_abc000000000000000000000000 ep_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"headers\": {
+    \"X-Example\": \"123\",
+    \"X-Foobar\": \"Bar\"
+  }
+}\n")]
     UpdateHeaders {
         app_id: String,
         id: String,
@@ -265,11 +432,20 @@ pub enum EndpointCommands {
     /// Partially set the additional headers to be sent with the webhook.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix endpoint patch-headers app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix endpoint patch-headers app_abc000000000000000000000000 ep_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"deleteHeaders\": [\"...\"],
+  \"headers\": {
+    \"X-Example\": \"123\",
+    \"X-Foobar\": \"Bar\"
+  }
+}\n")]
     PatchHeaders {
         app_id: String,
         id: String,
@@ -292,11 +468,23 @@ pub enum EndpointCommands {
     /// ```
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix endpoint recover app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix endpoint recover app_abc000000000000000000000000 ep_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"since\": \"2030-01-01T00:00:00Z\",
+  \"until\": \"2030-01-01T00:00:00Z\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"id\": \"qtask_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"status\": \"running\",
+  \"task\": \"endpoint.replay\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Recover {
         app_id: String,
         id: String,
@@ -322,11 +510,23 @@ pub enum EndpointCommands {
     /// ```
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix endpoint replay-missing app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix endpoint replay-missing app_abc000000000000000000000000 ep_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"since\": \"2030-01-01T00:00:00Z\",
+  \"until\": \"2030-01-01T00:00:00Z\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"id\": \"qtask_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"status\": \"running\",
+  \"task\": \"endpoint.replay\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     ReplayMissing {
         app_id: String,
         id: String,
@@ -340,22 +540,32 @@ pub enum EndpointCommands {
     /// For more information please refer to [the consuming webhooks docs](https://docs.svix.com/consuming-webhooks/).
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix endpoint get-secret app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix endpoint get-secret app_abc000000000000000000000000 ep_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"key\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\"
+}\n")]
     GetSecret { app_id: String, id: String },
     /// Rotates the endpoint's signing secret.
     ///
     /// The previous secret will remain valid for the next 24 hours.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix endpoint rotate-secret app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix endpoint rotate-secret app_abc000000000000000000000000 ep_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"key\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\"
+}\n")]
     RotateSecret {
         app_id: String,
         id: String,
@@ -366,11 +576,31 @@ pub enum EndpointCommands {
     /// Send an example message for an event.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix endpoint send-example app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix endpoint send-example app_abc000000000000000000000000 ep_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"eventType\": \"user.signup\",
+  \"exampleIndex\": 123
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"channels\": [\"project_123\",\"group_2\"],
+  \"deliverAt\": \"2030-01-01T00:00:00Z\",
+  \"eventId\": \"unique-identifier\",
+  \"eventType\": \"user.signup\",
+  \"id\": \"msg_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"payload\": {
+    \"email\": \"test@example.com\",
+    \"type\": \"user.created\",
+    \"username\": \"test_user\"
+  },
+  \"tags\": [\"...\"],
+  \"timestamp\": \"2030-01-01T00:00:00Z\"
+}\n")]
     SendExample {
         app_id: String,
         id: String,
@@ -381,11 +611,19 @@ pub enum EndpointCommands {
     /// Get basic statistics for the endpoint.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix endpoint get-stats app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix endpoint get-stats app_abc000000000000000000000000 ep_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"fail\": 123,
+  \"pending\": 123,
+  \"sending\": 123,
+  \"success\": 123
+}\n")]
     GetStats {
         app_id: String,
         id: String,
@@ -395,20 +633,33 @@ pub enum EndpointCommands {
     /// Get the transformation code associated with this endpoint.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix endpoint transformation-get app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix endpoint transformation-get app_abc000000000000000000000000 ep_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"code\": \"...\",
+  \"enabled\": true,
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     TransformationGet { app_id: String, id: String },
     /// Set or unset the transformation code associated with this endpoint.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix endpoint patch-transformation app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix endpoint patch-transformation app_abc000000000000000000000000 ep_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"code\": \"function handler(webhook) { /* ... */ }\",
+  \"enabled\": true
+}\n")]
     PatchTransformation {
         app_id: String,
         id: String,
@@ -417,11 +668,17 @@ pub enum EndpointCommands {
     /// This operation was renamed to `set-transformation`.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix endpoint transformation-partial-update app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix endpoint transformation-partial-update app_abc000000000000000000000000 ep_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"code\": \"...\",
+  \"enabled\": true
+}\n")]
     TransformationPartialUpdate {
         app_id: String,
         id: String,

--- a/svix-cli/src/cmds/api/endpoint.rs
+++ b/svix-cli/src/cmds/api/endpoint.rs
@@ -146,7 +146,7 @@ pub enum EndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"data\": [{
     \"channels\": [\"project_123\",\"group_2\"],
@@ -183,7 +183,7 @@ pub enum EndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"channels\": [\"project_123\",\"group_2\"],
   \"description\": \"An example endpoint name\",
@@ -200,7 +200,7 @@ pub enum EndpointCommands {
   \"uid\": \"unique-identifier\",
   \"url\": \"https://example.com/webhook/\",
   \"version\": 1
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"channels\": [\"project_123\",\"group_2\"],
   \"createdAt\": \"2030-01-01T00:00:00Z\",
@@ -231,7 +231,7 @@ pub enum EndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"channels\": [\"project_123\",\"group_2\"],
   \"createdAt\": \"2030-01-01T00:00:00Z\",
@@ -257,7 +257,7 @@ pub enum EndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"channels\": [\"project_123\",\"group_2\"],
   \"description\": \"An example endpoint name\",
@@ -269,7 +269,7 @@ pub enum EndpointCommands {
   \"uid\": \"unique-identifier\",
   \"url\": \"https://example.com/webhook/\",
   \"version\": 1
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"channels\": [\"project_123\",\"group_2\"],
   \"createdAt\": \"2030-01-01T00:00:00Z\",
@@ -309,7 +309,7 @@ pub enum EndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"channels\": [\"...\"],
   \"description\": \"...\",
@@ -322,7 +322,7 @@ pub enum EndpointCommands {
   \"uid\": \"unique-identifier\",
   \"url\": \"...\",
   \"version\": 1
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"channels\": [\"project_123\",\"group_2\"],
   \"createdAt\": \"2030-01-01T00:00:00Z\",
@@ -367,7 +367,7 @@ pub enum EndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"channel\": \"project_1337\",
   \"eventTypes\": [\"...\"],
@@ -376,7 +376,7 @@ pub enum EndpointCommands {
   \"statusCodeClass\": 0,
   \"tag\": \"project_1337\",
   \"until\": \"2030-01-01T00:00:00Z\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"id\": \"qtask_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
   \"status\": \"running\",
@@ -399,7 +399,7 @@ pub enum EndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"headers\": {
     \"X-Example\": \"123\",
@@ -417,7 +417,7 @@ pub enum EndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"headers\": {
     \"X-Example\": \"123\",
@@ -438,7 +438,7 @@ pub enum EndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"deleteHeaders\": [\"...\"],
   \"headers\": {
@@ -474,11 +474,11 @@ pub enum EndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"since\": \"2030-01-01T00:00:00Z\",
   \"until\": \"2030-01-01T00:00:00Z\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"id\": \"qtask_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
   \"status\": \"running\",
@@ -516,11 +516,11 @@ pub enum EndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"since\": \"2030-01-01T00:00:00Z\",
   \"until\": \"2030-01-01T00:00:00Z\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"id\": \"qtask_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
   \"status\": \"running\",
@@ -546,7 +546,7 @@ pub enum EndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"key\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\"
 }\n")]
@@ -562,7 +562,7 @@ pub enum EndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"key\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\"
 }\n")]
@@ -582,11 +582,11 @@ pub enum EndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"eventType\": \"user.signup\",
   \"exampleIndex\": 123
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"channels\": [\"project_123\",\"group_2\"],
   \"deliverAt\": \"2030-01-01T00:00:00Z\",
@@ -617,7 +617,7 @@ pub enum EndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"fail\": 123,
   \"pending\": 123,
@@ -639,7 +639,7 @@ pub enum EndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"code\": \"...\",
   \"enabled\": true,
@@ -655,7 +655,7 @@ pub enum EndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"code\": \"function handler(webhook) { /* ... */ }\",
   \"enabled\": true
@@ -674,7 +674,7 @@ pub enum EndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"code\": \"...\",
   \"enabled\": true

--- a/svix-cli/src/cmds/api/endpoint.rs
+++ b/svix-cli/src/cmds/api/endpoint.rs
@@ -138,6 +138,13 @@ pub struct EndpointArgs {
 #[derive(Subcommand)]
 pub enum EndpointCommands {
     /// List the application's endpoints.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix endpoint list app_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     List {
         app_id: String,
         #[clap(flatten)]
@@ -146,6 +153,13 @@ pub enum EndpointCommands {
     /// Create a new endpoint for the application.
     ///
     /// When `secret` is `null` the secret is automatically generated (recommended).
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix endpoint create app_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Create {
         app_id: String,
         endpoint_in: crate::json::JsonOf<EndpointIn>,
@@ -153,16 +167,44 @@ pub enum EndpointCommands {
         options: EndpointCreateOptions,
     },
     /// Get an endpoint.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix endpoint get app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Get { app_id: String, id: String },
     /// Update an endpoint.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix endpoint update app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Update {
         app_id: String,
         id: String,
         endpoint_update: crate::json::JsonOf<EndpointUpdate>,
     },
     /// Delete an endpoint.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix endpoint delete app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Delete { app_id: String, id: String },
     /// Partially update an endpoint.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix endpoint patch app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Patch {
         app_id: String,
         id: String,
@@ -184,6 +226,13 @@ pub enum EndpointCommands {
     ///   }
     /// }
     /// ```
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix endpoint bulk-replay app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     BulkReplay {
         app_id: String,
         id: String,
@@ -192,14 +241,35 @@ pub enum EndpointCommands {
         options: EndpointBulkReplayOptions,
     },
     /// Get the additional headers to be sent with the webhook.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix endpoint get-headers app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     GetHeaders { app_id: String, id: String },
     /// Set the additional headers to be sent with the webhook.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix endpoint update-headers app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     UpdateHeaders {
         app_id: String,
         id: String,
         endpoint_headers_in: crate::json::JsonOf<EndpointHeadersIn>,
     },
     /// Partially set the additional headers to be sent with the webhook.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix endpoint patch-headers app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     PatchHeaders {
         app_id: String,
         id: String,
@@ -220,6 +290,13 @@ pub enum EndpointCommands {
     ///   }
     /// }
     /// ```
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix endpoint recover app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Recover {
         app_id: String,
         id: String,
@@ -243,6 +320,13 @@ pub enum EndpointCommands {
     ///   }
     /// }
     /// ```
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix endpoint replay-missing app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     ReplayMissing {
         app_id: String,
         id: String,
@@ -254,10 +338,24 @@ pub enum EndpointCommands {
     ///
     /// This is used to verify the authenticity of the webhook.
     /// For more information please refer to [the consuming webhooks docs](https://docs.svix.com/consuming-webhooks/).
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix endpoint get-secret app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     GetSecret { app_id: String, id: String },
     /// Rotates the endpoint's signing secret.
     ///
     /// The previous secret will remain valid for the next 24 hours.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix endpoint rotate-secret app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     RotateSecret {
         app_id: String,
         id: String,
@@ -266,6 +364,13 @@ pub enum EndpointCommands {
         options: EndpointRotateSecretOptions,
     },
     /// Send an example message for an event.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix endpoint send-example app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     SendExample {
         app_id: String,
         id: String,
@@ -274,6 +379,13 @@ pub enum EndpointCommands {
         options: EndpointSendExampleOptions,
     },
     /// Get basic statistics for the endpoint.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix endpoint get-stats app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     GetStats {
         app_id: String,
         id: String,
@@ -281,14 +393,35 @@ pub enum EndpointCommands {
         options: EndpointGetStatsOptions,
     },
     /// Get the transformation code associated with this endpoint.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix endpoint transformation-get app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     TransformationGet { app_id: String, id: String },
     /// Set or unset the transformation code associated with this endpoint.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix endpoint patch-transformation app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     PatchTransformation {
         app_id: String,
         id: String,
         endpoint_transformation_patch: Option<crate::json::JsonOf<EndpointTransformationPatch>>,
     },
     /// This operation was renamed to `set-transformation`.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix endpoint transformation-partial-update app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     TransformationPartialUpdate {
         app_id: String,
         id: String,

--- a/svix-cli/src/cmds/api/environment.rs
+++ b/svix-cli/src/cmds/api/environment.rs
@@ -43,11 +43,64 @@ pub enum EnvironmentCommands {
     /// herein are provided for convenience but should be treated as JSON blobs.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix environment export\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix environment export\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"connectors\": [{
+    \"allowedEventTypes\": [\"user.signup\",\"user.deleted\"],
+    \"createdAt\": \"2030-01-01T00:00:00Z\",
+    \"description\": \"...\",
+    \"featureFlags\": [\"cool-new-feature\"],
+    \"id\": \"trtmpl_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+    \"instructions\": \"...\",
+    \"kind\": \"Custom\",
+    \"logo\": \"...\",
+    \"name\": \"...\",
+    \"orgId\": \"org_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+    \"productType\": \"Dispatch\",
+    \"transformation\": \"...\",
+    \"transformationUpdatedAt\": \"2030-01-01T00:00:00Z\",
+    \"uid\": \"unique-identifier\",
+    \"updatedAt\": \"2030-01-01T00:00:00Z\"
+  }],
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"eventTypes\": [{
+    \"archived\": false,
+    \"createdAt\": \"2030-01-01T00:00:00Z\",
+    \"deprecated\": true,
+    \"description\": \"A user has signed up\",
+    \"featureFlag\": \"...\",
+    \"featureFlags\": [\"cool-new-feature\"],
+    \"groupName\": \"user\",
+    \"name\": \"user.signup\",
+    \"schemas\": {
+      \"1\": {
+        \"description\": \"An invoice was paid by a user\",
+        \"properties\": {
+          \"invoiceId\": {
+            \"description\": \"The invoice id\",
+            \"type\": \"string\"
+          },
+          \"userId\": {
+            \"description\": \"The user id\",
+            \"type\": \"string\"
+          }
+        },
+        \"required\": [\"invoiceId\",\"userId\"],
+        \"title\": \"Invoice Paid Event\",
+        \"type\": \"object\"
+      }
+    },
+    \"updatedAt\": \"2030-01-01T00:00:00Z\"
+  }],
+  \"settings\": {\"key\": \"...\"},
+  \"version\": 123
+}\n")]
     Export {
         #[clap(flatten)]
         options: EnvironmentExportOptions,
@@ -60,11 +113,55 @@ pub enum EnvironmentCommands {
     /// herein are provided for convenience but should be treated as JSON blobs.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix environment import\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix environment import {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"connectors\": [{
+    \"allowedEventTypes\": [\"user.signup\",\"user.deleted\"],
+    \"description\": \"Example connector description\",
+    \"featureFlags\": [\"...\"],
+    \"instructions\": \"Markdown-formatted instructions\",
+    \"kind\": \"Slack\",
+    \"logo\": \"https://example.com/logo.png\",
+    \"name\": \"My first connector\",
+    \"productType\": \"Dispatch\",
+    \"transformation\": \"function handler(webhook) { /* ... */ }\",
+    \"uid\": \"unique-identifier\"
+  }],
+  \"eventTypes\": [{
+    \"archived\": false,
+    \"deprecated\": true,
+    \"description\": \"A user has signed up\",
+    \"featureFlag\": \"...\",
+    \"featureFlags\": [\"cool-new-feature\"],
+    \"groupName\": \"user\",
+    \"name\": \"user.signup\",
+    \"schemas\": {
+      \"1\": {
+        \"description\": \"An invoice was paid by a user\",
+        \"properties\": {
+          \"invoiceId\": {
+            \"description\": \"The invoice id\",
+            \"type\": \"string\"
+          },
+          \"userId\": {
+            \"description\": \"The user id\",
+            \"type\": \"string\"
+          }
+        },
+        \"required\": [\"invoiceId\",\"userId\"],
+        \"title\": \"Invoice Paid Event\",
+        \"type\": \"object\"
+      }
+    }
+  }],
+  \"settings\": {\"key\": \"...\"}
+}\n")]
     Import {
         environment_in: Option<crate::json::JsonOf<EnvironmentIn>>,
         #[clap(flatten)]

--- a/svix-cli/src/cmds/api/environment.rs
+++ b/svix-cli/src/cmds/api/environment.rs
@@ -49,7 +49,7 @@ pub enum EnvironmentCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"connectors\": [{
     \"allowedEventTypes\": [\"user.signup\",\"user.deleted\"],
@@ -119,7 +119,7 @@ pub enum EnvironmentCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"connectors\": [{
     \"allowedEventTypes\": [\"user.signup\",\"user.deleted\"],

--- a/svix-cli/src/cmds/api/environment.rs
+++ b/svix-cli/src/cmds/api/environment.rs
@@ -41,6 +41,13 @@ pub enum EnvironmentCommands {
     ///
     /// Note that the schema for [`EnvironmentOut`] is subject to change. The fields
     /// herein are provided for convenience but should be treated as JSON blobs.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix environment export\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Export {
         #[clap(flatten)]
         options: EnvironmentExportOptions,
@@ -51,6 +58,13 @@ pub enum EnvironmentCommands {
     ///
     /// Note that the schema for [`EnvironmentIn`] is subject to change. The fields
     /// herein are provided for convenience but should be treated as JSON blobs.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix environment import\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Import {
         environment_in: Option<crate::json::JsonOf<EnvironmentIn>>,
         #[clap(flatten)]

--- a/svix-cli/src/cmds/api/event_type.rs
+++ b/svix-cli/src/cmds/api/event_type.rs
@@ -98,7 +98,7 @@ pub enum EventTypeCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"data\": [{
     \"archived\": false,
@@ -150,7 +150,7 @@ pub enum EventTypeCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"archived\": false,
   \"deprecated\": true,
@@ -177,7 +177,7 @@ pub enum EventTypeCommands {
       \"type\": \"object\"
     }
   }
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"archived\": false,
   \"createdAt\": \"2030-01-01T00:00:00Z\",
@@ -225,7 +225,7 @@ pub enum EventTypeCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"dryRun\": true,
   \"replaceAll\": true,
@@ -270,7 +270,7 @@ pub enum EventTypeCommands {
     }
   },
   \"specRaw\": \"\\n# Both YAML and JSON are supported\\nopenapi: 3.1.0\\ninfo:\\n  title: Webhook Example\\n  version: 1.0.0\\n# Since OAS 3.1.0 the paths element isn\\u0027t necessary. Now a valid OpenAPI Document can describe only paths, webhooks, or even only reusable components\\nwebhooks:\\n  # Each webhook needs a name\\n  \\\"pet.new\\\":\\n    # This is a Path Item Object, the only difference is that the request is initiated by the API provider\\n    post:\\n      requestBody:\\n        description: Information about a new pet in the system\\n        content:\\n          application/json:\\n            schema:\\n              $ref: \\\"#/components/schemas/Pet\\\"\\n      responses:\\n        \\\"200\\\":\\n          description: Return a 200 status to indicate that the data was received successfully\\n\\ncomponents:\\n  schemas:\\n    Pet:\\n      required:\\n        - id\\n        - name\\n      properties:\\n        id:\\n          type: integer\\n          format: int64\\n        name:\\n          type: string\\n        tag:\\n          type: string\\n\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"data\": {
     \"modified\": [\"...\"],
@@ -314,7 +314,7 @@ pub enum EventTypeCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"archived\": false,
   \"createdAt\": \"2030-01-01T00:00:00Z\",
@@ -354,7 +354,7 @@ pub enum EventTypeCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"archived\": false,
   \"deprecated\": true,
@@ -380,7 +380,7 @@ pub enum EventTypeCommands {
       \"type\": \"object\"
     }
   }
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"archived\": false,
   \"createdAt\": \"2030-01-01T00:00:00Z\",
@@ -442,7 +442,7 @@ pub enum EventTypeCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"archived\": true,
   \"deprecated\": true,
@@ -466,7 +466,7 @@ pub enum EventTypeCommands {
     \"title\": \"Invoice Paid Event\",
     \"type\": \"object\"
   }
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"archived\": false,
   \"createdAt\": \"2030-01-01T00:00:00Z\",

--- a/svix-cli/src/cmds/api/event_type.rs
+++ b/svix-cli/src/cmds/api/event_type.rs
@@ -92,11 +92,47 @@ pub enum EventTypeCommands {
     /// Return the list of event types.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix event-type list\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix event-type list\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"data\": [{
+    \"archived\": false,
+    \"createdAt\": \"2030-01-01T00:00:00Z\",
+    \"deprecated\": true,
+    \"description\": \"A user has signed up\",
+    \"featureFlag\": \"...\",
+    \"featureFlags\": [\"cool-new-feature\"],
+    \"groupName\": \"user\",
+    \"name\": \"user.signup\",
+    \"schemas\": {
+      \"1\": {
+        \"description\": \"An invoice was paid by a user\",
+        \"properties\": {
+          \"invoiceId\": {
+            \"description\": \"The invoice id\",
+            \"type\": \"string\"
+          },
+          \"userId\": {
+            \"description\": \"The user id\",
+            \"type\": \"string\"
+          }
+        },
+        \"required\": [\"invoiceId\",\"userId\"],
+        \"title\": \"Invoice Paid Event\",
+        \"type\": \"object\"
+      }
+    },
+    \"updatedAt\": \"2030-01-01T00:00:00Z\"
+  }],
+  \"done\": true,
+  \"iterator\": \"iterator\",
+  \"prevIterator\": \"-iterator\"
+}\n")]
     List {
         #[clap(flatten)]
         options: EventTypeListOptions,
@@ -108,11 +144,69 @@ pub enum EventTypeCommands {
     /// This operation does not preserve the description and schemas.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix event-type create\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix event-type create {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"archived\": false,
+  \"deprecated\": true,
+  \"description\": \"A user has signed up\",
+  \"featureFlag\": \"...\",
+  \"featureFlags\": [\"cool-new-feature\"],
+  \"groupName\": \"user\",
+  \"name\": \"user.signup\",
+  \"schemas\": {
+    \"1\": {
+      \"description\": \"An invoice was paid by a user\",
+      \"properties\": {
+        \"invoiceId\": {
+          \"description\": \"The invoice id\",
+          \"type\": \"string\"
+        },
+        \"userId\": {
+          \"description\": \"The user id\",
+          \"type\": \"string\"
+        }
+      },
+      \"required\": [\"invoiceId\",\"userId\"],
+      \"title\": \"Invoice Paid Event\",
+      \"type\": \"object\"
+    }
+  }
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"archived\": false,
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"deprecated\": true,
+  \"description\": \"A user has signed up\",
+  \"featureFlag\": \"...\",
+  \"featureFlags\": [\"cool-new-feature\"],
+  \"groupName\": \"user\",
+  \"name\": \"user.signup\",
+  \"schemas\": {
+    \"1\": {
+      \"description\": \"An invoice was paid by a user\",
+      \"properties\": {
+        \"invoiceId\": {
+          \"description\": \"The invoice id\",
+          \"type\": \"string\"
+        },
+        \"userId\": {
+          \"description\": \"The user id\",
+          \"type\": \"string\"
+        }
+      },
+      \"required\": [\"invoiceId\",\"userId\"],
+      \"title\": \"Invoice Paid Event\",
+      \"type\": \"object\"
+    }
+  },
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Create {
         event_type_in: crate::json::JsonOf<EventTypeIn>,
         #[clap(flatten)]
@@ -125,11 +219,87 @@ pub enum EventTypeCommands {
     /// top-level.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix event-type import-openapi\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix event-type import-openapi {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"dryRun\": true,
+  \"replaceAll\": true,
+  \"spec\": {
+    \"info\": {
+      \"title\": \"Webhook Example\",
+      \"version\": \"1.0.0\"
+    },
+    \"openapi\": \"3.1.0\",
+    \"webhooks\": {
+      \"pet.new\": {
+        \"post\": {
+          \"requestBody\": {
+            \"content\": {
+              \"application/json\": {
+                \"schema\": {
+                  \"properties\": {
+                    \"id\": {
+                      \"format\": \"int64\",
+                      \"type\": \"integer\"
+                    },
+                    \"name\": {
+                      \"type\": \"string\"
+                    },
+                    \"tag\": {
+                      \"type\": \"string\"
+                    }
+                  },
+                  \"required\": [\"id\",\"name\"]
+                }
+              }
+            },
+            \"description\": \"Information about a new pet in the system\"
+          },
+          \"responses\": {
+            \"200\": {
+              \"description\": \"Return a 200 status to indicate that the data was received successfully\"
+            }
+          }
+        }
+      }
+    }
+  },
+  \"specRaw\": \"\\n# Both YAML and JSON are supported\\nopenapi: 3.1.0\\ninfo:\\n  title: Webhook Example\\n  version: 1.0.0\\n# Since OAS 3.1.0 the paths element isn\\u0027t necessary. Now a valid OpenAPI Document can describe only paths, webhooks, or even only reusable components\\nwebhooks:\\n  # Each webhook needs a name\\n  \\\"pet.new\\\":\\n    # This is a Path Item Object, the only difference is that the request is initiated by the API provider\\n    post:\\n      requestBody:\\n        description: Information about a new pet in the system\\n        content:\\n          application/json:\\n            schema:\\n              $ref: \\\"#/components/schemas/Pet\\\"\\n      responses:\\n        \\\"200\\\":\\n          description: Return a 200 status to indicate that the data was received successfully\\n\\ncomponents:\\n  schemas:\\n    Pet:\\n      required:\\n        - id\\n        - name\\n      properties:\\n        id:\\n          type: integer\\n          format: int64\\n        name:\\n          type: string\\n        tag:\\n          type: string\\n\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"data\": {
+    \"modified\": [\"...\"],
+    \"to_modify\": [{
+      \"deprecated\": true,
+      \"description\": \"...\",
+      \"featureFlag\": \"...\",
+      \"featureFlags\": [\"...\"],
+      \"groupName\": \"user\",
+      \"name\": \"user.signup\",
+      \"schemas\": {
+        \"description\": \"An invoice was paid by a user\",
+        \"properties\": {
+          \"invoiceId\": {
+            \"description\": \"The invoice id\",
+            \"type\": \"string\"
+          },
+          \"userId\": {
+            \"description\": \"The user id\",
+            \"type\": \"string\"
+          }
+        },
+        \"required\": [\"invoiceId\",\"userId\"],
+        \"title\": \"Invoice Paid Event\",
+        \"type\": \"object\"
+      }
+    }]
+  }
+}\n")]
     ImportOpenapi {
         event_type_import_open_api_in: Option<crate::json::JsonOf<EventTypeImportOpenApiIn>>,
         #[clap(flatten)]
@@ -138,20 +308,108 @@ pub enum EventTypeCommands {
     /// Get an event type.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix event-type get example.event\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix event-type get example.event\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"archived\": false,
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"deprecated\": true,
+  \"description\": \"A user has signed up\",
+  \"featureFlag\": \"...\",
+  \"featureFlags\": [\"cool-new-feature\"],
+  \"groupName\": \"user\",
+  \"name\": \"user.signup\",
+  \"schemas\": {
+    \"1\": {
+      \"description\": \"An invoice was paid by a user\",
+      \"properties\": {
+        \"invoiceId\": {
+          \"description\": \"The invoice id\",
+          \"type\": \"string\"
+        },
+        \"userId\": {
+          \"description\": \"The user id\",
+          \"type\": \"string\"
+        }
+      },
+      \"required\": [\"invoiceId\",\"userId\"],
+      \"title\": \"Invoice Paid Event\",
+      \"type\": \"object\"
+    }
+  },
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Get { event_type_name: String },
     /// Update an event type.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix event-type update example.event\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix event-type update example.event {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"archived\": false,
+  \"deprecated\": true,
+  \"description\": \"A user has signed up\",
+  \"featureFlag\": \"...\",
+  \"featureFlags\": [\"cool-new-feature\"],
+  \"groupName\": \"user\",
+  \"schemas\": {
+    \"1\": {
+      \"description\": \"An invoice was paid by a user\",
+      \"properties\": {
+        \"invoiceId\": {
+          \"description\": \"The invoice id\",
+          \"type\": \"string\"
+        },
+        \"userId\": {
+          \"description\": \"The user id\",
+          \"type\": \"string\"
+        }
+      },
+      \"required\": [\"invoiceId\",\"userId\"],
+      \"title\": \"Invoice Paid Event\",
+      \"type\": \"object\"
+    }
+  }
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"archived\": false,
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"deprecated\": true,
+  \"description\": \"A user has signed up\",
+  \"featureFlag\": \"...\",
+  \"featureFlags\": [\"cool-new-feature\"],
+  \"groupName\": \"user\",
+  \"name\": \"user.signup\",
+  \"schemas\": {
+    \"1\": {
+      \"description\": \"An invoice was paid by a user\",
+      \"properties\": {
+        \"invoiceId\": {
+          \"description\": \"The invoice id\",
+          \"type\": \"string\"
+        },
+        \"userId\": {
+          \"description\": \"The user id\",
+          \"type\": \"string\"
+        }
+      },
+      \"required\": [\"invoiceId\",\"userId\"],
+      \"title\": \"Invoice Paid Event\",
+      \"type\": \"object\"
+    }
+  },
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Update {
         event_type_name: String,
         event_type_update: crate::json::JsonOf<EventTypeUpdate>,
@@ -164,10 +422,11 @@ pub enum EventTypeCommands {
     /// [create operation](#operation/create_event_type_api_v1_event_type__post).
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix event-type delete example.event\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix event-type delete example.event\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
     Delete {
         event_type_name: String,
@@ -177,11 +436,66 @@ pub enum EventTypeCommands {
     /// Partially update an event type.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix event-type patch example.event\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix event-type patch example.event {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"archived\": true,
+  \"deprecated\": true,
+  \"description\": \"...\",
+  \"featureFlag\": \"...\",
+  \"featureFlags\": [\"cool-new-feature\"],
+  \"groupName\": \"user\",
+  \"schemas\": {
+    \"description\": \"An invoice was paid by a user\",
+    \"properties\": {
+      \"invoiceId\": {
+        \"description\": \"The invoice id\",
+        \"type\": \"string\"
+      },
+      \"userId\": {
+        \"description\": \"The user id\",
+        \"type\": \"string\"
+      }
+    },
+    \"required\": [\"invoiceId\",\"userId\"],
+    \"title\": \"Invoice Paid Event\",
+    \"type\": \"object\"
+  }
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"archived\": false,
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"deprecated\": true,
+  \"description\": \"A user has signed up\",
+  \"featureFlag\": \"...\",
+  \"featureFlags\": [\"cool-new-feature\"],
+  \"groupName\": \"user\",
+  \"name\": \"user.signup\",
+  \"schemas\": {
+    \"1\": {
+      \"description\": \"An invoice was paid by a user\",
+      \"properties\": {
+        \"invoiceId\": {
+          \"description\": \"The invoice id\",
+          \"type\": \"string\"
+        },
+        \"userId\": {
+          \"description\": \"The user id\",
+          \"type\": \"string\"
+        }
+      },
+      \"required\": [\"invoiceId\",\"userId\"],
+      \"title\": \"Invoice Paid Event\",
+      \"type\": \"object\"
+    }
+  },
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Patch {
         event_type_name: String,
         event_type_patch: Option<crate::json::JsonOf<EventTypePatch>>,

--- a/svix-cli/src/cmds/api/event_type.rs
+++ b/svix-cli/src/cmds/api/event_type.rs
@@ -90,6 +90,13 @@ pub struct EventTypeArgs {
 #[derive(Subcommand)]
 pub enum EventTypeCommands {
     /// Return the list of event types.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix event-type list\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     List {
         #[clap(flatten)]
         options: EventTypeListOptions,
@@ -99,6 +106,13 @@ pub enum EventTypeCommands {
     /// Unarchiving an event type will allow endpoints to filter on it and messages to be sent with it.
     /// Endpoints filtering on the event type before archival will continue to filter on it.
     /// This operation does not preserve the description and schemas.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix event-type create\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Create {
         event_type_in: crate::json::JsonOf<EventTypeIn>,
         #[clap(flatten)]
@@ -109,14 +123,35 @@ pub enum EventTypeCommands {
     /// If an existing `archived` event type is updated, it will be unarchived.
     /// The importer will convert all webhooks found in the either the `webhooks` or `x-webhooks`
     /// top-level.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix event-type import-openapi\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     ImportOpenapi {
         event_type_import_open_api_in: Option<crate::json::JsonOf<EventTypeImportOpenApiIn>>,
         #[clap(flatten)]
         options: EventTypeImportOpenapiOptions,
     },
     /// Get an event type.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix event-type get example.event\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Get { event_type_name: String },
     /// Update an event type.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix event-type update example.event\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Update {
         event_type_name: String,
         event_type_update: crate::json::JsonOf<EventTypeUpdate>,
@@ -127,12 +162,26 @@ pub enum EventTypeCommands {
     /// However, new messages can not be sent with it and endpoints can not filter on it.
     /// An event type can be unarchived with the
     /// [create operation](#operation/create_event_type_api_v1_event_type__post).
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix event-type delete example.event\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Delete {
         event_type_name: String,
         #[clap(flatten)]
         options: EventTypeDeleteOptions,
     },
     /// Partially update an event type.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix event-type patch example.event\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Patch {
         event_type_name: String,
         event_type_patch: Option<crate::json::JsonOf<EventTypePatch>>,

--- a/svix-cli/src/cmds/api/ingest.rs
+++ b/svix-cli/src/cmds/api/ingest.rs
@@ -29,6 +29,13 @@ pub enum IngestCommands {
     Endpoint(IngestEndpointArgs),
     Source(IngestSourceArgs),
     /// Get access to the Ingest Source Consumer Portal.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix ingest dashboard src_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Dashboard {
         source_id: String,
         ingest_source_consumer_portal_access_in:

--- a/svix-cli/src/cmds/api/ingest.rs
+++ b/svix-cli/src/cmds/api/ingest.rs
@@ -3,7 +3,6 @@ use clap::{Args, Subcommand};
 use svix::api::*;
 
 use super::{ingest_endpoint::IngestEndpointArgs, ingest_source::IngestSourceArgs};
-
 #[derive(Args, Clone)]
 pub struct IngestDashboardOptions {
     #[arg(long)]
@@ -31,11 +30,21 @@ pub enum IngestCommands {
     /// Get access to the Ingest Source Consumer Portal.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix ingest dashboard src_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix ingest dashboard src_abc000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"expiry\": 123,
+  \"readOnly\": true
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"token\": \"appsk_kV3ts5tKPNJN4Dl25cMTfUNdmabxbX0O\",
+  \"url\": \"https://app.svix.com/login#key=eyJhcHBJZCI6ICJhcHBfMXRSdFl\"
+}\n")]
     Dashboard {
         source_id: String,
         ingest_source_consumer_portal_access_in:

--- a/svix-cli/src/cmds/api/ingest.rs
+++ b/svix-cli/src/cmds/api/ingest.rs
@@ -36,11 +36,11 @@ pub enum IngestCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"expiry\": 123,
   \"readOnly\": true
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"token\": \"appsk_kV3ts5tKPNJN4Dl25cMTfUNdmabxbX0O\",
   \"url\": \"https://app.svix.com/login#key=eyJhcHBJZCI6ICJhcHBfMXRSdFl\"

--- a/svix-cli/src/cmds/api/ingest_endpoint.rs
+++ b/svix-cli/src/cmds/api/ingest_endpoint.rs
@@ -74,7 +74,7 @@ pub enum IngestEndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"data\": [{
     \"createdAt\": \"2030-01-01T00:00:00Z\",
@@ -105,7 +105,7 @@ pub enum IngestEndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"description\": \"An example endpoint name\",
   \"disabled\": false,
@@ -114,7 +114,7 @@ pub enum IngestEndpointCommands {
   \"secret\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",
   \"uid\": \"unique-identifier\",
   \"url\": \"https://example.com/webhook/\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"createdAt\": \"2030-01-01T00:00:00Z\",
   \"description\": \"...\",
@@ -141,7 +141,7 @@ pub enum IngestEndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"createdAt\": \"2030-01-01T00:00:00Z\",
   \"description\": \"...\",
@@ -166,7 +166,7 @@ pub enum IngestEndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"description\": \"An example endpoint name\",
   \"disabled\": false,
@@ -174,7 +174,7 @@ pub enum IngestEndpointCommands {
   \"rateLimit\": 123,
   \"uid\": \"unique-identifier\",
   \"url\": \"https://example.com/webhook/\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"createdAt\": \"2030-01-01T00:00:00Z\",
   \"description\": \"...\",
@@ -213,7 +213,7 @@ pub enum IngestEndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"headers\": {
     \"X-Example\": \"123\",
@@ -234,7 +234,7 @@ pub enum IngestEndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"headers\": {
     \"X-Example\": \"123\",
@@ -258,7 +258,7 @@ pub enum IngestEndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"key\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\"
 }\n")]
@@ -277,7 +277,7 @@ pub enum IngestEndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"key\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\"
 }\n")]
@@ -297,7 +297,7 @@ pub enum IngestEndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"code\": \"...\",
   \"enabled\": true
@@ -315,7 +315,7 @@ pub enum IngestEndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"code\": \"...\",
   \"enabled\": true

--- a/svix-cli/src/cmds/api/ingest_endpoint.rs
+++ b/svix-cli/src/cmds/api/ingest_endpoint.rs
@@ -66,12 +66,26 @@ pub struct IngestEndpointArgs {
 #[derive(Subcommand)]
 pub enum IngestEndpointCommands {
     /// List ingest endpoints.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix ingest endpoint list src_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     List {
         source_id: String,
         #[clap(flatten)]
         options: IngestEndpointListOptions,
     },
     /// Create an ingest endpoint.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix ingest endpoint create src_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Create {
         source_id: String,
         ingest_endpoint_in: crate::json::JsonOf<IngestEndpointIn>,
@@ -79,27 +93,62 @@ pub enum IngestEndpointCommands {
         options: IngestEndpointCreateOptions,
     },
     /// Get an ingest endpoint.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix ingest endpoint get src_000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Get {
         source_id: String,
         endpoint_id: String,
     },
     /// Update an ingest endpoint.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix ingest endpoint update src_000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Update {
         source_id: String,
         endpoint_id: String,
         ingest_endpoint_update: crate::json::JsonOf<IngestEndpointUpdate>,
     },
     /// Delete an ingest endpoint.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix ingest endpoint delete src_000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Delete {
         source_id: String,
         endpoint_id: String,
     },
     /// Get the additional headers to be sent with the ingest.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix ingest endpoint get-headers src_000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     GetHeaders {
         source_id: String,
         endpoint_id: String,
     },
     /// Set the additional headers to be sent to the endpoint.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix ingest endpoint update-headers src_000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     UpdateHeaders {
         source_id: String,
         endpoint_id: String,
@@ -109,6 +158,13 @@ pub enum IngestEndpointCommands {
     ///
     /// This is used to verify the authenticity of the webhook.
     /// For more information please refer to [the consuming webhooks docs](https://docs.svix.com/consuming-webhooks/).
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix ingest endpoint get-secret src_000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     GetSecret {
         source_id: String,
         endpoint_id: String,
@@ -116,6 +172,13 @@ pub enum IngestEndpointCommands {
     /// Rotates an ingest endpoint's signing secret.
     ///
     /// The previous secret will remain valid for the next 24 hours.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix ingest endpoint rotate-secret src_000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     RotateSecret {
         source_id: String,
         endpoint_id: String,
@@ -124,11 +187,25 @@ pub enum IngestEndpointCommands {
         options: IngestEndpointRotateSecretOptions,
     },
     /// Get the transformation code associated with this ingest endpoint.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix ingest endpoint get-transformation src_000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     GetTransformation {
         source_id: String,
         endpoint_id: String,
     },
     /// Set or unset the transformation code associated with this ingest endpoint.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix ingest endpoint set-transformation src_000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     SetTransformation {
         source_id: String,
         endpoint_id: String,

--- a/svix-cli/src/cmds/api/ingest_endpoint.rs
+++ b/svix-cli/src/cmds/api/ingest_endpoint.rs
@@ -68,11 +68,29 @@ pub enum IngestEndpointCommands {
     /// List ingest endpoints.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix ingest endpoint list src_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix ingest endpoint list src_abc000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"data\": [{
+    \"createdAt\": \"2030-01-01T00:00:00Z\",
+    \"description\": \"...\",
+    \"disabled\": false,
+    \"id\": \"ep_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+    \"metadata\": {\"key\": \"...\"},
+    \"rateLimit\": 123,
+    \"uid\": \"unique-identifier\",
+    \"updatedAt\": \"2030-01-01T00:00:00Z\",
+    \"url\": \"https://example.com/webhook/\"
+  }],
+  \"done\": true,
+  \"iterator\": \"iterator\",
+  \"prevIterator\": \"-iterator\"
+}\n")]
     List {
         source_id: String,
         #[clap(flatten)]
@@ -81,11 +99,33 @@ pub enum IngestEndpointCommands {
     /// Create an ingest endpoint.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix ingest endpoint create src_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix ingest endpoint create src_abc000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"description\": \"An example endpoint name\",
+  \"disabled\": false,
+  \"metadata\": {\"key\": \"...\"},
+  \"rateLimit\": 123,
+  \"secret\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",
+  \"uid\": \"unique-identifier\",
+  \"url\": \"https://example.com/webhook/\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"description\": \"...\",
+  \"disabled\": false,
+  \"id\": \"ep_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"metadata\": {\"key\": \"...\"},
+  \"rateLimit\": 123,
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\",
+  \"url\": \"https://example.com/webhook/\"
+}\n")]
     Create {
         source_id: String,
         ingest_endpoint_in: crate::json::JsonOf<IngestEndpointIn>,
@@ -95,11 +135,24 @@ pub enum IngestEndpointCommands {
     /// Get an ingest endpoint.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix ingest endpoint get src_000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix ingest endpoint get src_abc000000000000000000 ep_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"description\": \"...\",
+  \"disabled\": false,
+  \"id\": \"ep_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"metadata\": {\"key\": \"...\"},
+  \"rateLimit\": 123,
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\",
+  \"url\": \"https://example.com/webhook/\"
+}\n")]
     Get {
         source_id: String,
         endpoint_id: String,
@@ -107,11 +160,32 @@ pub enum IngestEndpointCommands {
     /// Update an ingest endpoint.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix ingest endpoint update src_000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix ingest endpoint update src_abc000000000000000000 ep_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"description\": \"An example endpoint name\",
+  \"disabled\": false,
+  \"metadata\": {\"key\": \"...\"},
+  \"rateLimit\": 123,
+  \"uid\": \"unique-identifier\",
+  \"url\": \"https://example.com/webhook/\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"description\": \"...\",
+  \"disabled\": false,
+  \"id\": \"ep_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"metadata\": {\"key\": \"...\"},
+  \"rateLimit\": 123,
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\",
+  \"url\": \"https://example.com/webhook/\"
+}\n")]
     Update {
         source_id: String,
         endpoint_id: String,
@@ -120,10 +194,11 @@ pub enum IngestEndpointCommands {
     /// Delete an ingest endpoint.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix ingest endpoint delete src_000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix ingest endpoint delete src_abc000000000000000000 ep_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
     Delete {
         source_id: String,
@@ -132,11 +207,20 @@ pub enum IngestEndpointCommands {
     /// Get the additional headers to be sent with the ingest.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix ingest endpoint get-headers src_000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix ingest endpoint get-headers src_abc000000000000000000 ep_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"headers\": {
+    \"X-Example\": \"123\",
+    \"X-Foobar\": \"Bar\"
+  },
+  \"sensitive\": [\"Authorization\"]
+}\n")]
     GetHeaders {
         source_id: String,
         endpoint_id: String,
@@ -144,11 +228,19 @@ pub enum IngestEndpointCommands {
     /// Set the additional headers to be sent to the endpoint.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix ingest endpoint update-headers src_000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix ingest endpoint update-headers src_abc000000000000000000 ep_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"headers\": {
+    \"X-Example\": \"123\",
+    \"X-Foobar\": \"Bar\"
+  }
+}\n")]
     UpdateHeaders {
         source_id: String,
         endpoint_id: String,
@@ -160,11 +252,16 @@ pub enum IngestEndpointCommands {
     /// For more information please refer to [the consuming webhooks docs](https://docs.svix.com/consuming-webhooks/).
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix ingest endpoint get-secret src_000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix ingest endpoint get-secret src_abc000000000000000000 ep_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"key\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\"
+}\n")]
     GetSecret {
         source_id: String,
         endpoint_id: String,
@@ -174,11 +271,16 @@ pub enum IngestEndpointCommands {
     /// The previous secret will remain valid for the next 24 hours.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix ingest endpoint rotate-secret src_000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix ingest endpoint rotate-secret src_abc000000000000000000 ep_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"key\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\"
+}\n")]
     RotateSecret {
         source_id: String,
         endpoint_id: String,
@@ -189,11 +291,17 @@ pub enum IngestEndpointCommands {
     /// Get the transformation code associated with this ingest endpoint.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix ingest endpoint get-transformation src_000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix ingest endpoint get-transformation src_abc000000000000000000 ep_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"code\": \"...\",
+  \"enabled\": true
+}\n")]
     GetTransformation {
         source_id: String,
         endpoint_id: String,
@@ -201,11 +309,17 @@ pub enum IngestEndpointCommands {
     /// Set or unset the transformation code associated with this ingest endpoint.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix ingest endpoint set-transformation src_000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix ingest endpoint set-transformation src_abc000000000000000000 ep_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"code\": \"...\",
+  \"enabled\": true
+}\n")]
     SetTransformation {
         source_id: String,
         endpoint_id: String,

--- a/svix-cli/src/cmds/api/ingest_source.rs
+++ b/svix-cli/src/cmds/api/ingest_source.rs
@@ -68,11 +68,19 @@ pub enum IngestSourceCommands {
     /// List of all the organization's Ingest Sources.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix ingest source list\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix ingest source list\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"data\": [{\"...\": \"...\"}],
+  \"done\": true,
+  \"iterator\": \"iterator\",
+  \"prevIterator\": \"-iterator\"
+}\n")]
     List {
         #[clap(flatten)]
         options: IngestSourceListOptions,
@@ -80,11 +88,27 @@ pub enum IngestSourceCommands {
     /// Create Ingest Source.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix ingest source create\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix ingest source create {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"metadata\": {\"key\": \"...\"},
+  \"name\": \"...\",
+  \"uid\": \"unique-identifier\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"id\": \"src_2yZwUhtgs5Ai8T9yRQJXA\",
+  \"ingestUrl\": \"...\",
+  \"metadata\": {\"key\": \"...\"},
+  \"name\": \"...\",
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Create {
         ingest_source_in: crate::json::JsonOf<IngestSourceIn>,
         #[clap(flatten)]
@@ -93,20 +117,47 @@ pub enum IngestSourceCommands {
     /// Get an Ingest Source by id or uid.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix ingest source get src_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix ingest source get src_abc000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"id\": \"src_2yZwUhtgs5Ai8T9yRQJXA\",
+  \"ingestUrl\": \"...\",
+  \"metadata\": {\"key\": \"...\"},
+  \"name\": \"...\",
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Get { source_id: String },
     /// Update an Ingest Source.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix ingest source update src_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix ingest source update src_abc000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"metadata\": {\"key\": \"...\"},
+  \"name\": \"...\",
+  \"uid\": \"unique-identifier\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"id\": \"src_2yZwUhtgs5Ai8T9yRQJXA\",
+  \"ingestUrl\": \"...\",
+  \"metadata\": {\"key\": \"...\"},
+  \"name\": \"...\",
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Update {
         source_id: String,
         ingest_source_in: crate::json::JsonOf<IngestSourceIn>,
@@ -114,10 +165,11 @@ pub enum IngestSourceCommands {
     /// Delete an Ingest Source.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix ingest source delete src_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix ingest source delete src_abc000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
     Delete { source_id: String },
     /// Rotate the Ingest Source's Url Token.
@@ -128,11 +180,16 @@ pub enum IngestSourceCommands {
     /// rotated a maximum of three times within the 48-hour period.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix ingest source rotate-token src_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix ingest source rotate-token src_abc000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"ingestUrl\": \"...\"
+}\n")]
     RotateToken {
         source_id: String,
         #[clap(flatten)]

--- a/svix-cli/src/cmds/api/ingest_source.rs
+++ b/svix-cli/src/cmds/api/ingest_source.rs
@@ -66,24 +66,59 @@ pub struct IngestSourceArgs {
 #[derive(Subcommand)]
 pub enum IngestSourceCommands {
     /// List of all the organization's Ingest Sources.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix ingest source list\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     List {
         #[clap(flatten)]
         options: IngestSourceListOptions,
     },
     /// Create Ingest Source.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix ingest source create\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Create {
         ingest_source_in: crate::json::JsonOf<IngestSourceIn>,
         #[clap(flatten)]
         options: IngestSourceCreateOptions,
     },
     /// Get an Ingest Source by id or uid.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix ingest source get src_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Get { source_id: String },
     /// Update an Ingest Source.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix ingest source update src_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Update {
         source_id: String,
         ingest_source_in: crate::json::JsonOf<IngestSourceIn>,
     },
     /// Delete an Ingest Source.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix ingest source delete src_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Delete { source_id: String },
     /// Rotate the Ingest Source's Url Token.
     ///
@@ -91,6 +126,13 @@ pub enum IngestSourceCommands {
     /// construct the unique `ingestUrl` for the source. Previous tokens
     /// will remain valid for 48 hours after rotation. The token can be
     /// rotated a maximum of three times within the 48-hour period.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix ingest source rotate-token src_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     RotateToken {
         source_id: String,
         #[clap(flatten)]

--- a/svix-cli/src/cmds/api/ingest_source.rs
+++ b/svix-cli/src/cmds/api/ingest_source.rs
@@ -74,7 +74,7 @@ pub enum IngestSourceCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"data\": [{\"...\": \"...\"}],
   \"done\": true,
@@ -94,12 +94,12 @@ pub enum IngestSourceCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"metadata\": {\"key\": \"...\"},
   \"name\": \"...\",
   \"uid\": \"unique-identifier\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"createdAt\": \"2030-01-01T00:00:00Z\",
   \"id\": \"src_2yZwUhtgs5Ai8T9yRQJXA\",
@@ -123,7 +123,7 @@ pub enum IngestSourceCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"createdAt\": \"2030-01-01T00:00:00Z\",
   \"id\": \"src_2yZwUhtgs5Ai8T9yRQJXA\",
@@ -143,12 +143,12 @@ pub enum IngestSourceCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"metadata\": {\"key\": \"...\"},
   \"name\": \"...\",
   \"uid\": \"unique-identifier\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"createdAt\": \"2030-01-01T00:00:00Z\",
   \"id\": \"src_2yZwUhtgs5Ai8T9yRQJXA\",
@@ -186,7 +186,7 @@ pub enum IngestSourceCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"ingestUrl\": \"...\"
 }\n")]

--- a/svix-cli/src/cmds/api/integration.rs
+++ b/svix-cli/src/cmds/api/integration.rs
@@ -68,11 +68,25 @@ pub enum IntegrationCommands {
     /// List the application's integrations.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix integration list app_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix integration list app_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"data\": [{
+    \"createdAt\": \"2030-01-01T00:00:00Z\",
+    \"featureFlags\": [],
+    \"id\": \"integ_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+    \"name\": \"Example Integration\",
+    \"updatedAt\": \"2030-01-01T00:00:00Z\"
+  }],
+  \"done\": true,
+  \"iterator\": \"iterator\",
+  \"prevIterator\": \"-iterator\"
+}\n")]
     List {
         app_id: String,
         #[clap(flatten)]
@@ -81,11 +95,24 @@ pub enum IntegrationCommands {
     /// Create an integration.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix integration create app_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix integration create app_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"featureFlags\": [],
+  \"name\": \"Example Integration\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"featureFlags\": [],
+  \"id\": \"integ_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"name\": \"Example Integration\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Create {
         app_id: String,
         integration_in: crate::json::JsonOf<IntegrationIn>,
@@ -95,20 +122,42 @@ pub enum IntegrationCommands {
     /// Get an integration.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix integration get app_000000000000000000000000000 integ_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix integration get app_abc000000000000000000000000 integ_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"featureFlags\": [],
+  \"id\": \"integ_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"name\": \"Example Integration\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Get { app_id: String, id: String },
     /// Update an integration.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix integration update app_000000000000000000000000000 integ_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix integration update app_abc000000000000000000000000 integ_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"featureFlags\": [],
+  \"name\": \"Example Integration\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"featureFlags\": [],
+  \"id\": \"integ_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"name\": \"Example Integration\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Update {
         app_id: String,
         id: String,
@@ -117,29 +166,40 @@ pub enum IntegrationCommands {
     /// Delete an integration.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix integration delete app_000000000000000000000000000 integ_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix integration delete app_abc000000000000000000000000 integ_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
     Delete { app_id: String, id: String },
     /// Get an integration's key.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix integration get-key app_000000000000000000000000000 integ_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix integration get-key app_abc000000000000000000000000 integ_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"key\": \"integsk_kV3ts5tKPNJN4Dl25cMTfUNdmabxbX0O\"
+}\n")]
     GetKey { app_id: String, id: String },
     /// Rotate the integration's key. The previous key will be immediately revoked.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix integration rotate-key app_000000000000000000000000000 integ_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix integration rotate-key app_abc000000000000000000000000 integ_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"key\": \"integsk_kV3ts5tKPNJN4Dl25cMTfUNdmabxbX0O\"
+}\n")]
     RotateKey {
         app_id: String,
         id: String,

--- a/svix-cli/src/cmds/api/integration.rs
+++ b/svix-cli/src/cmds/api/integration.rs
@@ -74,7 +74,7 @@ pub enum IntegrationCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"data\": [{
     \"createdAt\": \"2030-01-01T00:00:00Z\",
@@ -101,11 +101,11 @@ pub enum IntegrationCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"featureFlags\": [],
   \"name\": \"Example Integration\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"createdAt\": \"2030-01-01T00:00:00Z\",
   \"featureFlags\": [],
@@ -128,7 +128,7 @@ pub enum IntegrationCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"createdAt\": \"2030-01-01T00:00:00Z\",
   \"featureFlags\": [],
@@ -146,11 +146,11 @@ pub enum IntegrationCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"featureFlags\": [],
   \"name\": \"Example Integration\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"createdAt\": \"2030-01-01T00:00:00Z\",
   \"featureFlags\": [],
@@ -182,7 +182,7 @@ pub enum IntegrationCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"key\": \"integsk_kV3ts5tKPNJN4Dl25cMTfUNdmabxbX0O\"
 }\n")]
@@ -196,7 +196,7 @@ pub enum IntegrationCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"key\": \"integsk_kV3ts5tKPNJN4Dl25cMTfUNdmabxbX0O\"
 }\n")]

--- a/svix-cli/src/cmds/api/integration.rs
+++ b/svix-cli/src/cmds/api/integration.rs
@@ -66,12 +66,26 @@ pub struct IntegrationArgs {
 #[derive(Subcommand)]
 pub enum IntegrationCommands {
     /// List the application's integrations.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix integration list app_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     List {
         app_id: String,
         #[clap(flatten)]
         options: IntegrationListOptions,
     },
     /// Create an integration.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix integration create app_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Create {
         app_id: String,
         integration_in: crate::json::JsonOf<IntegrationIn>,
@@ -79,18 +93,53 @@ pub enum IntegrationCommands {
         options: IntegrationCreateOptions,
     },
     /// Get an integration.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix integration get app_000000000000000000000000000 integ_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Get { app_id: String, id: String },
     /// Update an integration.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix integration update app_000000000000000000000000000 integ_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Update {
         app_id: String,
         id: String,
         integration_update: crate::json::JsonOf<IntegrationUpdate>,
     },
     /// Delete an integration.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix integration delete app_000000000000000000000000000 integ_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Delete { app_id: String, id: String },
     /// Get an integration's key.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix integration get-key app_000000000000000000000000000 integ_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     GetKey { app_id: String, id: String },
     /// Rotate the integration's key. The previous key will be immediately revoked.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix integration rotate-key app_000000000000000000000000000 integ_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     RotateKey {
         app_id: String,
         id: String,

--- a/svix-cli/src/cmds/api/message.rs
+++ b/svix-cli/src/cmds/api/message.rs
@@ -139,6 +139,13 @@ pub enum MessageCommands {
     /// relative to now or, if an iterator is provided, 90 days before/after the time indicated
     /// by the iterator ID. If you require data beyond those time ranges, you will need to explicitly
     /// set the `before` or `after` parameter as appropriate.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix message list app_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     List {
         app_id: String,
         #[clap(flatten)]
@@ -153,6 +160,13 @@ pub enum MessageCommands {
     /// Messages can also have `channels`, which similar to event types let endpoints filter by them. Unlike event types, messages can have multiple channels, and channels don't imply a specific message content or schema.
     ///
     /// The `payload` property is the webhook's body (the actual webhook message). Svix supports payload sizes of up to 1MiB, though it's generally a good idea to keep webhook payloads small, probably no larger than 40kb.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix message create app_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Create {
         app_id: String,
         message_in: crate::json::JsonOf<MessageIn>,
@@ -174,6 +188,13 @@ pub enum MessageCommands {
     ///   }
     /// }
     /// ```
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix message expunge-all-contents app_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     ExpungeAllContents {
         app_id: String,
         #[clap(flatten)]
@@ -185,6 +206,13 @@ pub enum MessageCommands {
     /// Note: most people shouldn't be using this API. Svix doesn't bill you for
     /// messages not actually sent, so using this API doesn't save money.
     /// If unsure, please ask Svix support before using this API.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix message precheck app_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Precheck {
         app_id: String,
         message_precheck_in: crate::json::JsonOf<MessagePrecheckIn>,
@@ -192,6 +220,13 @@ pub enum MessageCommands {
         options: MessagePrecheckOptions,
     },
     /// Get a message by its ID or eventID.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix message get app_000000000000000000000000000 msg_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Get {
         app_id: String,
         id: String,
@@ -202,6 +237,13 @@ pub enum MessageCommands {
     ///
     /// Useful in cases when a message was accidentally sent with sensitive content.
     /// The message can't be replayed or resent once its payload has been deleted or expired.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix message expunge-content app_000000000000000000000000000 msg_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     ExpungeContent {
         app_id: String,
         id: String,

--- a/svix-cli/src/cmds/api/message.rs
+++ b/svix-cli/src/cmds/api/message.rs
@@ -3,7 +3,6 @@ use clap::{Args, Subcommand};
 use svix::api::*;
 
 use super::message_poller::MessagePollerArgs;
-
 #[derive(Args, Clone)]
 pub struct MessageListOptions {
     /// Limit the number of returned items
@@ -141,11 +140,32 @@ pub enum MessageCommands {
     /// set the `before` or `after` parameter as appropriate.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix message list app_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix message list app_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"data\": [{
+    \"channels\": [\"project_123\",\"group_2\"],
+    \"deliverAt\": \"2030-01-01T00:00:00Z\",
+    \"eventId\": \"unique-identifier\",
+    \"eventType\": \"user.signup\",
+    \"id\": \"msg_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+    \"payload\": {
+      \"email\": \"test@example.com\",
+      \"type\": \"user.created\",
+      \"username\": \"test_user\"
+    },
+    \"tags\": [\"...\"],
+    \"timestamp\": \"2030-01-01T00:00:00Z\"
+  }],
+  \"done\": true,
+  \"iterator\": \"iterator\",
+  \"prevIterator\": \"-iterator\"
+}\n")]
     List {
         app_id: String,
         #[clap(flatten)]
@@ -162,11 +182,49 @@ pub enum MessageCommands {
     /// The `payload` property is the webhook's body (the actual webhook message). Svix supports payload sizes of up to 1MiB, though it's generally a good idea to keep webhook payloads small, probably no larger than 40kb.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix message create app_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix message create app_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"application\": {
+    \"metadata\": {\"key\": \"...\"},
+    \"name\": \"My first application\",
+    \"rateLimit\": 123,
+    \"throttleRate\": 123,
+    \"uid\": \"unique-identifier\"
+  },
+  \"channels\": [\"project_123\",\"group_2\"],
+  \"deliverAt\": \"2030-01-01T00:00:00Z\",
+  \"eventId\": \"unique-identifier\",
+  \"eventType\": \"user.signup\",
+  \"payload\": {
+    \"email\": \"test@example.com\",
+    \"type\": \"user.created\",
+    \"username\": \"test_user\"
+  },
+  \"payloadRetentionHours\": 123,
+  \"payloadRetentionPeriod\": 90,
+  \"tags\": [\"my_tag\",\"other\"],
+  \"transformationsParams\": {\"key\": \"...\"}
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"channels\": [\"project_123\",\"group_2\"],
+  \"deliverAt\": \"2030-01-01T00:00:00Z\",
+  \"eventId\": \"unique-identifier\",
+  \"eventType\": \"user.signup\",
+  \"id\": \"msg_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"payload\": {
+    \"email\": \"test@example.com\",
+    \"type\": \"user.created\",
+    \"username\": \"test_user\"
+  },
+  \"tags\": [\"...\"],
+  \"timestamp\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Create {
         app_id: String,
         message_in: crate::json::JsonOf<MessageIn>,
@@ -190,11 +248,19 @@ pub enum MessageCommands {
     /// ```
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix message expunge-all-contents app_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix message expunge-all-contents app_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"id\": \"qtask_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"status\": \"running\",
+  \"task\": \"endpoint.replay\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     ExpungeAllContents {
         app_id: String,
         #[clap(flatten)]
@@ -208,11 +274,20 @@ pub enum MessageCommands {
     /// If unsure, please ask Svix support before using this API.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix message precheck app_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix message precheck app_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"channels\": [\"project_123\",\"group_2\"],
+  \"eventType\": \"user.signup\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"active\": true
+}\n")]
     Precheck {
         app_id: String,
         message_precheck_in: crate::json::JsonOf<MessagePrecheckIn>,
@@ -222,11 +297,27 @@ pub enum MessageCommands {
     /// Get a message by its ID or eventID.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix message get app_000000000000000000000000000 msg_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix message get app_abc000000000000000000000000 msg_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"channels\": [\"project_123\",\"group_2\"],
+  \"deliverAt\": \"2030-01-01T00:00:00Z\",
+  \"eventId\": \"unique-identifier\",
+  \"eventType\": \"user.signup\",
+  \"id\": \"msg_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"payload\": {
+    \"email\": \"test@example.com\",
+    \"type\": \"user.created\",
+    \"username\": \"test_user\"
+  },
+  \"tags\": [\"...\"],
+  \"timestamp\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Get {
         app_id: String,
         id: String,
@@ -239,10 +330,11 @@ pub enum MessageCommands {
     /// The message can't be replayed or resent once its payload has been deleted or expired.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix message expunge-content app_000000000000000000000000000 msg_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix message expunge-content app_abc000000000000000000000000 msg_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
     ExpungeContent {
         app_id: String,

--- a/svix-cli/src/cmds/api/message.rs
+++ b/svix-cli/src/cmds/api/message.rs
@@ -146,7 +146,7 @@ pub enum MessageCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"data\": [{
     \"channels\": [\"project_123\",\"group_2\"],
@@ -188,7 +188,7 @@ pub enum MessageCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"application\": {
     \"metadata\": {\"key\": \"...\"},
@@ -210,7 +210,7 @@ pub enum MessageCommands {
   \"payloadRetentionPeriod\": 90,
   \"tags\": [\"my_tag\",\"other\"],
   \"transformationsParams\": {\"key\": \"...\"}
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"channels\": [\"project_123\",\"group_2\"],
   \"deliverAt\": \"2030-01-01T00:00:00Z\",
@@ -254,7 +254,7 @@ pub enum MessageCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"id\": \"qtask_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
   \"status\": \"running\",
@@ -280,11 +280,11 @@ pub enum MessageCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"channels\": [\"project_123\",\"group_2\"],
   \"eventType\": \"user.signup\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"active\": true
 }\n")]
@@ -303,7 +303,7 @@ pub enum MessageCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"channels\": [\"project_123\",\"group_2\"],
   \"deliverAt\": \"2030-01-01T00:00:00Z\",

--- a/svix-cli/src/cmds/api/message_attempt.rs
+++ b/svix-cli/src/cmds/api/message_attempt.rs
@@ -253,7 +253,7 @@ pub enum MessageAttemptCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"data\": [{
     \"endpointId\": \"ep_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
@@ -306,7 +306,7 @@ pub enum MessageAttemptCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"data\": [{
     \"endpointId\": \"ep_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
@@ -361,7 +361,7 @@ pub enum MessageAttemptCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"data\": [{
     \"channels\": [\"project_123\",\"group_2\"],
@@ -399,7 +399,7 @@ pub enum MessageAttemptCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"endpointId\": \"ep_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
   \"id\": \"atmpt_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
@@ -461,7 +461,7 @@ pub enum MessageAttemptCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"data\": [{
     \"channels\": [\"project_123\",\"group_2\"],
@@ -499,7 +499,7 @@ pub enum MessageAttemptCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
 }\n")]
     Resend {

--- a/svix-cli/src/cmds/api/message_attempt.rs
+++ b/svix-cli/src/cmds/api/message_attempt.rs
@@ -247,11 +247,45 @@ pub enum MessageAttemptCommands {
     /// set the `before` or `after` parameter as appropriate.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix message-attempt list-by-endpoint app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix message-attempt list-by-endpoint app_abc000000000000000000000000 ep_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"data\": [{
+    \"endpointId\": \"ep_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+    \"id\": \"atmpt_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+    \"msg\": {
+      \"channels\": [\"project_123\",\"group_2\"],
+      \"deliverAt\": \"2030-01-01T00:00:00Z\",
+      \"eventId\": \"unique-identifier\",
+      \"eventType\": \"user.signup\",
+      \"id\": \"msg_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+      \"payload\": {
+        \"email\": \"test@example.com\",
+        \"type\": \"user.created\",
+        \"username\": \"test_user\"
+      },
+      \"tags\": [\"...\"],
+      \"timestamp\": \"2030-01-01T00:00:00Z\"
+    },
+    \"msgId\": \"msg_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+    \"response\": \"{}\",
+    \"responseDurationMs\": 123,
+    \"responseStatusCode\": 200,
+    \"status\": 0,
+    \"statusText\": \"success\",
+    \"timestamp\": \"2030-01-01T00:00:00Z\",
+    \"triggerType\": 0,
+    \"url\": \"https://example.com/webhook/\"
+  }],
+  \"done\": true,
+  \"iterator\": \"iterator\",
+  \"prevIterator\": \"-iterator\"
+}\n")]
     ListByEndpoint {
         app_id: String,
         endpoint_id: String,
@@ -266,11 +300,45 @@ pub enum MessageAttemptCommands {
     /// set the `before` or `after` parameter as appropriate.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix message-attempt list-by-msg app_000000000000000000000000000 msg_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix message-attempt list-by-msg app_abc000000000000000000000000 msg_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"data\": [{
+    \"endpointId\": \"ep_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+    \"id\": \"atmpt_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+    \"msg\": {
+      \"channels\": [\"project_123\",\"group_2\"],
+      \"deliverAt\": \"2030-01-01T00:00:00Z\",
+      \"eventId\": \"unique-identifier\",
+      \"eventType\": \"user.signup\",
+      \"id\": \"msg_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+      \"payload\": {
+        \"email\": \"test@example.com\",
+        \"type\": \"user.created\",
+        \"username\": \"test_user\"
+      },
+      \"tags\": [\"...\"],
+      \"timestamp\": \"2030-01-01T00:00:00Z\"
+    },
+    \"msgId\": \"msg_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+    \"response\": \"{}\",
+    \"responseDurationMs\": 123,
+    \"responseStatusCode\": 200,
+    \"status\": 0,
+    \"statusText\": \"success\",
+    \"timestamp\": \"2030-01-01T00:00:00Z\",
+    \"triggerType\": 0,
+    \"url\": \"https://example.com/webhook/\"
+  }],
+  \"done\": true,
+  \"iterator\": \"iterator\",
+  \"prevIterator\": \"-iterator\"
+}\n")]
     ListByMsg {
         app_id: String,
         msg_id: String,
@@ -287,11 +355,35 @@ pub enum MessageAttemptCommands {
     /// set the `before` or `after` parameter as appropriate.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix message-attempt list-attempted-messages app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix message-attempt list-attempted-messages app_abc000000000000000000000000 ep_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"data\": [{
+    \"channels\": [\"project_123\",\"group_2\"],
+    \"deliverAt\": \"2030-01-01T00:00:00Z\",
+    \"eventId\": \"unique-identifier\",
+    \"eventType\": \"user.signup\",
+    \"id\": \"msg_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+    \"nextAttempt\": \"2030-01-01T00:00:00Z\",
+    \"payload\": {
+      \"email\": \"test@example.com\",
+      \"type\": \"user.created\",
+      \"username\": \"test_user\"
+    },
+    \"status\": 0,
+    \"statusText\": \"success\",
+    \"tags\": [\"...\"],
+    \"timestamp\": \"2030-01-01T00:00:00Z\"
+  }],
+  \"done\": true,
+  \"iterator\": \"iterator\",
+  \"prevIterator\": \"-iterator\"
+}\n")]
     ListAttemptedMessages {
         app_id: String,
         endpoint_id: String,
@@ -301,11 +393,40 @@ pub enum MessageAttemptCommands {
     /// `msg_id`: Use a message id or a message `eventId`
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix message-attempt get app_000000000000000000000000000 msg_000000000000000000000000000 atmpt_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix message-attempt get app_abc000000000000000000000000 msg_abc000000000000000000000000 atmpt_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"endpointId\": \"ep_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"id\": \"atmpt_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"msg\": {
+    \"channels\": [\"project_123\",\"group_2\"],
+    \"deliverAt\": \"2030-01-01T00:00:00Z\",
+    \"eventId\": \"unique-identifier\",
+    \"eventType\": \"user.signup\",
+    \"id\": \"msg_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+    \"payload\": {
+      \"email\": \"test@example.com\",
+      \"type\": \"user.created\",
+      \"username\": \"test_user\"
+    },
+    \"tags\": [\"...\"],
+    \"timestamp\": \"2030-01-01T00:00:00Z\"
+  },
+  \"msgId\": \"msg_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"response\": \"{}\",
+  \"responseDurationMs\": 123,
+  \"responseStatusCode\": 200,
+  \"status\": 0,
+  \"statusText\": \"success\",
+  \"timestamp\": \"2030-01-01T00:00:00Z\",
+  \"triggerType\": 0,
+  \"url\": \"https://example.com/webhook/\"
+}\n")]
     Get {
         app_id: String,
         msg_id: String,
@@ -317,10 +438,11 @@ pub enum MessageAttemptCommands {
     /// The message can't be replayed or resent once its payload has been deleted or expired.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix message-attempt expunge-content app_000000000000000000000000000 msg_000000000000000000000000000 atmpt_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix message-attempt expunge-content app_abc000000000000000000000000 msg_abc000000000000000000000000 atmpt_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
     ExpungeContent {
         app_id: String,
@@ -333,11 +455,35 @@ pub enum MessageAttemptCommands {
     /// By default, endpoints are listed in ascending order by ID.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix message-attempt list-attempted-destinations app_000000000000000000000000000 msg_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix message-attempt list-attempted-destinations app_abc000000000000000000000000 msg_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"data\": [{
+    \"channels\": [\"project_123\",\"group_2\"],
+    \"createdAt\": \"2030-01-01T00:00:00Z\",
+    \"description\": \"...\",
+    \"disabled\": false,
+    \"filterTypes\": [\"user.signup\",\"user.deleted\"],
+    \"id\": \"ep_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+    \"nextAttempt\": \"2030-01-01T00:00:00Z\",
+    \"rateLimit\": 123,
+    \"status\": 0,
+    \"statusText\": \"success\",
+    \"throttleRate\": 123,
+    \"uid\": \"unique-identifier\",
+    \"updatedAt\": \"2030-01-01T00:00:00Z\",
+    \"url\": \"https://example.com/webhook/\",
+    \"version\": 1
+  }],
+  \"done\": true,
+  \"iterator\": \"iterator\",
+  \"prevIterator\": \"-iterator\"
+}\n")]
     ListAttemptedDestinations {
         app_id: String,
         msg_id: String,
@@ -347,11 +493,15 @@ pub enum MessageAttemptCommands {
     /// Resend a message to the specified endpoint.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix message-attempt resend app_000000000000000000000000000 msg_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix message-attempt resend app_abc000000000000000000000000 msg_abc000000000000000000000000 ep_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+}\n")]
     Resend {
         app_id: String,
         msg_id: String,

--- a/svix-cli/src/cmds/api/message_attempt.rs
+++ b/svix-cli/src/cmds/api/message_attempt.rs
@@ -245,6 +245,13 @@ pub enum MessageAttemptCommands {
     /// relative to now or, if an iterator is provided, 90 days before/after the time indicated
     /// by the iterator ID. If you require data beyond those time ranges, you will need to explicitly
     /// set the `before` or `after` parameter as appropriate.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix message-attempt list-by-endpoint app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     ListByEndpoint {
         app_id: String,
         endpoint_id: String,
@@ -257,6 +264,13 @@ pub enum MessageAttemptCommands {
     /// relative to now or, if an iterator is provided, 90 days before/after the time indicated
     /// by the iterator ID. If you require data beyond those time ranges, you will need to explicitly
     /// set the `before` or `after` parameter as appropriate.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix message-attempt list-by-msg app_000000000000000000000000000 msg_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     ListByMsg {
         app_id: String,
         msg_id: String,
@@ -271,6 +285,13 @@ pub enum MessageAttemptCommands {
     /// relative to now or, if an iterator is provided, 90 days before/after the time indicated
     /// by the iterator ID. If you require data beyond those time ranges, you will need to explicitly
     /// set the `before` or `after` parameter as appropriate.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix message-attempt list-attempted-messages app_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     ListAttemptedMessages {
         app_id: String,
         endpoint_id: String,
@@ -278,6 +299,13 @@ pub enum MessageAttemptCommands {
         options: MessageAttemptListAttemptedMessagesOptions,
     },
     /// `msg_id`: Use a message id or a message `eventId`
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix message-attempt get app_000000000000000000000000000 msg_000000000000000000000000000 atmpt_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Get {
         app_id: String,
         msg_id: String,
@@ -287,6 +315,13 @@ pub enum MessageAttemptCommands {
     ///
     /// Useful when an endpoint accidentally returned sensitive content.
     /// The message can't be replayed or resent once its payload has been deleted or expired.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix message-attempt expunge-content app_000000000000000000000000000 msg_000000000000000000000000000 atmpt_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     ExpungeContent {
         app_id: String,
         msg_id: String,
@@ -296,6 +331,13 @@ pub enum MessageAttemptCommands {
     ///
     /// Additionally includes metadata about the latest message attempt.
     /// By default, endpoints are listed in ascending order by ID.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix message-attempt list-attempted-destinations app_000000000000000000000000000 msg_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     ListAttemptedDestinations {
         app_id: String,
         msg_id: String,
@@ -303,6 +345,13 @@ pub enum MessageAttemptCommands {
         options: MessageAttemptListAttemptedDestinationsOptions,
     },
     /// Resend a message to the specified endpoint.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix message-attempt resend app_000000000000000000000000000 msg_000000000000000000000000000 ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Resend {
         app_id: String,
         msg_id: String,

--- a/svix-cli/src/cmds/api/message_poller.rs
+++ b/svix-cli/src/cmds/api/message_poller.rs
@@ -87,7 +87,7 @@ pub enum MessagePollerCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"data\": [{
     \"channels\": [\"project_123\",\"group_2\"],
@@ -123,7 +123,7 @@ pub enum MessagePollerCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"data\": [{
     \"channels\": [\"project_123\",\"group_2\"],
@@ -159,10 +159,10 @@ pub enum MessagePollerCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"after\": \"2025-04-21T11:20:34Z\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"iterator\": \"...\"
 }\n")]

--- a/svix-cli/src/cmds/api/message_poller.rs
+++ b/svix-cli/src/cmds/api/message_poller.rs
@@ -81,11 +81,32 @@ pub enum MessagePollerCommands {
     /// Reads the stream of created messages for an application, filtered on the Sink's event types and Channels.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix message poller poll app_000000000000000000000000000 sink_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix message poller poll app_abc000000000000000000000000 sink_abc000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"data\": [{
+    \"channels\": [\"project_123\",\"group_2\"],
+    \"deliverAt\": \"2030-01-01T00:00:00Z\",
+    \"eventId\": \"unique-identifier\",
+    \"eventType\": \"user.signup\",
+    \"headers\": {\"key\": \"...\"},
+    \"id\": \"msg_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+    \"payload\": {
+      \"email\": \"test@example.com\",
+      \"type\": \"user.created\",
+      \"username\": \"test_user\"
+    },
+    \"tags\": [\"...\"],
+    \"timestamp\": \"2030-01-01T00:00:00Z\"
+  }],
+  \"done\": true,
+  \"iterator\": \"...\"
+}\n")]
     Poll {
         app_id: String,
         sink_id: String,
@@ -96,11 +117,32 @@ pub enum MessagePollerCommands {
     /// Channels, using server-managed iterator tracking.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix message poller consumer-poll app_000000000000000000000000000 sink_000000000000000000000 CONSUMER_ID\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix message poller consumer-poll app_abc000000000000000000000000 sink_abc000000000000000000 CONSUMER_ID\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"data\": [{
+    \"channels\": [\"project_123\",\"group_2\"],
+    \"deliverAt\": \"2030-01-01T00:00:00Z\",
+    \"eventId\": \"unique-identifier\",
+    \"eventType\": \"user.signup\",
+    \"headers\": {\"key\": \"...\"},
+    \"id\": \"msg_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+    \"payload\": {
+      \"email\": \"test@example.com\",
+      \"type\": \"user.created\",
+      \"username\": \"test_user\"
+    },
+    \"tags\": [\"...\"],
+    \"timestamp\": \"2030-01-01T00:00:00Z\"
+  }],
+  \"done\": true,
+  \"iterator\": \"...\"
+}\n")]
     ConsumerPoll {
         app_id: String,
         sink_id: String,
@@ -111,11 +153,19 @@ pub enum MessagePollerCommands {
     /// Sets the starting offset for the consumer of a polling endpoint.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix message poller consumer-seek app_000000000000000000000000000 sink_000000000000000000000 CONSUMER_ID\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix message poller consumer-seek app_abc000000000000000000000000 sink_abc000000000000000000 CONSUMER_ID {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"after\": \"2025-04-21T11:20:34Z\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"iterator\": \"...\"
+}\n")]
     ConsumerSeek {
         app_id: String,
         sink_id: String,

--- a/svix-cli/src/cmds/api/message_poller.rs
+++ b/svix-cli/src/cmds/api/message_poller.rs
@@ -79,6 +79,13 @@ pub struct MessagePollerArgs {
 #[derive(Subcommand)]
 pub enum MessagePollerCommands {
     /// Reads the stream of created messages for an application, filtered on the Sink's event types and Channels.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix message poller poll app_000000000000000000000000000 sink_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Poll {
         app_id: String,
         sink_id: String,
@@ -87,6 +94,13 @@ pub enum MessagePollerCommands {
     },
     /// Reads the stream of created messages for an application, filtered on the Sink's event types and
     /// Channels, using server-managed iterator tracking.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix message poller consumer-poll app_000000000000000000000000000 sink_000000000000000000000 CONSUMER_ID\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     ConsumerPoll {
         app_id: String,
         sink_id: String,
@@ -95,6 +109,13 @@ pub enum MessagePollerCommands {
         options: MessagePollerConsumerPollOptions,
     },
     /// Sets the starting offset for the consumer of a polling endpoint.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix message poller consumer-seek app_000000000000000000000000000 sink_000000000000000000000 CONSUMER_ID\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     ConsumerSeek {
         app_id: String,
         sink_id: String,

--- a/svix-cli/src/cmds/api/operational_webhook_endpoint.rs
+++ b/svix-cli/src/cmds/api/operational_webhook_endpoint.rs
@@ -74,11 +74,30 @@ pub enum OperationalWebhookEndpointCommands {
     /// List operational webhook endpoints.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix operational-webhook endpoint list\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix operational-webhook endpoint list\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"data\": [{
+    \"createdAt\": \"2030-01-01T00:00:00Z\",
+    \"description\": \"...\",
+    \"disabled\": false,
+    \"filterTypes\": [\"message.attempt.failing\"],
+    \"id\": \"ep_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+    \"metadata\": {\"key\": \"...\"},
+    \"rateLimit\": 123,
+    \"uid\": \"unique-identifier\",
+    \"updatedAt\": \"2030-01-01T00:00:00Z\",
+    \"url\": \"https://example.com/webhook/\"
+  }],
+  \"done\": true,
+  \"iterator\": \"iterator\",
+  \"prevIterator\": \"-iterator\"
+}\n")]
     List {
         #[clap(flatten)]
         options: OperationalWebhookEndpointListOptions,
@@ -86,11 +105,35 @@ pub enum OperationalWebhookEndpointCommands {
     /// Create an operational webhook endpoint.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix operational-webhook endpoint create\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix operational-webhook endpoint create {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"description\": \"An example endpoint name\",
+  \"disabled\": false,
+  \"filterTypes\": [\"message.attempt.failing\"],
+  \"metadata\": {\"key\": \"...\"},
+  \"rateLimit\": 123,
+  \"secret\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",
+  \"uid\": \"unique-identifier\",
+  \"url\": \"https://example.com/webhook/\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"description\": \"...\",
+  \"disabled\": false,
+  \"filterTypes\": [\"message.attempt.failing\"],
+  \"id\": \"ep_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"metadata\": {\"key\": \"...\"},
+  \"rateLimit\": 123,
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\",
+  \"url\": \"https://example.com/webhook/\"
+}\n")]
     Create {
         operational_webhook_endpoint_in: crate::json::JsonOf<OperationalWebhookEndpointIn>,
         #[clap(flatten)]
@@ -99,20 +142,57 @@ pub enum OperationalWebhookEndpointCommands {
     /// Get an operational webhook endpoint.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix operational-webhook endpoint get ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix operational-webhook endpoint get ep_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"description\": \"...\",
+  \"disabled\": false,
+  \"filterTypes\": [\"message.attempt.failing\"],
+  \"id\": \"ep_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"metadata\": {\"key\": \"...\"},
+  \"rateLimit\": 123,
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\",
+  \"url\": \"https://example.com/webhook/\"
+}\n")]
     Get { endpoint_id: String },
     /// Update an operational webhook endpoint.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix operational-webhook endpoint update ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix operational-webhook endpoint update ep_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"description\": \"An example endpoint name\",
+  \"disabled\": false,
+  \"filterTypes\": [\"message.attempt.failing\"],
+  \"metadata\": {\"key\": \"...\"},
+  \"rateLimit\": 123,
+  \"uid\": \"unique-identifier\",
+  \"url\": \"https://example.com/webhook/\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"description\": \"...\",
+  \"disabled\": false,
+  \"filterTypes\": [\"message.attempt.failing\"],
+  \"id\": \"ep_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"metadata\": {\"key\": \"...\"},
+  \"rateLimit\": 123,
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\",
+  \"url\": \"https://example.com/webhook/\"
+}\n")]
     Update {
         endpoint_id: String,
         operational_webhook_endpoint_update: crate::json::JsonOf<OperationalWebhookEndpointUpdate>,
@@ -120,29 +200,47 @@ pub enum OperationalWebhookEndpointCommands {
     /// Delete an operational webhook endpoint.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix operational-webhook endpoint delete ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix operational-webhook endpoint delete ep_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
     Delete { endpoint_id: String },
     /// Get the additional headers to be sent with the operational webhook.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix operational-webhook endpoint get-headers ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix operational-webhook endpoint get-headers ep_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"headers\": {
+    \"X-Example\": \"123\",
+    \"X-Foobar\": \"Bar\"
+  },
+  \"sensitive\": [\"Authorization\"]
+}\n")]
     GetHeaders { endpoint_id: String },
     /// Set the additional headers to be sent with the operational webhook.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix operational-webhook endpoint update-headers ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix operational-webhook endpoint update-headers ep_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"headers\": {
+    \"X-Example\": \"123\",
+    \"X-Foobar\": \"Bar\"
+  }
+}\n")]
     UpdateHeaders {
         endpoint_id: String,
         operational_webhook_endpoint_headers_in:
@@ -154,22 +252,32 @@ pub enum OperationalWebhookEndpointCommands {
     /// For more information please refer to [the consuming webhooks docs](https://docs.svix.com/consuming-webhooks/).
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix operational-webhook endpoint get-secret ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix operational-webhook endpoint get-secret ep_abc000000000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"key\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\"
+}\n")]
     GetSecret { endpoint_id: String },
     /// Rotates an operational webhook endpoint's signing secret.
     ///
     /// The previous secret will remain valid for the next 24 hours.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix operational-webhook endpoint rotate-secret ep_000000000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix operational-webhook endpoint rotate-secret ep_abc000000000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"key\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\"
+}\n")]
     RotateSecret {
         endpoint_id: String,
         operational_webhook_endpoint_secret_in:

--- a/svix-cli/src/cmds/api/operational_webhook_endpoint.rs
+++ b/svix-cli/src/cmds/api/operational_webhook_endpoint.rs
@@ -80,7 +80,7 @@ pub enum OperationalWebhookEndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"data\": [{
     \"createdAt\": \"2030-01-01T00:00:00Z\",
@@ -111,7 +111,7 @@ pub enum OperationalWebhookEndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"description\": \"An example endpoint name\",
   \"disabled\": false,
@@ -121,7 +121,7 @@ pub enum OperationalWebhookEndpointCommands {
   \"secret\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",
   \"uid\": \"unique-identifier\",
   \"url\": \"https://example.com/webhook/\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"createdAt\": \"2030-01-01T00:00:00Z\",
   \"description\": \"...\",
@@ -148,7 +148,7 @@ pub enum OperationalWebhookEndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"createdAt\": \"2030-01-01T00:00:00Z\",
   \"description\": \"...\",
@@ -171,7 +171,7 @@ pub enum OperationalWebhookEndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"description\": \"An example endpoint name\",
   \"disabled\": false,
@@ -180,7 +180,7 @@ pub enum OperationalWebhookEndpointCommands {
   \"rateLimit\": 123,
   \"uid\": \"unique-identifier\",
   \"url\": \"https://example.com/webhook/\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"createdAt\": \"2030-01-01T00:00:00Z\",
   \"description\": \"...\",
@@ -216,7 +216,7 @@ pub enum OperationalWebhookEndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"headers\": {
     \"X-Example\": \"123\",
@@ -234,7 +234,7 @@ pub enum OperationalWebhookEndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"headers\": {
     \"X-Example\": \"123\",
@@ -258,7 +258,7 @@ pub enum OperationalWebhookEndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"key\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\"
 }\n")]
@@ -274,7 +274,7 @@ pub enum OperationalWebhookEndpointCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"key\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\"
 }\n")]

--- a/svix-cli/src/cmds/api/operational_webhook_endpoint.rs
+++ b/svix-cli/src/cmds/api/operational_webhook_endpoint.rs
@@ -72,28 +72,77 @@ pub struct OperationalWebhookEndpointArgs {
 #[derive(Subcommand)]
 pub enum OperationalWebhookEndpointCommands {
     /// List operational webhook endpoints.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix operational-webhook endpoint list\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     List {
         #[clap(flatten)]
         options: OperationalWebhookEndpointListOptions,
     },
     /// Create an operational webhook endpoint.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix operational-webhook endpoint create\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Create {
         operational_webhook_endpoint_in: crate::json::JsonOf<OperationalWebhookEndpointIn>,
         #[clap(flatten)]
         options: OperationalWebhookEndpointCreateOptions,
     },
     /// Get an operational webhook endpoint.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix operational-webhook endpoint get ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Get { endpoint_id: String },
     /// Update an operational webhook endpoint.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix operational-webhook endpoint update ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Update {
         endpoint_id: String,
         operational_webhook_endpoint_update: crate::json::JsonOf<OperationalWebhookEndpointUpdate>,
     },
     /// Delete an operational webhook endpoint.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix operational-webhook endpoint delete ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Delete { endpoint_id: String },
     /// Get the additional headers to be sent with the operational webhook.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix operational-webhook endpoint get-headers ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     GetHeaders { endpoint_id: String },
     /// Set the additional headers to be sent with the operational webhook.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix operational-webhook endpoint update-headers ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     UpdateHeaders {
         endpoint_id: String,
         operational_webhook_endpoint_headers_in:
@@ -103,10 +152,24 @@ pub enum OperationalWebhookEndpointCommands {
     ///
     /// This is used to verify the authenticity of the webhook.
     /// For more information please refer to [the consuming webhooks docs](https://docs.svix.com/consuming-webhooks/).
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix operational-webhook endpoint get-secret ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     GetSecret { endpoint_id: String },
     /// Rotates an operational webhook endpoint's signing secret.
     ///
     /// The previous secret will remain valid for the next 24 hours.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix operational-webhook endpoint rotate-secret ep_000000000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     RotateSecret {
         endpoint_id: String,
         operational_webhook_endpoint_secret_in:

--- a/svix-cli/src/cmds/api/streaming.rs
+++ b/svix-cli/src/cmds/api/streaming.rs
@@ -21,17 +21,38 @@ pub enum StreamingCommands {
     Sink(StreamingSinkArgs),
     Stream(StreamingStreamArgs),
     /// Get the HTTP sink headers. Only valid for `http` or `otelTracing` sinks.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming sink-headers-get strm_000000000000000000000 sink_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     SinkHeadersGet {
         stream_id: String,
         sink_id: String,
     },
     /// Updates the Sink's headers. Only valid for `http` or `otelTracing` sinks.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming sink-headers-patch strm_000000000000000000000 sink_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     SinkHeadersPatch {
         stream_id: String,
         sink_id: String,
         http_sink_headers_patch_in: crate::json::JsonOf<HttpSinkHeadersPatchIn>,
     },
     /// Get the transformation code associated with this sink.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming sink-transformation-get strm_000000000000000000000 sink_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     SinkTransformationGet {
         stream_id: String,
         sink_id: String,

--- a/svix-cli/src/cmds/api/streaming.rs
+++ b/svix-cli/src/cmds/api/streaming.rs
@@ -29,7 +29,7 @@ pub enum StreamingCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"headers\": {
     \"X-Example\": \"123\",
@@ -50,13 +50,13 @@ pub enum StreamingCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"headers\": {
     \"X-Example\": \"123\",
     \"X-Foobar\": \"Bar\"
   }
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"headers\": {
     \"X-Example\": \"123\",
@@ -78,7 +78,7 @@ pub enum StreamingCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"code\": \"...\",
   \"enabled\": true

--- a/svix-cli/src/cmds/api/streaming.rs
+++ b/svix-cli/src/cmds/api/streaming.rs
@@ -23,11 +23,20 @@ pub enum StreamingCommands {
     /// Get the HTTP sink headers. Only valid for `http` or `otelTracing` sinks.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming sink-headers-get strm_000000000000000000000 sink_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming sink-headers-get strm_abc000000000000000000 sink_abc000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"headers\": {
+    \"X-Example\": \"123\",
+    \"X-Foobar\": \"Bar\"
+  },
+  \"sensitive\": [\"Authorization\"]
+}\n")]
     SinkHeadersGet {
         stream_id: String,
         sink_id: String,
@@ -35,11 +44,26 @@ pub enum StreamingCommands {
     /// Updates the Sink's headers. Only valid for `http` or `otelTracing` sinks.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming sink-headers-patch strm_000000000000000000000 sink_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming sink-headers-patch strm_abc000000000000000000 sink_abc000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"headers\": {
+    \"X-Example\": \"123\",
+    \"X-Foobar\": \"Bar\"
+  }
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"headers\": {
+    \"X-Example\": \"123\",
+    \"X-Foobar\": \"Bar\"
+  },
+  \"sensitive\": [\"Authorization\"]
+}\n")]
     SinkHeadersPatch {
         stream_id: String,
         sink_id: String,
@@ -48,11 +72,17 @@ pub enum StreamingCommands {
     /// Get the transformation code associated with this sink.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming sink-transformation-get strm_000000000000000000000 sink_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming sink-transformation-get strm_abc000000000000000000 sink_abc000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"code\": \"...\",
+  \"enabled\": true
+}\n")]
     SinkTransformationGet {
         stream_id: String,
         sink_id: String,

--- a/svix-cli/src/cmds/api/streaming_event_type.rs
+++ b/svix-cli/src/cmds/api/streaming_event_type.rs
@@ -80,7 +80,7 @@ pub enum StreamingEventTypeCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"data\": [{
     \"archived\": true,
@@ -108,14 +108,14 @@ pub enum StreamingEventTypeCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"archived\": true,
   \"deprecated\": true,
   \"description\": \"...\",
   \"featureFlags\": [\"cool-new-feature\"],
   \"name\": \"user.signup\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"archived\": true,
   \"createdAt\": \"2030-01-01T00:00:00Z\",
@@ -139,7 +139,7 @@ pub enum StreamingEventTypeCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"archived\": true,
   \"createdAt\": \"2030-01-01T00:00:00Z\",
@@ -159,14 +159,14 @@ pub enum StreamingEventTypeCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"archived\": true,
   \"deprecated\": true,
   \"description\": \"...\",
   \"featureFlags\": [\"cool-new-feature\"],
   \"name\": \"user.signup\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"archived\": true,
   \"createdAt\": \"2030-01-01T00:00:00Z\",
@@ -203,14 +203,14 @@ pub enum StreamingEventTypeCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"archived\": true,
   \"deprecated\": true,
   \"description\": \"...\",
   \"featureFlags\": [\"cool-new-feature\"],
   \"name\": \"user.signup\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"archived\": true,
   \"createdAt\": \"2030-01-01T00:00:00Z\",

--- a/svix-cli/src/cmds/api/streaming_event_type.rs
+++ b/svix-cli/src/cmds/api/streaming_event_type.rs
@@ -74,11 +74,27 @@ pub enum StreamingEventTypeCommands {
     /// List of all the organization's event types for streaming.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming event-type list\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming event-type list\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"data\": [{
+    \"archived\": true,
+    \"createdAt\": \"2030-01-01T00:00:00Z\",
+    \"deprecated\": true,
+    \"description\": \"...\",
+    \"featureFlags\": [\"cool-new-feature\"],
+    \"name\": \"user.signup\",
+    \"updatedAt\": \"2030-01-01T00:00:00Z\"
+  }],
+  \"done\": true,
+  \"iterator\": \"iterator\",
+  \"prevIterator\": \"-iterator\"
+}\n")]
     List {
         #[clap(flatten)]
         options: StreamingEventTypeListOptions,
@@ -86,11 +102,29 @@ pub enum StreamingEventTypeCommands {
     /// Create an event type for Streams.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming event-type create\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming event-type create {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"archived\": true,
+  \"deprecated\": true,
+  \"description\": \"...\",
+  \"featureFlags\": [\"cool-new-feature\"],
+  \"name\": \"user.signup\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"archived\": true,
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"deprecated\": true,
+  \"description\": \"...\",
+  \"featureFlags\": [\"cool-new-feature\"],
+  \"name\": \"user.signup\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Create {
         stream_event_type_in: crate::json::JsonOf<StreamEventTypeIn>,
         #[clap(flatten)]
@@ -99,20 +133,49 @@ pub enum StreamingEventTypeCommands {
     /// Get an event type.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming event-type get NAME\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming event-type get NAME\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"archived\": true,
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"deprecated\": true,
+  \"description\": \"...\",
+  \"featureFlags\": [\"cool-new-feature\"],
+  \"name\": \"user.signup\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Get { name: String },
     /// Update or create a event type for Streams.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming event-type update NAME\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming event-type update NAME {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"archived\": true,
+  \"deprecated\": true,
+  \"description\": \"...\",
+  \"featureFlags\": [\"cool-new-feature\"],
+  \"name\": \"user.signup\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"archived\": true,
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"deprecated\": true,
+  \"description\": \"...\",
+  \"featureFlags\": [\"cool-new-feature\"],
+  \"name\": \"user.signup\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Update {
         name: String,
         stream_event_type_in: crate::json::JsonOf<StreamEventTypeIn>,
@@ -120,10 +183,11 @@ pub enum StreamingEventTypeCommands {
     /// Delete an event type.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming event-type delete NAME\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming event-type delete NAME\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
     Delete {
         name: String,
@@ -133,11 +197,29 @@ pub enum StreamingEventTypeCommands {
     /// Patch an event type for Streams.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming event-type patch NAME\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming event-type patch NAME {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"archived\": true,
+  \"deprecated\": true,
+  \"description\": \"...\",
+  \"featureFlags\": [\"cool-new-feature\"],
+  \"name\": \"user.signup\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"archived\": true,
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"deprecated\": true,
+  \"description\": \"...\",
+  \"featureFlags\": [\"cool-new-feature\"],
+  \"name\": \"user.signup\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Patch {
         name: String,
         stream_event_type_patch: Option<crate::json::JsonOf<StreamEventTypePatch>>,

--- a/svix-cli/src/cmds/api/streaming_event_type.rs
+++ b/svix-cli/src/cmds/api/streaming_event_type.rs
@@ -72,30 +72,72 @@ pub struct StreamingEventTypeArgs {
 #[derive(Subcommand)]
 pub enum StreamingEventTypeCommands {
     /// List of all the organization's event types for streaming.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming event-type list\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     List {
         #[clap(flatten)]
         options: StreamingEventTypeListOptions,
     },
     /// Create an event type for Streams.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming event-type create\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Create {
         stream_event_type_in: crate::json::JsonOf<StreamEventTypeIn>,
         #[clap(flatten)]
         options: StreamingEventTypeCreateOptions,
     },
     /// Get an event type.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming event-type get NAME\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Get { name: String },
     /// Update or create a event type for Streams.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming event-type update NAME\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Update {
         name: String,
         stream_event_type_in: crate::json::JsonOf<StreamEventTypeIn>,
     },
     /// Delete an event type.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming event-type delete NAME\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Delete {
         name: String,
         #[clap(flatten)]
         options: StreamingEventTypeDeleteOptions,
     },
     /// Patch an event type for Streams.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming event-type patch NAME\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Patch {
         name: String,
         stream_event_type_patch: Option<crate::json::JsonOf<StreamEventTypePatch>>,

--- a/svix-cli/src/cmds/api/streaming_events.rs
+++ b/svix-cli/src/cmds/api/streaming_events.rs
@@ -60,7 +60,7 @@ pub enum StreamingEventsCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"events\": [{\"eventType\":\"user.signup\",\"payload\":\"{\\\"email\\\":\\\"test@example.com\\\",\\\"username\\\":\\\"test_user\\\"}\"}],
   \"stream\": {
@@ -68,7 +68,7 @@ pub enum StreamingEventsCommands {
     \"name\": \"...\",
     \"uid\": \"unique-identifier\"
   }
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
 }\n")]
     Create {
@@ -88,7 +88,7 @@ pub enum StreamingEventsCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"data\": [{
     \"eventType\": \"user.signup\",

--- a/svix-cli/src/cmds/api/streaming_events.rs
+++ b/svix-cli/src/cmds/api/streaming_events.rs
@@ -54,11 +54,23 @@ pub enum StreamingEventsCommands {
     /// Creates events on the Stream.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming events create strm_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming events create strm_abc000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"events\": [{\"eventType\":\"user.signup\",\"payload\":\"{\\\"email\\\":\\\"test@example.com\\\",\\\"username\\\":\\\"test_user\\\"}\"}],
+  \"stream\": {
+    \"metadata\": {\"key\": \"...\"},
+    \"name\": \"...\",
+    \"uid\": \"unique-identifier\"
+  }
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+}\n")]
     Create {
         stream_id: String,
         create_stream_events_in: crate::json::JsonOf<CreateStreamEventsIn>,
@@ -70,11 +82,22 @@ pub enum StreamingEventsCommands {
     /// The sink must be of type `poller` to use the poller endpoint.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming events get strm_000000000000000000000 sink_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming events get strm_abc000000000000000000 sink_abc000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"data\": [{
+    \"eventType\": \"user.signup\",
+    \"payload\": \"...\",
+    \"timestamp\": \"2030-01-01T00:00:00Z\"
+  }],
+  \"done\": true,
+  \"iterator\": \"...\"
+}\n")]
     Get {
         stream_id: String,
         sink_id: String,

--- a/svix-cli/src/cmds/api/streaming_events.rs
+++ b/svix-cli/src/cmds/api/streaming_events.rs
@@ -52,6 +52,13 @@ pub struct StreamingEventsArgs {
 #[derive(Subcommand)]
 pub enum StreamingEventsCommands {
     /// Creates events on the Stream.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming events create strm_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Create {
         stream_id: String,
         create_stream_events_in: crate::json::JsonOf<CreateStreamEventsIn>,
@@ -61,6 +68,13 @@ pub enum StreamingEventsCommands {
     /// Iterate over a stream of events.
     ///
     /// The sink must be of type `poller` to use the poller endpoint.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming events get strm_000000000000000000000 sink_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Get {
         stream_id: String,
         sink_id: String,

--- a/svix-cli/src/cmds/api/streaming_sink.rs
+++ b/svix-cli/src/cmds/api/streaming_sink.rs
@@ -68,11 +68,19 @@ pub enum StreamingSinkCommands {
     /// List of all the stream's sinks.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming sink list strm_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming sink list strm_abc000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"data\": [{\"...\": \"...\"}],
+  \"done\": true,
+  \"iterator\": \"iterator\",
+  \"prevIterator\": \"-iterator\"
+}\n")]
     List {
         stream_id: String,
         #[clap(flatten)]
@@ -81,11 +89,35 @@ pub enum StreamingSinkCommands {
     /// Creates a new sink.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming sink create strm_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming sink create strm_abc000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"batchSize\": 100,
+  \"eventTypes\": [\"...\"],
+  \"maxWaitSecs\": 123,
+  \"metadata\": {\"key\": \"...\"},
+  \"status\": \"enabled\",
+  \"uid\": \"unique-identifier\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"batchSize\": 123,
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"currentIterator\": \"...\",
+  \"eventTypes\": [\"...\"],
+  \"failureReason\": \"...\",
+  \"id\": \"sink_2yZwUhtgs5Ai8T9yRQJXA\",
+  \"maxWaitSecs\": 123,
+  \"metadata\": {\"key\": \"...\"},
+  \"nextRetryAt\": \"2030-01-01T00:00:00Z\",
+  \"status\": \"enabled\",
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Create {
         stream_id: String,
         stream_sink_in: Option<crate::json::JsonOf<StreamSinkIn>>,
@@ -95,20 +127,60 @@ pub enum StreamingSinkCommands {
     /// Get a sink by id or uid.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming sink get strm_000000000000000000000 sink_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming sink get strm_abc000000000000000000 sink_abc000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"batchSize\": 123,
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"currentIterator\": \"...\",
+  \"eventTypes\": [\"...\"],
+  \"failureReason\": \"...\",
+  \"id\": \"sink_2yZwUhtgs5Ai8T9yRQJXA\",
+  \"maxWaitSecs\": 123,
+  \"metadata\": {\"key\": \"...\"},
+  \"nextRetryAt\": \"2030-01-01T00:00:00Z\",
+  \"status\": \"enabled\",
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Get { stream_id: String, sink_id: String },
     /// Update a sink.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming sink update strm_000000000000000000000 sink_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming sink update strm_abc000000000000000000 sink_abc000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"batchSize\": 100,
+  \"eventTypes\": [\"...\"],
+  \"maxWaitSecs\": 123,
+  \"metadata\": {\"key\": \"...\"},
+  \"status\": \"enabled\",
+  \"uid\": \"unique-identifier\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"batchSize\": 123,
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"currentIterator\": \"...\",
+  \"eventTypes\": [\"...\"],
+  \"failureReason\": \"...\",
+  \"id\": \"sink_2yZwUhtgs5Ai8T9yRQJXA\",
+  \"maxWaitSecs\": 123,
+  \"metadata\": {\"key\": \"...\"},
+  \"nextRetryAt\": \"2030-01-01T00:00:00Z\",
+  \"status\": \"enabled\",
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Update {
         stream_id: String,
         sink_id: String,
@@ -117,20 +189,45 @@ pub enum StreamingSinkCommands {
     /// Delete a sink.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming sink delete strm_000000000000000000000 sink_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming sink delete strm_abc000000000000000000 sink_abc000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
     Delete { stream_id: String, sink_id: String },
     /// Partially update a sink.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming sink patch strm_000000000000000000000 sink_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming sink patch strm_abc000000000000000000 sink_abc000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"batchSize\": 100,
+  \"eventTypes\": [\"...\"],
+  \"maxWaitSecs\": 123,
+  \"metadata\": {\"key\": \"...\"},
+  \"status\": \"enabled\",
+  \"uid\": \"unique-identifier\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"batchSize\": 123,
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"currentIterator\": \"...\",
+  \"eventTypes\": [\"...\"],
+  \"failureReason\": \"...\",
+  \"id\": \"sink_2yZwUhtgs5Ai8T9yRQJXA\",
+  \"maxWaitSecs\": 123,
+  \"metadata\": {\"key\": \"...\"},
+  \"nextRetryAt\": \"2030-01-01T00:00:00Z\",
+  \"status\": \"enabled\",
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Patch {
         stream_id: String,
         sink_id: String,
@@ -143,20 +240,32 @@ pub enum StreamingSinkCommands {
     /// For more information please refer to [the consuming webhooks docs](https://docs.svix.com/consuming-webhooks/).
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming sink get-secret strm_000000000000000000000 sink_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming sink get-secret strm_abc000000000000000000 sink_abc000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"key\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\"
+}\n")]
     GetSecret { stream_id: String, sink_id: String },
     /// Rotates the signing secret (only supported for http sinks).
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming sink rotate-secret strm_000000000000000000000 sink_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming sink rotate-secret strm_abc000000000000000000 sink_abc000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"key\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+}\n")]
     RotateSecret {
         stream_id: String,
         sink_id: String,
@@ -167,11 +276,18 @@ pub enum StreamingSinkCommands {
     /// Set or unset the transformation code associated with this sink.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming sink transformation-partial-update strm_000000000000000000000 sink_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming sink transformation-partial-update strm_abc000000000000000000 sink_abc000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"code\": \"...\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+}\n")]
     TransformationPartialUpdate {
         stream_id: String,
         sink_id: String,

--- a/svix-cli/src/cmds/api/streaming_sink.rs
+++ b/svix-cli/src/cmds/api/streaming_sink.rs
@@ -66,12 +66,26 @@ pub struct StreamingSinkArgs {
 #[derive(Subcommand)]
 pub enum StreamingSinkCommands {
     /// List of all the stream's sinks.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming sink list strm_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     List {
         stream_id: String,
         #[clap(flatten)]
         options: StreamingSinkListOptions,
     },
     /// Creates a new sink.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming sink create strm_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Create {
         stream_id: String,
         stream_sink_in: Option<crate::json::JsonOf<StreamSinkIn>>,
@@ -79,16 +93,44 @@ pub enum StreamingSinkCommands {
         options: StreamingSinkCreateOptions,
     },
     /// Get a sink by id or uid.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming sink get strm_000000000000000000000 sink_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Get { stream_id: String, sink_id: String },
     /// Update a sink.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming sink update strm_000000000000000000000 sink_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Update {
         stream_id: String,
         sink_id: String,
         stream_sink_in: Option<crate::json::JsonOf<StreamSinkIn>>,
     },
     /// Delete a sink.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming sink delete strm_000000000000000000000 sink_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Delete { stream_id: String, sink_id: String },
     /// Partially update a sink.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming sink patch strm_000000000000000000000 sink_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Patch {
         stream_id: String,
         sink_id: String,
@@ -99,8 +141,22 @@ pub enum StreamingSinkCommands {
     /// This is used to verify the authenticity of the delivery.
     ///
     /// For more information please refer to [the consuming webhooks docs](https://docs.svix.com/consuming-webhooks/).
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming sink get-secret strm_000000000000000000000 sink_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     GetSecret { stream_id: String, sink_id: String },
     /// Rotates the signing secret (only supported for http sinks).
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming sink rotate-secret strm_000000000000000000000 sink_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     RotateSecret {
         stream_id: String,
         sink_id: String,
@@ -109,6 +165,13 @@ pub enum StreamingSinkCommands {
         options: StreamingSinkRotateSecretOptions,
     },
     /// Set or unset the transformation code associated with this sink.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming sink transformation-partial-update strm_000000000000000000000 sink_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     TransformationPartialUpdate {
         stream_id: String,
         sink_id: String,

--- a/svix-cli/src/cmds/api/streaming_sink.rs
+++ b/svix-cli/src/cmds/api/streaming_sink.rs
@@ -74,7 +74,7 @@ pub enum StreamingSinkCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"data\": [{\"...\": \"...\"}],
   \"done\": true,
@@ -95,7 +95,7 @@ pub enum StreamingSinkCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"batchSize\": 100,
   \"eventTypes\": [\"...\"],
@@ -103,7 +103,7 @@ pub enum StreamingSinkCommands {
   \"metadata\": {\"key\": \"...\"},
   \"status\": \"enabled\",
   \"uid\": \"unique-identifier\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"batchSize\": 123,
   \"createdAt\": \"2030-01-01T00:00:00Z\",
@@ -133,7 +133,7 @@ pub enum StreamingSinkCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"batchSize\": 123,
   \"createdAt\": \"2030-01-01T00:00:00Z\",
@@ -158,7 +158,7 @@ pub enum StreamingSinkCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"batchSize\": 100,
   \"eventTypes\": [\"...\"],
@@ -166,7 +166,7 @@ pub enum StreamingSinkCommands {
   \"metadata\": {\"key\": \"...\"},
   \"status\": \"enabled\",
   \"uid\": \"unique-identifier\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"batchSize\": 123,
   \"createdAt\": \"2030-01-01T00:00:00Z\",
@@ -205,7 +205,7 @@ pub enum StreamingSinkCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"batchSize\": 100,
   \"eventTypes\": [\"...\"],
@@ -213,7 +213,7 @@ pub enum StreamingSinkCommands {
   \"metadata\": {\"key\": \"...\"},
   \"status\": \"enabled\",
   \"uid\": \"unique-identifier\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"batchSize\": 123,
   \"createdAt\": \"2030-01-01T00:00:00Z\",
@@ -246,7 +246,7 @@ pub enum StreamingSinkCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"key\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\"
 }\n")]
@@ -260,10 +260,10 @@ pub enum StreamingSinkCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"key\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
 }\n")]
     RotateSecret {
@@ -282,10 +282,10 @@ pub enum StreamingSinkCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"code\": \"...\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
 }\n")]
     TransformationPartialUpdate {

--- a/svix-cli/src/cmds/api/streaming_stream.rs
+++ b/svix-cli/src/cmds/api/streaming_stream.rs
@@ -61,7 +61,7 @@ pub enum StreamingStreamCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"data\": [{
     \"createdAt\": \"2030-01-01T00:00:00Z\",
@@ -88,12 +88,12 @@ pub enum StreamingStreamCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"metadata\": {\"key\": \"...\"},
   \"name\": \"...\",
   \"uid\": \"unique-identifier\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"createdAt\": \"2030-01-01T00:00:00Z\",
   \"id\": \"strm_2yZwUhtgs5Ai8T9yRQJXA\",
@@ -116,7 +116,7 @@ pub enum StreamingStreamCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+    #[command(after_help = "Example response:
 {
   \"createdAt\": \"2030-01-01T00:00:00Z\",
   \"id\": \"strm_2yZwUhtgs5Ai8T9yRQJXA\",
@@ -135,12 +135,12 @@ pub enum StreamingStreamCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"metadata\": {\"key\": \"...\"},
   \"name\": \"...\",
   \"uid\": \"unique-identifier\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"createdAt\": \"2030-01-01T00:00:00Z\",
   \"id\": \"strm_2yZwUhtgs5Ai8T9yRQJXA\",
@@ -172,12 +172,12 @@ pub enum StreamingStreamCommands {
             "\n",
             "{all-args}",
         ))]
-    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+    #[command(after_help = "Example body:
 {
   \"description\": \"...\",
   \"metadata\": {\"key\": \"...\"},
   \"uid\": \"unique-identifier\"
-}\n\n\x1b[1;4mExample response:\x1b[0m
+}\n\nExample response:
 {
   \"createdAt\": \"2030-01-01T00:00:00Z\",
   \"id\": \"strm_2yZwUhtgs5Ai8T9yRQJXA\",

--- a/svix-cli/src/cmds/api/streaming_stream.rs
+++ b/svix-cli/src/cmds/api/streaming_stream.rs
@@ -53,26 +53,68 @@ pub struct StreamingStreamArgs {
 #[derive(Subcommand)]
 pub enum StreamingStreamCommands {
     /// List of all the organization's streams.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming stream list\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     List {
         #[clap(flatten)]
         options: StreamingStreamListOptions,
     },
     /// Creates a new stream.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming stream create\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Create {
         stream_in: crate::json::JsonOf<StreamIn>,
         #[clap(flatten)]
         options: StreamingStreamCreateOptions,
     },
     /// Get a stream by id or uid.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming stream get strm_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Get { stream_id: String },
     /// Update a stream.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming stream update strm_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Update {
         stream_id: String,
         stream_in: crate::json::JsonOf<StreamIn>,
     },
     /// Delete a stream.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming stream delete strm_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Delete { stream_id: String },
     /// Partially update a stream.
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n",
+            "Example:   svix streaming stream patch strm_000000000000000000000\n",
+            "\n",
+            "{all-args}{after-help}",
+        ))]
     Patch {
         stream_id: String,
         stream_patch: Option<crate::json::JsonOf<StreamPatch>>,

--- a/svix-cli/src/cmds/api/streaming_stream.rs
+++ b/svix-cli/src/cmds/api/streaming_stream.rs
@@ -55,11 +55,26 @@ pub enum StreamingStreamCommands {
     /// List of all the organization's streams.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming stream list\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming stream list\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"data\": [{
+    \"createdAt\": \"2030-01-01T00:00:00Z\",
+    \"id\": \"strm_2yZwUhtgs5Ai8T9yRQJXA\",
+    \"metadata\": {\"key\": \"...\"},
+    \"name\": \"...\",
+    \"uid\": \"unique-identifier\",
+    \"updatedAt\": \"2030-01-01T00:00:00Z\"
+  }],
+  \"done\": true,
+  \"iterator\": \"iterator\",
+  \"prevIterator\": \"-iterator\"
+}\n")]
     List {
         #[clap(flatten)]
         options: StreamingStreamListOptions,
@@ -67,11 +82,26 @@ pub enum StreamingStreamCommands {
     /// Creates a new stream.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming stream create\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming stream create {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"metadata\": {\"key\": \"...\"},
+  \"name\": \"...\",
+  \"uid\": \"unique-identifier\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"id\": \"strm_2yZwUhtgs5Ai8T9yRQJXA\",
+  \"metadata\": {\"key\": \"...\"},
+  \"name\": \"...\",
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Create {
         stream_in: crate::json::JsonOf<StreamIn>,
         #[clap(flatten)]
@@ -80,20 +110,45 @@ pub enum StreamingStreamCommands {
     /// Get a stream by id or uid.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming stream get strm_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming stream get strm_abc000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample response:\x1b[0m
+{
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"id\": \"strm_2yZwUhtgs5Ai8T9yRQJXA\",
+  \"metadata\": {\"key\": \"...\"},
+  \"name\": \"...\",
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Get { stream_id: String },
     /// Update a stream.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming stream update strm_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming stream update strm_abc000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"metadata\": {\"key\": \"...\"},
+  \"name\": \"...\",
+  \"uid\": \"unique-identifier\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"id\": \"strm_2yZwUhtgs5Ai8T9yRQJXA\",
+  \"metadata\": {\"key\": \"...\"},
+  \"name\": \"...\",
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Update {
         stream_id: String,
         stream_in: crate::json::JsonOf<StreamIn>,
@@ -101,20 +156,36 @@ pub enum StreamingStreamCommands {
     /// Delete a stream.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming stream delete strm_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming stream delete strm_abc000000000000000000\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
     Delete { stream_id: String },
     /// Partially update a stream.
     #[command(help_template = concat!(
             "{about-with-newline}\n",
-            "{usage-heading} {usage}\n",
-            "Example:   svix streaming stream patch strm_000000000000000000000\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix streaming stream patch strm_abc000000000000000000 {...}\n",
+            "{after-help}",
             "\n",
-            "{all-args}{after-help}",
+            "{all-args}",
         ))]
+    #[command(after_help = "\x1b[1;4mExample body:\x1b[0m
+{
+  \"description\": \"...\",
+  \"metadata\": {\"key\": \"...\"},
+  \"uid\": \"unique-identifier\"
+}\n\n\x1b[1;4mExample response:\x1b[0m
+{
+  \"createdAt\": \"2030-01-01T00:00:00Z\",
+  \"id\": \"strm_2yZwUhtgs5Ai8T9yRQJXA\",
+  \"metadata\": {\"key\": \"...\"},
+  \"name\": \"...\",
+  \"uid\": \"unique-identifier\",
+  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+}\n")]
     Patch {
         stream_id: String,
         stream_patch: Option<crate::json::JsonOf<StreamPatch>>,


### PR DESCRIPTION
closes https://github.com/svix/monorepo-private/issues/12825

## Motivation

Add real world examples for the CLI, making it easier to use

## Solution

- Add a map with semi-realistic fake tokens `svix-cli/api_resource.rs.jinja`. 
- Update the CLI to show command examples when `--help` is passed

## Result

### svix ingest endpoint set-transformation --help
```
Set or unset the transformation code associated with this ingest endpoint

Usage: svix ingest endpoint set-transformation [OPTIONS] <SOURCE_ID> <ENDPOINT_ID> [INGEST_ENDPOINT_TRANSFORMATION_PATCH]

Example: svix ingest endpoint set-transformation src_abc000000000000000000 ep_abc000000000000000000000000 {...}


Example body:
{
  "code": "...",
  "enabled": true
}

Arguments:
  <SOURCE_ID>                             
  <ENDPOINT_ID>                           
  [INGEST_ENDPOINT_TRANSFORMATION_PATCH]  

Options:
      --color <WHEN>  Controls when to use color [default: auto] [possible values: auto, always, never]
  -h, --help          Print help
```

### svix ingest endpoint get-headers  --help

```
Get the additional headers to be sent with the ingest

Usage: svix ingest endpoint get-headers [OPTIONS] <SOURCE_ID> <ENDPOINT_ID>

Example: svix ingest endpoint get-headers src_abc000000000000000000 ep_abc000000000000000000000000


Example response:
{
  "headers": {
    "X-Example": "123",
    "X-Foobar": "Bar"
  },
  "sensitive": ["Authorization"]
}

Arguments:
  <SOURCE_ID>    
  <ENDPOINT_ID>  

Options:
      --color <WHEN>  Controls when to use color [default: auto] [possible values: auto, always, never]
  -h, --help          Print help
```