### PR TITLE
csharp: use Random.Shared for svix-req-id

### DIFF
--- a/csharp/Svix/SvixHttpClient.cs
+++ b/csharp/Svix/SvixHttpClient.cs
@@ -65,7 +65,7 @@ namespace Svix
             }
 
             byte[] randomBytes = new byte[8];
-            new Random().NextBytes(randomBytes);
+            Random.Shared.NextBytes(randomBytes);
             ulong req_id = BitConverter.ToUInt64(randomBytes, 0);
 
             // In C# they don't let you send the same request twice :(


### PR DESCRIPTION
## Motivation

`SvixHttpClient.SendRequestAsync` builds the `svix-req-id` header from `new Random().NextBytes(...)`. Two issues with that:

1. `new Random()` (no seed) is seeded from the system clock. Two requests fired from different threads in the same tick will get the same seed and produce the same 8 bytes, so the req_id collides. The header is used for log correlation, so collisions silently make it harder to trace a single request through the pipeline.
2. It allocates a fresh `Random` per request when we don't need to.

The Java SDK already uses `ThreadLocalRandom.current()` for the same header (svix-libs/.../SvixHttpClient.java:69), which avoids both problems.

## Solution

Swap `new Random().NextBytes(...)` for `Random.Shared.NextBytes(...)`. `Random.Shared` is the recommended thread-safe singleton on .NET 6+ and the csproj already targets net8.0, so no version bump needed.

Not switching to `RandomNumberGenerator` / SecureRandom because the req_id is correlation metadata, not security-sensitive, so the slower path would be the wrong trade.