### PR TITLE
Don't run JavaScript release on merge to main

### DIFF
--- a/.github/workflows/javascript-release.yml
+++ b/.github/workflows/javascript-release.yml
@@ -1,13 +1,6 @@
 name: JavaScript Release
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'lib-openapi.json'
-      - 'javascript/**'
-      - '.github/workflows/javascript-release.yml'
   workflow_dispatch:
   workflow_call:
 
@@ -19,6 +12,9 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     environment: release
+    defaults:
+      run:
+        working-directory: javascript
 
     steps:
       - uses: actions/checkout@v5
@@ -29,13 +25,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install modules and update NPM
-        working-directory: javascript
         run: |
           npm install -g npm@latest
           npm install
 
       - name: Publish
-        if: ${{ github.ref_type == 'tag' || startsWith(github.event.workflow_run.head_branch,'v') }}
-        working-directory: javascript
         run: |
           npm publish


### PR DESCRIPTION
This should have been done back in #1910.