### PR TITLE
fix(javascript): upgrade uuid to ^14.0.0 and TypeScript to ^5.0

### DIFF
--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -10,14 +10,14 @@
       "license": "MIT",
       "dependencies": {
         "standardwebhooks": "1.0.0",
-        "uuid": "^10.0.0"
+        "uuid": "^14.0.0"
       },
       "devDependencies": {
         "@biomejs/biome": "2.2.4",
         "@stablelib/utf8": "^2.0.0",
         "@types/uuid": "^10.0.0",
         "mockttp": "^3.15.5",
-        "typescript": "^4.0"
+        "typescript": "^5.0"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -2451,9 +2451,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2461,7 +2461,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {
@@ -2506,16 +2506,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/value-or-promise": {

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -29,13 +29,13 @@
   },
   "dependencies": {
     "standardwebhooks": "1.0.0",
-    "uuid": "^10.0.0"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.4",
     "@stablelib/utf8": "^2.0.0",
     "@types/uuid": "^10.0.0",
     "mockttp": "^3.15.5",
-    "typescript": "^4.0"
+    "typescript": "^5.0"
   }
 }


### PR DESCRIPTION
## Motivation

`uuid@14` fixes [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) (CWE-122, buffer bounds check in uuid v3/v5/v6). The existing Dependabot PR #2284 bumped uuid but CI failed with:

```
node_modules/uuid/dist/index.d.ts(5,1): error TS1383: Only named exports may use 'export type'.
```

`uuid@14`'s type declarations use `export type *` syntax which requires TypeScript 5.0+.

## Solution

Bump `uuid` from `^10.0.0` to `^14.0.0` and `typescript` from `^4.0` to `^5.0` together. svix only uses `uuid.v4()` (idempotency keys in `request.ts`), no v3/v5/v6 usage, so no API risk.

- [x] `npm install` completes without errors
- [x] `npm run build` passes
- [x] `npm test` passes (44 pass, 1 skipped, 0 fail)
- [x] `npm audit` shows 0 critical vulnerabilities for uuid