### PR TITLE
Add background sql migrations

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -5169,6 +5169,7 @@ dependencies = [
  "chacha20poly1305",
  "chrono",
  "clap",
+ "crc",
  "ctor",
  "dotenvy",
  "ed25519-compact",

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -31,6 +31,7 @@ bytes = "1.1.0"
 chacha20poly1305 = "0.10.1"
 chrono = { version = "0.4.26", features = ["serde"] }
 clap = { version = "4.1.8", features = ["derive"] }
+crc = "3"
 dotenvy = "0.15.7"
 ed25519-compact = "2.1.1"
 enum_dispatch = "0.3.8"

--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -110,7 +110,7 @@ api_enabled = true
 worker_enabled = true
 
 # Should this instance run background migrations
-background_migrations_enabled = false
+background_migrations_enabled = true
 
 # Subnets to whitelist for outbound webhooks. Note that allowing endpoints in private IP space
 # is a security risk and should only be allowed if you are using the service internally or for

--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -109,6 +109,9 @@ api_enabled = true
 # Should this instance run the message worker
 worker_enabled = true
 
+# Should this instance run background migrations
+background_migrations_enabled = false
+
 # Subnets to whitelist for outbound webhooks. Note that allowing endpoints in private IP space
 # is a security risk and should only be allowed if you are using the service internally or for
 # testing purposes. Should be specified in CIDR notation, e.g., `[127.0.0.1/32, 172.17.0.0/16, 192.168.0.0/16]`

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -246,6 +246,9 @@ pub struct ConfigurationInner {
     #[serde(default = "default_redis_pending_duration_secs")]
     pub redis_pending_duration_secs: u64,
 
+    /// Should this instance run background migrations
+    pub background_migrations_enabled: bool,
+
     #[serde(flatten)]
     pub internal: InternalConfig,
 }

--- a/server/svix-server/src/db/background_migrations.rs
+++ b/server/svix-server/src/db/background_migrations.rs
@@ -41,10 +41,13 @@ async fn advisory_lock_acquire(
 }
 
 async fn advisory_lock_release(conn: &mut sqlx::PgConnection, key: i64) {
-    let _ = sqlx::query("SELECT pg_advisory_unlock($1)")
+    if let Err(e) = sqlx::query("SELECT pg_advisory_unlock($1)")
         .bind(key)
         .execute(conn)
-        .await;
+        .await
+    {
+        tracing::warn!(error = %e, "Failed to release advisory lock");
+    }
 }
 
 // Modeled after sqlx implementation
@@ -184,7 +187,7 @@ pub async fn run(cfg: &Configuration) {
 
 pub async fn run_with_pool(pool: &PgPool, migrations: &[BackgroundMigration]) {
     if let Err(e) = ensure_table(pool).await {
-        tracing::error!("Failed to create _svix_background_migrations table: {e}");
+        tracing::error!(error = %e, "Failed to create _svix_background_migrations table");
         return;
     }
 
@@ -231,8 +234,8 @@ pub async fn try_revert(
     migration: &BackgroundMigration,
 ) -> Result<bool, sqlx::Error> {
     if migration.revert_sql.is_none() {
-        tracing::info!("No revert SQl for migration {}", migration.id);
-    };
+        tracing::warn!(id = migration.id, "No revert SQl for migration");
+    }
 
     let key = lock_key(migration.id);
     let mut conn = pool.acquire().await?;

--- a/server/svix-server/src/db/background_migrations.rs
+++ b/server/svix-server/src/db/background_migrations.rs
@@ -17,7 +17,6 @@ pub static MIGRATIONS: &[BackgroundMigration] = &[BackgroundMigration {
     "#],
     cleanup_sql: None,
     revert_sql: Some(&["DROP INDEX CONCURRENTLY IF EXISTS messageattempt_per_endp_no_status"]),
-    required_for_startup: false,
 }];
 
 pub struct BackgroundMigration {
@@ -29,12 +28,6 @@ pub struct BackgroundMigration {
     pub cleanup_sql: Option<&'static [&'static str]>,
     /// Optional Sql statements to run for reverting the migration.
     pub revert_sql: Option<&'static [&'static str]>,
-    /// If true, the application will fail to start if this migration is missing.
-    ///
-    /// Ideally you would first add the migration with this field set to false, and only
-    /// set it to true in a subsequent application version after verifying the migration has
-    /// successfully run.
-    pub required_for_startup: bool,
 }
 
 async fn advisory_lock_acquire(
@@ -187,45 +180,6 @@ async fn apply_inner(pool: &PgPool, migration: &BackgroundMigration) -> Result<b
 pub async fn run(cfg: &Configuration) {
     let pool = super::connect(&cfg.db_dsn, cfg.db_pool_max_size).await;
     run_with_pool(&pool, MIGRATIONS).await;
-}
-
-pub async fn check_required_for_startup(cfg: &Configuration) {
-    let pool = super::connect(&cfg.db_dsn, cfg.db_pool_max_size).await;
-    if let Err(e) = check_required_for_startup_with_pool(&pool, MIGRATIONS).await {
-        panic!("{e}");
-    }
-}
-
-pub async fn check_required_for_startup_with_pool(
-    pool: &PgPool,
-    migrations: &[BackgroundMigration],
-) -> Result<(), String> {
-    if let Err(e) = ensure_table(pool).await {
-        return Err(format!("Failed to check required migrations: {e}"));
-    }
-    for migration in migrations.iter().filter(|m| m.required_for_startup) {
-        let success: Result<Option<bool>, sqlx::Error> =
-            sqlx::query_scalar("SELECT success FROM _svix_background_migrations WHERE id = $1")
-                .bind(migration.id)
-                .fetch_optional(pool)
-                .await;
-        match success {
-            Ok(Some(true)) => {}
-            Ok(_) => {
-                return Err(format!(
-                    "Required background migration '{}' has not completed.",
-                    migration.id
-                ));
-            }
-            Err(e) => {
-                return Err(format!(
-                    "Failed to check required migration '{}': {e}",
-                    migration.id
-                ));
-            }
-        }
-    }
-    Ok(())
 }
 
 pub async fn run_with_pool(pool: &PgPool, migrations: &[BackgroundMigration]) {

--- a/server/svix-server/src/db/background_migrations.rs
+++ b/server/svix-server/src/db/background_migrations.rs
@@ -1,0 +1,335 @@
+// SPDX-FileCopyrightText: © 2022 Svix Authors
+// SPDX-License-Identifier: MIT
+
+use std::time::Duration;
+
+use sqlx::{PgPool, Row as _};
+
+use crate::cfg::Configuration;
+
+// Background migrations go here:
+pub static MIGRATIONS: &[BackgroundMigration] = &[BackgroundMigration {
+    id: "2026_04_1777303796_messageattempt_per_endp_no_status",
+    apply_sql: &[r#"
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS messageattempt_per_endp_no_status
+        ON messageattempt USING btree (endp_id, id DESC)
+        INCLUDE (status, response_status_code)
+    "#],
+    cleanup_sql: None,
+    revert_sql: Some(&["DROP INDEX CONCURRENTLY IF EXISTS messageattempt_per_endp_no_status"]),
+    required_for_startup: false,
+}];
+
+pub struct BackgroundMigration {
+    /// Unique id for the migration.
+    pub id: &'static str,
+    /// Sql statements to apply the migration.
+    pub apply_sql: &'static [&'static str],
+    /// Optional Sql statements that should be run before re-applying if the migration fails.
+    pub cleanup_sql: Option<&'static [&'static str]>,
+    /// Optional Sql statements to run for reverting the migration.
+    pub revert_sql: Option<&'static [&'static str]>,
+    /// If true, the application will fail to start if this migration is missing.
+    ///
+    /// Ideally you would first add the migration with this field set to false, and only
+    /// set it to true in a subsequent application version after verifying the migration has
+    /// successfully run.
+    pub required_for_startup: bool,
+}
+
+async fn advisory_lock_acquire(
+    conn: &mut sqlx::PgConnection,
+    key: i64,
+) -> Result<bool, sqlx::Error> {
+    sqlx::query_scalar("SELECT pg_try_advisory_lock($1)")
+        .bind(key)
+        .fetch_one(conn)
+        .await
+}
+
+async fn advisory_lock_release(conn: &mut sqlx::PgConnection, key: i64) {
+    let _ = sqlx::query("SELECT pg_advisory_unlock($1)")
+        .bind(key)
+        .execute(conn)
+        .await;
+}
+
+// Modeled after sqlx implementation
+fn lock_key(id: &str) -> i64 {
+    const CRC_IEEE: crc::Crc<u32> = crc::Crc::<u32>::new(&crc::CRC_32_ISO_HDLC);
+    0x7a9f2c51 * (CRC_IEEE.checksum(id.as_bytes()) as i64)
+}
+
+pub async fn ensure_table(pool: &PgPool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS _svix_background_migrations (
+            id          TEXT        PRIMARY KEY,
+            started_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+            finished_at TIMESTAMPTZ,
+            success     BOOLEAN     NOT NULL DEFAULT FALSE,
+            attempts    INTEGER     NOT NULL DEFAULT 0,
+            last_error  TEXT
+        )",
+    )
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+pub async fn try_apply(
+    pool: &PgPool,
+    migration: &BackgroundMigration,
+) -> Result<bool, sqlx::Error> {
+    let key = lock_key(migration.id);
+
+    let mut conn = pool.acquire().await?;
+
+    if !advisory_lock_acquire(&mut conn, key).await? {
+        let done: Option<bool> =
+            sqlx::query_scalar("SELECT success FROM _svix_background_migrations WHERE id = $1")
+                .bind(migration.id)
+                .fetch_optional(pool)
+                .await?;
+        return Ok(done.unwrap_or(false));
+    }
+
+    let result = apply_inner(pool, migration).await;
+    advisory_lock_release(&mut conn, key).await;
+    result
+}
+
+async fn apply_inner(pool: &PgPool, migration: &BackgroundMigration) -> Result<bool, sqlx::Error> {
+    let existing =
+        sqlx::query("SELECT success, attempts FROM _svix_background_migrations WHERE id = $1")
+            .bind(migration.id)
+            .fetch_optional(pool)
+            .await?;
+
+    match existing {
+        Some(row) if row.get::<bool, _>("success") => return Ok(true),
+        Some(row) => {
+            let attempts: i32 = row.get("attempts");
+            tracing::warn!(
+                id = migration.id,
+                attempts,
+                "Background migration previously failed; running cleanup before retry"
+            );
+            if let Some(stmts) = migration.cleanup_sql {
+                tracing::info!(id = migration.id, "Running cleanup before retry");
+                for stmt in stmts {
+                    if let Err(e) = sqlx::query(stmt).execute(pool).await {
+                        let _ = sqlx::query(
+                            "UPDATE _svix_background_migrations SET last_error = $1 WHERE id = $2",
+                        )
+                        .bind(e.to_string())
+                        .bind(migration.id)
+                        .execute(pool)
+                        .await;
+                        return Err(e);
+                    }
+                }
+                tracing::info!(id = migration.id, "Cleanup completed");
+            }
+            sqlx::query(
+                "UPDATE _svix_background_migrations
+                 SET attempts = attempts + 1, last_error = NULL
+                 WHERE id = $1",
+            )
+            .bind(migration.id)
+            .execute(pool)
+            .await?;
+        }
+        None => {
+            sqlx::query("INSERT INTO _svix_background_migrations (id) VALUES ($1)")
+                .bind(migration.id)
+                .execute(pool)
+                .await?;
+        }
+    }
+
+    tracing::info!(id = migration.id, "Starting background migration");
+    let started = std::time::Instant::now();
+
+    let apply_result: Result<(), sqlx::Error> = async {
+        for stmt in migration.apply_sql {
+            sqlx::query(stmt).execute(pool).await?;
+        }
+        Ok(())
+    }
+    .await;
+
+    if let Err(ref e) = apply_result {
+        let _ = sqlx::query("UPDATE _svix_background_migrations SET last_error = $1 WHERE id = $2")
+            .bind(e.to_string())
+            .bind(migration.id)
+            .execute(pool)
+            .await;
+        return apply_result.map(|_| false);
+    }
+
+    sqlx::query(
+        "UPDATE _svix_background_migrations
+         SET success = TRUE, finished_at = now()
+         WHERE id = $1",
+    )
+    .bind(migration.id)
+    .execute(pool)
+    .await?;
+
+    tracing::info!(
+        id = migration.id,
+        elapsed_secs = started.elapsed().as_secs_f64(),
+        "Background migration completed"
+    );
+    Ok(true)
+}
+
+pub async fn run(cfg: &Configuration) {
+    let pool = super::connect(&cfg.db_dsn, cfg.db_pool_max_size).await;
+    run_with_pool(&pool, MIGRATIONS).await;
+}
+
+pub async fn check_required_for_startup(cfg: &Configuration) {
+    let pool = super::connect(&cfg.db_dsn, cfg.db_pool_max_size).await;
+    if let Err(e) = check_required_for_startup_with_pool(&pool, MIGRATIONS).await {
+        panic!("{e}");
+    }
+}
+
+pub async fn check_required_for_startup_with_pool(
+    pool: &PgPool,
+    migrations: &[BackgroundMigration],
+) -> Result<(), String> {
+    if let Err(e) = ensure_table(pool).await {
+        return Err(format!("Failed to check required migrations: {e}"));
+    }
+    for migration in migrations.iter().filter(|m| m.required_for_startup) {
+        let success: Result<Option<bool>, sqlx::Error> =
+            sqlx::query_scalar("SELECT success FROM _svix_background_migrations WHERE id = $1")
+                .bind(migration.id)
+                .fetch_optional(pool)
+                .await;
+        match success {
+            Ok(Some(true)) => {}
+            Ok(_) => {
+                return Err(format!(
+                    "Required background migration '{}' has not completed.",
+                    migration.id
+                ));
+            }
+            Err(e) => {
+                return Err(format!(
+                    "Failed to check required migration '{}': {e}",
+                    migration.id
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+pub async fn run_with_pool(pool: &PgPool, migrations: &[BackgroundMigration]) {
+    if let Err(e) = ensure_table(pool).await {
+        tracing::error!("Failed to create _svix_background_migrations table: {e}");
+        return;
+    }
+
+    let shutdown = crate::shutting_down_token();
+    let mut backoff = Duration::from_secs(5);
+
+    loop {
+        let mut pending = false;
+
+        for migration in migrations {
+            match try_apply(pool, migration).await {
+                Ok(true) => {}
+                Ok(false) => {
+                    pending = true;
+                    break;
+                }
+                Err(e) => {
+                    tracing::error!(
+                        id = migration.id,
+                        error = %e,
+                        "Background migration failed"
+                    );
+                    pending = true;
+                    break;
+                }
+            }
+        }
+
+        if !pending {
+            tracing::debug!("Background migration worker exiting.");
+            break;
+        }
+
+        tokio::select! {
+            _ = tokio::time::sleep(backoff) => {}
+            _ = shutdown.cancelled() => break,
+        }
+        backoff = (backoff * 2).min(Duration::from_secs(600));
+    }
+}
+
+pub async fn try_revert(
+    pool: &PgPool,
+    migration: &BackgroundMigration,
+) -> Result<bool, sqlx::Error> {
+    if migration.revert_sql.is_none() {
+        tracing::info!("No revert SQl for migration {}", migration.id);
+    };
+
+    let key = lock_key(migration.id);
+    let mut conn = pool.acquire().await?;
+
+    if !advisory_lock_acquire(&mut conn, key).await? {
+        return Ok(false);
+    }
+
+    let result = revert_inner(pool, migration, migration.revert_sql).await;
+    advisory_lock_release(&mut conn, key).await;
+    result
+}
+
+// If there's no actual revert script, only the migrations table row
+// will be deleted.
+async fn revert_inner(
+    pool: &PgPool,
+    migration: &BackgroundMigration,
+    statements: Option<&[&str]>,
+) -> Result<bool, sqlx::Error> {
+    let success: Option<bool> =
+        sqlx::query_scalar("SELECT success FROM _svix_background_migrations WHERE id = $1")
+            .bind(migration.id)
+            .fetch_optional(pool)
+            .await?;
+
+    if success != Some(true) {
+        return Ok(false);
+    }
+
+    tracing::info!(id = migration.id, "Reverting background migration");
+    if let Some(statements) = statements {
+        for stmt in statements {
+            if let Err(e) = sqlx::query(stmt).execute(pool).await {
+                let _ = sqlx::query(
+                    "UPDATE _svix_background_migrations SET last_error = $1 WHERE id = $2",
+                )
+                .bind(e.to_string())
+                .bind(migration.id)
+                .execute(pool)
+                .await;
+                return Err(e);
+            }
+        }
+    }
+
+    sqlx::query("DELETE FROM _svix_background_migrations WHERE id = $1")
+        .bind(migration.id)
+        .execute(pool)
+        .await?;
+
+    tracing::info!(id = migration.id, "Background migration reverted");
+    Ok(true)
+}

--- a/server/svix-server/src/db/background_migrations.rs
+++ b/server/svix-server/src/db/background_migrations.rs
@@ -112,7 +112,7 @@ async fn apply_inner(pool: &PgPool, migration: &BackgroundMigration) -> Result<b
             tracing::warn!(
                 id = migration.id,
                 attempts,
-                "Background migration previously failed; running cleanup before retry"
+                "Background migration previously failed"
             );
             if let Some(stmts) = migration.cleanup_sql {
                 tracing::info!(id = migration.id, "Running cleanup before retry");

--- a/server/svix-server/src/db/mod.rs
+++ b/server/svix-server/src/db/mod.rs
@@ -13,6 +13,7 @@ use crate::{
     core::types::{BaseId, MessageId, OrganizationId},
 };
 
+pub mod background_migrations;
 pub mod models;
 use models::{application, endpoint, eventtype, message, messageattempt};
 

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -128,8 +128,6 @@ pub async fn run_with_prefix(
     let pool = init_db(&cfg).await;
     tracing::debug!("DB: Started");
 
-    db::background_migrations::check_required_for_startup(&cfg).await;
-
     tracing::debug!("Cache: Initializing {:?}", cfg.cache_type);
     let cache_backend = cfg.cache_backend();
     let cache = match &cache_backend {

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -128,6 +128,8 @@ pub async fn run_with_prefix(
     let pool = init_db(&cfg).await;
     tracing::debug!("DB: Started");
 
+    db::background_migrations::check_required_for_startup(&cfg).await;
+
     tracing::debug!("Cache: Initializing {:?}", cfg.cache_type);
     let cache_backend = cfg.cache_backend();
     let cache = match &cache_backend {
@@ -193,9 +195,10 @@ pub async fn run_with_prefix(
 
     let with_api = cfg.api_enabled;
     let with_worker = cfg.worker_enabled;
+    let with_background_migrations = cfg.background_migrations_enabled;
     let listen_address = cfg.listen_address;
 
-    let ((), worker_loop, expired_message_cleaner_loop) = tokio::join!(
+    let ((), worker_loop, expired_message_cleaner_loop, ()) = tokio::join!(
         async {
             if with_api {
                 let listener = match listener {
@@ -239,6 +242,14 @@ pub async fn run_with_prefix(
             } else {
                 tracing::debug!("Expired message cleaner: off");
                 Ok(())
+            }
+        },
+        async {
+            if with_background_migrations {
+                tracing::debug!("Background migrations: Started");
+                db::background_migrations::run(&cfg).await
+            } else {
+                tracing::debug!("Background migrations: off");
             }
         }
     );

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -15,7 +15,7 @@ use svix_server::{
         types::{EndpointSecretInternal, OrganizationId},
     },
     db,
-    db::{prune_messages, wipe_org},
+    db::{background_migrations, prune_messages, wipe_org},
     run, setup_tracing,
 };
 use tracing_subscriber::util::SubscriberInitExt;
@@ -70,6 +70,13 @@ enum Commands {
     /// Run database migrations and exit
     #[clap()]
     Migrate,
+
+    /// Revert a background migration by id
+    #[clap()]
+    RevertBackgroundMigration {
+        /// id of the background migration to revert
+        id: String,
+    },
 
     #[clap()]
     Wipe {
@@ -199,7 +206,22 @@ async fn main() -> anyhow::Result<()> {
     match args.command {
         Some(Commands::Migrate) => {
             db::run_migrations(&cfg).await;
+            background_migrations::run(&cfg).await;
             println!("Migrations: success");
+        }
+        Some(Commands::RevertBackgroundMigration { id }) => {
+            let migration = background_migrations::MIGRATIONS
+                .iter()
+                .find(|m| m.id == id)
+                .ok_or_else(|| anyhow::anyhow!("unknown migration id: '{id}'"))?;
+            let pool = sqlx::postgres::PgPoolOptions::new()
+                .max_connections(cfg.db_pool_max_size.into())
+                .connect(&cfg.db_dsn)
+                .await?;
+            match background_migrations::try_revert(&pool, migration).await? {
+                true => println!("Migration reverted: {id}"),
+                false => println!("Nothing to revert for: {id}"),
+            }
         }
         Some(Commands::Jwt {
             command: JwtCommands::Generate { org_id },

--- a/server/svix-server/tests/it/background_migrations.rs
+++ b/server/svix-server/tests/it/background_migrations.rs
@@ -3,7 +3,7 @@
 use futures::future::join_all;
 use sqlx::PgPool;
 use svix_server::db::background_migrations::{
-    BackgroundMigration, check_required_for_startup_with_pool, ensure_table, try_apply, try_revert,
+    BackgroundMigration, ensure_table, try_apply, try_revert,
 };
 
 use crate::utils::get_default_test_config;
@@ -39,7 +39,6 @@ async fn test_fresh_apply_succeeds() {
         apply_sql: &["SELECT 1"],
         cleanup_sql: None,
         revert_sql: None,
-        required_for_startup: false,
     };
 
     let done = try_apply(&pool, &migration).await.unwrap();
@@ -66,7 +65,6 @@ async fn test_apply_is_idempotent() {
         apply_sql: &["SELECT 1"],
         cleanup_sql: None,
         revert_sql: None,
-        required_for_startup: false,
     };
 
     try_apply(&pool, &migration).await.unwrap();
@@ -111,7 +109,6 @@ async fn test_cleanup_runs_on_retry() {
             "INSERT INTO _test_bgmig_cleanup VALUES ('ran') ON CONFLICT DO NOTHING",
         ]),
         revert_sql: None,
-        required_for_startup: false,
     };
 
     try_apply(&pool, &migration).await.unwrap();
@@ -140,7 +137,6 @@ async fn test_failed_sql_records_error() {
         apply_sql: &["this is not valid sql"],
         cleanup_sql: None,
         revert_sql: None,
-        required_for_startup: false,
     };
 
     let result = try_apply(&pool, &migration).await;
@@ -177,7 +173,6 @@ async fn test_failed_cleanup_records_error() {
         apply_sql: &["SELECT 1"],
         cleanup_sql: Some(&["this is not valid sql"]),
         revert_sql: None,
-        required_for_startup: false,
     };
 
     let result = try_apply(&pool, &migration).await;
@@ -209,7 +204,6 @@ async fn test_revert_succeeds() {
         apply_sql: &["INSERT INTO _test_bgmig_revert VALUES ('applied') ON CONFLICT DO NOTHING"],
         cleanup_sql: None,
         revert_sql: Some(&["DELETE FROM _test_bgmig_revert WHERE id = 'applied'"]),
-        required_for_startup: false,
     };
 
     try_apply(&pool, &migration).await.unwrap();
@@ -254,7 +248,6 @@ async fn test_empty_revert_sql_deletes_row() {
         apply_sql: &["SELECT 1"],
         cleanup_sql: None,
         revert_sql: None,
-        required_for_startup: false,
     };
 
     try_apply(&pool, &migration).await.unwrap();
@@ -289,7 +282,6 @@ async fn test_revert_unapplied_migration_is_noop() {
         apply_sql: &["SELECT 1"],
         cleanup_sql: None,
         revert_sql: Some(&["SELECT 1"]),
-        required_for_startup: false,
     };
 
     let reverted = try_revert(&pool, &migration).await.unwrap();
@@ -311,7 +303,6 @@ async fn test_concurrent_apply() {
         apply_sql: &["INSERT INTO _test_bgmig_concurrent VALUES (gen_random_uuid()::text)"],
         cleanup_sql: Some(&["DELETE FROM _test_bgmig_concurrent"]),
         revert_sql: None,
-        required_for_startup: false,
     };
 
     let results = join_all((0..8).map(|_| try_apply(&pool, &migration))).await;
@@ -342,45 +333,6 @@ async fn test_concurrent_apply() {
 }
 
 #[tokio::test]
-async fn test_required_migration_not_applied_fails_startup_check() {
-    let pool = test_pool().await;
-    ensure_table(&pool).await.unwrap();
-
-    let migration = BackgroundMigration {
-        id: "test_required_not_applied",
-        apply_sql: &["SELECT 1"],
-        cleanup_sql: None,
-        revert_sql: None,
-        required_for_startup: true,
-    };
-
-    let result = check_required_for_startup_with_pool(&pool, &[migration]).await;
-    assert!(result.is_err());
-}
-
-#[tokio::test]
-async fn test_required_migration_applied_passes_startup_check() {
-    let pool = test_pool().await;
-    ensure_table(&pool).await.unwrap();
-
-    let migration = BackgroundMigration {
-        id: "test_required_applied",
-        apply_sql: &["SELECT 1"],
-        cleanup_sql: None,
-        revert_sql: None,
-        required_for_startup: true,
-    };
-    let id = migration.id;
-
-    try_apply(&pool, &migration).await.unwrap();
-
-    let result = check_required_for_startup_with_pool(&pool, &[migration]).await;
-    assert!(result.is_ok());
-
-    cleanup(&pool, id).await;
-}
-
-#[tokio::test]
 async fn test_revert_failed_migration_is_noop() {
     let pool = test_pool().await;
     ensure_table(&pool).await.unwrap();
@@ -399,7 +351,6 @@ async fn test_revert_failed_migration_is_noop() {
         apply_sql: &["SELECT 1"],
         cleanup_sql: None,
         revert_sql: Some(&["SELECT 1"]),
-        required_for_startup: false,
     };
 
     let reverted = try_revert(&pool, &migration).await.unwrap();

--- a/server/svix-server/tests/it/background_migrations.rs
+++ b/server/svix-server/tests/it/background_migrations.rs
@@ -1,0 +1,409 @@
+// SPDX-FileCopyrightText: © 2022 Svix Authors
+// SPDX-License-Identifier: MIT
+use futures::future::join_all;
+use sqlx::PgPool;
+use svix_server::db::background_migrations::{
+    BackgroundMigration, check_required_for_startup_with_pool, ensure_table, try_apply, try_revert,
+};
+
+use crate::utils::get_default_test_config;
+
+async fn test_pool() -> PgPool {
+    test_pool_with_conns(5).await
+}
+
+async fn test_pool_with_conns(num_conns: u32) -> PgPool {
+    let cfg = get_default_test_config();
+    sqlx::postgres::PgPoolOptions::new()
+        .max_connections(num_conns)
+        .connect(&cfg.db_dsn)
+        .await
+        .unwrap()
+}
+
+async fn cleanup(pool: &PgPool, id: &str) {
+    sqlx::query("DELETE FROM _svix_background_migrations WHERE id = $1")
+        .bind(id)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_fresh_apply_succeeds() {
+    let pool = test_pool().await;
+    ensure_table(&pool).await.unwrap();
+
+    let migration = BackgroundMigration {
+        id: "test_fresh_apply",
+        apply_sql: &["SELECT 1"],
+        cleanup_sql: None,
+        revert_sql: None,
+        required_for_startup: false,
+    };
+
+    let done = try_apply(&pool, &migration).await.unwrap();
+    assert!(done);
+
+    let success: bool =
+        sqlx::query_scalar("SELECT success FROM _svix_background_migrations WHERE id = $1")
+            .bind(migration.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(success);
+
+    cleanup(&pool, migration.id).await;
+}
+
+#[tokio::test]
+async fn test_apply_is_idempotent() {
+    let pool = test_pool().await;
+    ensure_table(&pool).await.unwrap();
+
+    let migration = BackgroundMigration {
+        id: "test_idempotent",
+        apply_sql: &["SELECT 1"],
+        cleanup_sql: None,
+        revert_sql: None,
+        required_for_startup: false,
+    };
+
+    try_apply(&pool, &migration).await.unwrap();
+    let done = try_apply(&pool, &migration).await.unwrap();
+    assert!(done);
+
+    let attempts: i32 =
+        sqlx::query_scalar("SELECT attempts FROM _svix_background_migrations WHERE id = $1")
+            .bind(migration.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(attempts, 0);
+
+    cleanup(&pool, migration.id).await;
+}
+
+#[tokio::test]
+async fn test_cleanup_runs_on_retry() {
+    let pool = test_pool().await;
+    ensure_table(&pool).await.unwrap();
+
+    sqlx::query("CREATE TABLE IF NOT EXISTS _test_bgmig_cleanup (id TEXT PRIMARY KEY)")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // Seed a failed row so apply_inner takes the retry branch
+    sqlx::query(
+        "INSERT INTO _svix_background_migrations (id, success, attempts) VALUES ($1, FALSE, 1)
+         ON CONFLICT (id) DO UPDATE SET success = FALSE, attempts = 1",
+    )
+    .bind("test_cleanup_retry")
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let migration = BackgroundMigration {
+        id: "test_cleanup_retry",
+        apply_sql: &["SELECT 1"],
+        cleanup_sql: Some(&[
+            "INSERT INTO _test_bgmig_cleanup VALUES ('ran') ON CONFLICT DO NOTHING",
+        ]),
+        revert_sql: None,
+        required_for_startup: false,
+    };
+
+    try_apply(&pool, &migration).await.unwrap();
+
+    let result: Option<String> =
+        sqlx::query_scalar("SELECT id FROM _test_bgmig_cleanup WHERE id = 'ran'")
+            .fetch_optional(&pool)
+            .await
+            .unwrap();
+    assert!(result.is_some(),);
+
+    sqlx::query("DROP TABLE _test_bgmig_cleanup")
+        .execute(&pool)
+        .await
+        .unwrap();
+    cleanup(&pool, migration.id).await;
+}
+
+#[tokio::test]
+async fn test_failed_sql_records_error() {
+    let pool = test_pool().await;
+    ensure_table(&pool).await.unwrap();
+
+    let migration = BackgroundMigration {
+        id: "test_failed_sql",
+        apply_sql: &["this is not valid sql"],
+        cleanup_sql: None,
+        revert_sql: None,
+        required_for_startup: false,
+    };
+
+    let result = try_apply(&pool, &migration).await;
+    assert!(result.is_err());
+
+    let last_error: Option<String> =
+        sqlx::query_scalar("SELECT last_error FROM _svix_background_migrations WHERE id = $1")
+            .bind(migration.id)
+            .fetch_optional(&pool)
+            .await
+            .unwrap();
+    assert!(last_error.is_some());
+
+    cleanup(&pool, migration.id).await;
+}
+
+#[tokio::test]
+async fn test_failed_cleanup_records_error() {
+    let pool = test_pool().await;
+    ensure_table(&pool).await.unwrap();
+
+    // Seed a failed row so apply_inner takes the retry/cleanup branch
+    sqlx::query(
+        "INSERT INTO _svix_background_migrations (id, success, attempts) VALUES ($1, FALSE, 1)
+         ON CONFLICT (id) DO UPDATE SET success = FALSE, attempts = 1",
+    )
+    .bind("test_failed_cleanup")
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let migration = BackgroundMigration {
+        id: "test_failed_cleanup",
+        apply_sql: &["SELECT 1"],
+        cleanup_sql: Some(&["this is not valid sql"]),
+        revert_sql: None,
+        required_for_startup: false,
+    };
+
+    let result = try_apply(&pool, &migration).await;
+    assert!(result.is_err());
+
+    let last_error: Option<String> =
+        sqlx::query_scalar("SELECT last_error FROM _svix_background_migrations WHERE id = $1")
+            .bind(migration.id)
+            .fetch_optional(&pool)
+            .await
+            .unwrap();
+    assert!(last_error.is_some());
+
+    cleanup(&pool, migration.id).await;
+}
+
+#[tokio::test]
+async fn test_revert_succeeds() {
+    let pool = test_pool().await;
+    ensure_table(&pool).await.unwrap();
+
+    sqlx::query("CREATE TABLE IF NOT EXISTS _test_bgmig_revert (id TEXT PRIMARY KEY)")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let migration = BackgroundMigration {
+        id: "test_revert",
+        apply_sql: &["INSERT INTO _test_bgmig_revert VALUES ('applied') ON CONFLICT DO NOTHING"],
+        cleanup_sql: None,
+        revert_sql: Some(&["DELETE FROM _test_bgmig_revert WHERE id = 'applied'"]),
+        required_for_startup: false,
+    };
+
+    try_apply(&pool, &migration).await.unwrap();
+
+    let row: Option<String> =
+        sqlx::query_scalar("SELECT id FROM _test_bgmig_revert WHERE id = 'applied'")
+            .fetch_optional(&pool)
+            .await
+            .unwrap();
+    assert!(row.is_some());
+
+    try_revert(&pool, &migration).await.unwrap();
+
+    let row: Option<String> =
+        sqlx::query_scalar("SELECT id FROM _test_bgmig_revert WHERE id = 'applied'")
+            .fetch_optional(&pool)
+            .await
+            .unwrap();
+    assert!(row.is_none());
+
+    let tracking: Option<bool> =
+        sqlx::query_scalar("SELECT success FROM _svix_background_migrations WHERE id = $1")
+            .bind(migration.id)
+            .fetch_optional(&pool)
+            .await
+            .unwrap();
+    assert!(tracking.is_none());
+
+    sqlx::query("DROP TABLE _test_bgmig_revert")
+        .execute(&pool)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_empty_revert_sql_deletes_row() {
+    let pool = test_pool().await;
+    ensure_table(&pool).await.unwrap();
+
+    let migration = BackgroundMigration {
+        id: "test_revert_no_sql",
+        apply_sql: &["SELECT 1"],
+        cleanup_sql: None,
+        revert_sql: None,
+        required_for_startup: false,
+    };
+
+    try_apply(&pool, &migration).await.unwrap();
+
+    let tracking_before: Option<bool> =
+        sqlx::query_scalar("SELECT success FROM _svix_background_migrations WHERE id = $1")
+            .bind(migration.id)
+            .fetch_optional(&pool)
+            .await
+            .unwrap();
+    assert!(tracking_before.is_some());
+
+    let reverted = try_revert(&pool, &migration).await.unwrap();
+    assert!(reverted);
+
+    let tracking_after: Option<bool> =
+        sqlx::query_scalar("SELECT success FROM _svix_background_migrations WHERE id = $1")
+            .bind(migration.id)
+            .fetch_optional(&pool)
+            .await
+            .unwrap();
+    assert!(tracking_after.is_none());
+}
+
+#[tokio::test]
+async fn test_revert_unapplied_migration_is_noop() {
+    let pool = test_pool().await;
+    ensure_table(&pool).await.unwrap();
+
+    let migration = BackgroundMigration {
+        id: "test_revert_unapplied",
+        apply_sql: &["SELECT 1"],
+        cleanup_sql: None,
+        revert_sql: Some(&["SELECT 1"]),
+        required_for_startup: false,
+    };
+
+    let reverted = try_revert(&pool, &migration).await.unwrap();
+    assert!(!reverted);
+}
+
+#[tokio::test]
+async fn test_concurrent_apply() {
+    let pool = test_pool_with_conns(20).await;
+    ensure_table(&pool).await.unwrap();
+
+    sqlx::query("CREATE TABLE IF NOT EXISTS _test_bgmig_concurrent (id TEXT PRIMARY KEY)")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let migration = BackgroundMigration {
+        id: "test_concurrent",
+        apply_sql: &["INSERT INTO _test_bgmig_concurrent VALUES (gen_random_uuid()::text)"],
+        cleanup_sql: Some(&["DELETE FROM _test_bgmig_concurrent"]),
+        revert_sql: None,
+        required_for_startup: false,
+    };
+
+    let results = join_all((0..8).map(|_| try_apply(&pool, &migration))).await;
+
+    for result in results {
+        assert!(result.is_ok());
+    }
+
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM _test_bgmig_concurrent")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count, 1);
+
+    let success: bool =
+        sqlx::query_scalar("SELECT success FROM _svix_background_migrations WHERE id = $1")
+            .bind(migration.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(success);
+
+    sqlx::query("DROP TABLE _test_bgmig_concurrent")
+        .execute(&pool)
+        .await
+        .unwrap();
+    cleanup(&pool, migration.id).await;
+}
+
+#[tokio::test]
+async fn test_required_migration_not_applied_fails_startup_check() {
+    let pool = test_pool().await;
+    ensure_table(&pool).await.unwrap();
+
+    let migration = BackgroundMigration {
+        id: "test_required_not_applied",
+        apply_sql: &["SELECT 1"],
+        cleanup_sql: None,
+        revert_sql: None,
+        required_for_startup: true,
+    };
+
+    let result = check_required_for_startup_with_pool(&pool, &[migration]).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_required_migration_applied_passes_startup_check() {
+    let pool = test_pool().await;
+    ensure_table(&pool).await.unwrap();
+
+    let migration = BackgroundMigration {
+        id: "test_required_applied",
+        apply_sql: &["SELECT 1"],
+        cleanup_sql: None,
+        revert_sql: None,
+        required_for_startup: true,
+    };
+    let id = migration.id;
+
+    try_apply(&pool, &migration).await.unwrap();
+
+    let result = check_required_for_startup_with_pool(&pool, &[migration]).await;
+    assert!(result.is_ok());
+
+    cleanup(&pool, id).await;
+}
+
+#[tokio::test]
+async fn test_revert_failed_migration_is_noop() {
+    let pool = test_pool().await;
+    ensure_table(&pool).await.unwrap();
+
+    sqlx::query(
+        "INSERT INTO _svix_background_migrations (id, success, attempts) VALUES ($1, FALSE, 1)
+         ON CONFLICT (id) DO UPDATE SET success = FALSE, attempts = 1",
+    )
+    .bind("test_revert_failed")
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let migration = BackgroundMigration {
+        id: "test_revert_failed",
+        apply_sql: &["SELECT 1"],
+        cleanup_sql: None,
+        revert_sql: Some(&["SELECT 1"]),
+        required_for_startup: false,
+    };
+
+    let reverted = try_revert(&pool, &migration).await.unwrap();
+    assert!(!reverted);
+
+    cleanup(&pool, migration.id).await;
+}

--- a/server/svix-server/tests/it/main.rs
+++ b/server/svix-server/tests/it/main.rs
@@ -1,3 +1,4 @@
+mod background_migrations;
 mod db;
 mod e2e_application;
 mod e2e_attempt;


### PR DESCRIPTION
This adds support for running certain migrations as background tasks 
within the application, which prevents situations where long-running 
migrations, e.g., adding indexes to existing tables, cannot complete
without blocking application startup for an excessive amount of time.

The approach is straightforward. The changes add a background worker, 
similiar to our other background workers, which, if enabled, will 
invoke the long-running migrations in a worker thread that doesn't 
block the rest of the application. If the migration fails, or if 
the application  is restarted before it completes, an optional cleanup 
script will run before the migration is attempted again. The migrations 
can be reverted with a separate `revert-background-migration` command 
if needed. 

There is an optional flag on the migration struct that, if true, will
prevent application startup if the migration does not exist. This 
allows for mandatory migrations to first be added with the flag set
to false, then set to true in a later version of the application that
will actually leverage the changes made by the migration.

This changeset also adds the migration needed for #2183.