### PR TITLE
Ensure ordered background migrations

### DIFF
--- a/server/.config/nextest.toml
+++ b/server/.config/nextest.toml
@@ -1,3 +1,10 @@
 [profile.default]
 retries = 2
 slow-timeout = { period = "30s", terminate-after = 2 }
+
+[[profile.default.overrides]]
+filter = "test(background_migrations)"
+test-group = "background-migrations"
+
+[test-groups]
+background-migrations = { max-threads = 1 }

--- a/server/svix-server/src/db/background_migrations.rs
+++ b/server/svix-server/src/db/background_migrations.rs
@@ -105,7 +105,7 @@ pub async fn run_migrations(
     Ok(true)
 }
 
-async fn apply(pool: &PgPool, migration: &BackgroundMigration) -> Result<bool, sqlx::Error> {
+async fn apply(pool: &PgPool, migration: &BackgroundMigration) -> Result<(), sqlx::Error> {
     let existing =
         sqlx::query("SELECT success, attempts FROM _svix_background_migrations WHERE id = $1")
             .bind(migration.id)
@@ -113,7 +113,8 @@ async fn apply(pool: &PgPool, migration: &BackgroundMigration) -> Result<bool, s
             .await?;
 
     match existing {
-        Some(row) if row.get::<bool, _>("success") => return Ok(true),
+        Some(row) if row.get::<bool, _>("success") => return Ok(()),
+        // Attempt to clean up previously failed migration
         Some(row) => {
             let attempts: i32 = row.get("attempts");
             tracing::warn!(
@@ -165,13 +166,13 @@ async fn apply(pool: &PgPool, migration: &BackgroundMigration) -> Result<bool, s
     }
     .await;
 
-    if let Err(ref e) = apply_result {
+    if let Err(e) = apply_result {
         let _ = sqlx::query("UPDATE _svix_background_migrations SET last_error = $1 WHERE id = $2")
             .bind(e.to_string())
             .bind(migration.id)
             .execute(pool)
             .await;
-        return apply_result.map(|_| false);
+        return Err(e);
     }
 
     sqlx::query(
@@ -188,7 +189,8 @@ async fn apply(pool: &PgPool, migration: &BackgroundMigration) -> Result<bool, s
         elapsed_secs = started.elapsed().as_secs_f64(),
         "Background migration completed"
     );
-    Ok(true)
+
+    Ok(())
 }
 
 pub async fn run(cfg: &Configuration) {

--- a/server/svix-server/src/db/background_migrations.rs
+++ b/server/svix-server/src/db/background_migrations.rs
@@ -7,6 +7,16 @@ use sqlx::{PgPool, Row as _};
 
 use crate::cfg::Configuration;
 
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("database error: {0}")]
+    Db(#[from] sqlx::Error),
+    #[error("{0}")]
+    Migration(String),
+}
+
+const GLOBAL_LOCK_ID: &str = "_svix_background_migrations";
+
 // Background migrations go here:
 pub static MIGRATIONS: &[BackgroundMigration] = &[BackgroundMigration {
     id: "2026_04_1777303796_messageattempt_per_endp_no_status",
@@ -19,6 +29,7 @@ pub static MIGRATIONS: &[BackgroundMigration] = &[BackgroundMigration {
     revert_sql: Some(&["DROP INDEX CONCURRENTLY IF EXISTS messageattempt_per_endp_no_status"]),
 }];
 
+#[derive(Copy, Clone)]
 pub struct BackgroundMigration {
     /// Unique id for the migration.
     pub id: &'static str,
@@ -30,17 +41,16 @@ pub struct BackgroundMigration {
     pub revert_sql: Option<&'static [&'static str]>,
 }
 
-async fn advisory_lock_acquire(
-    conn: &mut sqlx::PgConnection,
-    key: i64,
-) -> Result<bool, sqlx::Error> {
+async fn advisory_lock_acquire(conn: &mut sqlx::PgConnection) -> Result<bool, sqlx::Error> {
+    let key = lock_key(GLOBAL_LOCK_ID);
     sqlx::query_scalar("SELECT pg_try_advisory_lock($1)")
         .bind(key)
         .fetch_one(conn)
         .await
 }
 
-async fn advisory_lock_release(conn: &mut sqlx::PgConnection, key: i64) {
+async fn advisory_lock_release(conn: &mut sqlx::PgConnection) {
+    let key = lock_key(GLOBAL_LOCK_ID);
     if let Err(e) = sqlx::query("SELECT pg_advisory_unlock($1)")
         .bind(key)
         .execute(conn)
@@ -72,29 +82,30 @@ pub async fn ensure_table(pool: &PgPool) -> Result<(), sqlx::Error> {
     Ok(())
 }
 
-pub async fn try_apply(
+pub async fn run_migrations(
     pool: &PgPool,
-    migration: &BackgroundMigration,
+    migrations: &[BackgroundMigration],
 ) -> Result<bool, sqlx::Error> {
-    let key = lock_key(migration.id);
-
     let mut conn = pool.acquire().await?;
 
-    if !advisory_lock_acquire(&mut conn, key).await? {
-        let done: Option<bool> =
-            sqlx::query_scalar("SELECT success FROM _svix_background_migrations WHERE id = $1")
-                .bind(migration.id)
-                .fetch_optional(pool)
-                .await?;
-        return Ok(done.unwrap_or(false));
+    if !advisory_lock_acquire(&mut conn).await? {
+        return Ok(false);
     }
 
-    let result = apply_inner(pool, migration).await;
-    advisory_lock_release(&mut conn, key).await;
-    result
+    let mut apply_result = Ok(());
+    for migration in migrations {
+        if let Err(e) = apply(pool, migration).await {
+            apply_result = Err(e);
+            break;
+        }
+    }
+
+    advisory_lock_release(&mut conn).await;
+    apply_result?;
+    Ok(true)
 }
 
-async fn apply_inner(pool: &PgPool, migration: &BackgroundMigration) -> Result<bool, sqlx::Error> {
+async fn apply(pool: &PgPool, migration: &BackgroundMigration) -> Result<bool, sqlx::Error> {
     let existing =
         sqlx::query("SELECT success, attempts FROM _svix_background_migrations WHERE id = $1")
             .bind(migration.id)
@@ -195,35 +206,23 @@ pub async fn run_with_pool(pool: &PgPool, migrations: &[BackgroundMigration]) {
     let mut backoff = Duration::from_secs(5);
 
     loop {
-        let mut pending = false;
-
-        for migration in migrations {
-            match try_apply(pool, migration).await {
-                Ok(true) => {}
-                Ok(false) => {
-                    pending = true;
-                    break;
-                }
-                Err(e) => {
-                    tracing::error!(
-                        id = migration.id,
-                        error = %e,
-                        "Background migration failed"
-                    );
-                    pending = true;
-                    break;
-                }
+        match run_migrations(pool, migrations).await {
+            Ok(true) => {
+                tracing::debug!("Background migrations complete. Exiting.");
+                return;
             }
-        }
-
-        if !pending {
-            tracing::debug!("Background migration worker exiting.");
-            break;
+            Ok(false) => {
+                tracing::info!("Background migrations are already locked. Exiting.");
+                return;
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "Background migration error");
+            }
         }
 
         tokio::select! {
             _ = tokio::time::sleep(backoff) => {}
-            _ = shutdown.cancelled() => break,
+            _ = shutdown.cancelled() => return,
         }
         backoff = (backoff * 2).min(Duration::from_secs(600));
     }
@@ -231,21 +230,39 @@ pub async fn run_with_pool(pool: &PgPool, migrations: &[BackgroundMigration]) {
 
 pub async fn try_revert(
     pool: &PgPool,
-    migration: &BackgroundMigration,
-) -> Result<bool, sqlx::Error> {
-    if migration.revert_sql.is_none() {
-        tracing::warn!(id = migration.id, "No revert SQl for migration");
-    }
-
-    let key = lock_key(migration.id);
+    migrations: &[BackgroundMigration],
+    id: &str,
+) -> Result<bool, Error> {
     let mut conn = pool.acquire().await?;
 
-    if !advisory_lock_acquire(&mut conn, key).await? {
+    if !advisory_lock_acquire(&mut conn).await? {
         return Ok(false);
     }
 
-    let result = revert_inner(pool, migration, migration.revert_sql).await;
-    advisory_lock_release(&mut conn, key).await;
+    let applied: std::collections::HashSet<String> =
+        sqlx::query_scalar("SELECT id FROM _svix_background_migrations WHERE success = TRUE")
+            .fetch_all(pool)
+            .await?
+            .into_iter()
+            .collect();
+
+    let Some(last_applied) = migrations.iter().rev().find(|m| applied.contains(m.id)) else {
+        return Err(Error::Migration(format!(
+            "migration '{id}' has not been applied"
+        )));
+    };
+    if last_applied.id != id {
+        return Err(Error::Migration(format!(
+            "migration '{id}' is not the last applied migration and cannot be reverted out of order"
+        )));
+    }
+
+    if last_applied.revert_sql.is_none() {
+        tracing::warn!(id, "No revert SQL for migration");
+    }
+
+    let result = revert_inner(pool, last_applied, last_applied.revert_sql).await;
+    advisory_lock_release(&mut conn).await;
     result
 }
 
@@ -255,7 +272,7 @@ async fn revert_inner(
     pool: &PgPool,
     migration: &BackgroundMigration,
     statements: Option<&[&str]>,
-) -> Result<bool, sqlx::Error> {
+) -> Result<bool, Error> {
     let success: Option<bool> =
         sqlx::query_scalar("SELECT success FROM _svix_background_migrations WHERE id = $1")
             .bind(migration.id)
@@ -277,7 +294,7 @@ async fn revert_inner(
                 .bind(migration.id)
                 .execute(pool)
                 .await;
-                return Err(e);
+                return Err(e.into());
             }
         }
     }

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -210,15 +210,13 @@ async fn main() -> anyhow::Result<()> {
             println!("Migrations: success");
         }
         Some(Commands::RevertBackgroundMigration { id }) => {
-            let migration = background_migrations::MIGRATIONS
-                .iter()
-                .find(|m| m.id == id)
-                .ok_or_else(|| anyhow::anyhow!("unknown migration id: '{id}'"))?;
             let pool = sqlx::postgres::PgPoolOptions::new()
                 .max_connections(cfg.db_pool_max_size.into())
                 .connect(&cfg.db_dsn)
                 .await?;
-            match background_migrations::try_revert(&pool, migration).await? {
+            match background_migrations::try_revert(&pool, background_migrations::MIGRATIONS, &id)
+                .await?
+            {
                 true => println!("Migration reverted: {id}"),
                 false => println!("Nothing to revert for: {id}"),
             }

--- a/server/svix-server/tests/it/background_migrations.rs
+++ b/server/svix-server/tests/it/background_migrations.rs
@@ -369,6 +369,63 @@ async fn test_revert_failed_migration_errors() {
 }
 
 #[tokio::test]
+async fn test_failure_stops_subsequent_migrations() {
+    let pool = test_pool().await;
+    ensure_table(&pool).await.unwrap();
+
+    let migrations = [
+        BackgroundMigration {
+            id: "test_stop_on_fail_1",
+            apply_sql: &["SELECT 1"],
+            cleanup_sql: None,
+            revert_sql: None,
+        },
+        BackgroundMigration {
+            id: "test_stop_on_fail_2",
+            apply_sql: &["this is not valid sql"],
+            cleanup_sql: None,
+            revert_sql: None,
+        },
+        BackgroundMigration {
+            id: "test_stop_on_fail_3",
+            apply_sql: &["SELECT 1"],
+            cleanup_sql: None,
+            revert_sql: None,
+        },
+        BackgroundMigration {
+            id: "test_stop_on_fail_4",
+            apply_sql: &["SELECT 1"],
+            cleanup_sql: None,
+            revert_sql: None,
+        },
+        BackgroundMigration {
+            id: "test_stop_on_fail_5",
+            apply_sql: &["SELECT 1"],
+            cleanup_sql: None,
+            revert_sql: None,
+        },
+    ];
+
+    run_migrations(&pool, &migrations).await.unwrap_err();
+
+    let ran: Vec<String> = sqlx::query_scalar(
+        "SELECT id FROM _svix_background_migrations WHERE id LIKE 'test_stop_on_fail_%'",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert!(ran.contains(&"test_stop_on_fail_1".to_string()));
+    assert!(ran.contains(&"test_stop_on_fail_2".to_string()));
+    assert!(!ran.contains(&"test_stop_on_fail_3".to_string()));
+    assert!(!ran.contains(&"test_stop_on_fail_4".to_string()));
+    assert!(!ran.contains(&"test_stop_on_fail_5".to_string()));
+
+    for m in &migrations {
+        cleanup(&pool, m.id).await;
+    }
+}
+
+#[tokio::test]
 async fn test_revert_non_latest_errors() {
     let pool = test_pool().await;
     ensure_table(&pool).await.unwrap();

--- a/server/svix-server/tests/it/background_migrations.rs
+++ b/server/svix-server/tests/it/background_migrations.rs
@@ -3,7 +3,7 @@
 use futures::future::join_all;
 use sqlx::PgPool;
 use svix_server::db::background_migrations::{
-    BackgroundMigration, ensure_table, try_apply, try_revert,
+    BackgroundMigration, ensure_table, run_migrations, run_with_pool, try_revert,
 };
 
 use crate::utils::get_default_test_config;
@@ -41,8 +41,7 @@ async fn test_fresh_apply_succeeds() {
         revert_sql: None,
     };
 
-    let done = try_apply(&pool, &migration).await.unwrap();
-    assert!(done);
+    run_with_pool(&pool, &[migration]).await;
 
     let success: bool =
         sqlx::query_scalar("SELECT success FROM _svix_background_migrations WHERE id = $1")
@@ -67,9 +66,8 @@ async fn test_apply_is_idempotent() {
         revert_sql: None,
     };
 
-    try_apply(&pool, &migration).await.unwrap();
-    let done = try_apply(&pool, &migration).await.unwrap();
-    assert!(done);
+    run_with_pool(&pool, &[migration]).await;
+    run_with_pool(&pool, &[migration]).await;
 
     let attempts: i32 =
         sqlx::query_scalar("SELECT attempts FROM _svix_background_migrations WHERE id = $1")
@@ -87,7 +85,11 @@ async fn test_cleanup_runs_on_retry() {
     let pool = test_pool().await;
     ensure_table(&pool).await.unwrap();
 
-    sqlx::query("CREATE TABLE IF NOT EXISTS _test_bgmig_cleanup (id TEXT PRIMARY KEY)")
+    sqlx::query("DROP TABLE IF EXISTS _test_bgmig_cleanup")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("CREATE TABLE _test_bgmig_cleanup (id TEXT PRIMARY KEY)")
         .execute(&pool)
         .await
         .unwrap();
@@ -111,7 +113,7 @@ async fn test_cleanup_runs_on_retry() {
         revert_sql: None,
     };
 
-    try_apply(&pool, &migration).await.unwrap();
+    run_with_pool(&pool, &[migration]).await;
 
     let result: Option<String> =
         sqlx::query_scalar("SELECT id FROM _test_bgmig_cleanup WHERE id = 'ran'")
@@ -139,8 +141,7 @@ async fn test_failed_sql_records_error() {
         revert_sql: None,
     };
 
-    let result = try_apply(&pool, &migration).await;
-    assert!(result.is_err());
+    run_migrations(&pool, &[migration]).await.unwrap_err();
 
     let last_error: Option<String> =
         sqlx::query_scalar("SELECT last_error FROM _svix_background_migrations WHERE id = $1")
@@ -175,8 +176,7 @@ async fn test_failed_cleanup_records_error() {
         revert_sql: None,
     };
 
-    let result = try_apply(&pool, &migration).await;
-    assert!(result.is_err());
+    run_migrations(&pool, &[migration]).await.unwrap_err();
 
     let last_error: Option<String> =
         sqlx::query_scalar("SELECT last_error FROM _svix_background_migrations WHERE id = $1")
@@ -194,7 +194,11 @@ async fn test_revert_succeeds() {
     let pool = test_pool().await;
     ensure_table(&pool).await.unwrap();
 
-    sqlx::query("CREATE TABLE IF NOT EXISTS _test_bgmig_revert (id TEXT PRIMARY KEY)")
+    sqlx::query("DROP TABLE IF EXISTS _test_bgmig_revert")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("CREATE TABLE _test_bgmig_revert (id TEXT PRIMARY KEY)")
         .execute(&pool)
         .await
         .unwrap();
@@ -206,7 +210,7 @@ async fn test_revert_succeeds() {
         revert_sql: Some(&["DELETE FROM _test_bgmig_revert WHERE id = 'applied'"]),
     };
 
-    try_apply(&pool, &migration).await.unwrap();
+    run_with_pool(&pool, &[migration]).await;
 
     let row: Option<String> =
         sqlx::query_scalar("SELECT id FROM _test_bgmig_revert WHERE id = 'applied'")
@@ -215,7 +219,7 @@ async fn test_revert_succeeds() {
             .unwrap();
     assert!(row.is_some());
 
-    try_revert(&pool, &migration).await.unwrap();
+    try_revert(&pool, &[migration], migration.id).await.unwrap();
 
     let row: Option<String> =
         sqlx::query_scalar("SELECT id FROM _test_bgmig_revert WHERE id = 'applied'")
@@ -250,7 +254,7 @@ async fn test_empty_revert_sql_deletes_row() {
         revert_sql: None,
     };
 
-    try_apply(&pool, &migration).await.unwrap();
+    run_with_pool(&pool, &[migration]).await;
 
     let tracking_before: Option<bool> =
         sqlx::query_scalar("SELECT success FROM _svix_background_migrations WHERE id = $1")
@@ -260,7 +264,7 @@ async fn test_empty_revert_sql_deletes_row() {
             .unwrap();
     assert!(tracking_before.is_some());
 
-    let reverted = try_revert(&pool, &migration).await.unwrap();
+    let reverted = try_revert(&pool, &[migration], migration.id).await.unwrap();
     assert!(reverted);
 
     let tracking_after: Option<bool> =
@@ -273,7 +277,7 @@ async fn test_empty_revert_sql_deletes_row() {
 }
 
 #[tokio::test]
-async fn test_revert_unapplied_migration_is_noop() {
+async fn test_revert_unapplied_migration_errors() {
     let pool = test_pool().await;
     ensure_table(&pool).await.unwrap();
 
@@ -284,8 +288,8 @@ async fn test_revert_unapplied_migration_is_noop() {
         revert_sql: Some(&["SELECT 1"]),
     };
 
-    let reverted = try_revert(&pool, &migration).await.unwrap();
-    assert!(!reverted);
+    let result = try_revert(&pool, &[migration], migration.id).await;
+    assert!(result.is_err());
 }
 
 #[tokio::test]
@@ -293,7 +297,12 @@ async fn test_concurrent_apply() {
     let pool = test_pool_with_conns(20).await;
     ensure_table(&pool).await.unwrap();
 
-    sqlx::query("CREATE TABLE IF NOT EXISTS _test_bgmig_concurrent (id TEXT PRIMARY KEY)")
+    // Drop and recreate to clear any state left by a previous failed test run.
+    sqlx::query("DROP TABLE IF EXISTS _test_bgmig_concurrent")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("CREATE TABLE _test_bgmig_concurrent (id TEXT PRIMARY KEY)")
         .execute(&pool)
         .await
         .unwrap();
@@ -304,12 +313,12 @@ async fn test_concurrent_apply() {
         cleanup_sql: Some(&["DELETE FROM _test_bgmig_concurrent"]),
         revert_sql: None,
     };
+    cleanup(&pool, migration.id).await;
 
-    let results = join_all((0..8).map(|_| try_apply(&pool, &migration))).await;
-
-    for result in results {
-        assert!(result.is_ok());
-    }
+    // Concurrent callers race on the tracking-table insert; only the one that
+    // wins should execute the migration SQL.
+    let migrations = [migration];
+    join_all((0..8).map(|_| run_with_pool(&pool, &migrations))).await;
 
     let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM _test_bgmig_concurrent")
         .fetch_one(&pool)
@@ -333,7 +342,7 @@ async fn test_concurrent_apply() {
 }
 
 #[tokio::test]
-async fn test_revert_failed_migration_is_noop() {
+async fn test_revert_failed_migration_errors() {
     let pool = test_pool().await;
     ensure_table(&pool).await.unwrap();
 
@@ -353,8 +362,36 @@ async fn test_revert_failed_migration_is_noop() {
         revert_sql: Some(&["SELECT 1"]),
     };
 
-    let reverted = try_revert(&pool, &migration).await.unwrap();
-    assert!(!reverted);
+    let result = try_revert(&pool, &[migration], migration.id).await;
+    assert!(result.is_err());
 
     cleanup(&pool, migration.id).await;
+}
+
+#[tokio::test]
+async fn test_revert_non_latest_errors() {
+    let pool = test_pool().await;
+    ensure_table(&pool).await.unwrap();
+
+    let m1 = BackgroundMigration {
+        id: "test_revert_non_latest_m1",
+        apply_sql: &["SELECT 1"],
+        cleanup_sql: None,
+        revert_sql: Some(&["SELECT 1"]),
+    };
+    let m2 = BackgroundMigration {
+        id: "test_revert_non_latest_m2",
+        apply_sql: &["SELECT 1"],
+        cleanup_sql: None,
+        revert_sql: Some(&["SELECT 1"]),
+    };
+    let migrations = [m1, m2];
+
+    run_with_pool(&pool, &migrations).await;
+
+    let result = try_revert(&pool, &migrations, migrations[0].id).await;
+    assert!(result.is_err());
+
+    cleanup(&pool, migrations[0].id).await;
+    cleanup(&pool, migrations[1].id).await;
 }


### PR DESCRIPTION
Ensure that background migrations can't be run out of order by using a global instead of per-migration lock. Also, don't allow reverting a migration if it's not the last-applied migration.

This also simplifies the workers by simply exiting if there's already a migration lock acquired.
