### PR TITLE
[PHP] Add missing throws phpdoc

### DIFF
--- a/codegen/templates/php/api_extra/application_create.php
+++ b/codegen/templates/php/api_extra/application_create.php
@@ -1,4 +1,8 @@
-/** Get or create a new application */
+/**
+ * Get or create a new application
+ *
+ * @throws ApiException
+ */
 public function getOrCreate(
     ApplicationIn $applicationIn,
     ?ApplicationCreateOptions $options = null,

--- a/codegen/templates/php/api_resource.php.jinja
+++ b/codegen/templates/php/api_resource.php.jinja
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Svix\Api;
 
+use Svix\Exception\ApiException;
 use Svix\Request\SvixHttpClient;
 {% for c in referenced_components -%}
 use Svix\Models\{{ c | to_upper_camel_case }};
@@ -26,11 +27,14 @@ class {{ resource_type_name }}
         {% endfor -%}
     }
 
-
     {% for op in resource.operations -%}
+    /**
     {% if op.description is defined %}
-    {{ op.description | to_doc_comment(style="php_class") }}
+    * {{ op.description | to_doc_comment(style="php_field") }}
+    *
     {% endif -%}
+    * @throws ApiException
+    */
     public function {{ op.name | to_lower_camel_case }}(
         {% for p in op.path_params -%}
         string ${{ p | to_lower_camel_case }},

--- a/php/src/Api/Application.php
+++ b/php/src/Api/Application.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Svix\Api;
 
+use Svix\Exception\ApiException;
 use Svix\Models\ApplicationIn;
 use Svix\Models\ApplicationOut;
 use Svix\Models\ApplicationPatch;
@@ -18,7 +19,11 @@ class Application
     ) {
     }
 
-    /** List of all the organization's applications. */
+    /**
+     * List of all the organization's applications.
+     *
+     * @throws ApiException
+     */
     public function list(
         ?ApplicationListOptions $options = null,
     ): ListResponseApplicationOut {
@@ -36,7 +41,11 @@ class Application
         return ListResponseApplicationOut::fromJson($res);
     }
 
-    /** Create a new application. */
+    /**
+     * Create a new application.
+     *
+     * @throws ApiException
+     */
     public function create(
         ApplicationIn $applicationIn,
         ?ApplicationCreateOptions $options = null,
@@ -51,7 +60,11 @@ class Application
         return ApplicationOut::fromJson($res);
     }
 
-    /** Get or create a new application */
+    /**
+     * Get or create a new application
+     *
+     * @throws ApiException
+     */
     public function getOrCreate(
         ApplicationIn $applicationIn,
         ?ApplicationCreateOptions $options = null,
@@ -67,7 +80,11 @@ class Application
         return ApplicationOut::fromJson($res);
     }
 
-    /** Get an application. */
+    /**
+     * Get an application.
+     *
+     * @throws ApiException
+     */
     public function get(
         string $appId,
     ): ApplicationOut {
@@ -77,7 +94,11 @@ class Application
         return ApplicationOut::fromJson($res);
     }
 
-    /** Update an application. */
+    /**
+     * Update an application.
+     *
+     * @throws ApiException
+     */
     public function update(
         string $appId,
         ApplicationIn $applicationIn,
@@ -89,7 +110,11 @@ class Application
         return ApplicationOut::fromJson($res);
     }
 
-    /** Delete an application. */
+    /**
+     * Delete an application.
+     *
+     * @throws ApiException
+     */
     public function delete(
         string $appId,
     ): void {
@@ -97,7 +122,11 @@ class Application
         $res = $this->client->sendNoResponseBody($request);
     }
 
-    /** Partially update an application. */
+    /**
+     * Partially update an application.
+     *
+     * @throws ApiException
+     */
     public function patch(
         string $appId,
         ApplicationPatch $applicationPatch,

--- a/php/src/Api/Application.php
+++ b/php/src/Api/Application.php
@@ -61,7 +61,7 @@ class Application
     }
 
     /**
-     * Get or create a new application
+     * Get or create a new application.
      *
      * @throws ApiException
      */

--- a/php/src/Api/Authentication.php
+++ b/php/src/Api/Authentication.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Svix\Api;
 
+use Svix\Exception\ApiException;
 use Svix\Models\ApiTokenOut;
 use Svix\Models\ApplicationTokenExpireIn;
 use Svix\Models\AppPortalAccessIn;
@@ -21,7 +22,12 @@ class Authentication
     ) {
     }
 
-    /** Use this function to get magic links (and authentication codes) for connecting your users to the Consumer Application Portal. */
+    /**
+     * Use this function to get magic links (and authentication codes) for connecting your users to the Consumer
+     * Application Portal.
+     *
+     * @throws ApiException
+     */
     public function appPortalAccess(
         string $appId,
         AppPortalAccessIn $appPortalAccessIn,
@@ -37,7 +43,11 @@ class Authentication
         return AppPortalAccessOut::fromJson($res);
     }
 
-    /** Expire all of the tokens associated with a specific application. */
+    /**
+     * Expire all of the tokens associated with a specific application.
+     *
+     * @throws ApiException
+     */
     public function expireAll(
         string $appId,
         ApplicationTokenExpireIn $applicationTokenExpireIn,
@@ -55,6 +65,8 @@ class Authentication
      * Logout an app token.
      *
      * Trying to log out other tokens will fail.
+     *
+     * @throws ApiException
      */
     public function logout(
         ?AuthenticationLogoutOptions $options = null,
@@ -70,6 +82,8 @@ class Authentication
      * Logout a stream token.
      *
      * Trying to log out other tokens will fail.
+     *
+     * @throws ApiException
      */
     public function streamLogout(
         ?AuthenticationStreamLogoutOptions $options = null,
@@ -81,7 +95,12 @@ class Authentication
         $res = $this->client->sendNoResponseBody($request);
     }
 
-    /** Use this function to get magic links (and authentication codes) for connecting your users to the Stream Consumer Portal. */
+    /**
+     * Use this function to get magic links (and authentication codes) for connecting your users to the Stream Consumer
+     * Portal.
+     *
+     * @throws ApiException
+     */
     public function streamPortalAccess(
         string $streamId,
         StreamPortalAccessIn $streamPortalAccessIn,
@@ -111,7 +130,11 @@ class Authentication
         $res = $this->client->sendNoResponseBody($request);
     }
 
-    /** Get the current auth token for the stream poller. */
+    /**
+     * Get the current auth token for the stream poller.
+     *
+     * @throws ApiException
+     */
     public function getStreamPollerToken(
         string $streamId,
         string $sinkId,
@@ -122,7 +145,11 @@ class Authentication
         return ApiTokenOut::fromJson($res);
     }
 
-    /** Create a new auth token for the stream poller API. */
+    /**
+     * Create a new auth token for the stream poller API.
+     *
+     * @throws ApiException
+     */
     public function rotateStreamPollerToken(
         string $streamId,
         string $sinkId,

--- a/php/src/Api/Authentication.php
+++ b/php/src/Api/Authentication.php
@@ -23,8 +23,7 @@ class Authentication
     }
 
     /**
-     * Use this function to get magic links (and authentication codes) for connecting your users to the Consumer
-     * Application Portal.
+     * Use this function to get magic links (and authentication codes) for connecting your users to the Consumer Application Portal.
      *
      * @throws ApiException
      */
@@ -96,8 +95,7 @@ class Authentication
     }
 
     /**
-     * Use this function to get magic links (and authentication codes) for connecting your users to the Stream Consumer
-     * Portal.
+     * Use this function to get magic links (and authentication codes) for connecting your users to the Stream Consumer Portal.
      *
      * @throws ApiException
      */
@@ -116,7 +114,11 @@ class Authentication
         return AppPortalAccessOut::fromJson($res);
     }
 
-    /** Expire all of the tokens associated with a specific stream. */
+    /**
+     * Expire all of the tokens associated with a specific stream.
+     *
+     * @throws ApiException
+     */
     public function streamExpireAll(
         string $streamId,
         StreamTokenExpireIn $streamTokenExpireIn,

--- a/php/src/Api/BackgroundTask.php
+++ b/php/src/Api/BackgroundTask.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Svix\Api;
 
+use Svix\Exception\ApiException;
 use Svix\Models\BackgroundTaskOut;
 use Svix\Models\ListResponseBackgroundTaskOut;
 use Svix\Request\SvixHttpClient;
@@ -16,7 +17,11 @@ class BackgroundTask
     ) {
     }
 
-    /** List background tasks executed in the past 90 days. */
+    /**
+     * List background tasks executed in the past 90 days.
+     *
+     * @throws ApiException
+     */
     public function list(
         ?BackgroundTaskListOptions $options = null,
     ): ListResponseBackgroundTaskOut {
@@ -33,7 +38,11 @@ class BackgroundTask
         return ListResponseBackgroundTaskOut::fromJson($res);
     }
 
-    /** Get a background task by ID. */
+    /**
+     * Get a background task by ID.
+     *
+     * @throws ApiException
+     */
     public function get(
         string $taskId,
     ): BackgroundTaskOut {

--- a/php/src/Api/Connector.php
+++ b/php/src/Api/Connector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Svix\Api;
 
+use Svix\Exception\ApiException;
 use Svix\Models\ConnectorIn;
 use Svix\Models\ConnectorOut;
 use Svix\Models\ConnectorPatch;
@@ -19,7 +20,11 @@ class Connector
     ) {
     }
 
-    /** List all connectors for an application. */
+    /**
+     * List all connectors for an application.
+     *
+     * @throws ApiException
+     */
     public function list(
         ?ConnectorListOptions $options = null,
     ): ListResponseConnectorOut {
@@ -35,7 +40,11 @@ class Connector
         return ListResponseConnectorOut::fromJson($res);
     }
 
-    /** Create a new connector. */
+    /**
+     * Create a new connector.
+     *
+     * @throws ApiException
+     */
     public function create(
         ConnectorIn $connectorIn,
         ?ConnectorCreateOptions $options = null,
@@ -50,7 +59,11 @@ class Connector
         return ConnectorOut::fromJson($res);
     }
 
-    /** Get a connector. */
+    /**
+     * Get a connector.
+     *
+     * @throws ApiException
+     */
     public function get(
         string $connectorId,
     ): ConnectorOut {
@@ -60,7 +73,11 @@ class Connector
         return ConnectorOut::fromJson($res);
     }
 
-    /** Update a connector. */
+    /**
+     * Update a connector.
+     *
+     * @throws ApiException
+     */
     public function update(
         string $connectorId,
         ConnectorUpdate $connectorUpdate,
@@ -72,7 +89,11 @@ class Connector
         return ConnectorOut::fromJson($res);
     }
 
-    /** Delete a connector. */
+    /**
+     * Delete a connector.
+     *
+     * @throws ApiException
+     */
     public function delete(
         string $connectorId,
     ): void {
@@ -80,7 +101,11 @@ class Connector
         $res = $this->client->sendNoResponseBody($request);
     }
 
-    /** Partially update a connector. */
+    /**
+     * Partially update a connector.
+     *
+     * @throws ApiException
+     */
     public function patch(
         string $connectorId,
         ConnectorPatch $connectorPatch,

--- a/php/src/Api/Endpoint.php
+++ b/php/src/Api/Endpoint.php
@@ -142,8 +142,10 @@ class Endpoint
 
     /**
      * Bulk replay messages sent to the endpoint.
+     *
      * Only messages that were created after `since` will be sent.
      * This will replay both successful, and failed messages
+     *
      * A completed task will return a payload like the following:
      * ```json
      * {
@@ -221,7 +223,9 @@ class Endpoint
 
     /**
      * Resend all failed messages since a given time.
+     *
      * Messages that were sent successfully, even if failed initially, are not resent.
+     *
      * A completed task will return a payload like the following:
      * ```json
      * {
@@ -254,8 +258,10 @@ class Endpoint
 
     /**
      * Replays messages to the endpoint.
+     *
      * Only messages that were created after `since` will be sent.
      * Messages that were previously sent to the endpoint are not resent.
+     *
      * A completed task will return a payload like the following:
      * ```json
      * {

--- a/php/src/Api/Endpoint.php
+++ b/php/src/Api/Endpoint.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Svix\Api;
 
+use Svix\Exception\ApiException;
 use Svix\Models\BulkReplayIn;
 use Svix\Models\EndpointHeadersIn;
 use Svix\Models\EndpointHeadersOut;
@@ -35,7 +36,11 @@ class Endpoint
     ) {
     }
 
-    /** List the application's endpoints. */
+    /**
+     * List the application's endpoints.
+     *
+     * @throws ApiException
+     */
     public function list(
         string $appId,
         ?EndpointListOptions $options = null,
@@ -55,6 +60,8 @@ class Endpoint
      * Create a new endpoint for the application.
      *
      * When `secret` is `null` the secret is automatically generated (recommended).
+     *
+     * @throws ApiException
      */
     public function create(
         string $appId,
@@ -71,7 +78,11 @@ class Endpoint
         return EndpointOut::fromJson($res);
     }
 
-    /** Get an endpoint. */
+    /**
+     * Get an endpoint.
+     *
+     * @throws ApiException
+     */
     public function get(
         string $appId,
         string $endpointId,
@@ -82,7 +93,11 @@ class Endpoint
         return EndpointOut::fromJson($res);
     }
 
-    /** Update an endpoint. */
+    /**
+     * Update an endpoint.
+     *
+     * @throws ApiException
+     */
     public function update(
         string $appId,
         string $endpointId,
@@ -95,7 +110,11 @@ class Endpoint
         return EndpointOut::fromJson($res);
     }
 
-    /** Delete an endpoint. */
+    /**
+     * Delete an endpoint.
+     *
+     * @throws ApiException
+     */
     public function delete(
         string $appId,
         string $endpointId,
@@ -104,7 +123,11 @@ class Endpoint
         $res = $this->client->sendNoResponseBody($request);
     }
 
-    /** Partially update an endpoint. */
+    /**
+     * Partially update an endpoint.
+     *
+     * @throws ApiException
+     */
     public function patch(
         string $appId,
         string $endpointId,
@@ -119,10 +142,8 @@ class Endpoint
 
     /**
      * Bulk replay messages sent to the endpoint.
-     *
      * Only messages that were created after `since` will be sent.
      * This will replay both successful, and failed messages
-     *
      * A completed task will return a payload like the following:
      * ```json
      * {
@@ -134,6 +155,8 @@ class Endpoint
      *   }
      * }
      * ```
+     *
+     * @throws ApiException
      */
     public function bulkReplay(
         string $appId,
@@ -151,7 +174,11 @@ class Endpoint
         return ReplayOut::fromJson($res);
     }
 
-    /** Get the additional headers to be sent with the webhook. */
+    /**
+     * Get the additional headers to be sent with the webhook.
+     *
+     * @throws ApiException
+     */
     public function getHeaders(
         string $appId,
         string $endpointId,
@@ -162,7 +189,11 @@ class Endpoint
         return EndpointHeadersOut::fromJson($res);
     }
 
-    /** Set the additional headers to be sent with the webhook. */
+    /**
+     * Set the additional headers to be sent with the webhook.
+     *
+     * @throws ApiException
+     */
     public function updateHeaders(
         string $appId,
         string $endpointId,
@@ -173,7 +204,11 @@ class Endpoint
         $res = $this->client->sendNoResponseBody($request);
     }
 
-    /** Partially set the additional headers to be sent with the webhook. */
+    /**
+     * Partially set the additional headers to be sent with the webhook.
+     *
+     * @throws ApiException
+     */
     public function patchHeaders(
         string $appId,
         string $endpointId,
@@ -186,9 +221,7 @@ class Endpoint
 
     /**
      * Resend all failed messages since a given time.
-     *
      * Messages that were sent successfully, even if failed initially, are not resent.
-     *
      * A completed task will return a payload like the following:
      * ```json
      * {
@@ -200,6 +233,8 @@ class Endpoint
      *   }
      * }
      * ```
+     *
+     * @throws ApiException
      */
     public function recover(
         string $appId,
@@ -219,10 +254,8 @@ class Endpoint
 
     /**
      * Replays messages to the endpoint.
-     *
      * Only messages that were created after `since` will be sent.
      * Messages that were previously sent to the endpoint are not resent.
-     *
      * A completed task will return a payload like the following:
      * ```json
      * {
@@ -234,6 +267,8 @@ class Endpoint
      *   }
      * }
      * ```
+     *
+     * @throws ApiException
      */
     public function replayMissing(
         string $appId,
@@ -256,6 +291,8 @@ class Endpoint
      *
      * This is used to verify the authenticity of the webhook.
      * For more information please refer to [the consuming webhooks docs](https://docs.svix.com/consuming-webhooks/).
+     *
+     * @throws ApiException
      */
     public function getSecret(
         string $appId,
@@ -271,6 +308,8 @@ class Endpoint
      * Rotates the endpoint's signing secret.
      *
      * The previous secret will remain valid for the next 24 hours.
+     *
+     * @throws ApiException
      */
     public function rotateSecret(
         string $appId,
@@ -286,7 +325,11 @@ class Endpoint
         $res = $this->client->sendNoResponseBody($request);
     }
 
-    /** Send an example message for an event. */
+    /**
+     * Send an example message for an event.
+     *
+     * @throws ApiException
+     */
     public function sendExample(
         string $appId,
         string $endpointId,
@@ -303,7 +346,11 @@ class Endpoint
         return MessageOut::fromJson($res);
     }
 
-    /** Get basic statistics for the endpoint. */
+    /**
+     * Get basic statistics for the endpoint.
+     *
+     * @throws ApiException
+     */
     public function getStats(
         string $appId,
         string $endpointId,
@@ -319,7 +366,11 @@ class Endpoint
         return EndpointStats::fromJson($res);
     }
 
-    /** Get the transformation code associated with this endpoint. */
+    /**
+     * Get the transformation code associated with this endpoint.
+     *
+     * @throws ApiException
+     */
     public function transformationGet(
         string $appId,
         string $endpointId,
@@ -330,7 +381,11 @@ class Endpoint
         return EndpointTransformationOut::fromJson($res);
     }
 
-    /** Set or unset the transformation code associated with this endpoint. */
+    /**
+     * Set or unset the transformation code associated with this endpoint.
+     *
+     * @throws ApiException
+     */
     public function patchTransformation(
         string $appId,
         string $endpointId,
@@ -341,7 +396,11 @@ class Endpoint
         $res = $this->client->sendNoResponseBody($request);
     }
 
-    /** This operation was renamed to `set-transformation`. */
+    /**
+     * This operation was renamed to `set-transformation`.
+     *
+     * @throws ApiException
+     */
     public function transformationPartialUpdate(
         string $appId,
         string $endpointId,

--- a/php/src/Api/Environment.php
+++ b/php/src/Api/Environment.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Svix\Api;
 
+use Svix\Exception\ApiException;
 use Svix\Models\EnvironmentIn;
 use Svix\Models\EnvironmentOut;
 use Svix\Request\SvixHttpClient;
@@ -21,6 +22,8 @@ class Environment
      *
      * Note that the schema for [`EnvironmentOut`] is subject to change. The fields
      * herein are provided for convenience but should be treated as JSON blobs.
+     *
+     * @throws ApiException
      */
     public function export(
         ?EnvironmentExportOptions $options = null,
@@ -41,6 +44,8 @@ class Environment
      *
      * Note that the schema for [`EnvironmentIn`] is subject to change. The fields
      * herein are provided for convenience but should be treated as JSON blobs.
+     *
+     * @throws ApiException
      */
     public function import(
         EnvironmentIn $environmentIn,

--- a/php/src/Api/EventType.php
+++ b/php/src/Api/EventType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Svix\Api;
 
+use Svix\Exception\ApiException;
 use Svix\Models\EventTypeImportOpenApiIn;
 use Svix\Models\EventTypeImportOpenApiOut;
 use Svix\Models\EventTypeIn;
@@ -21,7 +22,11 @@ class EventType
     ) {
     }
 
-    /** Return the list of event types. */
+    /**
+     * Return the list of event types.
+     *
+     * @throws ApiException
+     */
     public function list(
         ?EventTypeListOptions $options = null,
     ): ListResponseEventTypeOut {
@@ -44,6 +49,8 @@ class EventType
      * Unarchiving an event type will allow endpoints to filter on it and messages to be sent with it.
      * Endpoints filtering on the event type before archival will continue to filter on it.
      * This operation does not preserve the description and schemas.
+     *
+     * @throws ApiException
      */
     public function create(
         EventTypeIn $eventTypeIn,
@@ -65,6 +72,8 @@ class EventType
      * If an existing `archived` event type is updated, it will be unarchived.
      * The importer will convert all webhooks found in the either the `webhooks` or `x-webhooks`
      * top-level.
+     *
+     * @throws ApiException
      */
     public function importOpenapi(
         EventTypeImportOpenApiIn $eventTypeImportOpenApiIn,
@@ -80,7 +89,11 @@ class EventType
         return EventTypeImportOpenApiOut::fromJson($res);
     }
 
-    /** Get an event type. */
+    /**
+     * Get an event type.
+     *
+     * @throws ApiException
+     */
     public function get(
         string $eventTypeName,
     ): EventTypeOut {
@@ -90,7 +103,11 @@ class EventType
         return EventTypeOut::fromJson($res);
     }
 
-    /** Update an event type. */
+    /**
+     * Update an event type.
+     *
+     * @throws ApiException
+     */
     public function update(
         string $eventTypeName,
         EventTypeUpdate $eventTypeUpdate,
@@ -109,6 +126,8 @@ class EventType
      * However, new messages can not be sent with it and endpoints can not filter on it.
      * An event type can be unarchived with the
      * [create operation](#operation/create_event_type_api_v1_event_type__post).
+     *
+     * @throws ApiException
      */
     public function delete(
         string $eventTypeName,
@@ -121,7 +140,11 @@ class EventType
         $res = $this->client->sendNoResponseBody($request);
     }
 
-    /** Partially update an event type. */
+    /**
+     * Partially update an event type.
+     *
+     * @throws ApiException
+     */
     public function patch(
         string $eventTypeName,
         EventTypePatch $eventTypePatch,

--- a/php/src/Api/Health.php
+++ b/php/src/Api/Health.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Svix\Api;
 
+use Svix\Exception\ApiException;
 use Svix\Request\SvixHttpClient;
 
 class Health
@@ -14,7 +15,11 @@ class Health
     ) {
     }
 
-    /** Verify the API server is up and running. */
+    /**
+     * Verify the API server is up and running.
+     *
+     * @throws ApiException
+     */
     public function get(
     ): void {
         $request = $this->client->newReq('GET', '/api/v1/health');

--- a/php/src/Api/Ingest.php
+++ b/php/src/Api/Ingest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Svix\Api;
 
+use Svix\Exception\ApiException;
 use Svix\Models\DashboardAccessOut;
 use Svix\Models\IngestSourceConsumerPortalAccessIn;
 use Svix\Request\SvixHttpClient;
@@ -21,7 +22,11 @@ class Ingest
         $this->source = new IngestSource($client);
     }
 
-    /** Get access to the Ingest Source Consumer Portal. */
+    /**
+     * Get access to the Ingest Source Consumer Portal.
+     *
+     * @throws ApiException
+     */
     public function dashboard(
         string $sourceId,
         IngestSourceConsumerPortalAccessIn $ingestSourceConsumerPortalAccessIn,

--- a/php/src/Api/IngestEndpoint.php
+++ b/php/src/Api/IngestEndpoint.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Svix\Api;
 
+use Svix\Exception\ApiException;
 use Svix\Models\IngestEndpointHeadersIn;
 use Svix\Models\IngestEndpointHeadersOut;
 use Svix\Models\IngestEndpointIn;
@@ -24,7 +25,11 @@ class IngestEndpoint
     ) {
     }
 
-    /** List ingest endpoints. */
+    /**
+     * List ingest endpoints.
+     *
+     * @throws ApiException
+     */
     public function list(
         string $sourceId,
         ?IngestEndpointListOptions $options = null,
@@ -40,7 +45,11 @@ class IngestEndpoint
         return ListResponseIngestEndpointOut::fromJson($res);
     }
 
-    /** Create an ingest endpoint. */
+    /**
+     * Create an ingest endpoint.
+     *
+     * @throws ApiException
+     */
     public function create(
         string $sourceId,
         IngestEndpointIn $ingestEndpointIn,
@@ -56,7 +65,11 @@ class IngestEndpoint
         return IngestEndpointOut::fromJson($res);
     }
 
-    /** Get an ingest endpoint. */
+    /**
+     * Get an ingest endpoint.
+     *
+     * @throws ApiException
+     */
     public function get(
         string $sourceId,
         string $endpointId,
@@ -67,7 +80,11 @@ class IngestEndpoint
         return IngestEndpointOut::fromJson($res);
     }
 
-    /** Update an ingest endpoint. */
+    /**
+     * Update an ingest endpoint.
+     *
+     * @throws ApiException
+     */
     public function update(
         string $sourceId,
         string $endpointId,
@@ -80,7 +97,11 @@ class IngestEndpoint
         return IngestEndpointOut::fromJson($res);
     }
 
-    /** Delete an ingest endpoint. */
+    /**
+     * Delete an ingest endpoint.
+     *
+     * @throws ApiException
+     */
     public function delete(
         string $sourceId,
         string $endpointId,
@@ -89,7 +110,11 @@ class IngestEndpoint
         $res = $this->client->sendNoResponseBody($request);
     }
 
-    /** Get the additional headers to be sent with the ingest. */
+    /**
+     * Get the additional headers to be sent with the ingest.
+     *
+     * @throws ApiException
+     */
     public function getHeaders(
         string $sourceId,
         string $endpointId,
@@ -100,7 +125,11 @@ class IngestEndpoint
         return IngestEndpointHeadersOut::fromJson($res);
     }
 
-    /** Set the additional headers to be sent to the endpoint. */
+    /**
+     * Set the additional headers to be sent to the endpoint.
+     *
+     * @throws ApiException
+     */
     public function updateHeaders(
         string $sourceId,
         string $endpointId,
@@ -116,6 +145,8 @@ class IngestEndpoint
      *
      * This is used to verify the authenticity of the webhook.
      * For more information please refer to [the consuming webhooks docs](https://docs.svix.com/consuming-webhooks/).
+     *
+     * @throws ApiException
      */
     public function getSecret(
         string $sourceId,
@@ -131,6 +162,8 @@ class IngestEndpoint
      * Rotates an ingest endpoint's signing secret.
      *
      * The previous secret will remain valid for the next 24 hours.
+     *
+     * @throws ApiException
      */
     public function rotateSecret(
         string $sourceId,
@@ -146,7 +179,11 @@ class IngestEndpoint
         $res = $this->client->sendNoResponseBody($request);
     }
 
-    /** Get the transformation code associated with this ingest endpoint. */
+    /**
+     * Get the transformation code associated with this ingest endpoint.
+     *
+     * @throws ApiException
+     */
     public function getTransformation(
         string $sourceId,
         string $endpointId,
@@ -157,7 +194,11 @@ class IngestEndpoint
         return IngestEndpointTransformationOut::fromJson($res);
     }
 
-    /** Set or unset the transformation code associated with this ingest endpoint. */
+    /**
+     * Set or unset the transformation code associated with this ingest endpoint.
+     *
+     * @throws ApiException
+     */
     public function setTransformation(
         string $sourceId,
         string $endpointId,

--- a/php/src/Api/IngestSource.php
+++ b/php/src/Api/IngestSource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Svix\Api;
 
+use Svix\Exception\ApiException;
 use Svix\Models\RotateTokenOut;
 use Svix\Request\SvixHttpClient;
 
@@ -22,6 +23,8 @@ class IngestSource
      * construct the unique `ingestUrl` for the source. Previous tokens
      * will remain valid for 48 hours after rotation. The token can be
      * rotated a maximum of three times within the 48-hour period.
+     *
+     * @throws ApiException
      */
     public function rotateToken(
         string $sourceId,

--- a/php/src/Api/Integration.php
+++ b/php/src/Api/Integration.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Svix\Api;
 
+use Svix\Exception\ApiException;
 use Svix\Models\IntegrationIn;
 use Svix\Models\IntegrationKeyOut;
 use Svix\Models\IntegrationOut;
@@ -19,7 +20,11 @@ class Integration
     ) {
     }
 
-    /** List the application's integrations. */
+    /**
+     * List the application's integrations.
+     *
+     * @throws ApiException
+     */
     public function list(
         string $appId,
         ?IntegrationListOptions $options = null,
@@ -35,7 +40,11 @@ class Integration
         return ListResponseIntegrationOut::fromJson($res);
     }
 
-    /** Create an integration. */
+    /**
+     * Create an integration.
+     *
+     * @throws ApiException
+     */
     public function create(
         string $appId,
         IntegrationIn $integrationIn,
@@ -51,7 +60,11 @@ class Integration
         return IntegrationOut::fromJson($res);
     }
 
-    /** Get an integration. */
+    /**
+     * Get an integration.
+     *
+     * @throws ApiException
+     */
     public function get(
         string $appId,
         string $integId,
@@ -62,7 +75,11 @@ class Integration
         return IntegrationOut::fromJson($res);
     }
 
-    /** Update an integration. */
+    /**
+     * Update an integration.
+     *
+     * @throws ApiException
+     */
     public function update(
         string $appId,
         string $integId,
@@ -75,7 +92,11 @@ class Integration
         return IntegrationOut::fromJson($res);
     }
 
-    /** Delete an integration. */
+    /**
+     * Delete an integration.
+     *
+     * @throws ApiException
+     */
     public function delete(
         string $appId,
         string $integId,
@@ -84,7 +105,11 @@ class Integration
         $res = $this->client->sendNoResponseBody($request);
     }
 
-    /** Get an integration's key. */
+    /**
+     * Get an integration's key.
+     *
+     * @throws ApiException
+     */
     public function getKey(
         string $appId,
         string $integId,
@@ -95,7 +120,11 @@ class Integration
         return IntegrationKeyOut::fromJson($res);
     }
 
-    /** Rotate the integration's key. The previous key will be immediately revoked. */
+    /**
+     * Rotate the integration's key. The previous key will be immediately revoked.
+     *
+     * @throws ApiException
+     */
     public function rotateKey(
         string $appId,
         string $integId,

--- a/php/src/Api/Message.php
+++ b/php/src/Api/Message.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Svix\Api;
 
+use Svix\Exception\ApiException;
 use Svix\Models\ExpungeAllContentsOut;
 use Svix\Models\ListResponseMessageOut;
 use Svix\Models\MessageIn;
@@ -33,6 +34,8 @@ class Message
      * relative to now or, if an iterator is provided, 90 days before/after the time indicated
      * by the iterator ID. If you require data beyond those time ranges, you will need to explicitly
      * set the `before` or `after` parameter as appropriate.
+     *
+     * @throws ApiException
      */
     public function list(
         string $appId,
@@ -64,6 +67,8 @@ class Message
      * Messages can also have `channels`, which similar to event types let endpoints filter by them. Unlike event types, messages can have multiple channels, and channels don't imply a specific message content or schema.
      *
      * The `payload` property is the webhook's body (the actual webhook message). Svix supports payload sizes of up to 1MiB, though it's generally a good idea to keep webhook payloads small, probably no larger than 40kb.
+     *
+     *  @throws ApiException
      */
     public function create(
         string $appId,
@@ -97,6 +102,8 @@ class Message
      *   }
      * }
      * ```
+     *
+     * @throws ApiException
      */
     public function expungeAllContents(
         string $appId,
@@ -118,6 +125,8 @@ class Message
      * Note: most people shouldn't be using this API. Svix doesn't bill you for
      * messages not actually sent, so using this API doesn't save money.
      * If unsure, please ask Svix support before using this API.
+     *
+     * @throws ApiException
      */
     public function precheck(
         string $appId,
@@ -134,7 +143,11 @@ class Message
         return MessagePrecheckOut::fromJson($res);
     }
 
-    /** Get a message by its ID or eventID. */
+    /**
+     * Get a message by its ID or eventID.
+     *
+     * @throws ApiException
+     */
     public function get(
         string $appId,
         string $msgId,
@@ -154,6 +167,8 @@ class Message
      *
      * Useful in cases when a message was accidentally sent with sensitive content.
      * The message can't be replayed or resent once its payload has been deleted or expired.
+     *
+     * @throws ApiException
      */
     public function expungeContent(
         string $appId,

--- a/php/src/Api/Message.php
+++ b/php/src/Api/Message.php
@@ -68,7 +68,7 @@ class Message
      *
      * The `payload` property is the webhook's body (the actual webhook message). Svix supports payload sizes of up to 1MiB, though it's generally a good idea to keep webhook payloads small, probably no larger than 40kb.
      *
-     *  @throws ApiException
+     * @throws ApiException
      */
     public function create(
         string $appId,

--- a/php/src/Api/MessageAttempt.php
+++ b/php/src/Api/MessageAttempt.php
@@ -126,7 +126,7 @@ class MessageAttempt
     }
 
     /**
-     * `msg_id`: Use a message id or a message `eventId`
+     * `msg_id`: Use a message id or a message `eventId`.
      *
      * @throws ApiException
      */

--- a/php/src/Api/MessageAttempt.php
+++ b/php/src/Api/MessageAttempt.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Svix\Api;
 
+use Svix\Exception\ApiException;
 use Svix\Models\EmptyResponse;
 use Svix\Models\ListResponseEndpointMessageOut;
 use Svix\Models\ListResponseMessageAttemptOut;
@@ -26,6 +27,8 @@ class MessageAttempt
      * relative to now or, if an iterator is provided, 90 days before/after the time indicated
      * by the iterator ID. If you require data beyond those time ranges, you will need to explicitly
      * set the `before` or `after` parameter as appropriate.
+     *
+     * @throws ApiException
      */
     public function listByEndpoint(
         string $appId,
@@ -59,6 +62,8 @@ class MessageAttempt
      * relative to now or, if an iterator is provided, 90 days before/after the time indicated
      * by the iterator ID. If you require data beyond those time ranges, you will need to explicitly
      * set the `before` or `after` parameter as appropriate.
+     *
+     * @throws ApiException
      */
     public function listByMsg(
         string $appId,
@@ -94,6 +99,8 @@ class MessageAttempt
      * relative to now or, if an iterator is provided, 90 days before/after the time indicated
      * by the iterator ID. If you require data beyond those time ranges, you will need to explicitly
      * set the `before` or `after` parameter as appropriate.
+     *
+     * @throws ApiException
      */
     public function listAttemptedMessages(
         string $appId,
@@ -118,7 +125,11 @@ class MessageAttempt
         return ListResponseEndpointMessageOut::fromJson($res);
     }
 
-    /** `msg_id`: Use a message id or a message `eventId` */
+    /**
+     * `msg_id`: Use a message id or a message `eventId`
+     *
+     * @throws ApiException
+     */
     public function get(
         string $appId,
         string $msgId,
@@ -139,6 +150,8 @@ class MessageAttempt
      *
      * Useful when an endpoint accidentally returned sensitive content.
      * The message can't be replayed or resent once its payload has been deleted or expired.
+     *
+     * @throws ApiException
      */
     public function expungeContent(
         string $appId,
@@ -154,6 +167,8 @@ class MessageAttempt
      *
      * Additionally includes metadata about the latest message attempt.
      * By default, endpoints are listed in ascending order by ID.
+     *
+     * @throws ApiException
      */
     public function listAttemptedDestinations(
         string $appId,
@@ -170,7 +185,11 @@ class MessageAttempt
         return ListResponseMessageEndpointOut::fromJson($res);
     }
 
-    /** Resend a message to the specified endpoint. */
+    /**
+     * Resend a message to the specified endpoint.
+     *
+     * @throws ApiException
+     */
     public function resend(
         string $appId,
         string $msgId,

--- a/php/src/Api/MessagePoller.php
+++ b/php/src/Api/MessagePoller.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Svix\Api;
 
+use Svix\Exception\ApiException;
 use Svix\Models\PollingEndpointConsumerSeekIn;
 use Svix\Models\PollingEndpointConsumerSeekOut;
 use Svix\Models\PollingEndpointOut;
@@ -17,7 +18,11 @@ class MessagePoller
     ) {
     }
 
-    /** Reads the stream of created messages for an application, filtered on the Sink's event types and Channels. */
+    /**
+     * Reads the stream of created messages for an application, filtered on the Sink's event types and Channels.
+     *
+     * @throws ApiException
+     */
     public function poll(
         string $appId,
         string $sinkId,
@@ -39,6 +44,8 @@ class MessagePoller
     /**
      * Reads the stream of created messages for an application, filtered on the Sink's event types and
      * Channels, using server-managed iterator tracking.
+     *
+     * @throws ApiException
      */
     public function consumerPoll(
         string $appId,
@@ -56,7 +63,11 @@ class MessagePoller
         return PollingEndpointOut::fromJson($res);
     }
 
-    /** Sets the starting offset for the consumer of a polling endpoint. */
+    /**
+     * Sets the starting offset for the consumer of a polling endpoint.
+     *
+     * @throws ApiException
+     */
     public function consumerSeek(
         string $appId,
         string $sinkId,

--- a/php/src/Api/OperationalWebhookEndpoint.php
+++ b/php/src/Api/OperationalWebhookEndpoint.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Svix\Api;
 
+use Svix\Exception\ApiException;
 use Svix\Models\ListResponseOperationalWebhookEndpointOut;
 use Svix\Models\OperationalWebhookEndpointHeadersIn;
 use Svix\Models\OperationalWebhookEndpointHeadersOut;
@@ -22,7 +23,11 @@ class OperationalWebhookEndpoint
     ) {
     }
 
-    /** List operational webhook endpoints. */
+    /**
+     * List operational webhook endpoints.
+     *
+     * @throws ApiException
+     */
     public function list(
         ?OperationalWebhookEndpointListOptions $options = null,
     ): ListResponseOperationalWebhookEndpointOut {
@@ -37,7 +42,11 @@ class OperationalWebhookEndpoint
         return ListResponseOperationalWebhookEndpointOut::fromJson($res);
     }
 
-    /** Create an operational webhook endpoint. */
+    /**
+     * Create an operational webhook endpoint.
+     *
+     * @throws ApiException
+     */
     public function create(
         OperationalWebhookEndpointIn $operationalWebhookEndpointIn,
         ?OperationalWebhookEndpointCreateOptions $options = null,
@@ -52,7 +61,11 @@ class OperationalWebhookEndpoint
         return OperationalWebhookEndpointOut::fromJson($res);
     }
 
-    /** Get an operational webhook endpoint. */
+    /**
+     * Get an operational webhook endpoint.
+     *
+     * @throws ApiException
+     */
     public function get(
         string $endpointId,
     ): OperationalWebhookEndpointOut {
@@ -62,7 +75,11 @@ class OperationalWebhookEndpoint
         return OperationalWebhookEndpointOut::fromJson($res);
     }
 
-    /** Update an operational webhook endpoint. */
+    /**
+     * Update an operational webhook endpoint.
+     *
+     * @throws ApiException
+     */
     public function update(
         string $endpointId,
         OperationalWebhookEndpointUpdate $operationalWebhookEndpointUpdate,
@@ -74,7 +91,11 @@ class OperationalWebhookEndpoint
         return OperationalWebhookEndpointOut::fromJson($res);
     }
 
-    /** Delete an operational webhook endpoint. */
+    /**
+     * Delete an operational webhook endpoint.
+     *
+     * @throws ApiException
+     */
     public function delete(
         string $endpointId,
     ): void {
@@ -82,7 +103,11 @@ class OperationalWebhookEndpoint
         $res = $this->client->sendNoResponseBody($request);
     }
 
-    /** Get the additional headers to be sent with the operational webhook. */
+    /**
+     * Get the additional headers to be sent with the operational webhook.
+     *
+     * @throws ApiException
+     */
     public function getHeaders(
         string $endpointId,
     ): OperationalWebhookEndpointHeadersOut {
@@ -92,7 +117,11 @@ class OperationalWebhookEndpoint
         return OperationalWebhookEndpointHeadersOut::fromJson($res);
     }
 
-    /** Set the additional headers to be sent with the operational webhook. */
+    /**
+     * Set the additional headers to be sent with the operational webhook.
+     *
+     * @throws ApiException
+     */
     public function updateHeaders(
         string $endpointId,
         OperationalWebhookEndpointHeadersIn $operationalWebhookEndpointHeadersIn,
@@ -107,6 +136,8 @@ class OperationalWebhookEndpoint
      *
      * This is used to verify the authenticity of the webhook.
      * For more information please refer to [the consuming webhooks docs](https://docs.svix.com/consuming-webhooks/).
+     *
+     * @throws ApiException
      */
     public function getSecret(
         string $endpointId,
@@ -121,6 +152,8 @@ class OperationalWebhookEndpoint
      * Rotates an operational webhook endpoint's signing secret.
      *
      * The previous secret will remain valid for the next 24 hours.
+     *
+     * @throws ApiException
      */
     public function rotateSecret(
         string $endpointId,

--- a/php/src/Api/Statistics.php
+++ b/php/src/Api/Statistics.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Svix\Api;
 
+use Svix\Exception\ApiException;
 use Svix\Models\AggregateEventTypesOut;
 use Svix\Models\AppUsageStatsIn;
 use Svix\Models\AppUsageStatsOut;
@@ -40,6 +41,8 @@ class Statistics
      *   }
      * }
      * ```
+     *
+     * @throws ApiException
      */
     public function aggregateAppStats(
         AppUsageStatsIn $appUsageStatsIn,
@@ -78,6 +81,8 @@ class Statistics
      *   }
      * }
      * ```
+     *
+     * @throws ApiException
      */
     public function aggregateEventTypes(
     ): AggregateEventTypesOut {

--- a/php/src/Api/Streaming.php
+++ b/php/src/Api/Streaming.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Svix\Api;
 
+use Svix\Exception\ApiException;
 use Svix\Models\EndpointHeadersOut;
 use Svix\Models\HttpSinkHeadersPatchIn;
 use Svix\Models\SinkTransformationOut;
@@ -26,7 +27,11 @@ class Streaming
         $this->stream = new StreamingStream($client);
     }
 
-    /** Get the HTTP sink headers. Only valid for `http` or `otelTracing` sinks. */
+    /**
+     * Get the HTTP sink headers. Only valid for `http` or `otelTracing` sinks.
+     *
+     * @throws ApiException
+     */
     public function sinkHeadersGet(
         string $streamId,
         string $sinkId,
@@ -37,7 +42,11 @@ class Streaming
         return EndpointHeadersOut::fromJson($res);
     }
 
-    /** Updates the Sink's headers. Only valid for `http` or `otelTracing` sinks. */
+    /**
+     * Updates the Sink's headers. Only valid for `http` or `otelTracing` sinks.
+     *
+     * @throws ApiException
+     */
     public function sinkHeadersPatch(
         string $streamId,
         string $sinkId,
@@ -50,7 +59,11 @@ class Streaming
         return EndpointHeadersOut::fromJson($res);
     }
 
-    /** Get the transformation code associated with this sink. */
+    /**
+     * Get the transformation code associated with this sink.
+     *
+     * @throws ApiException
+     */
     public function sinkTransformationGet(
         string $streamId,
         string $sinkId,

--- a/php/src/Api/StreamingEventType.php
+++ b/php/src/Api/StreamingEventType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Svix\Api;
 
+use Svix\Exception\ApiException;
 use Svix\Models\ListResponseStreamEventTypeOut;
 use Svix\Models\StreamEventTypeIn;
 use Svix\Models\StreamEventTypeOut;
@@ -18,7 +19,11 @@ class StreamingEventType
     ) {
     }
 
-    /** List of all the organization's event types for streaming. */
+    /**
+     * List of all the organization's event types for streaming.
+     *
+     * @throws ApiException
+     */
     public function list(
         ?StreamingEventTypeListOptions $options = null,
     ): ListResponseStreamEventTypeOut {
@@ -34,7 +39,11 @@ class StreamingEventType
         return ListResponseStreamEventTypeOut::fromJson($res);
     }
 
-    /** Create an event type for Streams. */
+    /**
+     * Create an event type for Streams.
+     *
+     * @throws ApiException
+     */
     public function create(
         StreamEventTypeIn $streamEventTypeIn,
         ?StreamingEventTypeCreateOptions $options = null,
@@ -49,7 +58,11 @@ class StreamingEventType
         return StreamEventTypeOut::fromJson($res);
     }
 
-    /** Get an event type. */
+    /**
+     * Get an event type.
+     *
+     * @throws ApiException
+     */
     public function get(
         string $name,
     ): StreamEventTypeOut {
@@ -59,7 +72,11 @@ class StreamingEventType
         return StreamEventTypeOut::fromJson($res);
     }
 
-    /** Update or create a event type for Streams. */
+    /**
+     * Update or create a event type for Streams.
+     *
+     * @throws ApiException
+     */
     public function update(
         string $name,
         StreamEventTypeIn $streamEventTypeIn,
@@ -71,7 +88,11 @@ class StreamingEventType
         return StreamEventTypeOut::fromJson($res);
     }
 
-    /** Delete an event type. */
+    /**
+     * Delete an event type.
+     *
+     * @throws ApiException
+     */
     public function delete(
         string $name,
         ?StreamingEventTypeDeleteOptions $options = null,
@@ -83,7 +104,11 @@ class StreamingEventType
         $res = $this->client->sendNoResponseBody($request);
     }
 
-    /** Patch an event type for Streams. */
+    /**
+     * Patch an event type for Streams.
+     *
+     * @throws ApiException
+     */
     public function patch(
         string $name,
         StreamEventTypePatch $streamEventTypePatch,

--- a/php/src/Api/StreamingEvents.php
+++ b/php/src/Api/StreamingEvents.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Svix\Api;
 
+use Svix\Exception\ApiException;
 use Svix\Models\CreateStreamEventsIn;
 use Svix\Models\CreateStreamEventsOut;
 use Svix\Models\EventStreamOut;
@@ -17,7 +18,11 @@ class StreamingEvents
     ) {
     }
 
-    /** Creates events on the Stream. */
+    /**
+     * Creates events on the Stream.
+     *
+     * @throws ApiException
+     */
     public function create(
         string $streamId,
         CreateStreamEventsIn $createStreamEventsIn,
@@ -37,6 +42,8 @@ class StreamingEvents
      * Iterate over a stream of events.
      *
      * The sink must be of type `poller` to use the poller endpoint.
+     *
+     * @throws ApiException
      */
     public function get(
         string $streamId,

--- a/php/src/Api/StreamingSink.php
+++ b/php/src/Api/StreamingSink.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Svix\Api;
 
+use Svix\Exception\ApiException;
 use Svix\Models\EmptyResponse;
 use Svix\Models\EndpointSecretRotateIn;
 use Svix\Models\ListResponseStreamSinkOut;
@@ -22,7 +23,11 @@ class StreamingSink
     ) {
     }
 
-    /** List of all the stream's sinks. */
+    /**
+     * List of all the stream's sinks.
+     *
+     * @throws ApiException
+     */
     public function list(
         string $streamId,
         ?StreamingSinkListOptions $options = null,
@@ -38,7 +43,11 @@ class StreamingSink
         return ListResponseStreamSinkOut::fromJson($res);
     }
 
-    /** Creates a new sink. */
+    /**
+     * Creates a new sink.
+     *
+     * @throws ApiException
+     */
     public function create(
         string $streamId,
         StreamSinkIn $streamSinkIn,
@@ -54,7 +63,11 @@ class StreamingSink
         return StreamSinkOut::fromJson($res);
     }
 
-    /** Get a sink by id or uid. */
+    /**
+     * Get a sink by id or uid.
+     *
+     * @throws ApiException
+     */
     public function get(
         string $streamId,
         string $sinkId,
@@ -65,7 +78,11 @@ class StreamingSink
         return StreamSinkOut::fromJson($res);
     }
 
-    /** Update a sink. */
+    /**
+     * Update a sink.
+     *
+     * @throws ApiException
+     */
     public function update(
         string $streamId,
         string $sinkId,
@@ -78,7 +95,11 @@ class StreamingSink
         return StreamSinkOut::fromJson($res);
     }
 
-    /** Delete a sink. */
+    /**
+     * Delete a sink.
+     *
+     * @throws ApiException
+     */
     public function delete(
         string $streamId,
         string $sinkId,
@@ -87,7 +108,11 @@ class StreamingSink
         $res = $this->client->sendNoResponseBody($request);
     }
 
-    /** Partially update a sink. */
+    /**
+     * Partially update a sink.
+     *
+     * @throws ApiException
+     */
     public function patch(
         string $streamId,
         string $sinkId,
@@ -106,6 +131,8 @@ class StreamingSink
      * This is used to verify the authenticity of the delivery.
      *
      * For more information please refer to [the consuming webhooks docs](https://docs.svix.com/consuming-webhooks/).
+     *
+     * @throws ApiException
      */
     public function getSecret(
         string $streamId,
@@ -117,7 +144,11 @@ class StreamingSink
         return SinkSecretOut::fromJson($res);
     }
 
-    /** Rotates the signing secret (only supported for http sinks). */
+    /**
+     * Rotates the signing secret (only supported for http sinks).
+     *
+     * @throws ApiException
+     */
     public function rotateSecret(
         string $streamId,
         string $sinkId,
@@ -134,7 +165,11 @@ class StreamingSink
         return EmptyResponse::fromJson($res);
     }
 
-    /** Set or unset the transformation code associated with this sink. */
+    /**
+     * Set or unset the transformation code associated with this sink.
+     *
+     * @throws ApiException
+     */
     public function transformationPartialUpdate(
         string $streamId,
         string $sinkId,

--- a/php/src/Api/StreamingStream.php
+++ b/php/src/Api/StreamingStream.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace Svix\Api;
 
+use Svix\Exception\ApiException;
 use Svix\Models\ListResponseStreamOut;
 use Svix\Models\StreamIn;
 use Svix\Models\StreamOut;
@@ -18,7 +19,11 @@ class StreamingStream
     ) {
     }
 
-    /** List of all the organization's streams. */
+    /**
+     * List of all the organization's streams.
+     *
+     * @throws ApiException
+     */
     public function list(
         ?StreamingStreamListOptions $options = null,
     ): ListResponseStreamOut {
@@ -33,7 +38,11 @@ class StreamingStream
         return ListResponseStreamOut::fromJson($res);
     }
 
-    /** Creates a new stream. */
+    /**
+     * Creates a new stream.
+     *
+     * @throws ApiException
+     */
     public function create(
         StreamIn $streamIn,
         ?StreamingStreamCreateOptions $options = null,
@@ -48,7 +57,11 @@ class StreamingStream
         return StreamOut::fromJson($res);
     }
 
-    /** Get a stream by id or uid. */
+    /**
+     * Get a stream by id or uid.
+     *
+     * @throws ApiException
+     */
     public function get(
         string $streamId,
     ): StreamOut {
@@ -58,7 +71,11 @@ class StreamingStream
         return StreamOut::fromJson($res);
     }
 
-    /** Update a stream. */
+    /**
+     * Update a stream.
+     *
+     * @throws ApiException
+     */
     public function update(
         string $streamId,
         StreamIn $streamIn,
@@ -70,7 +87,11 @@ class StreamingStream
         return StreamOut::fromJson($res);
     }
 
-    /** Delete a stream. */
+    /**
+     * Delete a stream.
+     *
+     * @throws ApiException
+     */
     public function delete(
         string $streamId,
     ): void {
@@ -78,7 +99,11 @@ class StreamingStream
         $res = $this->client->sendNoResponseBody($request);
     }
 
-    /** Partially update a stream. */
+    /**
+     * Partially update a stream.
+     *
+     * @throws ApiException
+     */
     public function patch(
         string $streamId,
         StreamPatch $streamPatch,

--- a/php/src/Request/SvixHttpClient.php
+++ b/php/src/Request/SvixHttpClient.php
@@ -32,18 +32,26 @@ class SvixHttpClient
         return new SvixRequest($method, $url);
     }
 
+    /**
+     * @throws ApiException
+     */
     public function send(SvixRequest $req): ?string
     {
         $response = $this->sendInner($req);
         return $response['body'];
     }
 
+    /**
+     * @throws ApiException
+     */
     public function sendNoResponseBody(SvixRequest $req): void
     {
         $this->sendInner($req);
     }
 
-
+    /**
+     * @throws ApiException
+     */
     private function sendInner(SvixRequest $req): array
     {
         // Set idempotency key for POST requests

--- a/php/src/Webhook.php
+++ b/php/src/Webhook.php
@@ -23,6 +23,10 @@ class Webhook
         return $obj;
     }
 
+    /**
+     * @throws Exception\WebhookVerificationException
+     * @throws Exception\WebhookSigningException
+     */
     public function verify($payload, $headers)
     {
         if (
@@ -73,6 +77,9 @@ class Webhook
         throw new Exception\WebhookVerificationException("No matching signature found");
     }
 
+    /**
+     * @throws Exception\WebhookSigningException
+     */
     public function sign($msgId, $timestamp, $payload)
     {
         if (!$this->isPositiveInteger($timestamp)) {
@@ -84,6 +91,9 @@ class Webhook
         return "v1,{$signature}";
     }
 
+    /**
+     * @throws Exception\WebhookVerificationException
+     */
     private function verifyTimestamp($timestampHeader)
     {
         $now = time();


### PR DESCRIPTION
## Motivation

Hi, the actual class methods are missing `@throws` phpdoc to explains which exception are thrown.
This is useful
- To know quickly what should be caught
- To have an alert from PHPStorm for uncaught exception
- To have an alert from Static analysis tool like PHPStan about uncaught exception

Currently when I try to `try/catch` some of svix code, PHPStan report that no exception are thrown because of the wrong PHPDoc.

## Solution

I update the phpdoc to show the expected result, but I also so some files are auto-generated, so I dunno where/what should be changed instead.

Could you help me on this @svix-lucho @svix-jbrown @svix-jplatte (I pinged some recent commiters, feel free to redirect me to the right person).

Thanks