### PR TITLE
deps: update webhook_http_client to use hickory 0.26

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1010,6 +1010,16 @@ checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1979,6 +1989,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto 0.26.1",
+ "idna",
+ "ipnet",
+ "jni",
+ "rand 0.10.1",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-proto"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2004,6 +2038,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-resolver"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2011,7 +2065,7 @@ checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-proto",
+ "hickory-proto 0.25.2",
  "ipconfig",
  "moka",
  "once_cell",
@@ -2019,6 +2073,32 @@ dependencies = [
  "rand 0.9.4",
  "resolv-conf",
  "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto 0.26.1",
+ "ipconfig",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.1",
+ "resolv-conf",
+ "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2430,6 +2510,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2757,6 +2886,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nix"
@@ -3651,6 +3786,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f561214012d3fc240a1f9c817cc4d57f5310910d066069c1b093f766bb5966"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4078,7 +4224,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "hickory-resolver",
+ "hickory-resolver 0.25.2",
  "http 1.4.0",
  "http-body",
  "http-body-util",
@@ -4334,6 +4480,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4489,7 +4644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4801,6 +4956,22 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -5178,7 +5349,7 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "hex",
- "hickory-resolver",
+ "hickory-resolver 0.26.1",
  "hmac-sha256",
  "http 0.2.12",
  "http 1.4.0",
@@ -5282,6 +5453,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -5995,6 +6187,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6201,6 +6403,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -39,7 +39,7 @@ figment = { version = "0.10", features = ["toml", "env", "test"] }
 form_urlencoded = "1.1.0"
 futures = "0.3"
 hex = "0.4.3"
-hickory-resolver = "0.25.2"
+hickory-resolver = "0.26.1"
 hmac-sha256 = "1"
 http = "1.1.0"
 http-body-util = "0.1.2"

--- a/server/svix-server/src/core/webhook_http_client.rs
+++ b/server/svix-server/src/core/webhook_http_client.rs
@@ -654,7 +654,9 @@ impl Iterator for SocketAddrs {
 }
 
 async fn new_resolver() -> Result<Arc<TokioResolver>, NetError> {
-    Ok(Arc::new(Resolver::builder_tokio()?.build()?))
+    let mut builder = Resolver::builder_tokio()?;
+    builder.options_mut().ip_strategy = hickory_resolver::config::LookupIpStrategy::Ipv4thenIpv6;
+    Ok(Arc::new(builder.build()?))
 }
 
 fn is_allowed(addr: IpAddr) -> bool {

--- a/server/svix-server/src/core/webhook_http_client.rs
+++ b/server/svix-server/src/core/webhook_http_client.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::VecDeque,
     future::Future,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     pin::Pin,
@@ -12,7 +13,7 @@ use axum::{body::Body, response::Response};
 use axum_extra::headers::{Authorization, authorization::Credentials};
 use bytes::Bytes;
 use futures::{FutureExt, future::BoxFuture};
-use hickory_resolver::{ResolveError, Resolver, TokioResolver, lookup_ip::LookupIpIntoIter};
+use hickory_resolver::{Resolver, TokioResolver, net::NetError};
 use http::{HeaderMap, HeaderValue, Method, StatusCode, Version};
 use http_body_util::Full;
 use hyper::{Uri, body::Incoming, ext::HeaderCaseMap};
@@ -54,7 +55,7 @@ pub enum Error {
     #[error("requests to this IP range are blocked (see the server configuration)")]
     BlockedIp,
     #[error("error resolving name: {0}")]
-    Resolve(#[from] ResolveError),
+    Resolve(#[from] NetError),
 
     #[error("request timed out")]
     TimedOut,
@@ -614,57 +615,46 @@ impl Service<Name> for NonLocalDnsResolver {
                 .iter()
                 .any(|whitelisted| whitelisted == name.as_str());
 
-            let lookup = resolver.lookup_ip(name.as_str()).await?;
+            let mut addresses = resolver
+                .lookup_ip(name.as_str())
+                .await?
+                .iter()
+                .collect::<VecDeque<_>>();
 
-            if lookup.iter().all(|ip| {
-                !is_allowed(ip)
-                    && !whitelist_nets.iter().any(|subnet| subnet.contains(&ip))
-                    && !whitelisted_name
-            }) {
-                Err(Error::BlockedIp)
-            } else {
-                Ok(SocketAddrs {
-                    iter: lookup.into_iter(),
-                    whitelist_nets,
-                    whitelisted_name,
-                })
+            if !addresses.is_empty() {
+                addresses.retain(move |ip| {
+                    is_allowed(*ip)
+                        || whitelist_nets.iter().any(|subnet| subnet.contains(ip))
+                        || whitelisted_name
+                });
+                if addresses.is_empty() {
+                    return Err(Error::BlockedIp);
+                }
             }
+
+            Ok(SocketAddrs {
+                filtered_addresses: addresses,
+            })
         })
     }
 }
 
 pub struct SocketAddrs {
-    iter: LookupIpIntoIter,
-    whitelist_nets: Arc<Vec<IpNet>>,
-    whitelisted_name: bool,
+    filtered_addresses: VecDeque<IpAddr>,
 }
 
 impl Iterator for SocketAddrs {
     type Item = SocketAddr;
 
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            match self.iter.next() {
-                Some(ip_addr) => {
-                    if is_allowed(ip_addr)
-                        || self
-                            .whitelist_nets
-                            .iter()
-                            .any(|subnet| subnet.contains(&ip_addr))
-                        || self.whitelisted_name
-                    {
-                        return Some(SocketAddr::from((ip_addr, 0)));
-                    }
-                }
-
-                None => return None,
-            }
-        }
+        self.filtered_addresses
+            .pop_front()
+            .map(|item| SocketAddr::from((item, 0)))
     }
 }
 
-async fn new_resolver() -> Result<Arc<TokioResolver>, ResolveError> {
-    Ok(Arc::new(Resolver::builder_tokio()?.build()))
+async fn new_resolver() -> Result<Arc<TokioResolver>, NetError> {
+    Ok(Arc::new(Resolver::builder_tokio()?.build()?))
 }
 
 fn is_allowed(addr: IpAddr) -> bool {


### PR DESCRIPTION
We still have hickory 0.25 in our dependency tree until https://github.com/seanmonstar/reqwest/pull/3014, but this preps us to move to hickory 0.26 as soon as reqwest is ready.

Same as svix/svix-webhooks-private#6296, just ported to the slightly different API in OSS.