### PR TITLE
silence some RUSTSEC advisories until a fix is available

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -25,6 +25,10 @@ ignore = [
     "RUSTSEC-2025-0134",
     # bincode (depended on by deno) is unmaintained
     "RUSTSEC-2025-0141",
+    # can't upgrade to hickory 0.26 until https://github.com/seanmonstar/reqwest/pull/3014 is landed
+    # on reqwest and all of our deps are updated to the new reqwest version
+    "RUSTSEC-2026-0118",
+    "RUSTSEC-2026-0119",
 ]
 
 [licenses]


### PR DESCRIPTION
[RUSTSEC-2026-0118](https://rustsec.org/advisories/RUSTSEC-2026-0118.html) and [RUSTSEC-2026-0119](https://rustsec.org/advisories/RUSTSEC-2026-0119.html) are both new advisories in hickory that are only fixed in the 0.26 branch, which reqwest doesn't support yet. https://github.com/seanmonstar/reqwest/pull/3014 is the relevant reqwest PR.