### PR TITLE
php: autoconfig sdk

### DIFF
--- a/codegen/codegen.toml
+++ b/codegen/codegen.toml
@@ -189,6 +189,9 @@ output_dir = "kotlin/lib/src/main/kotlin"
 
 
 [php]
+extra_shell_commands = [
+   "perl -pi -e 's/^namespace Svix\\\\Api;/namespace Svix\\\\ApiInternal;/g' php/src/ApiInternal/*.php",
+]
 extra_codegen_args = [
    # ingest requires struct enums and is excluded from initial release
    "--exclude-op-id=v1.ingest.source.list",
@@ -200,9 +203,24 @@ extra_codegen_args = [
 [[php.task]]
 template = "templates/php/component_type.php.jinja"
 output_dir = "php/src/Models"
+extra_codegen_args = [
+   "--exclude-op-id=v1.ingest.source.list",
+   "--exclude-op-id=v1.ingest.source.create",
+   "--exclude-op-id=v1.ingest.source.get",
+   "--exclude-op-id=v1.ingest.source.update",
+   "--exclude-op-id=v1.ingest.source.delete",
+   "--include-op-id=v1.endpoint.auto-config.update"
+]
 [[php.task]]
 template = "templates/php/api_resource.php.jinja"
 output_dir = "php/src/Api"
+[[php.task]]
+template = "templates/php/api_resource.php.jinja"
+output_dir = "php/src/ApiInternal"
+extra_codegen_args = [
+   "--include-mode=only-specified",
+   "--include-op-id=v1.endpoint.auto-config.update"
+]
 [[php.task]]
 template = "templates/php/operation_options.php.jinja"
 output_dir = "php/src/Api"

--- a/codegen/generated_files.json
+++ b/codegen/generated_files.json
@@ -1423,6 +1423,10 @@
         "php/src/Api/StreamingStreamListOptions.php"
     ],
     [
+        "php/src/ApiInternal/Endpoint.php",
+        "php/src/ApiInternal/EndpointAutoConfig.php"
+    ],
+    [
         "php/src/Models/AggregateEventTypesOut.php",
         "php/src/Models/AmazonS3PatchConfig.php",
         "php/src/Models/ApiTokenOut.php",
@@ -1591,7 +1595,8 @@
         "php/src/Models/StreamSinkIn.php",
         "php/src/Models/StreamSinkOut.php",
         "php/src/Models/StreamSinkPatch.php",
-        "php/src/Models/StreamTokenExpireIn.php"
+        "php/src/Models/StreamTokenExpireIn.php",
+        "php/src/Models/SubscribeIn.php"
     ],
     [
         "php/src/Svix.php"

--- a/php/src/ApiInternal/Endpoint.php
+++ b/php/src/ApiInternal/Endpoint.php
@@ -1,0 +1,31 @@
+<?php
+
+// this file is @generated
+declare(strict_types=1);
+
+namespace Svix\ApiInternal;
+
+use Svix\Models\EndpointTransformationIn;
+use Svix\Request\SvixHttpClient;
+
+class Endpoint
+{
+    public EndpointAutoConfig $autoConfig;
+
+    public function __construct(
+        private readonly SvixHttpClient $client,
+    ) {
+        $this->autoConfig = new EndpointAutoConfig($client);
+    }
+
+    /** This operation was renamed to `set-transformation`. */
+    public function transformationPartialUpdate(
+        string $appId,
+        string $endpointId,
+        EndpointTransformationIn $endpointTransformationIn,
+    ): void {
+        $request = $this->client->newReq('PATCH', "/api/v1/app/{$appId}/endpoint/{$endpointId}/transformation");
+        $request->setBody(json_encode($endpointTransformationIn));
+        $res = $this->client->sendNoResponseBody($request);
+    }
+}

--- a/php/src/ApiInternal/EndpointAutoConfig.php
+++ b/php/src/ApiInternal/EndpointAutoConfig.php
@@ -1,0 +1,31 @@
+<?php
+
+// this file is @generated
+declare(strict_types=1);
+
+namespace Svix\ApiInternal;
+
+use Svix\Models\EndpointOut;
+use Svix\Models\SubscribeIn;
+use Svix\Request\SvixHttpClient;
+
+class EndpointAutoConfig
+{
+    public function __construct(
+        private readonly SvixHttpClient $client,
+    ) {
+    }
+
+    /** Update an auto-config endpoint by providing endpoint details. */
+    public function update(
+        string $appId,
+        string $endpointId,
+        SubscribeIn $subscribeIn,
+    ): EndpointOut {
+        $request = $this->client->newReq('PUT', "/api/v1/app/{$appId}/endpoint/{$endpointId}/auto-config");
+        $request->setBody(json_encode($subscribeIn));
+        $res = $this->client->send($request);
+
+        return EndpointOut::fromJson($res);
+    }
+}

--- a/php/src/AutoConfig.php
+++ b/php/src/AutoConfig.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Svix;
+
+use GuzzleHttp\Client;
+use Svix\ApiInternal\EndpointAutoConfig;
+use Svix\Models\EndpointIn;
+use Svix\Models\EndpointOut;
+use Svix\Models\SubscribeIn;
+use Svix\Request\SvixHttpClient;
+
+final class AutoConfig
+{
+    private const AUTOCONFIG_TOKEN_PREFIX_V1 = 'auto_v1_';
+
+    private string $appId;
+
+    private string $endpointId;
+
+    private EndpointIn $endpoint;
+
+    private Webhook $webhook;
+
+    private SvixHttpClient $client;
+
+    public function __construct(string $token, EndpointIn $endpoint)
+    {
+        $content = self::decodeToken($token);
+        $this->appId = $content['app_id'];
+        $this->endpointId = $content['endpoint_id'];
+        $this->endpoint = $endpoint;
+
+        try {
+            $this->webhook = new Webhook($content['endpoint_secret']);
+        } catch (\Throwable $e) {
+            throw new \InvalidArgumentException('invalid token');
+        }
+
+        $opts = SvixOptions::newDefault($content['token_plaintext']);
+        $opts->serverUrl = $content['server_url'];
+
+        $this->client = new SvixHttpClient(
+            baseUrl: $content['server_url'],
+            token: $content['token_plaintext'],
+            guzzleClient: new Client(),
+            opts: $opts,
+        );
+    }
+
+    public function subscribe(): EndpointOut
+    {
+        return (new EndpointAutoConfig($this->client))->update(
+            $this->appId,
+            $this->endpointId,
+            SubscribeIn::create($this->endpoint),
+        );
+    }
+
+    public function verify(string $payload, array $headers): mixed
+    {
+        return $this->webhook->verify($payload, $headers);
+    }
+
+    /**
+     * @return array{app_id: string, endpoint_id: string, server_url: string, endpoint_secret: string, token_plaintext: string}
+     */
+    private static function decodeToken(string $token): array
+    {
+        if (!str_starts_with($token, self::AUTOCONFIG_TOKEN_PREFIX_V1)) {
+            throw new \InvalidArgumentException('invalid token');
+        }
+
+        $encoded = substr($token, strlen(self::AUTOCONFIG_TOKEN_PREFIX_V1));
+        if ($encoded === false || $encoded === '') {
+            throw new \InvalidArgumentException('invalid token');
+        }
+
+        $decoded = base64_decode($encoded, true);
+        if ($decoded === false) {
+            throw new \InvalidArgumentException('invalid token');
+        }
+
+        try {
+            $data = json_decode($decoded, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new \InvalidArgumentException('invalid token');
+        }
+
+        if (!is_array($data)) {
+            throw new \InvalidArgumentException('invalid token');
+        }
+
+        try {
+            return [
+                'app_id' => (string) $data['aid'],
+                'endpoint_id' => (string) $data['eid'],
+                'server_url' => (string) $data['surl'],
+                'endpoint_secret' => (string) $data['esec'],
+                'token_plaintext' => (string) $data['tok'],
+            ];
+        } catch (\Throwable $e) {
+            throw new \InvalidArgumentException('invalid token');
+        }
+    }
+}

--- a/php/src/Models/SubscribeIn.php
+++ b/php/src/Models/SubscribeIn.php
@@ -1,0 +1,58 @@
+<?php
+
+// this file is @generated
+declare(strict_types=1);
+
+namespace Svix\Models;
+
+class SubscribeIn implements \JsonSerializable
+{
+    private array $setFields = [];
+
+    private function __construct(
+        public readonly EndpointIn $endpoint,
+        array $setFields = [],
+    ) {
+        $this->setFields = $setFields;
+    }
+
+    /**
+     * Create an instance of SubscribeIn with required fields.
+     */
+    public static function create(
+        EndpointIn $endpoint,
+    ): self {
+        return new self(
+            endpoint: $endpoint,
+            setFields: ['endpoint' => true]
+        );
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        $data = [
+            'endpoint' => $this->endpoint];
+
+        return \Svix\Utils::newStdClassIfArrayIsEmpty($data);
+    }
+
+    /**
+     * Create an instance from a mixed obj.
+     */
+    public static function fromMixed(mixed $data): self
+    {
+        return new self(
+            endpoint: \Svix\Utils::deserializeObject($data, 'endpoint', true, 'SubscribeIn', [EndpointIn::class, 'fromMixed'])
+        );
+    }
+
+    /**
+     * Create an instance from a json string.
+     */
+    public static function fromJson(string $json): self
+    {
+        $data = json_decode(json: $json, associative: true, depth: 512, flags: JSON_THROW_ON_ERROR);
+
+        return self::fromMixed($data);
+    }
+}

--- a/php/tests/AutoConfigTest.php
+++ b/php/tests/AutoConfigTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Svix\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Svix\AutoConfig;
+use Svix\Models\EndpointIn;
+
+final class AutoConfigTest extends TestCase
+{
+    private static function encodeAutoConfigToken(array $payload): string
+    {
+        return 'auto_v1_' . base64_encode(json_encode($payload, JSON_THROW_ON_ERROR));
+    }
+
+    private static function minimalValidPayload(): array
+    {
+        return [
+            'aid' => 'app_1srOrx2ZWZBpBUvZwXKQmoEYga2',
+            'eid' => 'ep_1srOrx2ZWZBpBUvZwXKQmoEYga2',
+            'surl' => 'https://api.example.test',
+            // Same shape as WebhookTest secrets (base64 key material, no prefix required).
+            'esec' => 'MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw',
+            'tok' => 'appsk_test_token',
+        ];
+    }
+
+    public function testValidTokenConstructsAutoConfig(): void
+    {
+        $token = self::encodeAutoConfigToken(self::minimalValidPayload());
+
+        $ac = new AutoConfig($token, EndpointIn::create('https://consumer.example/webhook'));
+
+        $this->assertInstanceOf(AutoConfig::class, $ac);
+    }
+
+    public function testWrongPrefixThrowsInvalidArgument(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('invalid token');
+
+        new AutoConfig(
+            'not_auto_v1_' . base64_encode(json_encode(self::minimalValidPayload())),
+            EndpointIn::create('https://consumer.example/webhook'),
+        );
+    }
+
+    public function testNothingAfterPrefixThrowsInvalidArgument(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('invalid token');
+
+        new AutoConfig('auto_v1_', EndpointIn::create('https://consumer.example/webhook'));
+    }
+
+    public function testInvalidBase64ThrowsInvalidArgument(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('invalid token');
+
+        new AutoConfig(
+            'auto_v1_' . '!not-valid-base64!',
+            EndpointIn::create('https://consumer.example/webhook'),
+        );
+    }
+
+    public function testInvalidJsonThrowsInvalidArgument(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('invalid token');
+
+        new AutoConfig(
+            'auto_v1_' . base64_encode('{not json'),
+            EndpointIn::create('https://consumer.example/webhook'),
+        );
+    }
+}


### PR DESCRIPTION
Same as https://github.com/svix/svix-webhooks/pull/2302 - for PHP, using an internal API

Had to add the same weird perl script we have for Go to rewrite the internal package names.