### PR TITLE
js: Replace dependency `uuid` with native `crypto.randomUUID()`

### DIFF
--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -9,13 +9,11 @@
       "version": "1.91.1",
       "license": "MIT",
       "dependencies": {
-        "standardwebhooks": "1.0.0",
-        "uuid": "^10.0.0"
+        "standardwebhooks": "1.0.0"
       },
       "devDependencies": {
         "@biomejs/biome": "2.2.4",
         "@stablelib/utf8": "^2.0.0",
-        "@types/uuid": "^10.0.0",
         "mockttp": "^3.15.5",
         "typescript": "^4.0"
       }
@@ -337,13 +335,6 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -2503,19 +2494,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/value-or-promise": {

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -28,13 +28,11 @@
     "fmt": "biome format --write"
   },
   "dependencies": {
-    "standardwebhooks": "1.0.0",
-    "uuid": "^10.0.0"
+    "standardwebhooks": "1.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.4",
     "@stablelib/utf8": "^2.0.0",
-    "@types/uuid": "^10.0.0",
     "mockttp": "^3.15.5",
     "typescript": "^4.0"
   }

--- a/javascript/src/request.ts
+++ b/javascript/src/request.ts
@@ -1,6 +1,5 @@
 import { ApiException, type XOR } from "./util";
 import type { HttpErrorOut, HTTPValidationError } from "./HttpErrors";
-import { v4 as uuidv4 } from "uuid";
 
 export const LIB_VERSION = "1.91.1";
 const USER_AGENT = `svix-libs/${LIB_VERSION}/javascript`;
@@ -140,7 +139,7 @@ export class SvixRequest {
       this.headerParams["idempotency-key"] === undefined &&
       this.method.toUpperCase() === "POST"
     ) {
-      this.headerParams["idempotency-key"] = `auto_${uuidv4()}`;
+      this.headerParams["idempotency-key"] = `auto_${crypto.randomUUID()}`;
     }
 
     const randomId = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);


### PR DESCRIPTION
## Motivation

Same motivation as #2285 to fix the reported security vulnerability, but instead of upgrading `uuid`, I propose to replace it with the native `crypto.randomUUID()`. This also reduces dependencies by 2.

I'm not sure what the baseline requirements for this project are, but `crypto.randomUUID` is [well established](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID#browser_compatibility).

## Solution

Replace dependency `uuid` with native `crypto.randomUUID()`
