### PR TITLE
Java: fix compatibilty with Java 1.8.

### DIFF
--- a/java/lib/src/main/java/com/svix/Svix.java
+++ b/java/lib/src/main/java/com/svix/Svix.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 
 import okhttp3.HttpUrl;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @Getter
@@ -60,10 +61,9 @@ public class Svix {
             throw new IllegalArgumentException("Invalid base url");
         }
 
-        Map<String, String> defaultHeaders =
-                Map.of(
-                        "User-Agent", "svix-libs/" + Version.VERSION + "/java",
-                        "Authorization", "Bearer " + token);
+        Map<String, String> defaultHeaders = new HashMap<>();
+        defaultHeaders.put("User-Agent", "svix-libs/" + Version.VERSION + "/java");
+        defaultHeaders.put("Authorization", "Bearer " + token);
 
         SvixHttpClient httpClient =
                 new SvixHttpClient(parsedUrl, defaultHeaders, options.getRetrySchedule());


### PR DESCRIPTION
It's officially EOL, but there's extended support until 2030, and anyway the Svix library advertises support for it. It's only this line that broke compat, so it's an easy fix.