### PR TITLE
ban calls to dangerous tracing::enabled! macro

### DIFF
--- a/rust/.clippy.toml
+++ b/rust/.clippy.toml
@@ -1,6 +1,3 @@
-allow-mixed-uninlined-format-args = false
-avoid-breaking-exported-api = false
-
 disallowed-macros = [
     # https://github.com/tokio-rs/tracing/issues/2448
     "tracing::enabled"

--- a/server/.clippy.toml
+++ b/server/.clippy.toml
@@ -1,2 +1,7 @@
 allow-mixed-uninlined-format-args = false
 avoid-breaking-exported-api = false
+
+disallowed-macros = [
+    # https://github.com/tokio-rs/tracing/issues/2448
+    "tracing::enabled"
+]

--- a/svix-cli/.clippy.toml
+++ b/svix-cli/.clippy.toml
@@ -1,6 +1,3 @@
-allow-mixed-uninlined-format-args = false
-avoid-breaking-exported-api = false
-
 disallowed-macros = [
     # https://github.com/tokio-rs/tracing/issues/2448
     "tracing::enabled"


### PR DESCRIPTION
I was reading through https://github.com/tokio-rs/tracing/issues/2448 again and decided I want to do this everywhere.