### PR TITLE
ruby: Remove post-install message

### DIFF
--- a/ruby/svix.gemspec
+++ b/ruby/svix.gemspec
@@ -17,12 +17,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.2"
 
-  spec.post_install_message = <<~MESSAGE
-
-    Thank you for installing svix!
-
-  MESSAGE
-
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)


### PR DESCRIPTION
It's unnecessary noise. 

Closes #2317.