### PR TITLE
Publish svix-cli on NPM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,6 +339,36 @@ jobs:
           done
           git push
 
+  publish-npm:
+    needs:
+      - plan
+      - host
+    runs-on: "ubuntu-22.04"
+    environment: "release"
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PLAN: ${{ needs.plan.outputs.val }}
+    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
+    steps:
+      - name: Fetch npm packages
+        uses: actions/download-artifact@v7
+        with:
+          pattern: artifacts-*
+          path: npm/
+          merge-multiple: true
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: |
+          for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
+            pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)
+            npm publish --access public "./npm/${pkg}"
+          done
+
   announce:
     needs:
       - plan

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -22,6 +22,6 @@ dispatch-releases = true
 # A GitHub repo to push Homebrew formulas to
 tap = "svix/homebrew-svix"
 # Publish jobs to run in CI
-publish-jobs = ["homebrew"]
+publish-jobs = ["homebrew", "npm"]
 # Skip checking whether the specified configuration files are up to date
 allow-dirty = ["ci"]

--- a/svix-cli/Cargo.toml
+++ b/svix-cli/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = "1.88"
 
 [package.metadata.dist]
 dist = true
+npm-package = "svix-cli"
 
 [package.metadata.wix]
 upgrade-guid = "A64E8E7A-69C1-4C4A-96A6-D0BD11C42AF6"


### PR DESCRIPTION
closes https://github.com/svix/diom/issues/1050

# Motivation

 NPM is probably the largest 'language specific' package registry, publishing the library there will add more visibility and make it easier to use for our costumers from the JS land


# Solution

Similar to what we did in Diom here https://github.com/svix/diom/pull/1051. Just add npm to cargo-dist to the `publish-jobs` list