### PR TITLE
codegen: Some template code cleanup

### DIFF
--- a/codegen/templates/csharp/types/struct_fields.cs.jinja
+++ b/codegen/templates/csharp/types/struct_fields.cs.jinja
@@ -1,6 +1,6 @@
 {% for field in type.fields -%}
     {% set is_patch = type.name is endingwith "Patch" -%}
-    [JsonProperty("{{ field.name }}"{% if field.required and not field.nullable %},Required = Required.Always{% endif %})]
+    [JsonProperty("{{ field.name }}"{% if field.required and not field.nullable %}, Required = Required.Always{% endif %})]
     {% set f_ty = field.type.to_csharp() -%}
     {% set modifier = "public"-%}
     {% if field.nullable or not field.required -%}
@@ -15,9 +15,10 @@
         {% set f_val %}= {{ f_ty }}.Unset();{% endset -%}
     {% endif -%}
     {{ modifier }} {{ f_ty }} {{ field.name | to_upper_camel_case }} { get; set; } {{ f_val }}
-    {% if is_patch and field.nullable -%}
-    public bool ShouldSerialize{{ field.name | to_upper_camel_case }}() => !{{ field.name | to_upper_camel_case }}.IsUnset;
-    {% elif is_patch and not field.nullable -%}
-    public bool ShouldSerialize{{ field.name | to_upper_camel_case }}() => {{ field.name | to_upper_camel_case }} != null;
+    {% if is_patch -%}
+    public bool ShouldSerialize{{ field.name | to_upper_camel_case }}() =>
+        {%- if field.nullable %} !{{ field.name | to_upper_camel_case }}.IsUnset
+        {%- else %} {{ field.name | to_upper_camel_case }} != null
+        {%- endif %};
     {% endif -%}
 {% endfor -%}

--- a/codegen/templates/java/types/struct.java.jinja
+++ b/codegen/templates/java/types/struct.java.jinja
@@ -52,7 +52,7 @@ public class {{ type.name | to_upper_camel_case }} {
     {% if type.name == "MessageIn" and field.name == "payload" -%}
         {% set field_ty = "String" -%}
     {% elif type.name == "MessageIn" and field.name == "transformationsParams" -%}
-        {% set field_ty = "Map<String,Object>" -%}
+        {% set field_ty = "Map<String, Object>" -%}
     {% endif -%}
     {{ field_annotation}} private {{ field_ty }} {{ field.name | to_lower_camel_case }};
 {% endfor -%}
@@ -65,7 +65,7 @@ public class {{ type.name | to_upper_camel_case }} {
     {% if type.name == "MessageIn" and field.name == "payload" -%}
         {% set f_ty = "String" -%}
     {% elif type.name == "MessageIn" and field.name == "transformationsParams" -%}
-        {% set f_ty = "Map<String,Object>" -%}
+        {% set f_ty = "Map<String, Object>" -%}
     {% endif -%}
     {% set f_varname = field.name | to_lower_camel_case -%}
     {% set f_deprecated = "" -%}
@@ -84,21 +84,20 @@ public class {{ type.name | to_upper_camel_case }} {
     }
 
     {% if field.type.is_set() or field.type.is_list() -%}
-    {{ f_deprecated }} public {{ class_ty }} add{{ f_varname | to_upper_camel_case }}Item ({{ field.type.inner_type().to_java() }} {{ f_varname }}Item) {
+    {{ f_deprecated }} public {{ class_ty }} add{{ f_varname | to_upper_camel_case }}Item(
+        {{ field.type.inner_type().to_java() }} {{ f_varname }}Item
+    ) {
         if (this.{{ f_varname }} == null) {
             {% if field.type.is_set() -%}
-                {% if type.name is endingwith "Patch" and field.nullable -%}
-            this.{{ f_varname }} = new MaybeUnset<>(new LinkedHashSet<>());
-                {% else -%}
-            this.{{ f_varname }} = new LinkedHashSet<>();
-                {% endif -%}
+                {% set init_expr = "new LinkedHashSet<>()" -%}
             {% else -%}
-                {% if type.name is endingwith "Patch" and field.nullable -%}
-            this.{{ f_varname }} = new MaybeUnset<>(new ArrayList<>());
-                {% else -%}
-            this.{{ f_varname }} = new ArrayList<>();
-                {% endif -%}
+                {% set init_expr = "new ArrayList<>()" -%}
             {% endif -%}
+            {% if type.name is endingwith "Patch" and field.nullable -%}
+                {% set init_expr %}new MaybeUnset<>({{ init_expr }}){% endset -%}
+            {% endif -%}
+
+            this.{{ f_varname }} = {{ init_expr }};
         }
         {% if type.name is endingwith "Patch" and field.nullable -%}
         this.{{ f_varname }}.getValue().add({{ f_varname }}Item);

--- a/codegen/templates/javascript/types/struct_fields.ts.jinja
+++ b/codegen/templates/javascript/types/struct_fields.ts.jinja
@@ -5,6 +5,6 @@
     {% set field_lhs = field.name | to_lower_camel_case -%}
     {% if not field.required %}{% set field_lhs %}{{ field_lhs }}?{% endset %}{% endif -%}
     {% set ty = field.type.to_js() -%}
-    {% if field.nullable %}{% set ty %}{{ ty }} | null{% endset %}{% endif -%}
+    {% if field.nullable %}{% set ty = ty ~ " | null" %}{% endif -%}
     {{ field_lhs }}: {{ ty }};
 {% endfor -%}

--- a/codegen/templates/php/types/struct.php.jinja
+++ b/codegen/templates/php/types/struct.php.jinja
@@ -50,19 +50,19 @@ class {{ type.name | to_upper_camel_case }} implements \JsonSerializable
         return new self(
             {% for field in type.fields -%}
                 {% if field.required -%}
-            {{ field.name | to_lower_camel_case }}: ${{ field.name | to_lower_camel_case }},
+                    {% set init_expr = "$" ~ field.name | to_lower_camel_case -%}
                 {% else -%}
-            {{ field.name | to_lower_camel_case }}: null,
+                    {% set init_expr = "null" -%}
                 {% endif -%}
 
+            {{ field.name | to_lower_camel_case }}: {{ init_expr }},
             {% endfor -%}
 
             setFields: [
-            {%- for field in type.fields -%}
-                {%- if field.required -%}
-            '{{ field.name | to_lower_camel_case }}' => true,
-                {%- endif -%}
-            {%- endfor -%} ]
+                {%- for field in type.fields | selectattr("required") -%}
+                '{{ field.name | to_lower_camel_case }}' => true,
+                {%- endfor -%}
+            ]
         );
     }
 
@@ -102,14 +102,12 @@ class {{ type.name | to_upper_camel_case }} implements \JsonSerializable
     {
         $data = [
         {% set serialized_data -%}
-            {%- for field in type.fields -%}
-                {%- if field.required and not field.nullable -%}
-                    {% set field_expr %}$this->{{ field.name | to_lower_camel_case }}{% endset -%}
-                    {% if field.name == "payload" and type_name == "MessageIn" %}
-                    'payload' => \Svix\Utils::newStdClassIfArrayIsEmpty($this->payload),
-                    {% else -%}
-                    '{{ field.name }}' => {{ field_to_json(field_expr, field.type, field.required, type_name) }},
-                    {% endif -%}
+            {%- for field in type.fields | selectattr("required") | selectattr("nullable", "false") -%}
+                {% set field_expr %}$this->{{ field.name | to_lower_camel_case }}{% endset -%}
+                {% if field.name == "payload" and type_name == "MessageIn" %}
+                'payload' => \Svix\Utils::newStdClassIfArrayIsEmpty($this->payload),
+                {% else -%}
+                '{{ field.name }}' => {{ field_to_json(field_expr, field.type, field.required, type_name) }},
                 {% endif -%}
             {%- endfor -%}
         {%- endset -%}
@@ -140,9 +138,8 @@ class {{ type.name | to_upper_camel_case }} implements \JsonSerializable
     {
         return new self(
             {% for field in type.fields -%}
-                {% set trailing_comma %}{% if not loop.last %},{% endif %}{% endset -%}
-                {% set field_expr %}$data['{{ field.name }}']{% endset -%}
-                {{ field.name | to_lower_camel_case }}: {{ field_from_json(field.name, field.type, field.required, type_name) }} {{ trailing_comma }}
+                {{ field.name | to_lower_camel_case }}: {{ field_from_json(field.name, field.type, field.required, type_name) }}
+                {%- if not loop.last %},{% endif %}
             {% endfor -%}
         );
     }


### PR DESCRIPTION
Deduplicate some output bits in the templates, and bring over improvements found while working on the Diom templates that are derived from the ones here, specifically `selectattr` usage.