### PR TITLE
update client libraries with latest API spec

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,3 @@
+[formatting]
+align_entries = false
+indent_string = "    "

--- a/codegen/codegen.toml
+++ b/codegen/codegen.toml
@@ -3,7 +3,10 @@ input_files = ["lib-openapi.json", "api_extra.ron"]
 
 [rust]
 extra_mounts = { "rust/.rustfmt.toml" = "/app/.rustfmt.toml" }
-extra_codegen_args = ["-e=v1.health.get"]
+extra_codegen_args = [
+    "-e=v1.health.get",
+    "--include-op-id=v1.authentication.whoami",
+]
 [[rust.task]]
 template = "templates/rust/api_resource.rs.jinja"
 output_dir = "rust/src/api"
@@ -14,20 +17,22 @@ output_dir = "rust/src/api"
 template = "templates/rust/component_type_summary.rs.jinja"
 output_dir = "rust/src/models"
 extra_codegen_args = [
-   "--include-op-id=v1.endpoint.auto-config.update",
+    "--include-op-id=v1.endpoint.auto-config.update",
+    "--include-op-id=v1.authentication.whoami",
 ]
 [[rust.task]]
 template = "templates/rust/component_type.rs.jinja"
 output_dir = "rust/src/models"
 extra_codegen_args = [
-   "--include-op-id=v1.endpoint.auto-config.update",
+    "--include-op-id=v1.endpoint.auto-config.update",
+    "--include-op-id=v1.authentication.whoami",
 ]
 [[rust.task]]
 template = "templates/rust/api_resource.rs.jinja"
 output_dir = "rust/src/api_internal"
 extra_codegen_args = [
-   "--include-mode=only-specified",
-   "--include-op-id=v1.endpoint.auto-config.update"
+    "--include-mode=only-specified",
+    "--include-op-id=v1.endpoint.auto-config.update",
 ]
 
 [javascript]
@@ -40,9 +45,7 @@ output_dir = "javascript/src/models"
 [[javascript.task]]
 template = "templates/javascript/component_type.ts.jinja"
 output_dir = "javascript/src/models"
-extra_codegen_args = [
-   "--include-op-id=v1.endpoint.auto-config.update"
-]
+extra_codegen_args = ["--include-op-id=v1.endpoint.auto-config.update"]
 [[javascript.task]]
 template = "templates/javascript/summary.ts.jinja"
 output_dir = "javascript/src"
@@ -50,23 +53,32 @@ output_dir = "javascript/src"
 template = "templates/javascript/api_resource.ts.jinja"
 output_dir = "javascript/src/api_internal"
 extra_codegen_args = [
-   "--include-mode=only-specified",
-   "--include-op-id=v1.endpoint.auto-config.update"
+    "--include-mode=only-specified",
+    "--include-op-id=v1.endpoint.auto-config.update",
 ]
 
 
 [cli]
 extra_mounts = { "svix-cli/.rustfmt.toml" = "/app/.rustfmt.toml" }
 extra_codegen_args = [
-   "-e=v1.background-task.list",
-   "-e=v1.background-task.get",
-   "-e=v1.health.get",
-   "-e=v1.statistics.aggregate-event-types",
-   "-e=v1.statistics.aggregate-app-stats",
+    "-e=v1.background-task.list",
+    "-e=v1.background-task.get",
+    "-e=v1.health.get",
+    "-e=v1.statistics.aggregate-event-types",
+    "-e=v1.statistics.aggregate-app-stats",
+    "--include-op-id=v1.authentication.whoami",
 ]
 [[cli.task]]
 template = "templates/svix-cli/api_resource.rs.jinja"
 output_dir = "svix-cli/src/cmds/api"
+extra_codegen_args = [
+    "-e=v1.background-task.list",
+    "-e=v1.background-task.get",
+    "-e=v1.health.get",
+    "-e=v1.statistics.aggregate-event-types",
+    "-e=v1.statistics.aggregate-app-stats",
+    "--include-op-id=v1.authentication.whoami",
+]
 
 
 [python]
@@ -77,15 +89,11 @@ output_dir = "python/svix/api"
 [[python.task]]
 template = "templates/python/component_type_summary.py.jinja"
 output_dir = "python/svix/models"
-extra_codegen_args = [
-   "--include-op-id=v1.endpoint.auto-config.update"
-]
+extra_codegen_args = ["--include-op-id=v1.endpoint.auto-config.update"]
 [[python.task]]
 template = "templates/python/component_type.py.jinja"
 output_dir = "python/svix/models"
-extra_codegen_args = [
-   "--include-op-id=v1.endpoint.auto-config.update"
-]
+extra_codegen_args = ["--include-op-id=v1.endpoint.auto-config.update"]
 [[python.task]]
 template = "templates/python/api_summary.py.jinja"
 output_dir = "python/svix/api"
@@ -96,8 +104,8 @@ output_dir = "python/svix/api"
 template = "templates/python/api_resource.py.jinja"
 output_dir = "python/svix/api_internal"
 extra_codegen_args = [
-   "--include-mode=only-specified",
-   "--include-op-id=v1.endpoint.auto-config.update"
+    "--include-mode=only-specified",
+    "--include-op-id=v1.endpoint.auto-config.update",
 ]
 
 [ruby]
@@ -110,21 +118,19 @@ output_dir = "ruby/lib"
 [[ruby.task]]
 template = "templates/ruby/component_type.rb.jinja"
 output_dir = "ruby/lib/svix/models"
-extra_codegen_args = [
-   "--include-op-id=v1.endpoint.auto-config.update",
-]
+extra_codegen_args = ["--include-op-id=v1.endpoint.auto-config.update"]
 [[ruby.task]]
 template = "templates/ruby/api_resource.rb.jinja"
 output_dir = "ruby/lib/svix/api_internal"
 extra_codegen_args = [
-   "--include-mode=only-specified",
-   "--include-op-id=v1.endpoint.auto-config.update"
+    "--include-mode=only-specified",
+    "--include-op-id=v1.endpoint.auto-config.update",
 ]
 
 
 [csharp]
 extra_shell_commands = [
-   "perl -pi -e 's/namespace Svix/namespace Svix.ApiInternal/g' csharp/Svix/ApiInternal/*.cs",
+    "perl -pi -e 's/namespace Svix/namespace Svix.ApiInternal/g' csharp/Svix/ApiInternal/*.cs",
 ]
 [[csharp.task]]
 template = "templates/csharp/api_resource.cs.jinja"
@@ -132,21 +138,19 @@ output_dir = "csharp/Svix"
 [[csharp.task]]
 template = "templates/csharp/component_type.cs.jinja"
 output_dir = "csharp/Svix/Models"
-extra_codegen_args = [
-   "--include-op-id=v1.endpoint.auto-config.update"
-]
+extra_codegen_args = ["--include-op-id=v1.endpoint.auto-config.update"]
 [[csharp.task]]
 template = "templates/csharp/api_resource.cs.jinja"
 output_dir = "csharp/Svix/ApiInternal"
 extra_codegen_args = [
-   "--include-mode=only-specified",
-   "--include-op-id=v1.endpoint.auto-config.update"
+    "--include-mode=only-specified",
+    "--include-op-id=v1.endpoint.auto-config.update",
 ]
 
 
 [java]
 extra_shell_commands = [
-   "perl -pi -e 's/package com\\.svix\\.api/package com.svix.internalapi/g' java/lib/src/main/java/com/svix/internalapi/*.java",
+    "perl -pi -e 's/package com\\.svix\\.api/package com.svix.internalapi/g' java/lib/src/main/java/com/svix/internalapi/*.java",
 ]
 [[java.task]]
 template = "templates/java/api_resource.java.jinja"
@@ -157,21 +161,19 @@ output_dir = "java/lib/src/main/java/com/svix/api"
 [[java.task]]
 template = "templates/java/component_type.java.jinja"
 output_dir = "java/lib/src/main/java/com/svix/models"
-extra_codegen_args = [
-   "--include-op-id=v1.endpoint.auto-config.update"
-]
+extra_codegen_args = ["--include-op-id=v1.endpoint.auto-config.update"]
 [[java.task]]
 template = "templates/java/api_resource.java.jinja"
 output_dir = "java/lib/src/main/java/com/svix/internalapi"
 extra_codegen_args = [
-   "--include-mode=only-specified",
-   "--include-op-id=v1.endpoint.auto-config.update"
+    "--include-mode=only-specified",
+    "--include-op-id=v1.endpoint.auto-config.update",
 ]
 
 [go]
 extra_shell_commands = [
-   "perl -pi -e 's/package svix/package internalapi/g' go/internalapi/management*",
-   "perl -pi -e 's/package svix/package internalapi/g' go/internalapi/endpoint*",
+    "perl -pi -e 's/package svix/package internalapi/g' go/internalapi/management*",
+    "perl -pi -e 's/package svix/package internalapi/g' go/internalapi/endpoint*",
 ]
 extra_codegen_args = ["-e=v1.health.get"]
 
@@ -188,39 +190,39 @@ output_dir = "go"
 template = "templates/go/component_type.go.jinja"
 output_dir = "go/models"
 extra_codegen_args = [
-   # This is a limited list of operations required by terraform
-   "--include-op-id=v1.management.environment.list",
-   "--include-op-id=v1.management.environment.create",
-   "--include-op-id=v1.management.environment.get",
-   "--include-op-id=v1.management.environment.update",
-   "--include-op-id=v1.management.environment.delete",
-   "--include-op-id=v1.management.environment-settings.get",
-   "--include-op-id=v1.management.environment-settings.update",
-   "--include-op-id=v1.management.environment-settings.patch",
-   "--include-op-id=v1.management.authentication.create-api-token",
-   "--include-op-id=v1.management.authentication.expire-api-token",
-   "--include-op-id=v1.management.authentication.patch-api-token",
-   "--include-op-id=v1.endpoint.auto-config.update"
+    # This is a limited list of operations required by terraform
+    "--include-op-id=v1.management.environment.list",
+    "--include-op-id=v1.management.environment.create",
+    "--include-op-id=v1.management.environment.get",
+    "--include-op-id=v1.management.environment.update",
+    "--include-op-id=v1.management.environment.delete",
+    "--include-op-id=v1.management.environment-settings.get",
+    "--include-op-id=v1.management.environment-settings.update",
+    "--include-op-id=v1.management.environment-settings.patch",
+    "--include-op-id=v1.management.authentication.create-api-token",
+    "--include-op-id=v1.management.authentication.expire-api-token",
+    "--include-op-id=v1.management.authentication.patch-api-token",
+    "--include-op-id=v1.endpoint.auto-config.update",
 ]
 [[go.task]]
 template = "templates/go/api_resource.go.jinja"
 output_dir = "go/internalapi"
 input_files = ["lib-openapi.json"]
 extra_codegen_args = [
-   # This is a limited list of operations required by terraform
-   "--include-mode=only-specified",
-   "--include-op-id=v1.management.environment.list",
-   "--include-op-id=v1.management.environment.create",
-   "--include-op-id=v1.management.environment.get",
-   "--include-op-id=v1.management.environment.update",
-   "--include-op-id=v1.management.environment.delete",
-   "--include-op-id=v1.management.environment-settings.get",
-   "--include-op-id=v1.management.environment-settings.update",
-   "--include-op-id=v1.management.environment-settings.patch",
-   "--include-op-id=v1.management.authentication.create-api-token",
-   "--include-op-id=v1.management.authentication.expire-api-token",
-   "--include-op-id=v1.management.authentication.patch-api-token",
-   "--include-op-id=v1.endpoint.auto-config.update"
+    # This is a limited list of operations required by terraform
+    "--include-mode=only-specified",
+    "--include-op-id=v1.management.environment.list",
+    "--include-op-id=v1.management.environment.create",
+    "--include-op-id=v1.management.environment.get",
+    "--include-op-id=v1.management.environment.update",
+    "--include-op-id=v1.management.environment.delete",
+    "--include-op-id=v1.management.environment-settings.get",
+    "--include-op-id=v1.management.environment-settings.update",
+    "--include-op-id=v1.management.environment-settings.patch",
+    "--include-op-id=v1.management.authentication.create-api-token",
+    "--include-op-id=v1.management.authentication.expire-api-token",
+    "--include-op-id=v1.management.authentication.patch-api-token",
+    "--include-op-id=v1.endpoint.auto-config.update",
 ]
 
 
@@ -236,26 +238,26 @@ output_dir = "kotlin/lib/src/main/kotlin"
 
 [php]
 extra_shell_commands = [
-   "perl -pi -e 's/^namespace Svix\\\\Api;/namespace Svix\\\\ApiInternal;/g' php/src/ApiInternal/*.php",
+    "perl -pi -e 's/^namespace Svix\\\\Api;/namespace Svix\\\\ApiInternal;/g' php/src/ApiInternal/*.php",
 ]
 extra_codegen_args = [
-   # ingest requires struct enums and is excluded from initial release
-   "--exclude-op-id=v1.ingest.source.list",
-   "--exclude-op-id=v1.ingest.source.create",
-   "--exclude-op-id=v1.ingest.source.get",
-   "--exclude-op-id=v1.ingest.source.update",
-   "--exclude-op-id=v1.ingest.source.delete",
+    # ingest requires struct enums and is excluded from initial release
+    "--exclude-op-id=v1.ingest.source.list",
+    "--exclude-op-id=v1.ingest.source.create",
+    "--exclude-op-id=v1.ingest.source.get",
+    "--exclude-op-id=v1.ingest.source.update",
+    "--exclude-op-id=v1.ingest.source.delete",
 ]
 [[php.task]]
 template = "templates/php/component_type.php.jinja"
 output_dir = "php/src/Models"
 extra_codegen_args = [
-   "--exclude-op-id=v1.ingest.source.list",
-   "--exclude-op-id=v1.ingest.source.create",
-   "--exclude-op-id=v1.ingest.source.get",
-   "--exclude-op-id=v1.ingest.source.update",
-   "--exclude-op-id=v1.ingest.source.delete",
-   "--include-op-id=v1.endpoint.auto-config.update"
+    "--exclude-op-id=v1.ingest.source.list",
+    "--exclude-op-id=v1.ingest.source.create",
+    "--exclude-op-id=v1.ingest.source.get",
+    "--exclude-op-id=v1.ingest.source.update",
+    "--exclude-op-id=v1.ingest.source.delete",
+    "--include-op-id=v1.endpoint.auto-config.update",
 ]
 [[php.task]]
 template = "templates/php/api_resource.php.jinja"
@@ -264,8 +266,8 @@ output_dir = "php/src/Api"
 template = "templates/php/api_resource.php.jinja"
 output_dir = "php/src/ApiInternal"
 extra_codegen_args = [
-   "--include-mode=only-specified",
-   "--include-op-id=v1.endpoint.auto-config.update"
+    "--include-mode=only-specified",
+    "--include-op-id=v1.endpoint.auto-config.update",
 ]
 [[php.task]]
 template = "templates/php/operation_options.php.jinja"

--- a/codegen/generated_files.json
+++ b/codegen/generated_files.json
@@ -2171,6 +2171,7 @@
         "rust/src/models/application_out.rs",
         "rust/src/models/application_patch.rs",
         "rust/src/models/application_token_expire_in.rs",
+        "rust/src/models/authentication_source.rs",
         "rust/src/models/azure_blob_storage_config.rs",
         "rust/src/models/azure_blob_storage_patch_config.rs",
         "rust/src/models/background_task_finished_event.rs",
@@ -2371,6 +2372,7 @@
         "rust/src/models/veriff_config_out.rs",
         "rust/src/models/vgs_config.rs",
         "rust/src/models/vgs_config_out.rs",
+        "rust/src/models/whoami_out.rs",
         "rust/src/models/zoom_config.rs",
         "rust/src/models/zoom_config_out.rs"
     ],

--- a/codegen/lib-openapi.json
+++ b/codegen/lib-openapi.json
@@ -923,6 +923,17 @@
                 ],
                 "type": "object"
             },
+            "AuthenticationSource": {
+                "description": "The authentication type of the current request",
+                "enum": [
+                    "OidcJwt",
+                    "SvixJwt",
+                    "RegionalAuthToken",
+                    "GlobalAuthToken",
+                    "Unknown"
+                ],
+                "type": "string"
+            },
             "AutoConfigCensoredOut": {
                 "properties": {
                     "endpId": {
@@ -1253,6 +1264,10 @@
             "CompletionMessage": {
                 "properties": {
                     "content": {
+                        "type": "string"
+                    },
+                    "refusal": {
+                        "nullable": true,
                         "type": "string"
                     },
                     "role": {
@@ -3374,6 +3389,13 @@
                         "format": "date-time",
                         "nullable": true,
                         "type": "string"
+                    },
+                    "variables": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "nullable": true,
+                        "type": "object"
                     }
                 },
                 "type": "object"
@@ -3389,6 +3411,13 @@
                     },
                     "enabled": {
                         "type": "boolean"
+                    },
+                    "variables": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "nullable": true,
+                        "type": "object"
                     }
                 },
                 "type": "object"
@@ -9957,6 +9986,10 @@
                         "default": true,
                         "type": "boolean"
                     },
+                    "webhooksAutoConfig": {
+                        "default": false,
+                        "type": "boolean"
+                    },
                     "whitelabelHeaders": {
                         "default": false,
                         "type": "boolean"
@@ -10125,6 +10158,10 @@
                         "default": true,
                         "type": "boolean"
                     },
+                    "webhooksAutoConfig": {
+                        "default": false,
+                        "type": "boolean"
+                    },
                     "whitelabelHeaders": {
                         "default": false,
                         "type": "boolean"
@@ -10274,6 +10311,9 @@
                         "type": "boolean"
                     },
                     "showUseSvixPlay": {
+                        "type": "boolean"
+                    },
+                    "webhooksAutoConfig": {
                         "type": "boolean"
                     },
                     "whitelabelHeaders": {
@@ -10436,6 +10476,10 @@
                     },
                     "showUseSvixPlay": {
                         "default": true,
+                        "type": "boolean"
+                    },
+                    "webhooksAutoConfig": {
+                        "default": false,
                         "type": "boolean"
                     },
                     "whitelabelHeaders": {
@@ -11965,6 +12009,54 @@
             "VgsConfigOut": {
                 "type": "object"
             },
+            "WhoamiOut": {
+                "properties": {
+                    "appId": {
+                        "description": "The dispatch application that the current token is limited to, if there is one",
+                        "example": "app_1srOrx2ZWZBpBUvZwXKQmoEYga2",
+                        "maxLength": 31,
+                        "minLength": 31,
+                        "nullable": true,
+                        "pattern": "^app_[A-Za-z0-9]{27}$",
+                        "type": "string"
+                    },
+                    "envId": {
+                        "description": "The environment (\"organization\") that the current token is attached to",
+                        "example": "org_1srOrx2ZWZBpBUvZwXKQmoEYga2",
+                        "maxLength": 31,
+                        "minLength": 31,
+                        "nullable": true,
+                        "pattern": "^org_[A-Za-z0-9]{27}$",
+                        "type": "string"
+                    },
+                    "permissionSource": {
+                        "$ref": "#/components/schemas/AuthenticationSource",
+                        "description": "The source of the current request's authentication\n\nThis field is unstable and may change in the future."
+                    },
+                    "sessionId": {
+                        "description": "The session associated with the current request",
+                        "example": "user_1FB8",
+                        "maxLength": 64,
+                        "minLength": 1,
+                        "nullable": true,
+                        "pattern": "^[a-zA-Z0-9@_-]+$",
+                        "type": "string"
+                    },
+                    "streamAppId": {
+                        "description": "The stream application that the current token is limited to, if there is one",
+                        "example": "strm_2yZwUhtgs5Ai8T9yRQJXA",
+                        "maxLength": 27,
+                        "minLength": 26,
+                        "nullable": true,
+                        "pattern": "^strm_[A-Za-z0-9]{21,22}$",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "permissionSource"
+                ],
+                "type": "object"
+            },
             "ZoomConfig": {
                 "properties": {
                     "secret": {
@@ -12006,7 +12098,7 @@
     "info": {
         "description": "Welcome to the Svix API documentation!\n\nUseful links: [Homepage](https://www.svix.com) | [Support email](mailto:support+docs@svix.com) | [Blog](https://www.svix.com/blog/) | [Slack Community](https://www.svix.com/slack/)\n\n# Introduction\n\nThis is the reference documentation and schemas for the [Svix webhook service](https://www.svix.com) API. For tutorials and other documentation please refer to [the documentation](https://docs.svix.com).\n\n## Main concepts\n\nIn Svix you have four important entities you will be interacting with:\n\n- `messages`: these are the webhooks being sent. They can have contents and a few other properties.\n- `application`: this is where `messages` are sent to. Usually you want to create one application for each user on your platform.\n- `endpoint`: endpoints are the URLs messages will be sent to. Each application can have multiple `endpoints` and each message sent to that application will be sent to all of them (unless they are not subscribed to the sent event type).\n- `event-type`: event types are identifiers denoting the type of the message being sent. Event types are primarily used to decide which events are sent to which endpoint.\n\n\n## Authentication\n\nGet your authentication token (`AUTH_TOKEN`) from the [Svix dashboard](https://dashboard.svix.com) and use it as part of the `Authorization` header as such: `Authorization: Bearer ${AUTH_TOKEN}`. For more information on authentication, please refer to the [authentication token docs](https://docs.svix.com/api-keys).\n\n<SecurityDefinitions />\n\n\n## Code samples\n\nThe code samples assume you already have the respective libraries installed and you know how to use them. For the latest information on how to do that, please refer to [the documentation](https://docs.svix.com/).\n\n\n## Idempotency\n\nSvix supports [idempotency](https://en.wikipedia.org/wiki/Idempotence) for safely retrying requests without accidentally performing the same operation twice. This is useful when an API call is disrupted in transit and you do not receive a response.\n\nTo perform an idempotent request, pass the idempotency key in the `Idempotency-Key` header to the request. The idempotency key should be a unique value generated by the client. You can create the key in however way you like, though we suggest using UUID v4, or any other string with enough entropy to avoid collisions. Your idempotency key should not begin with the string `auto_`, which is reserved for internal use by the client libraries.\n\nSvix's idempotency works by saving the resulting status code and body of the first request made for any given idempotency key for any successful request. Subsequent requests with the same key return the same result for a period of up to 12 hours.\n\nPlease note that idempotency is only supported for `POST` requests.\n\n\n## Cross-Origin Resource Sharing\n\nThis API features Cross-Origin Resource Sharing (CORS) implemented in compliance with [W3C spec](https://www.w3.org/TR/cors/). And that allows cross-domain communication from the browser. All responses have a wildcard same-origin which makes them completely public and accessible to everyone, including any code on any site.\n",
         "title": "Svix API",
-        "version": "1.94.0",
+        "version": "1.84.0",
         "x-logo": {
             "altText": "Svix Logo",
             "url": "https://www.svix.com/static/img/brand-padded.svg"
@@ -12186,7 +12278,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.application.list();"
                     },
                     {
@@ -12201,7 +12293,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.application.list()"
                     },
                     {
@@ -12241,12 +12333,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix application list"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/app' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -12390,7 +12482,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.application.create({\n  name: \"My first application\",\n  rateLimit: 1,\n  throttleRate: 1,\n  uid: \"unique-identifier\",\n  metadata: {},\n});"
                     },
                     {
@@ -12405,7 +12497,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.application.create(\n    ApplicationIn(\n        name=\"My first application\",\n        rate_limit=1,\n        throttle_rate=1,\n        uid=\"unique-identifier\",\n        metadata={},\n    ),\n)"
                     },
                     {
@@ -12445,12 +12537,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix application create '{\n    \"metadata\": {},\n    \"name\": \"My first application\",\n    \"rateLimit\": 1,\n    \"throttleRate\": 1,\n    \"uid\": \"unique-identifier\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/app' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"metadata\": {},\n    \"name\": \"My first application\",\n    \"rateLimit\": 1,\n    \"throttleRate\": 1,\n    \"uid\": \"unique-identifier\"\n  }'"
                     }
                 ]
@@ -12564,7 +12656,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.application.delete(\"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\");"
                     },
                     {
@@ -12579,7 +12671,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.application.delete(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n)"
                     },
                     {
@@ -12619,12 +12711,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix application delete \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'DELETE' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2' \\\n  -H 'Authorization: Bearer AUTH_TOKEN'"
                     }
                 ]
@@ -12743,7 +12835,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.application.get(\"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\");"
                     },
                     {
@@ -12758,7 +12850,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.application.get(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n)"
                     },
                     {
@@ -12798,12 +12890,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix application get \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -12932,7 +13024,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.application.patch(\"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\", {\n  name: \"sample string\",\n  rateLimit: 1,\n  throttleRate: 1,\n  uid: \"unique-identifier\",\n  metadata: {},\n});"
                     },
                     {
@@ -12947,7 +13039,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.application.patch(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    ApplicationPatch(\n        name=\"sample string\",\n        rate_limit=1,\n        throttle_rate=1,\n        uid=\"unique-identifier\",\n        metadata={},\n    ),\n)"
                     },
                     {
@@ -12987,12 +13079,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix application patch \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" '{\n    \"metadata\": {},\n    \"name\": \"sample string\",\n    \"rateLimit\": 1,\n    \"throttleRate\": 1,\n    \"uid\": \"unique-identifier\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PATCH' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"metadata\": {},\n    \"name\": \"sample string\",\n    \"rateLimit\": 1,\n    \"throttleRate\": 1,\n    \"uid\": \"unique-identifier\"\n  }'"
                     }
                 ]
@@ -13131,7 +13223,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.application.update(\"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\", {\n  name: \"My first application\",\n  rateLimit: 1,\n  throttleRate: 1,\n  uid: \"unique-identifier\",\n  metadata: {},\n});"
                     },
                     {
@@ -13146,7 +13238,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.application.update(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    ApplicationIn(\n        name=\"My first application\",\n        rate_limit=1,\n        throttle_rate=1,\n        uid=\"unique-identifier\",\n        metadata={},\n    ),\n)"
                     },
                     {
@@ -13186,12 +13278,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix application update \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" '{\n    \"metadata\": {},\n    \"name\": \"My first application\",\n    \"rateLimit\": 1,\n    \"throttleRate\": 1,\n    \"uid\": \"unique-identifier\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PUT' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"metadata\": {},\n    \"name\": \"My first application\",\n    \"rateLimit\": 1,\n    \"throttleRate\": 1,\n    \"uid\": \"unique-identifier\"\n  }'"
                     }
                 ]
@@ -13601,7 +13693,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.messageAttempt.listByEndpoint(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\"\n);"
                     },
                     {
@@ -13616,7 +13708,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.message_attempt.list_by_endpoint(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n)"
                     },
                     {
@@ -13656,12 +13748,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix message-attempt list-by-endpoint \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/attempt/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -14182,7 +14274,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.messageAttempt.listByMsg(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f\"\n);"
                     },
                     {
@@ -14197,7 +14289,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.message_attempt.list_by_msg(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f\",\n)"
                     },
                     {
@@ -14237,12 +14329,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix message-attempt list-by-msg \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/attempt/msg/msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -14526,7 +14618,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.endpoint.list(\"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\");"
                     },
                     {
@@ -14541,7 +14633,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.endpoint.list(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n)"
                     },
                     {
@@ -14581,12 +14673,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix endpoint list \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/endpoint' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -14724,7 +14816,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.endpoint.create(\"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\", {\n  description: \"An example endpoint name\",\n  rateLimit: 1,\n  throttleRate: 1,\n  uid: \"unique-identifier\",\n  url: \"https://example.com/webhook/\",\n  headers: { \"X-Example\": \"123\", \"X-Foobar\": \"Bar\" },\n  disabled: true,\n  filterTypes: [\"user.signup\", \"user.deleted\"],\n  channels: [\"project_123\", \"group_2\"],\n  secret: \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",\n  metadata: {},\n});"
                     },
                     {
@@ -14739,7 +14831,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.endpoint.create(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    EndpointIn(\n        description=\"An example endpoint name\",\n        rate_limit=1,\n        throttle_rate=1,\n        uid=\"unique-identifier\",\n        url=\"https://example.com/webhook/\",\n        headers={\"X-Example\": \"123\", \"X-Foobar\": \"Bar\"},\n        disabled=True,\n        filter_types=[\n            \"user.signup\",\n            \"user.deleted\",\n        ],\n        channels=[\n            \"project_123\",\n            \"group_2\",\n        ],\n        secret=\"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",\n        metadata={},\n    ),\n)"
                     },
                     {
@@ -14779,12 +14871,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix endpoint create \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" '{\n    \"channels\": [\n      \"project_123\",\n      \"group_2\"\n    ],\n    \"description\": \"An example endpoint name\",\n    \"disabled\": true,\n    \"filterTypes\": [\n      \"user.signup\",\n      \"user.deleted\"\n    ],\n    \"headers\": {\n      \"X-Example\": \"123\",\n      \"X-Foobar\": \"Bar\"\n    },\n    \"metadata\": {},\n    \"rateLimit\": 1,\n    \"secret\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",\n    \"throttleRate\": 1,\n    \"uid\": \"unique-identifier\",\n    \"url\": \"https://example.com/webhook/\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/endpoint' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"channels\": [\n      \"project_123\",\n      \"group_2\"\n    ],\n    \"description\": \"An example endpoint name\",\n    \"disabled\": true,\n    \"filterTypes\": [\n      \"user.signup\",\n      \"user.deleted\"\n    ],\n    \"headers\": {\n      \"X-Example\": \"123\",\n      \"X-Foobar\": \"Bar\"\n    },\n    \"metadata\": {},\n    \"rateLimit\": 1,\n    \"secret\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",\n    \"throttleRate\": 1,\n    \"uid\": \"unique-identifier\",\n    \"url\": \"https://example.com/webhook/\"\n  }'"
                     }
                 ]
@@ -14913,7 +15005,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.endpoint.delete(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\"\n);"
                     },
                     {
@@ -14928,7 +15020,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.endpoint.delete(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n)"
                     },
                     {
@@ -14968,12 +15060,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix endpoint delete \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'DELETE' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1' \\\n  -H 'Authorization: Bearer AUTH_TOKEN'"
                     }
                 ]
@@ -15107,7 +15199,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.endpoint.get(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\"\n);"
                     },
                     {
@@ -15122,7 +15214,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.endpoint.get(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n)"
                     },
                     {
@@ -15162,12 +15254,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix endpoint get \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -15311,7 +15403,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.endpoint.patch(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n  {\n    description: \"sample string\",\n    rateLimit: 1,\n    throttleRate: 1,\n    uid: \"unique-identifier\",\n    url: \"sample string\",\n    metadata: {},\n    disabled: true,\n    filterTypes: [],\n    channels: [],\n  }\n);"
                     },
                     {
@@ -15326,7 +15418,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.endpoint.patch(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    EndpointPatch(\n        description=\"sample string\",\n        rate_limit=1,\n        throttle_rate=1,\n        uid=\"unique-identifier\",\n        url=\"sample string\",\n        metadata={},\n        disabled=True,\n        filter_types=[],\n        channels=[],\n    ),\n)"
                     },
                     {
@@ -15366,12 +15458,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix endpoint patch \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\" '{\n    \"channels\": [],\n    \"description\": \"sample string\",\n    \"disabled\": true,\n    \"filterTypes\": [],\n    \"metadata\": {},\n    \"rateLimit\": 1,\n    \"throttleRate\": 1,\n    \"uid\": \"unique-identifier\",\n    \"url\": \"sample string\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PATCH' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"channels\": [],\n    \"description\": \"sample string\",\n    \"disabled\": true,\n    \"filterTypes\": [],\n    \"metadata\": {},\n    \"rateLimit\": 1,\n    \"throttleRate\": 1,\n    \"uid\": \"unique-identifier\",\n    \"url\": \"sample string\"\n  }'"
                     }
                 ]
@@ -15525,7 +15617,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.endpoint.update(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n  {\n    description: \"An example endpoint name\",\n    rateLimit: 1,\n    throttleRate: 1,\n    uid: \"unique-identifier\",\n    url: \"https://example.com/webhook/\",\n    metadata: {},\n    disabled: true,\n    filterTypes: [\"user.signup\", \"user.deleted\"],\n    channels: [\"project_123\", \"group_2\"],\n  }\n);"
                     },
                     {
@@ -15540,7 +15632,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.endpoint.update(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    EndpointUpdate(\n        description=\"An example endpoint name\",\n        rate_limit=1,\n        throttle_rate=1,\n        uid=\"unique-identifier\",\n        url=\"https://example.com/webhook/\",\n        metadata={},\n        disabled=True,\n        filter_types=[\n            \"user.signup\",\n            \"user.deleted\",\n        ],\n        channels=[\n            \"project_123\",\n            \"group_2\",\n        ],\n    ),\n)"
                     },
                     {
@@ -15580,12 +15672,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix endpoint update \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\" '{\n    \"channels\": [\n      \"project_123\",\n      \"group_2\"\n    ],\n    \"description\": \"An example endpoint name\",\n    \"disabled\": true,\n    \"filterTypes\": [\n      \"user.signup\",\n      \"user.deleted\"\n    ],\n    \"metadata\": {},\n    \"rateLimit\": 1,\n    \"throttleRate\": 1,\n    \"uid\": \"unique-identifier\",\n    \"url\": \"https://example.com/webhook/\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PUT' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"channels\": [\n      \"project_123\",\n      \"group_2\"\n    ],\n    \"description\": \"An example endpoint name\",\n    \"disabled\": true,\n    \"filterTypes\": [\n      \"user.signup\",\n      \"user.deleted\"\n    ],\n    \"metadata\": {},\n    \"rateLimit\": 1,\n    \"throttleRate\": 1,\n    \"uid\": \"unique-identifier\",\n    \"url\": \"https://example.com/webhook/\"\n  }'"
                     }
                 ]
@@ -16147,7 +16239,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.endpoint.bulkReplay(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n  {\n    since: new Date(\"2025-10-02T20:28:42+00:00\"),\n    until: new Date(\"2025-10-02T20:28:42+00:00\"),\n    eventTypes: [],\n    channel: \"project_1337\",\n    tag: \"project_1337\",\n    status: MessageStatus.Success,\n    statusCodeClass: StatusCodeClass.CodeNone,\n  }\n);"
                     },
                     {
@@ -16162,7 +16254,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.endpoint.bulk_replay(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    BulkReplayIn(\n        since=datetime.fromisoformat(\"2025-10-02T20:28:42+00:00\"),\n        until=datetime.fromisoformat(\"2025-10-02T20:28:42+00:00\"),\n        event_types=[],\n        channel=\"project_1337\",\n        tag=\"project_1337\",\n        status=MessageStatus.SUCCESS,\n        status_code_class=StatusCodeClass.CODE_NONE,\n    ),\n)"
                     },
                     {
@@ -16202,12 +16294,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix endpoint bulk-replay \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\" '{\n    \"channel\": \"project_1337\",\n    \"eventTypes\": [],\n    \"since\": \"2025-10-02T20:28:42+00:00\",\n    \"status\": 0,\n    \"statusCodeClass\": 0,\n    \"tag\": \"project_1337\",\n    \"until\": \"2025-10-02T20:28:42+00:00\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/bulk-replay' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"channel\": \"project_1337\",\n    \"eventTypes\": [],\n    \"since\": \"2025-10-02T20:28:42+00:00\",\n    \"status\": 0,\n    \"statusCodeClass\": 0,\n    \"tag\": \"project_1337\",\n    \"until\": \"2025-10-02T20:28:42+00:00\"\n  }'"
                     }
                 ]
@@ -16870,7 +16962,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.endpoint.getHeaders(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\"\n);"
                     },
                     {
@@ -16885,7 +16977,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.endpoint.get_headers(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n)"
                     },
                     {
@@ -16925,12 +17017,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix endpoint get-headers \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/headers' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -17067,7 +17159,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.endpoint.patchHeaders(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n  {\n    headers: { \"X-Example\": \"123\", \"X-Foobar\": \"Bar\" },\n    deleteHeaders: [],\n  }\n);"
                     },
                     {
@@ -17082,7 +17174,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.endpoint.patch_headers(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    EndpointHeadersPatchIn(\n        headers={\"X-Example\": \"123\", \"X-Foobar\": \"Bar\"},\n        delete_headers=[],\n    ),\n)"
                     },
                     {
@@ -17122,12 +17214,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix endpoint patch-headers \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\" '{\n    \"deleteHeaders\": [],\n    \"headers\": {\n      \"X-Example\": \"123\",\n      \"X-Foobar\": \"Bar\"\n    }\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PATCH' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/headers' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"deleteHeaders\": [],\n    \"headers\": {\n      \"X-Example\": \"123\",\n      \"X-Foobar\": \"Bar\"\n    }\n  }'"
                     }
                 ]
@@ -17264,7 +17356,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.endpoint.updateHeaders(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n  {\n    headers: { \"X-Example\": \"123\", \"X-Foobar\": \"Bar\" },\n  }\n);"
                     },
                     {
@@ -17279,7 +17371,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.endpoint.update_headers(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    EndpointHeadersIn(\n        headers={\"X-Example\": \"123\", \"X-Foobar\": \"Bar\"},\n    ),\n)"
                     },
                     {
@@ -17319,12 +17411,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix endpoint update-headers \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\" '{\n    \"headers\": {\n      \"X-Example\": \"123\",\n      \"X-Foobar\": \"Bar\"\n    }\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PUT' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/headers' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"headers\": {\n      \"X-Example\": \"123\",\n      \"X-Foobar\": \"Bar\"\n    }\n  }'"
                     }
                 ]
@@ -17593,7 +17685,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.messageAttempt.listAttemptedMessages(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\"\n);"
                     },
                     {
@@ -17608,7 +17700,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.message_attempt.list_attempted_messages(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n)"
                     },
                     {
@@ -17648,12 +17740,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix message-attempt list-attempted-messages \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/msg' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -19111,7 +19203,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.endpoint.recover(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n  {\n    since: new Date(\"2025-10-02T20:28:42+00:00\"),\n    until: new Date(\"2025-10-02T20:28:42+00:00\"),\n  }\n);"
                     },
                     {
@@ -19126,7 +19218,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.endpoint.recover(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    RecoverIn(\n        since=datetime.fromisoformat(\"2025-10-02T20:28:42+00:00\"),\n        until=datetime.fromisoformat(\"2025-10-02T20:28:42+00:00\"),\n    ),\n)"
                     },
                     {
@@ -19166,12 +19258,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix endpoint recover \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\" '{\n    \"since\": \"2025-10-02T20:28:42+00:00\",\n    \"until\": \"2025-10-02T20:28:42+00:00\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/recover' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"since\": \"2025-10-02T20:28:42+00:00\",\n    \"until\": \"2025-10-02T20:28:42+00:00\"\n  }'"
                     }
                 ]
@@ -19326,7 +19418,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.endpoint.replayMissing(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n  {\n    since: new Date(\"2025-10-02T20:28:42+00:00\"),\n    until: new Date(\"2025-10-02T20:28:42+00:00\"),\n  }\n);"
                     },
                     {
@@ -19341,7 +19433,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.endpoint.replay_missing(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    ReplayIn(\n        since=datetime.fromisoformat(\"2025-10-02T20:28:42+00:00\"),\n        until=datetime.fromisoformat(\"2025-10-02T20:28:42+00:00\"),\n    ),\n)"
                     },
                     {
@@ -19381,12 +19473,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix endpoint replay-missing \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\" '{\n    \"since\": \"2025-10-02T20:28:42+00:00\",\n    \"until\": \"2025-10-02T20:28:42+00:00\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/replay-missing' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"since\": \"2025-10-02T20:28:42+00:00\",\n    \"until\": \"2025-10-02T20:28:42+00:00\"\n  }'"
                     }
                 ]
@@ -19522,7 +19614,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.endpoint.getSecret(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\"\n);"
                     },
                     {
@@ -19537,7 +19629,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.endpoint.get_secret(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n)"
                     },
                     {
@@ -19577,12 +19669,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix endpoint get-secret \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/secret' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -19730,7 +19822,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.endpoint.rotateSecret(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n  {\n    key: \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",\n  }\n);"
                     },
                     {
@@ -19745,7 +19837,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.endpoint.rotate_secret(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    EndpointSecretRotateIn(\n        key=\"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",\n    ),\n)"
                     },
                     {
@@ -19785,12 +19877,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix endpoint rotate-secret \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\" '{\n    \"key\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/secret/rotate' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"key\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\"\n  }'"
                     }
                 ]
@@ -19945,7 +20037,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.endpoint.sendExample(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n  {\n    eventType: \"user.signup\",\n    exampleIndex: 1,\n  }\n);"
                     },
                     {
@@ -19960,7 +20052,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.endpoint.send_example(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    EventExampleIn(\n        event_type=\"user.signup\",\n        example_index=1,\n    ),\n)"
                     },
                     {
@@ -20000,12 +20092,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix endpoint send-example \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\" '{\n    \"eventType\": \"user.signup\",\n    \"exampleIndex\": 1\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/send-example' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"eventType\": \"user.signup\",\n    \"exampleIndex\": 1\n  }'"
                     }
                 ]
@@ -20165,7 +20257,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.endpoint.getStats(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\"\n);"
                     },
                     {
@@ -20180,7 +20272,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.endpoint.get_stats(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n)"
                     },
                     {
@@ -20220,12 +20312,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix endpoint get-stats \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/stats' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -20361,7 +20453,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.endpoint.transformationGet(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\"\n);"
                     },
                     {
@@ -20376,7 +20468,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.endpoint.transformation_get(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n)"
                     },
                     {
@@ -20416,12 +20508,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix endpoint transformation-get \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/transformation' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -20558,68 +20650,68 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
-                        "source": "await svix.endpoint.patchTransformation(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n  {\n    code: \"function handler(webhook) { /* ... */ }\",\n    enabled: true,\n  }\n);"
+                        "lang": "TypeScript",
+                        "source": "await svix.endpoint.patchTransformation(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n  {\n    code: \"function handler(webhook) { /* ... */ }\",\n    enabled: true,\n    variables: {},\n  }\n);"
                     },
                     {
                         "label": "TypeScript",
                         "lang": "TypeScript",
-                        "source": "await svix.endpoint.patchTransformation(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n  {\n    code: \"function handler(webhook) { /* ... */ }\",\n    enabled: true,\n  }\n);"
+                        "source": "await svix.endpoint.patchTransformation(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n  {\n    code: \"function handler(webhook) { /* ... */ }\",\n    enabled: true,\n    variables: {},\n  }\n);"
                     },
                     {
                         "label": "Python",
                         "lang": "Python",
-                        "source": "svix.endpoint.patch_transformation(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    EndpointTransformationPatch(\n        code=\"function handler(webhook) { /* ... */ }\",\n        enabled=True,\n    ),\n)"
+                        "source": "svix.endpoint.patch_transformation(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    EndpointTransformationPatch(\n        code=\"function handler(webhook) { /* ... */ }\",\n        enabled=True,\n        variables={},\n    ),\n)"
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
-                        "source": "await svix.endpoint.patch_transformation(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    EndpointTransformationPatch(\n        code=\"function handler(webhook) { /* ... */ }\",\n        enabled=True,\n    ),\n)"
+                        "lang": "Python",
+                        "source": "await svix.endpoint.patch_transformation(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    EndpointTransformationPatch(\n        code=\"function handler(webhook) { /* ... */ }\",\n        enabled=True,\n        variables={},\n    ),\n)"
                     },
                     {
                         "label": "Go",
                         "lang": "Go",
-                        "source": "err := svix.Endpoint.PatchTransformation(\n\tctx,\n\t\"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n\t\"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n\tEndpointTransformationPatch{\n\t\tCode:    NewNullable(\"function handler(webhook) { /* ... */ }\"),\n\t\tEnabled: new(true),\n\t},\n)"
+                        "source": "err := svix.Endpoint.PatchTransformation(\n\tctx,\n\t\"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n\t\"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n\tEndpointTransformationPatch{\n\t\tCode:      NewNullable(\"function handler(webhook) { /* ... */ }\"),\n\t\tEnabled:   new(true),\n\t\tVariables: NewNullable(nil),\n\t},\n)"
                     },
                     {
                         "label": "Kotlin",
                         "lang": "Kotlin",
-                        "source": "svix.endpoint.patchTransformation(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    EndpointTransformationPatch(\n        code = MaybeUnset.Present(\"function handler(webhook) { /* ... */ }\"),\n        enabled = true,\n    ),\n)"
+                        "source": "svix.endpoint.patchTransformation(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    EndpointTransformationPatch(\n        code = MaybeUnset.Present(\"function handler(webhook) { /* ... */ }\"),\n        enabled = true,\n        variables = MaybeUnset.Present(mapOf()),\n    ),\n)"
                     },
                     {
                         "label": "Java",
                         "lang": "Java",
-                        "source": "svix.getEndpoint()\n        .patchTransformation(\n            \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n            \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n            new EndpointTransformationPatch()\n                .code(\"function handler(webhook) { /* ... */ }\")\n                .enabled(true));"
+                        "source": "svix.getEndpoint()\n        .patchTransformation(\n            \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n            \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n            new EndpointTransformationPatch()\n                .code(\"function handler(webhook) { /* ... */ }\")\n                .enabled(true)\n                .variables(Map.of()));"
                     },
                     {
                         "label": "Ruby",
                         "lang": "Ruby",
-                        "source": "response = svix\n  .endpoint\n  .patch_transformation(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    {code: \"function handler(webhook) { /* ... */ }\", enabled: true}\n  )"
+                        "source": "response = svix\n  .endpoint\n  .patch_transformation(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    {code: \"function handler(webhook) { /* ... */ }\", enabled: true, variables: {}}\n  )"
                     },
                     {
                         "label": "Rust",
                         "lang": "Rust",
-                        "source": "svix.endpoint()\n    .patch_transformation(\n        \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\".to_string(),\n        \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\".to_string(),\n        EndpointTransformationPatch {\n            code: js_option::JsOption::Some(\n                \"function handler(webhook) { /* ... */ }\".to_string(),\n            ),\n            enabled: Some(true),\n        },\n    )\n    .await?;"
+                        "source": "svix.endpoint()\n    .patch_transformation(\n        \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\".to_string(),\n        \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\".to_string(),\n        EndpointTransformationPatch {\n            code: js_option::JsOption::Some(\n                \"function handler(webhook) { /* ... */ }\".to_string(),\n            ),\n            enabled: Some(true),\n            variables: js_option::JsOption::Some(HashMap::new()),\n        },\n    )\n    .await?;"
                     },
                     {
                         "label": "C#",
                         "lang": "C#",
-                        "source": "var response = svix.Endpoint.PatchTransformation(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    new EndpointTransformationPatch\n    {\n        Code = \"function handler(webhook) { /* ... */ }\",\n        Enabled = true,\n    }\n);"
+                        "source": "var response = svix.Endpoint.PatchTransformation(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    new EndpointTransformationPatch\n    {\n        Code = \"function handler(webhook) { /* ... */ }\",\n        Enabled = true,\n        Variables = MaybeUnset<Dictionary<string, string>?>.Set([]),\n    }\n);"
                     },
                     {
                         "label": "PHP",
                         "lang": "PHP",
-                        "source": "$svix->endpoint->patchTransformation(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    EndpointTransformationPatch::create()\n    ->withCode(\"function handler(webhook) { /* ... */ }\")\n    ->withEnabled(true)\n);"
+                        "source": "$svix->endpoint->patchTransformation(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    EndpointTransformationPatch::create()\n    ->withCode(\"function handler(webhook) { /* ... */ }\")\n    ->withEnabled(true)\n    ->withVariables([])\n);"
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
-                        "source": "svix endpoint patch-transformation \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\" '{\n    \"code\": \"function handler(webhook) { /* ... */ }\",\n    \"enabled\": true\n  }'"
+                        "lang": "Shell",
+                        "source": "svix endpoint patch-transformation \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\" '{\n    \"code\": \"function handler(webhook) { /* ... */ }\",\n    \"enabled\": true,\n    \"variables\": {}\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
-                        "source": "curl -X 'PATCH' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/transformation' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"code\": \"function handler(webhook) { /* ... */ }\",\n    \"enabled\": true\n  }'"
+                        "lang": "Shell",
+                        "source": "curl -X 'PATCH' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/transformation' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"code\": \"function handler(webhook) { /* ... */ }\",\n    \"enabled\": true,\n    \"variables\": {}\n  }'"
                     }
                 ]
             }
@@ -21237,7 +21329,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.integration.list(\"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\");"
                     },
                     {
@@ -21252,7 +21344,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.integration.list(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n)"
                     },
                     {
@@ -21292,12 +21384,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix integration list \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/integration' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -21435,7 +21527,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.integration.create(\"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\", {\n  name: \"Example Integration\",\n  featureFlags: [],\n});"
                     },
                     {
@@ -21450,7 +21542,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.integration.create(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    IntegrationIn(\n        name=\"Example Integration\",\n        feature_flags=[],\n    ),\n)"
                     },
                     {
@@ -21490,12 +21582,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix integration create \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" '{\n    \"featureFlags\": [],\n    \"name\": \"Example Integration\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/integration' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"featureFlags\": [],\n    \"name\": \"Example Integration\"\n  }'"
                     }
                 ]
@@ -21624,7 +21716,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.integration.delete(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"integ_1srOrx2ZWZBpBUvZwXKQmoEYga2\"\n);"
                     },
                     {
@@ -21639,7 +21731,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.integration.delete(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"integ_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n)"
                     },
                     {
@@ -21679,12 +21771,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix integration delete \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"integ_1srOrx2ZWZBpBUvZwXKQmoEYga2\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'DELETE' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/integration/integ_1srOrx2ZWZBpBUvZwXKQmoEYga2' \\\n  -H 'Authorization: Bearer AUTH_TOKEN'"
                     }
                 ]
@@ -21818,7 +21910,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.integration.get(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"integ_1srOrx2ZWZBpBUvZwXKQmoEYga2\"\n);"
                     },
                     {
@@ -21833,7 +21925,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.integration.get(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"integ_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n)"
                     },
                     {
@@ -21873,12 +21965,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix integration get \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"integ_1srOrx2ZWZBpBUvZwXKQmoEYga2\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/integration/integ_1srOrx2ZWZBpBUvZwXKQmoEYga2' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -22022,7 +22114,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.integration.update(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"integ_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  {\n    name: \"Example Integration\",\n    featureFlags: [],\n  }\n);"
                     },
                     {
@@ -22037,7 +22129,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.integration.update(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"integ_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    IntegrationUpdate(\n        name=\"Example Integration\",\n        feature_flags=[],\n    ),\n)"
                     },
                     {
@@ -22077,12 +22169,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix integration update \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"integ_1srOrx2ZWZBpBUvZwXKQmoEYga2\" '{\n    \"featureFlags\": [],\n    \"name\": \"Example Integration\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PUT' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/integration/integ_1srOrx2ZWZBpBUvZwXKQmoEYga2' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"featureFlags\": [],\n    \"name\": \"Example Integration\"\n  }'"
                     }
                 ]
@@ -22219,7 +22311,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.integration.getKey(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"integ_1srOrx2ZWZBpBUvZwXKQmoEYga2\"\n);"
                     },
                     {
@@ -22234,7 +22326,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.integration.get_key(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"integ_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n)"
                     },
                     {
@@ -22274,12 +22366,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix integration get-key \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"integ_1srOrx2ZWZBpBUvZwXKQmoEYga2\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/integration/integ_1srOrx2ZWZBpBUvZwXKQmoEYga2/key' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -22424,7 +22516,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.integration.rotateKey(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"integ_1srOrx2ZWZBpBUvZwXKQmoEYga2\"\n);"
                     },
                     {
@@ -22439,7 +22531,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.integration.rotate_key(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"integ_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n)"
                     },
                     {
@@ -22479,12 +22571,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix integration rotate-key \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"integ_1srOrx2ZWZBpBUvZwXKQmoEYga2\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/integration/integ_1srOrx2ZWZBpBUvZwXKQmoEYga2/key/rotate' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -22715,7 +22807,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.message.list(\"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\");"
                     },
                     {
@@ -22730,7 +22822,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.message.list(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n)"
                     },
                     {
@@ -22770,12 +22862,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix message list \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/msg' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -22934,7 +23026,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.message.create(\"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\", {\n  eventId: \"unique-identifier\",\n  eventType: \"user.signup\",\n  payload: { email: \"test@example.com\", type: \"user.created\", username: \"test_user\" },\n  channels: [\"project_123\", \"group_2\"],\n  application: {\n    name: \"My first application\",\n    rateLimit: 1,\n    throttleRate: 1,\n    uid: \"unique-identifier\",\n    metadata: {},\n  },\n  tags: [\"my_tag\", \"other\"],\n  transformationsParams: {},\n  deliverAt: new Date(\"2025-10-02T20:28:42+00:00\"),\n  payloadRetentionPeriod: 90,\n  payloadRetentionHours: 1,\n});\n\n// Alternatively, with a raw string payload.\nconst response = await svix.message.create(\n  \"app_id\",\n  messageInRaw(\"user.signup\", \"This is a raw body.\", \"text/plain\")\n);"
                     },
                     {
@@ -22949,7 +23041,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.message.create(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    MessageIn(\n        event_id=\"unique-identifier\",\n        event_type=\"user.signup\",\n        payload={\n            \"email\": \"test@example.com\",\n            \"type\": \"user.created\",\n            \"username\": \"test_user\",\n        },\n        channels=[\n            \"project_123\",\n            \"group_2\",\n        ],\n        application=ApplicationIn(\n            name=\"My first application\",\n            rate_limit=1,\n            throttle_rate=1,\n            uid=\"unique-identifier\",\n            metadata={},\n        ),\n        tags=[\n            \"my_tag\",\n            \"other\",\n        ],\n        transformations_params={},\n        deliver_at=datetime.fromisoformat(\"2025-10-02T20:28:42+00:00\"),\n        payload_retention_period=90,\n        payload_retention_hours=1,\n    ),\n)\n\n# Alternatively, with a raw string payload.\nresponse = await svix.message.create(\n    \"app_id\",\n    message_in_raw(\n        event_type=\"user.signup\",\n        payload=\"This is a raw body.\",\n        content_type=\"text/plain\",\n    ),\n)"
                     },
                     {
@@ -22989,12 +23081,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix message create \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" '{\n    \"application\": {\n      \"metadata\": {},\n      \"name\": \"My first application\",\n      \"rateLimit\": 1,\n      \"throttleRate\": 1,\n      \"uid\": \"unique-identifier\"\n    },\n    \"channels\": [\n      \"project_123\",\n      \"group_2\"\n    ],\n    \"deliverAt\": \"2025-10-02T20:28:42+00:00\",\n    \"eventId\": \"unique-identifier\",\n    \"eventType\": \"user.signup\",\n    \"payload\": {\n      \"email\": \"test@example.com\",\n      \"type\": \"user.created\",\n      \"username\": \"test_user\"\n    },\n    \"payloadRetentionHours\": 1,\n    \"payloadRetentionPeriod\": 90,\n    \"tags\": [\n      \"my_tag\",\n      \"other\"\n    ],\n    \"transformationsParams\": {}\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/msg' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"application\": {\n      \"metadata\": {},\n      \"name\": \"My first application\",\n      \"rateLimit\": 1,\n      \"throttleRate\": 1,\n      \"uid\": \"unique-identifier\"\n    },\n    \"channels\": [\n      \"project_123\",\n      \"group_2\"\n    ],\n    \"deliverAt\": \"2025-10-02T20:28:42+00:00\",\n    \"eventId\": \"unique-identifier\",\n    \"eventType\": \"user.signup\",\n    \"payload\": {\n      \"email\": \"test@example.com\",\n      \"type\": \"user.created\",\n      \"username\": \"test_user\"\n    },\n    \"payloadRetentionHours\": 1,\n    \"payloadRetentionPeriod\": 90,\n    \"tags\": [\n      \"my_tag\",\n      \"other\"\n    ],\n    \"transformationsParams\": {}\n  }'\n\n\n# Alternatively, with a raw string payload.\ncurl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/app/{app_id}/msg' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n      \"eventType\": \"user.signup\",\n      \"payload\": {},\n      \"transformationsParams\": {\n          \"rawPayload\": \"This is a raw body.\",\n          \"headers\": { \"content-type\": \"text/plain\" }\n      }\n  }'"
                     }
                 ]
@@ -23124,7 +23216,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.message.expungeAllContents(\"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\");"
                     },
                     {
@@ -23139,7 +23231,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.message.expunge_all_contents(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n)"
                     },
                     {
@@ -23179,12 +23271,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix message expunge-all-contents \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/msg/expunge-all-contents' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -23324,7 +23416,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.message.precheck(\"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\", {\n  eventType: \"user.signup\",\n  channels: [\"project_123\", \"group_2\"],\n});"
                     },
                     {
@@ -23339,7 +23431,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.message.precheck(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    MessagePrecheckIn(\n        event_type=\"user.signup\",\n        channels=[\n            \"project_123\",\n            \"group_2\",\n        ],\n    ),\n)"
                     },
                     {
@@ -23379,12 +23471,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix message precheck \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" '{\n    \"channels\": [\n      \"project_123\",\n      \"group_2\"\n    ],\n    \"eventType\": \"user.signup\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/msg/precheck/active' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"channels\": [\n      \"project_123\",\n      \"group_2\"\n    ],\n    \"eventType\": \"user.signup\"\n  }'"
                     }
                 ]
@@ -23531,7 +23623,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.message.get(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f\"\n);"
                     },
                     {
@@ -23546,7 +23638,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.message.get(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f\",\n)"
                     },
                     {
@@ -23586,12 +23678,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix message get \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/msg/msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -23753,7 +23845,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.messageAttempt.get(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f\",\n  \"atmpt_1srOrx2ZWZBpBUvZwXKQmoEYga2\"\n);"
                     },
                     {
@@ -23768,7 +23860,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.message_attempt.get(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f\",\n    \"atmpt_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n)"
                     },
                     {
@@ -23808,12 +23900,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix message-attempt get \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f\" \"atmpt_1srOrx2ZWZBpBUvZwXKQmoEYga2\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/msg/msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f/attempt/atmpt_1srOrx2ZWZBpBUvZwXKQmoEYga2' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -23957,7 +24049,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.messageAttempt.expungeContent(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f\",\n  \"atmpt_1srOrx2ZWZBpBUvZwXKQmoEYga2\"\n);"
                     },
                     {
@@ -23972,7 +24064,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.message_attempt.expunge_content(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f\",\n    \"atmpt_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n)"
                     },
                     {
@@ -24012,12 +24104,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix message-attempt expunge-content \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f\" \"atmpt_1srOrx2ZWZBpBUvZwXKQmoEYga2\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'DELETE' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/msg/msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f/attempt/atmpt_1srOrx2ZWZBpBUvZwXKQmoEYga2/content' \\\n  -H 'Authorization: Bearer AUTH_TOKEN'"
                     }
                 ]
@@ -24291,7 +24383,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.message.expungeContent(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f\"\n);"
                     },
                     {
@@ -24306,7 +24398,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.message.expunge_content(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f\",\n)"
                     },
                     {
@@ -24346,12 +24438,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix message expunge-content \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'DELETE' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/msg/msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f/content' \\\n  -H 'Authorization: Bearer AUTH_TOKEN'"
                     }
                 ]
@@ -24515,7 +24607,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.messageAttempt.listAttemptedDestinations(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f\"\n);"
                     },
                     {
@@ -24530,7 +24622,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.message_attempt.list_attempted_destinations(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f\",\n)"
                     },
                     {
@@ -24570,12 +24662,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix message-attempt list-attempted-destinations \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/msg/msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f/endpoint' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -24735,7 +24827,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.messageAttempt.resend(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\"\n);"
                     },
                     {
@@ -24750,7 +24842,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.message_attempt.resend(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n)"
                     },
                     {
@@ -24790,12 +24882,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix message-attempt resend \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/msg/msg_33ZHzkmDazsPr4mDUsdzXJrGQ1f/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/resend' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -25123,7 +25215,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.message.poller.poll(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"sink_31Dc11sPYY9aLDkwPuGMa\"\n);"
                     },
                     {
@@ -25138,7 +25230,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.message.poller.poll(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"sink_31Dc11sPYY9aLDkwPuGMa\",\n)"
                     },
                     {
@@ -25178,12 +25270,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix message poller poll \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"sink_31Dc11sPYY9aLDkwPuGMa\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/poller/sink_31Dc11sPYY9aLDkwPuGMa' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -25352,7 +25444,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.message.poller.consumerPoll(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"sink_31Dc11sPYY9aLDkwPuGMa\",\n  \"consumer_id\"\n);"
                     },
                     {
@@ -25367,7 +25459,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.message.poller.consumer_poll(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"sink_31Dc11sPYY9aLDkwPuGMa\",\n    \"consumer_id\",\n)"
                     },
                     {
@@ -25407,12 +25499,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix message poller consumer-poll \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"sink_31Dc11sPYY9aLDkwPuGMa\" \"consumer_id\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/poller/sink_31Dc11sPYY9aLDkwPuGMa/consumer/consumer_id' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -25576,7 +25668,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.message.poller.consumerSeek(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  \"sink_31Dc11sPYY9aLDkwPuGMa\",\n  \"consumer_id\",\n  {\n    after: new Date(\"2025-10-02T20:28:42+00:00\"),\n  }\n);"
                     },
                     {
@@ -25591,7 +25683,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.message.poller.consumer_seek(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    \"sink_31Dc11sPYY9aLDkwPuGMa\",\n    \"consumer_id\",\n    PollingEndpointConsumerSeekIn(\n        after=datetime.fromisoformat(\"2025-10-02T20:28:42+00:00\"),\n    ),\n)"
                     },
                     {
@@ -25631,12 +25723,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix message poller consumer-seek \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" \"sink_31Dc11sPYY9aLDkwPuGMa\" \"consumer_id\" '{\n    \"after\": \"2025-10-02T20:28:42+00:00\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/poller/sink_31Dc11sPYY9aLDkwPuGMa/consumer/consumer_id/seek' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"after\": \"2025-10-02T20:28:42+00:00\"\n  }'"
                     }
                 ]
@@ -28479,7 +28571,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.authentication.appPortalAccess(\n  \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n  {\n    application: {\n      name: \"My first application\",\n      rateLimit: 1,\n      throttleRate: 1,\n      uid: \"unique-identifier\",\n      metadata: {},\n    },\n    readOnly: true,\n    capabilities: [],\n    featureFlags: [],\n    expiry: 1,\n    sessionId: \"user_1FB8\",\n  }\n);"
                     },
                     {
@@ -28494,7 +28586,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.authentication.app_portal_access(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    AppPortalAccessIn(\n        application=ApplicationIn(\n            name=\"My first application\",\n            rate_limit=1,\n            throttle_rate=1,\n            uid=\"unique-identifier\",\n            metadata={},\n        ),\n        read_only=True,\n        capabilities=[],\n        feature_flags=[],\n        expiry=1,\n        session_id=\"user_1FB8\",\n    ),\n)"
                     },
                     {
@@ -28534,12 +28626,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix authentication app-portal-access \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" '{\n    \"application\": {\n      \"metadata\": {},\n      \"name\": \"My first application\",\n      \"rateLimit\": 1,\n      \"throttleRate\": 1,\n      \"uid\": \"unique-identifier\"\n    },\n    \"capabilities\": [\n      \"ViewBase\",\n      \"ViewEndpointSecret\"\n    ],\n    \"expiry\": 1,\n    \"featureFlags\": [],\n    \"readOnly\": true,\n    \"sessionId\": \"user_1FB8\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/auth/app-portal-access/app_1srOrx2ZWZBpBUvZwXKQmoEYga2' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"application\": {\n      \"metadata\": {},\n      \"name\": \"My first application\",\n      \"rateLimit\": 1,\n      \"throttleRate\": 1,\n      \"uid\": \"unique-identifier\"\n    },\n    \"capabilities\": [\n      \"ViewBase\",\n      \"ViewEndpointSecret\"\n    ],\n    \"expiry\": 1,\n    \"featureFlags\": [],\n    \"readOnly\": true,\n    \"sessionId\": \"user_1FB8\"\n  }'"
                     }
                 ]
@@ -28806,7 +28898,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.authentication.expireAll(\"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\", {\n  expiry: 60,\n  sessionIds: [],\n});"
                     },
                     {
@@ -28821,7 +28913,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.authentication.expire_all(\n    \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n    ApplicationTokenExpireIn(\n        expiry=60,\n        session_ids=[],\n    ),\n)"
                     },
                     {
@@ -28861,12 +28953,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix authentication expire-all \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\" '{\n    \"expiry\": 60,\n    \"sessionIds\": []\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/auth/app/app_1srOrx2ZWZBpBUvZwXKQmoEYga2/expire-all' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"expiry\": 60,\n    \"sessionIds\": []\n  }'"
                     }
                 ]
@@ -29253,7 +29345,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.authentication.logout();"
                     },
                     {
@@ -29268,7 +29360,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.authentication.logout()"
                     },
                     {
@@ -29308,12 +29400,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix authentication logout"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/auth/logout' \\\n  -H 'Authorization: Bearer AUTH_TOKEN'"
                     }
                 ]
@@ -30048,7 +30140,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.authentication.streamLogout();"
                     },
                     {
@@ -30063,7 +30155,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.authentication.stream_logout()"
                     },
                     {
@@ -30103,12 +30195,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix authentication stream-logout"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/auth/stream-logout' \\\n  -H 'Authorization: Bearer AUTH_TOKEN'"
                     }
                 ]
@@ -30247,7 +30339,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.authentication.streamPortalAccess(\n  \"strm_31Dc0DD72P5AddYUguyBd\",\n  {\n    featureFlags: [],\n    expiry: 1,\n    sessionId: \"user_1FB8\",\n  }\n);"
                     },
                     {
@@ -30262,7 +30354,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.authentication.stream_portal_access(\n    \"strm_31Dc0DD72P5AddYUguyBd\",\n    StreamPortalAccessIn(\n        feature_flags=[],\n        expiry=1,\n        session_id=\"user_1FB8\",\n    ),\n)"
                     },
                     {
@@ -30302,12 +30394,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix authentication stream-portal-access \"strm_31Dc0DD72P5AddYUguyBd\" '{\n    \"expiry\": 1,\n    \"featureFlags\": [],\n    \"sessionId\": \"user_1FB8\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/auth/stream-portal-access/strm_31Dc0DD72P5AddYUguyBd' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"expiry\": 1,\n    \"featureFlags\": [],\n    \"sessionId\": \"user_1FB8\"\n  }'"
                     }
                 ]
@@ -30439,7 +30531,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.authentication.streamExpireAll(\"strm_31Dc0DD72P5AddYUguyBd\", {\n  expiry: 60,\n  sessionIds: [],\n});"
                     },
                     {
@@ -30454,7 +30546,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.authentication.stream_expire_all(\n    \"strm_31Dc0DD72P5AddYUguyBd\",\n    StreamTokenExpireIn(\n        expiry=60,\n        session_ids=[],\n    ),\n)"
                     },
                     {
@@ -30494,12 +30586,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix authentication stream-expire-all \"strm_31Dc0DD72P5AddYUguyBd\" '{\n    \"expiry\": 60,\n    \"sessionIds\": []\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/auth/stream/strm_31Dc0DD72P5AddYUguyBd/expire-all' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"expiry\": 60,\n    \"sessionIds\": []\n  }'"
                     }
                 ]
@@ -30633,7 +30725,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.authentication.getStreamPollerToken(\n  \"strm_31Dc0DD72P5AddYUguyBd\",\n  \"sink_31Dc11sPYY9aLDkwPuGMa\"\n);"
                     },
                     {
@@ -30648,7 +30740,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.authentication.get_stream_poller_token(\n    \"strm_31Dc0DD72P5AddYUguyBd\",\n    \"sink_31Dc11sPYY9aLDkwPuGMa\",\n)"
                     },
                     {
@@ -30688,12 +30780,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix authentication get-stream-poller-token \"strm_31Dc0DD72P5AddYUguyBd\" \"sink_31Dc11sPYY9aLDkwPuGMa\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/auth/stream/strm_31Dc0DD72P5AddYUguyBd/sink/sink_31Dc11sPYY9aLDkwPuGMa/poller/token' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -30846,7 +30938,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.authentication.rotateStreamPollerToken(\n  \"strm_31Dc0DD72P5AddYUguyBd\",\n  \"sink_31Dc11sPYY9aLDkwPuGMa\",\n  {\n    expiry: 1,\n    oldTokenExpiry: 1,\n  }\n);"
                     },
                     {
@@ -30861,7 +30953,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.authentication.rotate_stream_poller_token(\n    \"strm_31Dc0DD72P5AddYUguyBd\",\n    \"sink_31Dc11sPYY9aLDkwPuGMa\",\n    RotatePollerTokenIn(\n        expiry=1,\n        old_token_expiry=1,\n    ),\n)"
                     },
                     {
@@ -30901,15 +30993,113 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix authentication rotate-stream-poller-token \"strm_31Dc0DD72P5AddYUguyBd\" \"sink_31Dc11sPYY9aLDkwPuGMa\" '{\n    \"expiry\": 1,\n    \"oldTokenExpiry\": 1\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/auth/stream/strm_31Dc0DD72P5AddYUguyBd/sink/sink_31Dc11sPYY9aLDkwPuGMa/poller/token/rotate' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"expiry\": 1,\n    \"oldTokenExpiry\": 1\n  }'"
                     }
                 ]
+            }
+        },
+        "/api/v1/auth/whoami": {
+            "get": {
+                "description": "Return information about the account associated with the current token",
+                "operationId": "v1.authentication.whoami",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/WhoamiOut"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Bad request"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Forbidden"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "409": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Conflict"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        },
+                        "description": "Validation Error"
+                    },
+                    "429": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HttpErrorOut"
+                                }
+                            }
+                        },
+                        "description": "Too Many Requests"
+                    }
+                },
+                "security": [
+                    {
+                        "HTTPBearer": []
+                    }
+                ],
+                "summary": "Whoami",
+                "tags": [
+                    "Authentication"
+                ],
+                "x-internal": true
             }
         },
         "/api/v1/background-task": {
@@ -31073,7 +31263,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.backgroundTask.list();"
                     },
                     {
@@ -31088,7 +31278,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.background_task.list()"
                     },
                     {
@@ -31128,12 +31318,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix background-task list"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/background-task' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -31254,7 +31444,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.backgroundTask.get(\"qtask_1srOrx2ZWZBpBUvZwXKQmoEYga2\");"
                     },
                     {
@@ -31269,7 +31459,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.background_task.get(\n    \"qtask_1srOrx2ZWZBpBUvZwXKQmoEYga2\",\n)"
                     },
                     {
@@ -31309,12 +31499,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix background-task get \"qtask_1srOrx2ZWZBpBUvZwXKQmoEYga2\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/background-task/qtask_1srOrx2ZWZBpBUvZwXKQmoEYga2' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -31468,7 +31658,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.connector.list();"
                     },
                     {
@@ -31483,7 +31673,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.connector.list()"
                     },
                     {
@@ -31523,12 +31713,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix connector list"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/connector' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -31651,7 +31841,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.connector.create({\n  name: \"My first connector\",\n  uid: \"unique-identifier\",\n  logo: \"https://example.com/logo.png\",\n  description: \"Example connector description\",\n  kind: ConnectorKind.Custom,\n  instructions: \"Markdown-formatted instructions\",\n  allowedEventTypes: [\"user.signup\", \"user.deleted\"],\n  transformation: \"function handler(webhook) { /* ... */ }\",\n  featureFlags: [],\n  productType: ConnectorProduct.Dispatch,\n});"
                     },
                     {
@@ -31666,7 +31856,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.connector.create(\n    ConnectorIn(\n        name=\"My first connector\",\n        uid=\"unique-identifier\",\n        logo=\"https://example.com/logo.png\",\n        description=\"Example connector description\",\n        kind=ConnectorKind.CUSTOM,\n        instructions=\"Markdown-formatted instructions\",\n        allowed_event_types=[\n            \"user.signup\",\n            \"user.deleted\",\n        ],\n        transformation=\"function handler(webhook) { /* ... */ }\",\n        feature_flags=[],\n        product_type=ConnectorProduct.DISPATCH,\n    ),\n)"
                     },
                     {
@@ -31706,12 +31896,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix connector create '{\n    \"allowedEventTypes\": [\n      \"user.signup\",\n      \"user.deleted\"\n    ],\n    \"description\": \"Example connector description\",\n    \"featureFlags\": [],\n    \"instructions\": \"Markdown-formatted instructions\",\n    \"kind\": \"Custom\",\n    \"logo\": \"https://example.com/logo.png\",\n    \"name\": \"My first connector\",\n    \"productType\": \"Dispatch\",\n    \"transformation\": \"function handler(webhook) { /* ... */ }\",\n    \"uid\": \"unique-identifier\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/connector' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"allowedEventTypes\": [\n      \"user.signup\",\n      \"user.deleted\"\n    ],\n    \"description\": \"Example connector description\",\n    \"featureFlags\": [],\n    \"instructions\": \"Markdown-formatted instructions\",\n    \"kind\": \"Custom\",\n    \"logo\": \"https://example.com/logo.png\",\n    \"name\": \"My first connector\",\n    \"productType\": \"Dispatch\",\n    \"transformation\": \"function handler(webhook) { /* ... */ }\",\n    \"uid\": \"unique-identifier\"\n  }'"
                     }
                 ]
@@ -32420,7 +32610,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.connector.delete(\"connector_id\");"
                     },
                     {
@@ -32435,7 +32625,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.connector.delete(\n    \"connector_id\",\n)"
                     },
                     {
@@ -32475,12 +32665,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix connector delete \"connector_id\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'DELETE' \\\n  'https://api.eu.svix.com/api/v1/connector/connector_id' \\\n  -H 'Authorization: Bearer AUTH_TOKEN'"
                     }
                 ]
@@ -32599,7 +32789,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.connector.get(\"connector_id\");"
                     },
                     {
@@ -32614,7 +32804,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.connector.get(\n    \"connector_id\",\n)"
                     },
                     {
@@ -32654,12 +32844,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix connector get \"connector_id\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/connector/connector_id' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -32788,7 +32978,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.connector.patch(\"connector_id\", {\n  name: \"sample string\",\n  logo: \"sample string\",\n  description: \"sample string\",\n  kind: ConnectorKind.Custom,\n  instructions: \"sample string\",\n  allowedEventTypes: [\"user.signup\", \"user.deleted\"],\n  transformation: \"sample string\",\n  featureFlags: [\"cool-new-feature\"],\n});"
                     },
                     {
@@ -32803,7 +32993,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.connector.patch(\n    \"connector_id\",\n    ConnectorPatch(\n        name=\"sample string\",\n        logo=\"sample string\",\n        description=\"sample string\",\n        kind=ConnectorKind.CUSTOM,\n        instructions=\"sample string\",\n        allowed_event_types=[\n            \"user.signup\",\n            \"user.deleted\",\n        ],\n        transformation=\"sample string\",\n        feature_flags=[\n            \"cool-new-feature\",\n        ],\n    ),\n)"
                     },
                     {
@@ -32843,12 +33033,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix connector patch \"connector_id\" '{\n    \"allowedEventTypes\": [\n      \"user.signup\",\n      \"user.deleted\"\n    ],\n    \"description\": \"sample string\",\n    \"featureFlags\": [\n      \"cool-new-feature\"\n    ],\n    \"instructions\": \"sample string\",\n    \"kind\": \"Custom\",\n    \"logo\": \"sample string\",\n    \"name\": \"sample string\",\n    \"transformation\": \"sample string\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PATCH' \\\n  'https://api.eu.svix.com/api/v1/connector/connector_id' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"allowedEventTypes\": [\n      \"user.signup\",\n      \"user.deleted\"\n    ],\n    \"description\": \"sample string\",\n    \"featureFlags\": [\n      \"cool-new-feature\"\n    ],\n    \"instructions\": \"sample string\",\n    \"kind\": \"Custom\",\n    \"logo\": \"sample string\",\n    \"name\": \"sample string\",\n    \"transformation\": \"sample string\"\n  }'"
                     }
                 ]
@@ -32987,7 +33177,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.connector.update(\"connector_id\", {\n  name: \"My first connector\",\n  logo: \"https://example.com/logo.png\",\n  description: \"Example connector description\",\n  kind: ConnectorKind.Custom,\n  instructions: \"Markdown-formatted instructions\",\n  allowedEventTypes: [\"user.signup\", \"user.deleted\"],\n  transformation: \"function handler(webhook) { /* ... */ }\",\n  featureFlags: [\"cool-new-feature\"],\n});"
                     },
                     {
@@ -33002,7 +33192,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.connector.update(\n    \"connector_id\",\n    ConnectorUpdate(\n        name=\"My first connector\",\n        logo=\"https://example.com/logo.png\",\n        description=\"Example connector description\",\n        kind=ConnectorKind.CUSTOM,\n        instructions=\"Markdown-formatted instructions\",\n        allowed_event_types=[\n            \"user.signup\",\n            \"user.deleted\",\n        ],\n        transformation=\"function handler(webhook) { /* ... */ }\",\n        feature_flags=[\n            \"cool-new-feature\",\n        ],\n    ),\n)"
                     },
                     {
@@ -33042,12 +33232,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix connector update \"connector_id\" '{\n    \"allowedEventTypes\": [\n      \"user.signup\",\n      \"user.deleted\"\n    ],\n    \"description\": \"Example connector description\",\n    \"featureFlags\": [\n      \"cool-new-feature\"\n    ],\n    \"instructions\": \"Markdown-formatted instructions\",\n    \"kind\": \"Custom\",\n    \"logo\": \"https://example.com/logo.png\",\n    \"name\": \"My first connector\",\n    \"transformation\": \"function handler(webhook) { /* ... */ }\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PUT' \\\n  'https://api.eu.svix.com/api/v1/connector/connector_id' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"allowedEventTypes\": [\n      \"user.signup\",\n      \"user.deleted\"\n    ],\n    \"description\": \"Example connector description\",\n    \"featureFlags\": [\n      \"cool-new-feature\"\n    ],\n    \"instructions\": \"Markdown-formatted instructions\",\n    \"kind\": \"Custom\",\n    \"logo\": \"https://example.com/logo.png\",\n    \"name\": \"My first connector\",\n    \"transformation\": \"function handler(webhook) { /* ... */ }\"\n  }'"
                     }
                 ]
@@ -33403,7 +33593,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.environment.export();"
                     },
                     {
@@ -33418,7 +33608,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.environment.export()"
                     },
                     {
@@ -33458,12 +33648,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix environment export"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/environment/export' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -33581,7 +33771,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.environment.import({\n  eventTypes: [],\n  settings: {},\n  connectors: [],\n});"
                     },
                     {
@@ -33596,7 +33786,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.environment.import_(\n    EnvironmentIn(\n        event_types=[],\n        settings={},\n        connectors=[],\n    ),\n)"
                     },
                     {
@@ -33636,12 +33826,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix environment import '{\n    \"connectors\": [],\n    \"eventTypes\": [],\n    \"settings\": {}\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/environment/import' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"connectors\": [],\n    \"eventTypes\": [],\n    \"settings\": {}\n  }'"
                     }
                 ]
@@ -33905,7 +34095,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.eventType.list();"
                     },
                     {
@@ -33920,7 +34110,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.event_type.list()"
                     },
                     {
@@ -33960,12 +34150,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix event-type list"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/event-type' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -34088,7 +34278,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.eventType.create({\n  name: \"user.signup\",\n  description: \"A user has signed up\",\n  archived: true,\n  deprecated: true,\n  schemas: {\n    \"1\": {\n      description: \"An invoice was paid by a user\",\n      properties: {\n        invoiceId: { description: \"The invoice id\", type: \"string\" },\n        userId: { description: \"The user id\", type: \"string\" },\n      },\n      required: [\"invoiceId\", \"userId\"],\n      title: \"Invoice Paid Event\",\n      type: \"object\",\n    },\n  },\n  groupName: \"user\",\n  featureFlags: [\"cool-new-feature\"],\n  featureFlag: \"sample string\",\n});"
                     },
                     {
@@ -34103,7 +34293,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.event_type.create(\n    EventTypeIn(\n        name=\"user.signup\",\n        description=\"A user has signed up\",\n        archived=True,\n        deprecated=True,\n        schemas={\n            \"1\": {\n                \"description\": \"An invoice was paid by a user\",\n                \"properties\": {\n                    \"invoiceId\": {\"description\": \"The invoice id\", \"type\": \"string\"},\n                    \"userId\": {\"description\": \"The user id\", \"type\": \"string\"},\n                },\n                \"required\": [\"invoiceId\", \"userId\"],\n                \"title\": \"Invoice Paid Event\",\n                \"type\": \"object\",\n            }\n        },\n        group_name=\"user\",\n        feature_flags=[\n            \"cool-new-feature\",\n        ],\n        feature_flag=\"sample string\",\n    ),\n)"
                     },
                     {
@@ -34143,12 +34333,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix event-type create '{\n    \"archived\": true,\n    \"deprecated\": true,\n    \"description\": \"A user has signed up\",\n    \"featureFlag\": \"sample string\",\n    \"featureFlags\": [\n      \"cool-new-feature\"\n    ],\n    \"groupName\": \"user\",\n    \"name\": \"user.signup\",\n    \"schemas\": {\n      \"1\": {\n        \"description\": \"An invoice was paid by a user\",\n        \"properties\": {\n          \"invoiceId\": {\n            \"description\": \"The invoice id\",\n            \"type\": \"string\"\n          },\n          \"userId\": {\n            \"description\": \"The user id\",\n            \"type\": \"string\"\n          }\n        },\n        \"required\": [\n          \"invoiceId\",\n          \"userId\"\n        ],\n        \"title\": \"Invoice Paid Event\",\n        \"type\": \"object\"\n      }\n    }\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/event-type' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"archived\": true,\n    \"deprecated\": true,\n    \"description\": \"A user has signed up\",\n    \"featureFlag\": \"sample string\",\n    \"featureFlags\": [\n      \"cool-new-feature\"\n    ],\n    \"groupName\": \"user\",\n    \"name\": \"user.signup\",\n    \"schemas\": {\n      \"1\": {\n        \"description\": \"An invoice was paid by a user\",\n        \"properties\": {\n          \"invoiceId\": {\n            \"description\": \"The invoice id\",\n            \"type\": \"string\"\n          },\n          \"userId\": {\n            \"description\": \"The user id\",\n            \"type\": \"string\"\n          }\n        },\n        \"required\": [\n          \"invoiceId\",\n          \"userId\"\n        ],\n        \"title\": \"Invoice Paid Event\",\n        \"type\": \"object\"\n      }\n    }\n  }'"
                     }
                 ]
@@ -34383,7 +34573,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.eventType.importOpenapi({\n  dryRun: true,\n  replaceAll: true,\n  spec: {\n    info: { title: \"Webhook Example\", version: \"1.0.0\" },\n    openapi: \"3.1.0\",\n    webhooks: {\n      \"pet.new\": {\n        post: {\n          requestBody: {\n            content: {\n              \"application/json\": {\n                schema: {\n                  properties: {\n                    id: { format: \"int64\", type: \"integer\" },\n                    name: { type: \"string\" },\n                    tag: { type: \"string\" },\n                  },\n                  required: [\"id\", \"name\"],\n                },\n              },\n            },\n            description: \"Information about a new pet in the system\",\n          },\n          responses: {\n            \"200\": {\n              description:\n                \"Return a 200 status to indicate that the data was received successfully\",\n            },\n          },\n        },\n      },\n    },\n  },\n  specRaw: \"sample string\",\n});"
                     },
                     {
@@ -34398,7 +34588,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.event_type.import_openapi(\n    EventTypeImportOpenApiIn(\n        dry_run=True,\n        replace_all=True,\n        spec={\n            \"info\": {\"title\": \"Webhook Example\", \"version\": \"1.0.0\"},\n            \"openapi\": \"3.1.0\",\n            \"webhooks\": {\n                \"pet.new\": {\n                    \"post\": {\n                        \"requestBody\": {\n                            \"content\": {\n                                \"application/json\": {\n                                    \"schema\": {\n                                        \"properties\": {\n                                            \"id\": {\n                                                \"format\": \"int64\",\n                                                \"type\": \"integer\",\n                                            },\n                                            \"name\": {\"type\": \"string\"},\n                                            \"tag\": {\"type\": \"string\"},\n                                        },\n                                        \"required\": [\"id\", \"name\"],\n                                    }\n                                }\n                            },\n                            \"description\": \"Information about a new pet in the system\",\n                        },\n                        \"responses\": {\n                            \"200\": {\n                                \"description\": \"Return a 200 status to indicate that the data was received successfully\"\n                            }\n                        },\n                    }\n                }\n            },\n        },\n        spec_raw=\"sample string\",\n    ),\n)"
                     },
                     {
@@ -34438,12 +34628,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix event-type import-openapi '{\n    \"dryRun\": true,\n    \"replaceAll\": true,\n    \"spec\": {\n      \"info\": {\n        \"title\": \"Webhook Example\",\n        \"version\": \"1.0.0\"\n      },\n      \"openapi\": \"3.1.0\",\n      \"webhooks\": {\n        \"pet.new\": {\n          \"post\": {\n            \"requestBody\": {\n              \"content\": {\n                \"application/json\": {\n                  \"schema\": {\n                    \"properties\": {\n                      \"id\": {\n                        \"format\": \"int64\",\n                        \"type\": \"integer\"\n                      },\n                      \"name\": {\n                        \"type\": \"string\"\n                      },\n                      \"tag\": {\n                        \"type\": \"string\"\n                      }\n                    },\n                    \"required\": [\n                      \"id\",\n                      \"name\"\n                    ]\n                  }\n                }\n              },\n              \"description\": \"Information about a new pet in the system\"\n            },\n            \"responses\": {\n              \"200\": {\n                \"description\": \"Return a 200 status to indicate that the data was received successfully\"\n              }\n            }\n          }\n        }\n      }\n    },\n    \"specRaw\": \"sample string\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/event-type/import/openapi' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"dryRun\": true,\n    \"replaceAll\": true,\n    \"spec\": {\n      \"info\": {\n        \"title\": \"Webhook Example\",\n        \"version\": \"1.0.0\"\n      },\n      \"openapi\": \"3.1.0\",\n      \"webhooks\": {\n        \"pet.new\": {\n          \"post\": {\n            \"requestBody\": {\n              \"content\": {\n                \"application/json\": {\n                  \"schema\": {\n                    \"properties\": {\n                      \"id\": {\n                        \"format\": \"int64\",\n                        \"type\": \"integer\"\n                      },\n                      \"name\": {\n                        \"type\": \"string\"\n                      },\n                      \"tag\": {\n                        \"type\": \"string\"\n                      }\n                    },\n                    \"required\": [\n                      \"id\",\n                      \"name\"\n                    ]\n                  }\n                }\n              },\n              \"description\": \"Information about a new pet in the system\"\n            },\n            \"responses\": {\n              \"200\": {\n                \"description\": \"Return a 200 status to indicate that the data was received successfully\"\n              }\n            }\n          }\n        }\n      }\n    },\n    \"specRaw\": \"sample string\"\n  }'"
                     }
                 ]
@@ -34567,7 +34757,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.eventType.delete(\"user.signup\");"
                     },
                     {
@@ -34582,7 +34772,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.event_type.delete(\n    \"user.signup\",\n)"
                     },
                     {
@@ -34622,12 +34812,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix event-type delete \"user.signup\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'DELETE' \\\n  'https://api.eu.svix.com/api/v1/event-type/user.signup' \\\n  -H 'Authorization: Bearer AUTH_TOKEN'"
                     }
                 ]
@@ -34745,7 +34935,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.eventType.get(\"user.signup\");"
                     },
                     {
@@ -34760,7 +34950,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.event_type.get(\n    \"user.signup\",\n)"
                     },
                     {
@@ -34800,12 +34990,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix event-type get \"user.signup\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/event-type/user.signup' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -34933,7 +35123,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.eventType.patch(\"user.signup\", {\n  description: \"sample string\",\n  archived: true,\n  deprecated: true,\n  schemas: {\n    description: \"An invoice was paid by a user\",\n    properties: {\n      invoiceId: { description: \"The invoice id\", type: \"string\" },\n      userId: { description: \"The user id\", type: \"string\" },\n    },\n    required: [\"invoiceId\", \"userId\"],\n    title: \"Invoice Paid Event\",\n    type: \"object\",\n  },\n  featureFlags: [\"cool-new-feature\"],\n  featureFlag: \"sample string\",\n  groupName: \"user\",\n});"
                     },
                     {
@@ -34948,7 +35138,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.event_type.patch(\n    \"user.signup\",\n    EventTypePatch(\n        description=\"sample string\",\n        archived=True,\n        deprecated=True,\n        schemas={\n            \"description\": \"An invoice was paid by a user\",\n            \"properties\": {\n                \"invoiceId\": {\"description\": \"The invoice id\", \"type\": \"string\"},\n                \"userId\": {\"description\": \"The user id\", \"type\": \"string\"},\n            },\n            \"required\": [\"invoiceId\", \"userId\"],\n            \"title\": \"Invoice Paid Event\",\n            \"type\": \"object\",\n        },\n        feature_flags=[\n            \"cool-new-feature\",\n        ],\n        feature_flag=\"sample string\",\n        group_name=\"user\",\n    ),\n)"
                     },
                     {
@@ -34988,12 +35178,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix event-type patch \"user.signup\" '{\n    \"archived\": true,\n    \"deprecated\": true,\n    \"description\": \"sample string\",\n    \"featureFlag\": \"sample string\",\n    \"featureFlags\": [\n      \"cool-new-feature\"\n    ],\n    \"groupName\": \"user\",\n    \"schemas\": {\n      \"description\": \"An invoice was paid by a user\",\n      \"properties\": {\n        \"invoiceId\": {\n          \"description\": \"The invoice id\",\n          \"type\": \"string\"\n        },\n        \"userId\": {\n          \"description\": \"The user id\",\n          \"type\": \"string\"\n        }\n      },\n      \"required\": [\n        \"invoiceId\",\n        \"userId\"\n      ],\n      \"title\": \"Invoice Paid Event\",\n      \"type\": \"object\"\n    }\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PATCH' \\\n  'https://api.eu.svix.com/api/v1/event-type/user.signup' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"archived\": true,\n    \"deprecated\": true,\n    \"description\": \"sample string\",\n    \"featureFlag\": \"sample string\",\n    \"featureFlags\": [\n      \"cool-new-feature\"\n    ],\n    \"groupName\": \"user\",\n    \"schemas\": {\n      \"description\": \"An invoice was paid by a user\",\n      \"properties\": {\n        \"invoiceId\": {\n          \"description\": \"The invoice id\",\n          \"type\": \"string\"\n        },\n        \"userId\": {\n          \"description\": \"The user id\",\n          \"type\": \"string\"\n        }\n      },\n      \"required\": [\n        \"invoiceId\",\n        \"userId\"\n      ],\n      \"title\": \"Invoice Paid Event\",\n      \"type\": \"object\"\n    }\n  }'"
                     }
                 ]
@@ -35131,7 +35321,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.eventType.update(\"user.signup\", {\n  description: \"A user has signed up\",\n  archived: true,\n  deprecated: true,\n  schemas: {\n    \"1\": {\n      description: \"An invoice was paid by a user\",\n      properties: {\n        invoiceId: { description: \"The invoice id\", type: \"string\" },\n        userId: { description: \"The user id\", type: \"string\" },\n      },\n      required: [\"invoiceId\", \"userId\"],\n      title: \"Invoice Paid Event\",\n      type: \"object\",\n    },\n  },\n  featureFlags: [\"cool-new-feature\"],\n  featureFlag: \"sample string\",\n  groupName: \"user\",\n});"
                     },
                     {
@@ -35146,7 +35336,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.event_type.update(\n    \"user.signup\",\n    EventTypeUpdate(\n        description=\"A user has signed up\",\n        archived=True,\n        deprecated=True,\n        schemas={\n            \"1\": {\n                \"description\": \"An invoice was paid by a user\",\n                \"properties\": {\n                    \"invoiceId\": {\"description\": \"The invoice id\", \"type\": \"string\"},\n                    \"userId\": {\"description\": \"The user id\", \"type\": \"string\"},\n                },\n                \"required\": [\"invoiceId\", \"userId\"],\n                \"title\": \"Invoice Paid Event\",\n                \"type\": \"object\",\n            }\n        },\n        feature_flags=[\n            \"cool-new-feature\",\n        ],\n        feature_flag=\"sample string\",\n        group_name=\"user\",\n    ),\n)"
                     },
                     {
@@ -35186,12 +35376,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix event-type update \"user.signup\" '{\n    \"archived\": true,\n    \"deprecated\": true,\n    \"description\": \"A user has signed up\",\n    \"featureFlag\": \"sample string\",\n    \"featureFlags\": [\n      \"cool-new-feature\"\n    ],\n    \"groupName\": \"user\",\n    \"schemas\": {\n      \"1\": {\n        \"description\": \"An invoice was paid by a user\",\n        \"properties\": {\n          \"invoiceId\": {\n            \"description\": \"The invoice id\",\n            \"type\": \"string\"\n          },\n          \"userId\": {\n            \"description\": \"The user id\",\n            \"type\": \"string\"\n          }\n        },\n        \"required\": [\n          \"invoiceId\",\n          \"userId\"\n        ],\n        \"title\": \"Invoice Paid Event\",\n        \"type\": \"object\"\n      }\n    }\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PUT' \\\n  'https://api.eu.svix.com/api/v1/event-type/user.signup' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"archived\": true,\n    \"deprecated\": true,\n    \"description\": \"A user has signed up\",\n    \"featureFlag\": \"sample string\",\n    \"featureFlags\": [\n      \"cool-new-feature\"\n    ],\n    \"groupName\": \"user\",\n    \"schemas\": {\n      \"1\": {\n        \"description\": \"An invoice was paid by a user\",\n        \"properties\": {\n          \"invoiceId\": {\n            \"description\": \"The invoice id\",\n            \"type\": \"string\"\n          },\n          \"userId\": {\n            \"description\": \"The user id\",\n            \"type\": \"string\"\n          }\n        },\n        \"required\": [\n          \"invoiceId\",\n          \"userId\"\n        ],\n        \"title\": \"Invoice Paid Event\",\n        \"type\": \"object\"\n      }\n    }\n  }'"
                     }
                 ]
@@ -37977,7 +38167,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.operationalWebhook.endpoint.list();"
                     },
                     {
@@ -37992,7 +38182,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.operational_webhook.endpoint.list()"
                     },
                     {
@@ -38032,12 +38222,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix operational-webhook endpoint list"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/operational-webhook/endpoint' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -38160,7 +38350,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.operationalWebhook.endpoint.create({\n  description: \"An example endpoint name\",\n  rateLimit: 1,\n  throttleRate: 1,\n  uid: \"unique-identifier\",\n  url: \"https://example.com/webhook/\",\n  disabled: true,\n  filterTypes: [\"message.attempt.failing\"],\n  secret: \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",\n  metadata: {},\n});"
                     },
                     {
@@ -38175,7 +38365,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.operational_webhook.endpoint.create(\n    OperationalWebhookEndpointIn(\n        description=\"An example endpoint name\",\n        rate_limit=1,\n        throttle_rate=1,\n        uid=\"unique-identifier\",\n        url=\"https://example.com/webhook/\",\n        disabled=True,\n        filter_types=[\n            \"message.attempt.failing\",\n        ],\n        secret=\"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",\n        metadata={},\n    ),\n)"
                     },
                     {
@@ -38215,12 +38405,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix operational-webhook endpoint create '{\n    \"description\": \"An example endpoint name\",\n    \"disabled\": true,\n    \"filterTypes\": [\n      \"message.attempt.failing\"\n    ],\n    \"metadata\": {},\n    \"rateLimit\": 1,\n    \"secret\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",\n    \"throttleRate\": 1,\n    \"uid\": \"unique-identifier\",\n    \"url\": \"https://example.com/webhook/\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/operational-webhook/endpoint' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"description\": \"An example endpoint name\",\n    \"disabled\": true,\n    \"filterTypes\": [\n      \"message.attempt.failing\"\n    ],\n    \"metadata\": {},\n    \"rateLimit\": 1,\n    \"secret\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",\n    \"throttleRate\": 1,\n    \"uid\": \"unique-identifier\",\n    \"url\": \"https://example.com/webhook/\"\n  }'"
                     }
                 ]
@@ -38334,7 +38524,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.operationalWebhook.endpoint.delete(\"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\");"
                     },
                     {
@@ -38349,7 +38539,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.operational_webhook.endpoint.delete(\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n)"
                     },
                     {
@@ -38389,12 +38579,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix operational-webhook endpoint delete \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'DELETE' \\\n  'https://api.eu.svix.com/api/v1/operational-webhook/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1' \\\n  -H 'Authorization: Bearer AUTH_TOKEN'"
                     }
                 ]
@@ -38513,7 +38703,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.operationalWebhook.endpoint.get(\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\"\n);"
                     },
                     {
@@ -38528,7 +38718,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.operational_webhook.endpoint.get(\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n)"
                     },
                     {
@@ -38568,12 +38758,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix operational-webhook endpoint get \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/operational-webhook/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -38702,7 +38892,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.operationalWebhook.endpoint.update(\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n  {\n    description: \"An example endpoint name\",\n    rateLimit: 1,\n    throttleRate: 1,\n    uid: \"unique-identifier\",\n    url: \"https://example.com/webhook/\",\n    disabled: true,\n    filterTypes: [\"message.attempt.failing\"],\n    metadata: {},\n  }\n);"
                     },
                     {
@@ -38717,7 +38907,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.operational_webhook.endpoint.update(\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    OperationalWebhookEndpointUpdate(\n        description=\"An example endpoint name\",\n        rate_limit=1,\n        throttle_rate=1,\n        uid=\"unique-identifier\",\n        url=\"https://example.com/webhook/\",\n        disabled=True,\n        filter_types=[\n            \"message.attempt.failing\",\n        ],\n        metadata={},\n    ),\n)"
                     },
                     {
@@ -38757,12 +38947,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix operational-webhook endpoint update \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\" '{\n    \"description\": \"An example endpoint name\",\n    \"disabled\": true,\n    \"filterTypes\": [\n      \"message.attempt.failing\"\n    ],\n    \"metadata\": {},\n    \"rateLimit\": 1,\n    \"throttleRate\": 1,\n    \"uid\": \"unique-identifier\",\n    \"url\": \"https://example.com/webhook/\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PUT' \\\n  'https://api.eu.svix.com/api/v1/operational-webhook/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"description\": \"An example endpoint name\",\n    \"disabled\": true,\n    \"filterTypes\": [\n      \"message.attempt.failing\"\n    ],\n    \"metadata\": {},\n    \"rateLimit\": 1,\n    \"throttleRate\": 1,\n    \"uid\": \"unique-identifier\",\n    \"url\": \"https://example.com/webhook/\"\n  }'"
                     }
                 ]
@@ -38883,7 +39073,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.operationalWebhook.endpoint.getHeaders(\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\"\n);"
                     },
                     {
@@ -38898,7 +39088,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.operational_webhook.endpoint.get_headers(\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n)"
                     },
                     {
@@ -38938,12 +39128,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix operational-webhook endpoint get-headers \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/operational-webhook/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/headers' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -39065,7 +39255,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.operationalWebhook.endpoint.updateHeaders(\"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\", {\n  headers: { \"X-Example\": \"123\", \"X-Foobar\": \"Bar\" },\n});"
                     },
                     {
@@ -39080,7 +39270,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.operational_webhook.endpoint.update_headers(\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    OperationalWebhookEndpointHeadersIn(\n        headers={\"X-Example\": \"123\", \"X-Foobar\": \"Bar\"},\n    ),\n)"
                     },
                     {
@@ -39120,12 +39310,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix operational-webhook endpoint update-headers \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\" '{\n    \"headers\": {\n      \"X-Example\": \"123\",\n      \"X-Foobar\": \"Bar\"\n    }\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PUT' \\\n  'https://api.eu.svix.com/api/v1/operational-webhook/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/headers' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"headers\": {\n      \"X-Example\": \"123\",\n      \"X-Foobar\": \"Bar\"\n    }\n  }'"
                     }
                 ]
@@ -39246,7 +39436,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.operationalWebhook.endpoint.getSecret(\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\"\n);"
                     },
                     {
@@ -39261,7 +39451,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.operational_webhook.endpoint.get_secret(\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n)"
                     },
                     {
@@ -39301,12 +39491,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix operational-webhook endpoint get-secret \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/operational-webhook/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/secret' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -39439,7 +39629,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.operationalWebhook.endpoint.rotateSecret(\"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\", {\n  key: \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",\n});"
                     },
                     {
@@ -39454,7 +39644,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.operational_webhook.endpoint.rotate_secret(\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    OperationalWebhookEndpointSecretIn(\n        key=\"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",\n    ),\n)"
                     },
                     {
@@ -39494,12 +39684,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix operational-webhook endpoint rotate-secret \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\" '{\n    \"key\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/operational-webhook/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/secret/rotate' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"key\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\"\n  }'"
                     }
                 ]
@@ -39774,7 +39964,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.statistics.aggregateAppStats({\n  since: new Date(\"2025-10-02T20:28:42+00:00\"),\n  until: new Date(\"2025-10-02T20:28:42+00:00\"),\n  appIds: [],\n});"
                     },
                     {
@@ -39789,7 +39979,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.statistics.aggregate_app_stats(\n    AppUsageStatsIn(\n        since=datetime.fromisoformat(\"2025-10-02T20:28:42+00:00\"),\n        until=datetime.fromisoformat(\"2025-10-02T20:28:42+00:00\"),\n        app_ids=[],\n    ),\n)"
                     },
                     {
@@ -39829,12 +40019,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix statistics aggregate-app-stats '{\n    \"appIds\": [],\n    \"since\": \"2025-10-02T20:28:42+00:00\",\n    \"until\": \"2025-10-02T20:28:42+00:00\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/stats/usage/app' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"appIds\": [],\n    \"since\": \"2025-10-02T20:28:42+00:00\",\n    \"until\": \"2025-10-02T20:28:42+00:00\"\n  }'"
                     }
                 ]
@@ -39938,7 +40128,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.statistics.aggregateEventTypes();"
                     },
                     {
@@ -39953,7 +40143,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.statistics.aggregate_event_types()"
                     },
                     {
@@ -39993,12 +40183,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix statistics aggregate-event-types"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PUT' \\\n  'https://api.eu.svix.com/api/v1/stats/usage/event-types' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -40143,7 +40333,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.streaming.stream.list();"
                     },
                     {
@@ -40158,7 +40348,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.streaming.stream.list()"
                     },
                     {
@@ -40198,12 +40388,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming stream list"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/stream' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -40326,7 +40516,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.streaming.stream.create({\n  name: \"sample string\",\n  uid: \"unique-identifier\",\n  metadata: {},\n});"
                     },
                     {
@@ -40341,7 +40531,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.streaming.stream.create(\n    StreamIn(\n        name=\"sample string\",\n        uid=\"unique-identifier\",\n        metadata={},\n    ),\n)"
                     },
                     {
@@ -40381,12 +40571,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming stream create '{\n    \"metadata\": {},\n    \"name\": \"sample string\",\n    \"uid\": \"unique-identifier\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/stream' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"metadata\": {},\n    \"name\": \"sample string\",\n    \"uid\": \"unique-identifier\"\n  }'"
                     }
                 ]
@@ -40541,7 +40731,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.streaming.eventType.list();"
                     },
                     {
@@ -40556,7 +40746,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.streaming.event_type.list()"
                     },
                     {
@@ -40596,12 +40786,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming event-type list"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/stream/event-type' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -40724,7 +40914,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.streaming.eventType.create({\n  name: \"user.signup\",\n  description: \"sample string\",\n  featureFlags: [\"cool-new-feature\"],\n  deprecated: true,\n  archived: true,\n});"
                     },
                     {
@@ -40739,7 +40929,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.streaming.event_type.create(\n    StreamEventTypeIn(\n        name=\"user.signup\",\n        description=\"sample string\",\n        feature_flags=[\n            \"cool-new-feature\",\n        ],\n        deprecated=True,\n        archived=True,\n    ),\n)"
                     },
                     {
@@ -40779,12 +40969,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming event-type create '{\n    \"archived\": true,\n    \"deprecated\": true,\n    \"description\": \"sample string\",\n    \"featureFlags\": [\n      \"cool-new-feature\"\n    ],\n    \"name\": \"user.signup\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/stream/event-type' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"archived\": true,\n    \"deprecated\": true,\n    \"description\": \"sample string\",\n    \"featureFlags\": [\n      \"cool-new-feature\"\n    ],\n    \"name\": \"user.signup\"\n  }'"
                     }
                 ]
@@ -40908,7 +41098,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.streaming.eventType.delete(\"name\");"
                     },
                     {
@@ -40923,7 +41113,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.streaming.event_type.delete(\n    \"name\",\n)"
                     },
                     {
@@ -40963,12 +41153,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming event-type delete \"name\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'DELETE' \\\n  'https://api.eu.svix.com/api/v1/stream/event-type/name' \\\n  -H 'Authorization: Bearer AUTH_TOKEN'"
                     }
                 ]
@@ -41086,7 +41276,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.streaming.eventType.get(\"name\");"
                     },
                     {
@@ -41101,7 +41291,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.streaming.event_type.get(\n    \"name\",\n)"
                     },
                     {
@@ -41141,12 +41331,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming event-type get \"name\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/stream/event-type/name' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -41274,7 +41464,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.streaming.eventType.patch(\"name\", {\n  name: \"user.signup\",\n  description: \"sample string\",\n  featureFlags: [\"cool-new-feature\"],\n  deprecated: true,\n  archived: true,\n});"
                     },
                     {
@@ -41289,7 +41479,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.streaming.event_type.patch(\n    \"name\",\n    StreamEventTypePatch(\n        name=\"user.signup\",\n        description=\"sample string\",\n        feature_flags=[\n            \"cool-new-feature\",\n        ],\n        deprecated=True,\n        archived=True,\n    ),\n)"
                     },
                     {
@@ -41329,12 +41519,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming event-type patch \"name\" '{\n    \"archived\": true,\n    \"deprecated\": true,\n    \"description\": \"sample string\",\n    \"featureFlags\": [\n      \"cool-new-feature\"\n    ],\n    \"name\": \"user.signup\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PATCH' \\\n  'https://api.eu.svix.com/api/v1/stream/event-type/name' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"archived\": true,\n    \"deprecated\": true,\n    \"description\": \"sample string\",\n    \"featureFlags\": [\n      \"cool-new-feature\"\n    ],\n    \"name\": \"user.signup\"\n  }'"
                     }
                 ]
@@ -41472,7 +41662,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.streaming.eventType.update(\"name\", {\n  name: \"user.signup\",\n  description: \"sample string\",\n  featureFlags: [\"cool-new-feature\"],\n  deprecated: true,\n  archived: true,\n});"
                     },
                     {
@@ -41487,7 +41677,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.streaming.event_type.update(\n    \"name\",\n    StreamEventTypeIn(\n        name=\"user.signup\",\n        description=\"sample string\",\n        feature_flags=[\n            \"cool-new-feature\",\n        ],\n        deprecated=True,\n        archived=True,\n    ),\n)"
                     },
                     {
@@ -41527,12 +41717,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming event-type update \"name\" '{\n    \"archived\": true,\n    \"deprecated\": true,\n    \"description\": \"sample string\",\n    \"featureFlags\": [\n      \"cool-new-feature\"\n    ],\n    \"name\": \"user.signup\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PUT' \\\n  'https://api.eu.svix.com/api/v1/stream/event-type/name' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"archived\": true,\n    \"deprecated\": true,\n    \"description\": \"sample string\",\n    \"featureFlags\": [\n      \"cool-new-feature\"\n    ],\n    \"name\": \"user.signup\"\n  }'"
                     }
                 ]
@@ -41764,7 +41954,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.streaming.stream.delete(\"strm_31Dc0DD72P5AddYUguyBd\");"
                     },
                     {
@@ -41779,7 +41969,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.streaming.stream.delete(\n    \"strm_31Dc0DD72P5AddYUguyBd\",\n)"
                     },
                     {
@@ -41819,12 +42009,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming stream delete \"strm_31Dc0DD72P5AddYUguyBd\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'DELETE' \\\n  'https://api.eu.svix.com/api/v1/stream/strm_31Dc0DD72P5AddYUguyBd' \\\n  -H 'Authorization: Bearer AUTH_TOKEN'"
                     }
                 ]
@@ -41942,7 +42132,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.streaming.stream.get(\"strm_31Dc0DD72P5AddYUguyBd\");"
                     },
                     {
@@ -41957,7 +42147,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.streaming.stream.get(\n    \"strm_31Dc0DD72P5AddYUguyBd\",\n)"
                     },
                     {
@@ -41997,12 +42187,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming stream get \"strm_31Dc0DD72P5AddYUguyBd\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/stream/strm_31Dc0DD72P5AddYUguyBd' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -42130,7 +42320,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.streaming.stream.patch(\"strm_31Dc0DD72P5AddYUguyBd\", {\n  description: \"sample string\",\n  uid: \"unique-identifier\",\n  metadata: {},\n});"
                     },
                     {
@@ -42145,7 +42335,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.streaming.stream.patch(\n    \"strm_31Dc0DD72P5AddYUguyBd\",\n    StreamPatch(\n        description=\"sample string\",\n        uid=\"unique-identifier\",\n        metadata={},\n    ),\n)"
                     },
                     {
@@ -42185,12 +42375,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming stream patch \"strm_31Dc0DD72P5AddYUguyBd\" '{\n    \"description\": \"sample string\",\n    \"metadata\": {},\n    \"uid\": \"unique-identifier\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PATCH' \\\n  'https://api.eu.svix.com/api/v1/stream/strm_31Dc0DD72P5AddYUguyBd' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"description\": \"sample string\",\n    \"metadata\": {},\n    \"uid\": \"unique-identifier\"\n  }'"
                     }
                 ]
@@ -42328,7 +42518,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.streaming.stream.update(\"strm_31Dc0DD72P5AddYUguyBd\", {\n  name: \"sample string\",\n  uid: \"unique-identifier\",\n  metadata: {},\n});"
                     },
                     {
@@ -42343,7 +42533,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.streaming.stream.update(\n    \"strm_31Dc0DD72P5AddYUguyBd\",\n    StreamIn(\n        name=\"sample string\",\n        uid=\"unique-identifier\",\n        metadata={},\n    ),\n)"
                     },
                     {
@@ -42383,12 +42573,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming stream update \"strm_31Dc0DD72P5AddYUguyBd\" '{\n    \"metadata\": {},\n    \"name\": \"sample string\",\n    \"uid\": \"unique-identifier\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PUT' \\\n  'https://api.eu.svix.com/api/v1/stream/strm_31Dc0DD72P5AddYUguyBd' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"metadata\": {},\n    \"name\": \"sample string\",\n    \"uid\": \"unique-identifier\"\n  }'"
                     }
                 ]
@@ -42644,12 +42834,12 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "Javascript",
+                        "lang": "TypeScript",
                         "source": "await svix.streaming.events.create(\"rock_inc_uid\", {\n  events: [\n    {\n      \"eventType\": \"user.signup\",\n      \"payload\": '{\"email\":\"test@example.com\",\"username\":\"test_user\"}'\n    }\n  ]\n});"
                     },
                     {
                         "label": "TypeScript",
-                        "lang": "Typescript",
+                        "lang": "TypeScript",
                         "source": "await svix.streaming.events.create(\"rock_inc_uid\", {\n  events: [\n    {\n      \"eventType\": \"user.signup\",\n      \"payload\": '{\"email\":\"test@example.com\",\"username\":\"test_user\"}'\n    }\n  ]\n});"
                     },
                     {
@@ -42659,7 +42849,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.streaming.events.create(\"rock_inc_uid\", CreateStreamEventsIn(\n  events=[\n    EventIn(\n      eventType=\"user.signup\",\n      payload='{\"email\":\"test@example.com\",\"username\":\"test_user\"}'\n    )\n  ]\n))"
                     },
                     {
@@ -42689,7 +42879,7 @@
                     },
                     {
                         "label": "Php",
-                        "lang": "Php",
+                        "lang": "PHP",
                         "source": "$svix->streaming->events->create(\n  'rock_inc_uid',\n  CreateStreamEventsIn::create(\n    events: [\n      [\n        'eventType' => 'user.signup',\n        'payload' => '{\"email\":\"test@example.com\",\"username\":\"test_user\"}'\n      ]\n    ],\n  )\n);"
                     },
                     {
@@ -42699,12 +42889,12 @@
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\\\n  'https://api.svix.com/api/v1/stream/rock_inc_uid/events' \\\\\n  -H 'accept: application/json' \\\\\n  -H \"Authorization: Bearer \\${AUTH_TOKEN}\" \\\\\n  -H 'Content-Type: application/json' \\\\\n  -d '{\n  \"events\": [\n    {\n      \"eventType\":\"user.signup\",\n      \"payload\":\"{\\\\\"email\\\":\\\\\"test@example.com\\\\\",\\\\\"username\\\\\":\\\\\"test_user\\\\\"}\"\n    }\n  ],\n}'"
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "Coming soon to Svix CLI"
                     }
                 ]
@@ -42989,7 +43179,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.streaming.sink.list(\"strm_31Dc0DD72P5AddYUguyBd\");"
                     },
                     {
@@ -43004,7 +43194,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.streaming.sink.list(\n    \"strm_31Dc0DD72P5AddYUguyBd\",\n)"
                     },
                     {
@@ -43044,12 +43234,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming sink list \"strm_31Dc0DD72P5AddYUguyBd\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/stream/strm_31Dc0DD72P5AddYUguyBd/sink' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -43186,7 +43376,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.streaming.sink.create(\"strm_31Dc0DD72P5AddYUguyBd\", {\n  uid: \"unique-identifier\",\n  status: SinkStatusIn.Enabled,\n  batchSize: 100,\n  maxWaitSecs: 1,\n  eventTypes: [],\n  metadata: {},\n  type: \"azureBlobStorage\",\n  config: {\n    container: \"sample string\",\n    account: \"sample string\",\n    accessKey: \"sample string\",\n  },\n});"
                     },
                     {
@@ -43201,7 +43391,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.streaming.sink.create(\n    \"strm_31Dc0DD72P5AddYUguyBd\",\n    StreamSinkIn(\n        uid=\"unique-identifier\",\n        status=SinkStatusIn.ENABLED,\n        batch_size=100,\n        max_wait_secs=1,\n        event_types=[],\n        metadata={},\n        type=\"azureBlobStorage\",\n        config=AzureBlobStorageConfig(\n            container=\"sample string\",\n            account=\"sample string\",\n            access_key=\"sample string\",\n        ),\n    ),\n)"
                     },
                     {
@@ -43241,12 +43431,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming sink create \"strm_31Dc0DD72P5AddYUguyBd\" '{\n    \"batchSize\": 100,\n    \"config\": {\n      \"accessKey\": \"sample string\",\n      \"account\": \"sample string\",\n      \"container\": \"sample string\"\n    },\n    \"eventTypes\": [],\n    \"maxWaitSecs\": 1,\n    \"metadata\": {},\n    \"status\": \"enabled\",\n    \"type\": \"azureBlobStorage\",\n    \"uid\": \"unique-identifier\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/stream/strm_31Dc0DD72P5AddYUguyBd/sink' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"batchSize\": 100,\n    \"config\": {\n      \"accessKey\": \"sample string\",\n      \"account\": \"sample string\",\n      \"container\": \"sample string\"\n    },\n    \"eventTypes\": [],\n    \"maxWaitSecs\": 1,\n    \"metadata\": {},\n    \"status\": \"enabled\",\n    \"type\": \"azureBlobStorage\",\n    \"uid\": \"unique-identifier\"\n  }'"
                     }
                 ]
@@ -43373,7 +43563,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.streaming.sink.delete(\n  \"strm_31Dc0DD72P5AddYUguyBd\",\n  \"sink_31Dc11sPYY9aLDkwPuGMa\"\n);"
                     },
                     {
@@ -43388,7 +43578,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.streaming.sink.delete(\n    \"strm_31Dc0DD72P5AddYUguyBd\",\n    \"sink_31Dc11sPYY9aLDkwPuGMa\",\n)"
                     },
                     {
@@ -43428,12 +43618,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming sink delete \"strm_31Dc0DD72P5AddYUguyBd\" \"sink_31Dc11sPYY9aLDkwPuGMa\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'DELETE' \\\n  'https://api.eu.svix.com/api/v1/stream/strm_31Dc0DD72P5AddYUguyBd/sink/sink_31Dc11sPYY9aLDkwPuGMa' \\\n  -H 'Authorization: Bearer AUTH_TOKEN'"
                     }
                 ]
@@ -43565,7 +43755,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.streaming.sink.get(\n  \"strm_31Dc0DD72P5AddYUguyBd\",\n  \"sink_31Dc11sPYY9aLDkwPuGMa\"\n);"
                     },
                     {
@@ -43580,7 +43770,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.streaming.sink.get(\n    \"strm_31Dc0DD72P5AddYUguyBd\",\n    \"sink_31Dc11sPYY9aLDkwPuGMa\",\n)"
                     },
                     {
@@ -43620,12 +43810,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming sink get \"strm_31Dc0DD72P5AddYUguyBd\" \"sink_31Dc11sPYY9aLDkwPuGMa\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/stream/strm_31Dc0DD72P5AddYUguyBd/sink/sink_31Dc11sPYY9aLDkwPuGMa' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -43767,7 +43957,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.streaming.sink.patch(\n  \"strm_31Dc0DD72P5AddYUguyBd\",\n  \"sink_31Dc11sPYY9aLDkwPuGMa\",\n  {\n    uid: \"unique-identifier\",\n    status: SinkStatusIn.Enabled,\n    batchSize: 100,\n    maxWaitSecs: 1,\n    eventTypes: [],\n    metadata: {},\n    type: \"azureBlobStorage\",\n    config: {\n      container: \"sample string\",\n      account: \"sample string\",\n      accessKey: \"sample string\",\n    },\n  }\n);"
                     },
                     {
@@ -43782,7 +43972,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.streaming.sink.patch(\n    \"strm_31Dc0DD72P5AddYUguyBd\",\n    \"sink_31Dc11sPYY9aLDkwPuGMa\",\n    StreamSinkPatch(\n        uid=\"unique-identifier\",\n        status=SinkStatusIn.ENABLED,\n        batch_size=100,\n        max_wait_secs=1,\n        event_types=[],\n        metadata={},\n        type=\"azureBlobStorage\",\n        config=AzureBlobStoragePatchConfig(\n            container=\"sample string\",\n            account=\"sample string\",\n            access_key=\"sample string\",\n        ),\n    ),\n)"
                     },
                     {
@@ -43822,12 +44012,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming sink patch \"strm_31Dc0DD72P5AddYUguyBd\" \"sink_31Dc11sPYY9aLDkwPuGMa\" '{\n    \"batchSize\": 100,\n    \"config\": {\n      \"accessKey\": \"sample string\",\n      \"account\": \"sample string\",\n      \"container\": \"sample string\"\n    },\n    \"eventTypes\": [],\n    \"maxWaitSecs\": 1,\n    \"metadata\": {},\n    \"status\": \"enabled\",\n    \"type\": \"azureBlobStorage\",\n    \"uid\": \"unique-identifier\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PATCH' \\\n  'https://api.eu.svix.com/api/v1/stream/strm_31Dc0DD72P5AddYUguyBd/sink/sink_31Dc11sPYY9aLDkwPuGMa' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"batchSize\": 100,\n    \"config\": {\n      \"accessKey\": \"sample string\",\n      \"account\": \"sample string\",\n      \"container\": \"sample string\"\n    },\n    \"eventTypes\": [],\n    \"maxWaitSecs\": 1,\n    \"metadata\": {},\n    \"status\": \"enabled\",\n    \"type\": \"azureBlobStorage\",\n    \"uid\": \"unique-identifier\"\n  }'"
                     }
                 ]
@@ -43979,7 +44169,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.streaming.sink.update(\n  \"strm_31Dc0DD72P5AddYUguyBd\",\n  \"sink_31Dc11sPYY9aLDkwPuGMa\",\n  {\n    uid: \"unique-identifier\",\n    status: SinkStatusIn.Enabled,\n    batchSize: 100,\n    maxWaitSecs: 1,\n    eventTypes: [],\n    metadata: {},\n    type: \"azureBlobStorage\",\n    config: {\n      container: \"sample string\",\n      account: \"sample string\",\n      accessKey: \"sample string\",\n    },\n  }\n);"
                     },
                     {
@@ -43994,7 +44184,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.streaming.sink.update(\n    \"strm_31Dc0DD72P5AddYUguyBd\",\n    \"sink_31Dc11sPYY9aLDkwPuGMa\",\n    StreamSinkIn(\n        uid=\"unique-identifier\",\n        status=SinkStatusIn.ENABLED,\n        batch_size=100,\n        max_wait_secs=1,\n        event_types=[],\n        metadata={},\n        type=\"azureBlobStorage\",\n        config=AzureBlobStorageConfig(\n            container=\"sample string\",\n            account=\"sample string\",\n            access_key=\"sample string\",\n        ),\n    ),\n)"
                     },
                     {
@@ -44034,12 +44224,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming sink update \"strm_31Dc0DD72P5AddYUguyBd\" \"sink_31Dc11sPYY9aLDkwPuGMa\" '{\n    \"batchSize\": 100,\n    \"config\": {\n      \"accessKey\": \"sample string\",\n      \"account\": \"sample string\",\n      \"container\": \"sample string\"\n    },\n    \"eventTypes\": [],\n    \"maxWaitSecs\": 1,\n    \"metadata\": {},\n    \"status\": \"enabled\",\n    \"type\": \"azureBlobStorage\",\n    \"uid\": \"unique-identifier\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PUT' \\\n  'https://api.eu.svix.com/api/v1/stream/strm_31Dc0DD72P5AddYUguyBd/sink/sink_31Dc11sPYY9aLDkwPuGMa' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"batchSize\": 100,\n    \"config\": {\n      \"accessKey\": \"sample string\",\n      \"account\": \"sample string\",\n      \"container\": \"sample string\"\n    },\n    \"eventTypes\": [],\n    \"maxWaitSecs\": 1,\n    \"metadata\": {},\n    \"status\": \"enabled\",\n    \"type\": \"azureBlobStorage\",\n    \"uid\": \"unique-identifier\"\n  }'"
                     }
                 ]
@@ -44207,7 +44397,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.streaming.events.get(\n  \"strm_31Dc0DD72P5AddYUguyBd\",\n  \"sink_31Dc11sPYY9aLDkwPuGMa\"\n);"
                     },
                     {
@@ -44222,7 +44412,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.streaming.events.get(\n    \"strm_31Dc0DD72P5AddYUguyBd\",\n    \"sink_31Dc11sPYY9aLDkwPuGMa\",\n)"
                     },
                     {
@@ -44262,12 +44452,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming events get \"strm_31Dc0DD72P5AddYUguyBd\" \"sink_31Dc11sPYY9aLDkwPuGMa\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/stream/strm_31Dc0DD72P5AddYUguyBd/sink/sink_31Dc11sPYY9aLDkwPuGMa/events' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -44531,7 +44721,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.streaming.sinkHeadersGet(\n  \"strm_31Dc0DD72P5AddYUguyBd\",\n  \"sink_31Dc11sPYY9aLDkwPuGMa\"\n);"
                     },
                     {
@@ -44546,7 +44736,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.streaming.sink_headers_get(\n    \"strm_31Dc0DD72P5AddYUguyBd\",\n    \"sink_31Dc11sPYY9aLDkwPuGMa\",\n)"
                     },
                     {
@@ -44586,12 +44776,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming sink-headers-get \"strm_31Dc0DD72P5AddYUguyBd\" \"sink_31Dc11sPYY9aLDkwPuGMa\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/stream/strm_31Dc0DD72P5AddYUguyBd/sink/sink_31Dc11sPYY9aLDkwPuGMa/headers' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -44733,7 +44923,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.streaming.sinkHeadersPatch(\n  \"strm_31Dc0DD72P5AddYUguyBd\",\n  \"sink_31Dc11sPYY9aLDkwPuGMa\",\n  {\n    headers: { \"X-Example\": \"123\", \"X-Foobar\": \"Bar\" },\n  }\n);"
                     },
                     {
@@ -44748,7 +44938,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.streaming.sink_headers_patch(\n    \"strm_31Dc0DD72P5AddYUguyBd\",\n    \"sink_31Dc11sPYY9aLDkwPuGMa\",\n    HttpSinkHeadersPatchIn(\n        headers={\"X-Example\": \"123\", \"X-Foobar\": \"Bar\"},\n    ),\n)"
                     },
                     {
@@ -44788,12 +44978,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming sink-headers-patch \"strm_31Dc0DD72P5AddYUguyBd\" \"sink_31Dc11sPYY9aLDkwPuGMa\" '{\n    \"headers\": {\n      \"X-Example\": \"123\",\n      \"X-Foobar\": \"Bar\"\n    }\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PATCH' \\\n  'https://api.eu.svix.com/api/v1/stream/strm_31Dc0DD72P5AddYUguyBd/sink/sink_31Dc11sPYY9aLDkwPuGMa/headers' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"headers\": {\n      \"X-Example\": \"123\",\n      \"X-Foobar\": \"Bar\"\n    }\n  }'"
                     }
                 ]
@@ -45183,7 +45373,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.streaming.sink.getSecret(\n  \"strm_31Dc0DD72P5AddYUguyBd\",\n  \"sink_31Dc11sPYY9aLDkwPuGMa\"\n);"
                     },
                     {
@@ -45198,7 +45388,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.streaming.sink.get_secret(\n    \"strm_31Dc0DD72P5AddYUguyBd\",\n    \"sink_31Dc11sPYY9aLDkwPuGMa\",\n)"
                     },
                     {
@@ -45238,12 +45428,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming sink get-secret \"strm_31Dc0DD72P5AddYUguyBd\" \"sink_31Dc11sPYY9aLDkwPuGMa\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/stream/strm_31Dc0DD72P5AddYUguyBd/sink/sink_31Dc11sPYY9aLDkwPuGMa/secret' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -45396,7 +45586,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.streaming.sink.rotateSecret(\n  \"strm_31Dc0DD72P5AddYUguyBd\",\n  \"sink_31Dc11sPYY9aLDkwPuGMa\",\n  {\n    key: \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",\n  }\n);"
                     },
                     {
@@ -45411,7 +45601,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.streaming.sink.rotate_secret(\n    \"strm_31Dc0DD72P5AddYUguyBd\",\n    \"sink_31Dc11sPYY9aLDkwPuGMa\",\n    EndpointSecretRotateIn(\n        key=\"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",\n    ),\n)"
                     },
                     {
@@ -45451,12 +45641,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming sink rotate-secret \"strm_31Dc0DD72P5AddYUguyBd\" \"sink_31Dc11sPYY9aLDkwPuGMa\" '{\n    \"key\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/api/v1/stream/strm_31Dc0DD72P5AddYUguyBd/sink/sink_31Dc11sPYY9aLDkwPuGMa/secret/rotate' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"key\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\"\n  }'"
                     }
                 ]
@@ -45739,7 +45929,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.streaming.sinkTransformationGet(\n  \"strm_31Dc0DD72P5AddYUguyBd\",\n  \"sink_31Dc11sPYY9aLDkwPuGMa\"\n);"
                     },
                     {
@@ -45754,7 +45944,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.streaming.sink_transformation_get(\n    \"strm_31Dc0DD72P5AddYUguyBd\",\n    \"sink_31Dc11sPYY9aLDkwPuGMa\",\n)"
                     },
                     {
@@ -45794,12 +45984,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming sink-transformation-get \"strm_31Dc0DD72P5AddYUguyBd\" \"sink_31Dc11sPYY9aLDkwPuGMa\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/api/v1/stream/strm_31Dc0DD72P5AddYUguyBd/sink/sink_31Dc11sPYY9aLDkwPuGMa/transformation' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -45941,7 +46131,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.streaming.sink.transformationPartialUpdate(\n  \"strm_31Dc0DD72P5AddYUguyBd\",\n  \"sink_31Dc11sPYY9aLDkwPuGMa\",\n  {\n    code: \"sample string\",\n  }\n);"
                     },
                     {
@@ -45956,7 +46146,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.streaming.sink.transformation_partial_update(\n    \"strm_31Dc0DD72P5AddYUguyBd\",\n    \"sink_31Dc11sPYY9aLDkwPuGMa\",\n    SinkTransformIn(\n        code=\"sample string\",\n    ),\n)"
                     },
                     {
@@ -45996,12 +46186,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix streaming sink transformation-partial-update \"strm_31Dc0DD72P5AddYUguyBd\" \"sink_31Dc11sPYY9aLDkwPuGMa\" '{\n    \"code\": \"sample string\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PATCH' \\\n  'https://api.eu.svix.com/api/v1/stream/strm_31Dc0DD72P5AddYUguyBd/sink/sink_31Dc11sPYY9aLDkwPuGMa/transformation' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"code\": \"sample string\"\n  }'"
                     }
                 ]
@@ -46146,7 +46336,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.ingest.source.list();"
                     },
                     {
@@ -46161,7 +46351,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.ingest.source.list()"
                     },
                     {
@@ -46201,12 +46391,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix ingest source list"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/ingest/api/v1/source' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -46329,7 +46519,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.ingest.source.create({\n  name: \"sample string\",\n  uid: \"unique-identifier\",\n  metadata: {},\n  type: \"cron\",\n  config: {\n    schedule: \"sample string\",\n    payload: \"sample string\",\n    contentType: \"sample string\",\n  },\n});"
                     },
                     {
@@ -46344,7 +46534,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.ingest.source.create(\n    IngestSourceIn(\n        name=\"sample string\",\n        uid=\"unique-identifier\",\n        metadata={},\n        type=\"cron\",\n        config=CronConfig(\n            schedule=\"sample string\",\n            payload=\"sample string\",\n            content_type=\"sample string\",\n        ),\n    ),\n)"
                     },
                     {
@@ -46384,12 +46574,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix ingest source create '{\n    \"config\": {\n      \"contentType\": \"sample string\",\n      \"payload\": \"sample string\",\n      \"schedule\": \"sample string\"\n    },\n    \"metadata\": {},\n    \"name\": \"sample string\",\n    \"type\": \"cron\",\n    \"uid\": \"unique-identifier\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/ingest/api/v1/source' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"config\": {\n      \"contentType\": \"sample string\",\n      \"payload\": \"sample string\",\n      \"schedule\": \"sample string\"\n    },\n    \"metadata\": {},\n    \"name\": \"sample string\",\n    \"type\": \"cron\",\n    \"uid\": \"unique-identifier\"\n  }'"
                     }
                 ]
@@ -46502,7 +46692,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.ingest.source.delete(\"src_31Dc4Mx7vQVLfxFgArIhq\");"
                     },
                     {
@@ -46517,7 +46707,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.ingest.source.delete(\n    \"src_31Dc4Mx7vQVLfxFgArIhq\",\n)"
                     },
                     {
@@ -46557,12 +46747,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix ingest source delete \"src_31Dc4Mx7vQVLfxFgArIhq\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'DELETE' \\\n  'https://api.eu.svix.com/ingest/api/v1/source/src_31Dc4Mx7vQVLfxFgArIhq' \\\n  -H 'Authorization: Bearer AUTH_TOKEN'"
                     }
                 ]
@@ -46680,7 +46870,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.ingest.source.get(\"src_31Dc4Mx7vQVLfxFgArIhq\");"
                     },
                     {
@@ -46695,7 +46885,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.ingest.source.get(\n    \"src_31Dc4Mx7vQVLfxFgArIhq\",\n)"
                     },
                     {
@@ -46735,12 +46925,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix ingest source get \"src_31Dc4Mx7vQVLfxFgArIhq\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/ingest/api/v1/source/src_31Dc4Mx7vQVLfxFgArIhq' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -47000,7 +47190,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.ingest.source.update(\"src_31Dc4Mx7vQVLfxFgArIhq\", {\n  name: \"sample string\",\n  uid: \"unique-identifier\",\n  metadata: {},\n  type: \"cron\",\n  config: {\n    schedule: \"sample string\",\n    payload: \"sample string\",\n    contentType: \"sample string\",\n  },\n});"
                     },
                     {
@@ -47015,7 +47205,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.ingest.source.update(\n    \"src_31Dc4Mx7vQVLfxFgArIhq\",\n    IngestSourceIn(\n        name=\"sample string\",\n        uid=\"unique-identifier\",\n        metadata={},\n        type=\"cron\",\n        config=CronConfig(\n            schedule=\"sample string\",\n            payload=\"sample string\",\n            content_type=\"sample string\",\n        ),\n    ),\n)"
                     },
                     {
@@ -47055,12 +47245,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix ingest source update \"src_31Dc4Mx7vQVLfxFgArIhq\" '{\n    \"config\": {\n      \"contentType\": \"sample string\",\n      \"payload\": \"sample string\",\n      \"schedule\": \"sample string\"\n    },\n    \"metadata\": {},\n    \"name\": \"sample string\",\n    \"type\": \"cron\",\n    \"uid\": \"unique-identifier\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PUT' \\\n  'https://api.eu.svix.com/ingest/api/v1/source/src_31Dc4Mx7vQVLfxFgArIhq' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"config\": {\n      \"contentType\": \"sample string\",\n      \"payload\": \"sample string\",\n      \"schedule\": \"sample string\"\n    },\n    \"metadata\": {},\n    \"name\": \"sample string\",\n    \"type\": \"cron\",\n    \"uid\": \"unique-identifier\"\n  }'"
                     }
                 ]
@@ -47199,7 +47389,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.ingest.dashboard(\"src_31Dc4Mx7vQVLfxFgArIhq\", {\n  expiry: 1,\n  readOnly: true,\n});"
                     },
                     {
@@ -47214,7 +47404,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.ingest.dashboard(\n    \"src_31Dc4Mx7vQVLfxFgArIhq\",\n    IngestSourceConsumerPortalAccessIn(\n        expiry=1,\n        read_only=True,\n    ),\n)"
                     },
                     {
@@ -47254,12 +47444,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix ingest dashboard \"src_31Dc4Mx7vQVLfxFgArIhq\" '{\n    \"expiry\": 1,\n    \"readOnly\": true\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/ingest/api/v1/source/src_31Dc4Mx7vQVLfxFgArIhq/dashboard' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"expiry\": 1,\n    \"readOnly\": true\n  }'"
                     }
                 ]
@@ -47418,7 +47608,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.ingest.endpoint.list(\"src_31Dc4Mx7vQVLfxFgArIhq\");"
                     },
                     {
@@ -47433,7 +47623,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.ingest.endpoint.list(\n    \"src_31Dc4Mx7vQVLfxFgArIhq\",\n)"
                     },
                     {
@@ -47473,12 +47663,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix ingest endpoint list \"src_31Dc4Mx7vQVLfxFgArIhq\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/ingest/api/v1/source/src_31Dc4Mx7vQVLfxFgArIhq/endpoint' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -47615,7 +47805,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.ingest.endpoint.create(\"src_31Dc4Mx7vQVLfxFgArIhq\", {\n  description: \"An example endpoint name\",\n  rateLimit: 1,\n  uid: \"unique-identifier\",\n  url: \"https://example.com/webhook/\",\n  disabled: true,\n  secret: \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",\n  metadata: {},\n});"
                     },
                     {
@@ -47630,7 +47820,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.ingest.endpoint.create(\n    \"src_31Dc4Mx7vQVLfxFgArIhq\",\n    IngestEndpointIn(\n        description=\"An example endpoint name\",\n        rate_limit=1,\n        uid=\"unique-identifier\",\n        url=\"https://example.com/webhook/\",\n        disabled=True,\n        secret=\"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",\n        metadata={},\n    ),\n)"
                     },
                     {
@@ -47670,12 +47860,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix ingest endpoint create \"src_31Dc4Mx7vQVLfxFgArIhq\" '{\n    \"description\": \"An example endpoint name\",\n    \"disabled\": true,\n    \"metadata\": {},\n    \"rateLimit\": 1,\n    \"secret\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",\n    \"uid\": \"unique-identifier\",\n    \"url\": \"https://example.com/webhook/\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/ingest/api/v1/source/src_31Dc4Mx7vQVLfxFgArIhq/endpoint' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"description\": \"An example endpoint name\",\n    \"disabled\": true,\n    \"metadata\": {},\n    \"rateLimit\": 1,\n    \"secret\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",\n    \"uid\": \"unique-identifier\",\n    \"url\": \"https://example.com/webhook/\"\n  }'"
                     }
                 ]
@@ -47803,7 +47993,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.ingest.endpoint.delete(\n  \"src_31Dc4Mx7vQVLfxFgArIhq\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\"\n);"
                     },
                     {
@@ -47818,7 +48008,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.ingest.endpoint.delete(\n    \"src_31Dc4Mx7vQVLfxFgArIhq\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n)"
                     },
                     {
@@ -47858,12 +48048,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix ingest endpoint delete \"src_31Dc4Mx7vQVLfxFgArIhq\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'DELETE' \\\n  'https://api.eu.svix.com/ingest/api/v1/source/src_31Dc4Mx7vQVLfxFgArIhq/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1' \\\n  -H 'Authorization: Bearer AUTH_TOKEN'"
                     }
                 ]
@@ -47996,7 +48186,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.ingest.endpoint.get(\n  \"src_31Dc4Mx7vQVLfxFgArIhq\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\"\n);"
                     },
                     {
@@ -48011,7 +48201,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.ingest.endpoint.get(\n    \"src_31Dc4Mx7vQVLfxFgArIhq\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n)"
                     },
                     {
@@ -48051,12 +48241,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix ingest endpoint get \"src_31Dc4Mx7vQVLfxFgArIhq\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/ingest/api/v1/source/src_31Dc4Mx7vQVLfxFgArIhq/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -48199,7 +48389,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.ingest.endpoint.update(\n  \"src_31Dc4Mx7vQVLfxFgArIhq\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n  {\n    description: \"An example endpoint name\",\n    rateLimit: 1,\n    uid: \"unique-identifier\",\n    url: \"https://example.com/webhook/\",\n    disabled: true,\n    metadata: {},\n  }\n);"
                     },
                     {
@@ -48214,7 +48404,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.ingest.endpoint.update(\n    \"src_31Dc4Mx7vQVLfxFgArIhq\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    IngestEndpointUpdate(\n        description=\"An example endpoint name\",\n        rate_limit=1,\n        uid=\"unique-identifier\",\n        url=\"https://example.com/webhook/\",\n        disabled=True,\n        metadata={},\n    ),\n)"
                     },
                     {
@@ -48254,12 +48444,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix ingest endpoint update \"src_31Dc4Mx7vQVLfxFgArIhq\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\" '{\n    \"description\": \"An example endpoint name\",\n    \"disabled\": true,\n    \"metadata\": {},\n    \"rateLimit\": 1,\n    \"uid\": \"unique-identifier\",\n    \"url\": \"https://example.com/webhook/\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PUT' \\\n  'https://api.eu.svix.com/ingest/api/v1/source/src_31Dc4Mx7vQVLfxFgArIhq/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"description\": \"An example endpoint name\",\n    \"disabled\": true,\n    \"metadata\": {},\n    \"rateLimit\": 1,\n    \"uid\": \"unique-identifier\",\n    \"url\": \"https://example.com/webhook/\"\n  }'"
                     }
                 ]
@@ -48394,7 +48584,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.ingest.endpoint.getHeaders(\n  \"src_31Dc4Mx7vQVLfxFgArIhq\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\"\n);"
                     },
                     {
@@ -48409,7 +48599,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.ingest.endpoint.get_headers(\n    \"src_31Dc4Mx7vQVLfxFgArIhq\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n)"
                     },
                     {
@@ -48449,12 +48639,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix ingest endpoint get-headers \"src_31Dc4Mx7vQVLfxFgArIhq\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/ingest/api/v1/source/src_31Dc4Mx7vQVLfxFgArIhq/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/headers' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -48590,7 +48780,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.ingest.endpoint.updateHeaders(\n  \"src_31Dc4Mx7vQVLfxFgArIhq\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n  {\n    headers: { \"X-Example\": \"123\", \"X-Foobar\": \"Bar\" },\n  }\n);"
                     },
                     {
@@ -48605,7 +48795,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.ingest.endpoint.update_headers(\n    \"src_31Dc4Mx7vQVLfxFgArIhq\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    IngestEndpointHeadersIn(\n        headers={\"X-Example\": \"123\", \"X-Foobar\": \"Bar\"},\n    ),\n)"
                     },
                     {
@@ -48645,12 +48835,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix ingest endpoint update-headers \"src_31Dc4Mx7vQVLfxFgArIhq\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\" '{\n    \"headers\": {\n      \"X-Example\": \"123\",\n      \"X-Foobar\": \"Bar\"\n    }\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PUT' \\\n  'https://api.eu.svix.com/ingest/api/v1/source/src_31Dc4Mx7vQVLfxFgArIhq/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/headers' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"headers\": {\n      \"X-Example\": \"123\",\n      \"X-Foobar\": \"Bar\"\n    }\n  }'"
                     }
                 ]
@@ -48785,7 +48975,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.ingest.endpoint.getSecret(\n  \"src_31Dc4Mx7vQVLfxFgArIhq\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\"\n);"
                     },
                     {
@@ -48800,7 +48990,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.ingest.endpoint.get_secret(\n    \"src_31Dc4Mx7vQVLfxFgArIhq\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n)"
                     },
                     {
@@ -48840,12 +49030,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix ingest endpoint get-secret \"src_31Dc4Mx7vQVLfxFgArIhq\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/ingest/api/v1/source/src_31Dc4Mx7vQVLfxFgArIhq/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/secret' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -48992,7 +49182,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.ingest.endpoint.rotateSecret(\n  \"src_31Dc4Mx7vQVLfxFgArIhq\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n  {\n    key: \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",\n  }\n);"
                     },
                     {
@@ -49007,7 +49197,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.ingest.endpoint.rotate_secret(\n    \"src_31Dc4Mx7vQVLfxFgArIhq\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    IngestEndpointSecretIn(\n        key=\"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\",\n    ),\n)"
                     },
                     {
@@ -49047,12 +49237,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix ingest endpoint rotate-secret \"src_31Dc4Mx7vQVLfxFgArIhq\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\" '{\n    \"key\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\"\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/ingest/api/v1/source/src_31Dc4Mx7vQVLfxFgArIhq/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/secret/rotate' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"key\": \"whsec_C2FVsBQIhrscChlQIMV+b5sSYspob7oD\"\n  }'"
                     }
                 ]
@@ -49187,7 +49377,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.ingest.endpoint.getTransformation(\n  \"src_31Dc4Mx7vQVLfxFgArIhq\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\"\n);"
                     },
                     {
@@ -49202,7 +49392,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.ingest.endpoint.get_transformation(\n    \"src_31Dc4Mx7vQVLfxFgArIhq\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n)"
                     },
                     {
@@ -49242,12 +49432,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix ingest endpoint get-transformation \"src_31Dc4Mx7vQVLfxFgArIhq\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'GET' \\\n  'https://api.eu.svix.com/ingest/api/v1/source/src_31Dc4Mx7vQVLfxFgArIhq/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/transformation' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]
@@ -49383,7 +49573,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "await svix.ingest.endpoint.setTransformation(\n  \"src_31Dc4Mx7vQVLfxFgArIhq\",\n  \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n  {\n    code: \"sample string\",\n    enabled: true,\n  }\n);"
                     },
                     {
@@ -49398,7 +49588,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "await svix.ingest.endpoint.set_transformation(\n    \"src_31Dc4Mx7vQVLfxFgArIhq\",\n    \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\",\n    IngestEndpointTransformationPatch(\n        code=\"sample string\",\n        enabled=True,\n    ),\n)"
                     },
                     {
@@ -49438,12 +49628,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix ingest endpoint set-transformation \"src_31Dc4Mx7vQVLfxFgArIhq\" \"ep_33ZIBDmz66FcPG35FnsbM6Ie4X1\" '{\n    \"code\": \"sample string\",\n    \"enabled\": true\n  }'"
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'PATCH' \\\n  'https://api.eu.svix.com/ingest/api/v1/source/src_31Dc4Mx7vQVLfxFgArIhq/endpoint/ep_33ZIBDmz66FcPG35FnsbM6Ie4X1/transformation' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Content-Type: application/json' \\\n  -d '{\n    \"code\": \"sample string\",\n    \"enabled\": true\n  }'"
                     }
                 ]
@@ -49851,7 +50041,7 @@
                 "x-codeSamples": [
                     {
                         "label": "JavaScript",
-                        "lang": "JavaScript",
+                        "lang": "TypeScript",
                         "source": "const response = await svix.ingest.source.rotateToken(\"src_31Dc4Mx7vQVLfxFgArIhq\");"
                     },
                     {
@@ -49866,7 +50056,7 @@
                     },
                     {
                         "label": "Python (Async)",
-                        "lang": "Python (Async)",
+                        "lang": "Python",
                         "source": "response = await svix.ingest.source.rotate_token(\n    \"src_31Dc4Mx7vQVLfxFgArIhq\",\n)"
                     },
                     {
@@ -49906,12 +50096,12 @@
                     },
                     {
                         "label": "CLI",
-                        "lang": "CLI",
+                        "lang": "Shell",
                         "source": "svix ingest source rotate-token \"src_31Dc4Mx7vQVLfxFgArIhq\""
                     },
                     {
                         "label": "cURL",
-                        "lang": "cURL",
+                        "lang": "Shell",
                         "source": "curl -X 'POST' \\\n  'https://api.eu.svix.com/ingest/api/v1/source/src_31Dc4Mx7vQVLfxFgArIhq/token/rotate' \\\n  -H 'Authorization: Bearer AUTH_TOKEN' \\\n  -H 'Accept: application/json'"
                     }
                 ]

--- a/csharp/Svix/Models/EndpointTransformationOut.cs
+++ b/csharp/Svix/Models/EndpointTransformationOut.cs
@@ -15,6 +15,9 @@ namespace Svix.Models
         [JsonProperty("updatedAt")]
         public DateTime? UpdatedAt { get; set; } = null;
 
+        [JsonProperty("variables")]
+        public Dictionary<string, string>? Variables { get; set; } = null;
+
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
@@ -23,6 +26,7 @@ namespace Svix.Models
             sb.Append("  Code: ").Append(Code).Append('\n');
             sb.Append("  Enabled: ").Append(Enabled).Append('\n');
             sb.Append("  UpdatedAt: ").Append(UpdatedAt).Append('\n');
+            sb.Append("  Variables: ").Append(Variables).Append('\n');
             sb.Append("}\n");
             return sb.ToString();
         }

--- a/csharp/Svix/Models/EndpointTransformationPatch.cs
+++ b/csharp/Svix/Models/EndpointTransformationPatch.cs
@@ -16,6 +16,12 @@ namespace Svix.Models
 
         public bool ShouldSerializeEnabled() => Enabled != null;
 
+        [JsonProperty("variables")]
+        public MaybeUnset<Dictionary<string, string>?> Variables { get; set; } =
+            MaybeUnset<Dictionary<string, string>?>.Unset();
+
+        public bool ShouldSerializeVariables() => !Variables.IsUnset;
+
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
@@ -23,6 +29,7 @@ namespace Svix.Models
             sb.Append("class EndpointTransformationPatch {\n");
             sb.Append("  Code: ").Append(Code).Append('\n');
             sb.Append("  Enabled: ").Append(Enabled).Append('\n');
+            sb.Append("  Variables: ").Append(Variables).Append('\n');
             sb.Append("}\n");
             return sb.ToString();
         }

--- a/go/models/endpoint_transformation_out.go
+++ b/go/models/endpoint_transformation_out.go
@@ -4,7 +4,8 @@ package models
 import "time"
 
 type EndpointTransformationOut struct {
-	Code      *string    `json:"code,omitempty"`
-	Enabled   *bool      `json:"enabled,omitempty"`
-	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
+	Code      *string            `json:"code,omitempty"`
+	Enabled   *bool              `json:"enabled,omitempty"`
+	UpdatedAt *time.Time         `json:"updatedAt,omitempty"`
+	Variables *map[string]string `json:"variables,omitempty"`
 }

--- a/go/models/endpoint_transformation_patch.go
+++ b/go/models/endpoint_transformation_patch.go
@@ -8,8 +8,9 @@ import (
 )
 
 type EndpointTransformationPatch struct {
-	Code    utils.Nullable[string] `json:"code"`
-	Enabled *bool                  `json:"enabled,omitempty"`
+	Code      utils.Nullable[string]            `json:"code"`
+	Enabled   *bool                             `json:"enabled,omitempty"`
+	Variables utils.Nullable[map[string]string] `json:"variables"`
 }
 
 func (o EndpointTransformationPatch) MarshalJSON() ([]byte, error) {
@@ -19,6 +20,9 @@ func (o EndpointTransformationPatch) MarshalJSON() ([]byte, error) {
 	}
 	if o.Enabled != nil {
 		toSerialize["enabled"] = o.Enabled
+	}
+	if o.Variables.IsSet() {
+		toSerialize["variables"] = o.Variables
 	}
 	return json.Marshal(toSerialize)
 }

--- a/go/models/settings_internal_in.go
+++ b/go/models/settings_internal_in.go
@@ -34,6 +34,7 @@ type SettingsInternalIn struct {
 	SendSvixWebhookHeaders        *bool                   `json:"sendSvixWebhookHeaders,omitempty"`
 	ShowFeatureTooltips           *bool                   `json:"showFeatureTooltips,omitempty"`
 	ShowUseSvixPlay               *bool                   `json:"showUseSvixPlay,omitempty"`
+	WebhooksAutoConfig            *bool                   `json:"webhooksAutoConfig,omitempty"`
 	WhitelabelHeaders             *bool                   `json:"whitelabelHeaders,omitempty"`
 	WipeSuccessfulPayload         *bool                   `json:"wipeSuccessfulPayload,omitempty"`
 }

--- a/go/models/settings_internal_out.go
+++ b/go/models/settings_internal_out.go
@@ -35,6 +35,7 @@ type SettingsInternalOut struct {
 	ShowFeatureTooltips           *bool                   `json:"showFeatureTooltips,omitempty"`
 	ShowSvixBrandFooter           *bool                   `json:"showSvixBrandFooter,omitempty"`
 	ShowUseSvixPlay               *bool                   `json:"showUseSvixPlay,omitempty"`
+	WebhooksAutoConfig            *bool                   `json:"webhooksAutoConfig,omitempty"`
 	WhitelabelHeaders             *bool                   `json:"whitelabelHeaders,omitempty"`
 	WhitelabelLogo                *string                 `json:"whitelabelLogo,omitempty"`
 	WipeSuccessfulPayload         *bool                   `json:"wipeSuccessfulPayload,omitempty"`

--- a/go/models/settings_internal_patch.go
+++ b/go/models/settings_internal_patch.go
@@ -40,6 +40,7 @@ type SettingsInternalPatch struct {
 	SendSvixWebhookHeaders        *bool                                 `json:"sendSvixWebhookHeaders,omitempty"`
 	ShowFeatureTooltips           *bool                                 `json:"showFeatureTooltips,omitempty"`
 	ShowUseSvixPlay               *bool                                 `json:"showUseSvixPlay,omitempty"`
+	WebhooksAutoConfig            *bool                                 `json:"webhooksAutoConfig,omitempty"`
 	WhitelabelHeaders             *bool                                 `json:"whitelabelHeaders,omitempty"`
 	WipeSuccessfulPayload         *bool                                 `json:"wipeSuccessfulPayload,omitempty"`
 }
@@ -141,6 +142,9 @@ func (o SettingsInternalPatch) MarshalJSON() ([]byte, error) {
 	}
 	if o.ShowUseSvixPlay != nil {
 		toSerialize["showUseSvixPlay"] = o.ShowUseSvixPlay
+	}
+	if o.WebhooksAutoConfig != nil {
+		toSerialize["webhooksAutoConfig"] = o.WebhooksAutoConfig
 	}
 	if o.WhitelabelHeaders != nil {
 		toSerialize["whitelabelHeaders"] = o.WhitelabelHeaders

--- a/go/models/settings_internal_update_out.go
+++ b/go/models/settings_internal_update_out.go
@@ -34,6 +34,7 @@ type SettingsInternalUpdateOut struct {
 	SendSvixWebhookHeaders        *bool                   `json:"sendSvixWebhookHeaders,omitempty"`
 	ShowFeatureTooltips           *bool                   `json:"showFeatureTooltips,omitempty"`
 	ShowUseSvixPlay               *bool                   `json:"showUseSvixPlay,omitempty"`
+	WebhooksAutoConfig            *bool                   `json:"webhooksAutoConfig,omitempty"`
 	WhitelabelHeaders             *bool                   `json:"whitelabelHeaders,omitempty"`
 	WipeSuccessfulPayload         *bool                   `json:"wipeSuccessfulPayload,omitempty"`
 }

--- a/java/lib/src/main/java/com/svix/models/EndpointTransformationOut.java
+++ b/java/lib/src/main/java/com/svix/models/EndpointTransformationOut.java
@@ -12,6 +12,8 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.Map;
 
 @ToString
 @EqualsAndHashCode
@@ -21,6 +23,7 @@ public class EndpointTransformationOut {
     @JsonProperty private String code;
     @JsonProperty private Boolean enabled;
     @JsonProperty private OffsetDateTime updatedAt;
+    @JsonProperty private Map<String, String> variables;
 
     public EndpointTransformationOut() {}
 
@@ -79,6 +82,34 @@ public class EndpointTransformationOut {
 
     public void setUpdatedAt(OffsetDateTime updatedAt) {
         this.updatedAt = updatedAt;
+    }
+
+    public EndpointTransformationOut variables(Map<String, String> variables) {
+        this.variables = variables;
+        return this;
+    }
+
+    public EndpointTransformationOut putVariablesItem(String key, String variablesItem) {
+        if (this.variables == null) {
+            this.variables = new HashMap<>();
+        }
+        this.variables.put(key, variablesItem);
+
+        return this;
+    }
+
+    /**
+     * Get variables
+     *
+     * @return variables
+     */
+    @javax.annotation.Nullable
+    public Map<String, String> getVariables() {
+        return variables;
+    }
+
+    public void setVariables(Map<String, String> variables) {
+        this.variables = variables;
     }
 
     /**

--- a/java/lib/src/main/java/com/svix/models/EndpointTransformationPatch.java
+++ b/java/lib/src/main/java/com/svix/models/EndpointTransformationPatch.java
@@ -12,6 +12,9 @@ import com.svix.Utils;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @ToString
 @EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -19,6 +22,7 @@ import lombok.ToString;
 public class EndpointTransformationPatch {
     @JsonProperty private MaybeUnset<String> code;
     @JsonProperty private Boolean enabled;
+    @JsonProperty private MaybeUnset<Map<String, String>> variables;
 
     public EndpointTransformationPatch() {}
 
@@ -61,6 +65,37 @@ public class EndpointTransformationPatch {
 
     public void setEnabled(Boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public EndpointTransformationPatch variables(Map<String, String> variables) {
+        this.variables = new MaybeUnset<>(variables);
+        return this;
+    }
+
+    public EndpointTransformationPatch putVariablesItem(String key, String variablesItem) {
+        if (this.variables == null) {
+            this.variables = new MaybeUnset<>(new HashMap<>());
+        }
+        this.variables.getValue().put(key, variablesItem);
+
+        return this;
+    }
+
+    /**
+     * Get variables
+     *
+     * @return variables
+     */
+    @javax.annotation.Nullable
+    public Map<String, String> getVariables() {
+        if (variables == null) {
+            return null;
+        }
+        return variables.getValue();
+    }
+
+    public void setVariables(Map<String, String> variables) {
+        this.variables = new MaybeUnset<>(variables);
     }
 
     /**

--- a/javascript/src/models/endpointTransformationOut.ts
+++ b/javascript/src/models/endpointTransformationOut.ts
@@ -4,6 +4,7 @@ export interface EndpointTransformationOut {
   code?: string | null;
   enabled?: boolean;
   updatedAt?: Date | null;
+  variables?: { [key: string]: string } | null;
 }
 
 export const EndpointTransformationOutSerializer = {
@@ -12,6 +13,7 @@ export const EndpointTransformationOutSerializer = {
       code: object["code"],
       enabled: object["enabled"],
       updatedAt: object["updatedAt"] ? new Date(object["updatedAt"]) : null,
+      variables: object["variables"],
     };
   },
 
@@ -20,6 +22,7 @@ export const EndpointTransformationOutSerializer = {
       code: self.code,
       enabled: self.enabled,
       updatedAt: self.updatedAt,
+      variables: self.variables,
     };
   },
 };

--- a/javascript/src/models/endpointTransformationPatch.ts
+++ b/javascript/src/models/endpointTransformationPatch.ts
@@ -3,6 +3,7 @@
 export interface EndpointTransformationPatch {
   code?: string | null;
   enabled?: boolean;
+  variables?: { [key: string]: string } | null;
 }
 
 export const EndpointTransformationPatchSerializer = {
@@ -10,6 +11,7 @@ export const EndpointTransformationPatchSerializer = {
     return {
       code: object["code"],
       enabled: object["enabled"],
+      variables: object["variables"],
     };
   },
 
@@ -17,6 +19,7 @@ export const EndpointTransformationPatchSerializer = {
     return {
       code: self.code,
       enabled: self.enabled,
+      variables: self.variables,
     };
   },
 };

--- a/kotlin/lib/src/main/kotlin/models/EndpointTransformationOut.kt
+++ b/kotlin/lib/src/main/kotlin/models/EndpointTransformationOut.kt
@@ -9,4 +9,5 @@ data class EndpointTransformationOut(
     val code: String? = null,
     val enabled: Boolean? = null,
     val updatedAt: Instant? = null,
+    val variables: Map<String, String>? = null,
 )

--- a/kotlin/lib/src/main/kotlin/models/EndpointTransformationPatch.kt
+++ b/kotlin/lib/src/main/kotlin/models/EndpointTransformationPatch.kt
@@ -8,4 +8,5 @@ import kotlinx.serialization.Serializable
 data class EndpointTransformationPatch(
     val code: MaybeUnset<String> = MaybeUnset.Unset,
     val enabled: Boolean? = null,
+    val variables: MaybeUnset<Map<String, String>> = MaybeUnset.Unset,
 )

--- a/php/src/Models/EndpointTransformationOut.php
+++ b/php/src/Models/EndpointTransformationOut.php
@@ -9,10 +9,14 @@ class EndpointTransformationOut implements \JsonSerializable
 {
     private array $setFields = [];
 
+    /**
+     * @param array<string, string>|null $variables
+     */
     private function __construct(
         public readonly ?string $code = null,
         public readonly ?bool $enabled = null,
         public readonly ?\DateTimeImmutable $updatedAt = null,
+        public readonly ?array $variables = null,
         array $setFields = [],
     ) {
         $this->setFields = $setFields;
@@ -27,6 +31,7 @@ class EndpointTransformationOut implements \JsonSerializable
             code: null,
             enabled: null,
             updatedAt: null,
+            variables: null,
             setFields: []
         );
     }
@@ -40,6 +45,7 @@ class EndpointTransformationOut implements \JsonSerializable
             code: $code,
             enabled: $this->enabled,
             updatedAt: $this->updatedAt,
+            variables: $this->variables,
             setFields: $setFields
         );
     }
@@ -53,6 +59,7 @@ class EndpointTransformationOut implements \JsonSerializable
             code: $this->code,
             enabled: $enabled,
             updatedAt: $this->updatedAt,
+            variables: $this->variables,
             setFields: $setFields
         );
     }
@@ -66,6 +73,21 @@ class EndpointTransformationOut implements \JsonSerializable
             code: $this->code,
             enabled: $this->enabled,
             updatedAt: $updatedAt,
+            variables: $this->variables,
+            setFields: $setFields
+        );
+    }
+
+    public function withVariables(?array $variables): self
+    {
+        $setFields = $this->setFields;
+        $setFields['variables'] = true;
+
+        return new self(
+            code: $this->code,
+            enabled: $this->enabled,
+            updatedAt: $this->updatedAt,
+            variables: $variables,
             setFields: $setFields
         );
     }
@@ -84,6 +106,9 @@ class EndpointTransformationOut implements \JsonSerializable
         if (isset($this->setFields['updatedAt'])) {
             $data['updatedAt'] = $this->updatedAt->format('c');
         }
+        if (isset($this->setFields['variables'])) {
+            $data['variables'] = $this->variables;
+        }
 
         return \Svix\Utils::newStdClassIfArrayIsEmpty($data);
     }
@@ -96,7 +121,8 @@ class EndpointTransformationOut implements \JsonSerializable
         return new self(
             code: \Svix\Utils::deserializeString($data, 'code', false, 'EndpointTransformationOut'),
             enabled: \Svix\Utils::deserializeBool($data, 'enabled', false, 'EndpointTransformationOut'),
-            updatedAt: \Svix\Utils::deserializeDt($data, 'updatedAt', false, 'EndpointTransformationOut')
+            updatedAt: \Svix\Utils::deserializeDt($data, 'updatedAt', false, 'EndpointTransformationOut'),
+            variables: \Svix\Utils::getValFromJson($data, 'variables', false, 'EndpointTransformationOut')
         );
     }
 

--- a/php/src/Models/EndpointTransformationPatch.php
+++ b/php/src/Models/EndpointTransformationPatch.php
@@ -9,9 +9,13 @@ class EndpointTransformationPatch implements \JsonSerializable
 {
     private array $setFields = [];
 
+    /**
+     * @param array<string, string>|null $variables
+     */
     private function __construct(
         public readonly ?string $code = null,
         public readonly ?bool $enabled = null,
+        public readonly ?array $variables = null,
         array $setFields = [],
     ) {
         $this->setFields = $setFields;
@@ -25,6 +29,7 @@ class EndpointTransformationPatch implements \JsonSerializable
         return new self(
             code: null,
             enabled: null,
+            variables: null,
             setFields: []
         );
     }
@@ -37,6 +42,7 @@ class EndpointTransformationPatch implements \JsonSerializable
         return new self(
             code: $code,
             enabled: $this->enabled,
+            variables: $this->variables,
             setFields: $setFields
         );
     }
@@ -49,6 +55,20 @@ class EndpointTransformationPatch implements \JsonSerializable
         return new self(
             code: $this->code,
             enabled: $enabled,
+            variables: $this->variables,
+            setFields: $setFields
+        );
+    }
+
+    public function withVariables(?array $variables): self
+    {
+        $setFields = $this->setFields;
+        $setFields['variables'] = true;
+
+        return new self(
+            code: $this->code,
+            enabled: $this->enabled,
+            variables: $variables,
             setFields: $setFields
         );
     }
@@ -64,6 +84,9 @@ class EndpointTransformationPatch implements \JsonSerializable
         if (null !== $this->enabled) {
             $data['enabled'] = $this->enabled;
         }
+        if (isset($this->setFields['variables'])) {
+            $data['variables'] = $this->variables;
+        }
 
         return \Svix\Utils::newStdClassIfArrayIsEmpty($data);
     }
@@ -75,7 +98,8 @@ class EndpointTransformationPatch implements \JsonSerializable
     {
         return new self(
             code: \Svix\Utils::deserializeString($data, 'code', false, 'EndpointTransformationPatch'),
-            enabled: \Svix\Utils::deserializeBool($data, 'enabled', false, 'EndpointTransformationPatch')
+            enabled: \Svix\Utils::deserializeBool($data, 'enabled', false, 'EndpointTransformationPatch'),
+            variables: \Svix\Utils::getValFromJson($data, 'variables', false, 'EndpointTransformationPatch')
         );
     }
 

--- a/python/svix/models/endpoint_transformation_out.py
+++ b/python/svix/models/endpoint_transformation_out.py
@@ -11,3 +11,5 @@ class EndpointTransformationOut(BaseModel):
     enabled: t.Optional[bool] = None
 
     updated_at: t.Optional[datetime] = None
+
+    variables: t.Optional[t.Dict[str, str]] = None

--- a/python/svix/models/endpoint_transformation_patch.py
+++ b/python/svix/models/endpoint_transformation_patch.py
@@ -8,3 +8,5 @@ class EndpointTransformationPatch(BaseModel):
     code: t.Optional[str] = None
 
     enabled: t.Optional[bool] = None
+
+    variables: t.Optional[t.Dict[str, str]] = None

--- a/ruby/lib/svix/models/endpoint_transformation_out.rb
+++ b/ruby/lib/svix/models/endpoint_transformation_out.rb
@@ -7,8 +7,9 @@ module Svix
     attr_accessor :code
     attr_accessor :enabled
     attr_accessor :updated_at
+    attr_accessor :variables
 
-    ALL_FIELD ||= ["code", "enabled", "updated_at"].freeze
+    ALL_FIELD ||= ["code", "enabled", "updated_at", "variables"].freeze
     private_constant :ALL_FIELD
 
     def initialize(attributes = {})
@@ -35,6 +36,7 @@ module Svix
       attrs["code"] = attributes["code"]
       attrs["enabled"] = attributes["enabled"]
       attrs["updated_at"] = DateTime.rfc3339(attributes["updatedAt"]).to_time if attributes["updatedAt"]
+      attrs["variables"] = attributes["variables"]
       new(attrs)
     end
 
@@ -43,6 +45,7 @@ module Svix
       out["code"] = Svix::serialize_primitive(@code) if @code
       out["enabled"] = Svix::serialize_primitive(@enabled) if @enabled
       out["updatedAt"] = Svix::serialize_primitive(@updated_at) if @updated_at
+      out["variables"] = Svix::serialize_primitive(@variables) if @variables
       out
     end
 

--- a/ruby/lib/svix/models/endpoint_transformation_patch.rb
+++ b/ruby/lib/svix/models/endpoint_transformation_patch.rb
@@ -6,8 +6,9 @@ module Svix
   class EndpointTransformationPatch
     attr_accessor :code
     attr_accessor :enabled
+    attr_accessor :variables
 
-    ALL_FIELD ||= ["code", "enabled"].freeze
+    ALL_FIELD ||= ["code", "enabled", "variables"].freeze
     private_constant :ALL_FIELD
 
     def initialize(attributes = {})
@@ -33,6 +34,7 @@ module Svix
       attrs = Hash.new
       attrs["code"] = attributes["code"]
       attrs["enabled"] = attributes["enabled"]
+      attrs["variables"] = attributes["variables"]
       new(attrs)
     end
 
@@ -40,6 +42,7 @@ module Svix
       out = Hash.new
       out["code"] = Svix::serialize_primitive(@code) if @__code_is_defined
       out["enabled"] = Svix::serialize_primitive(@enabled) if @enabled
+      out["variables"] = Svix::serialize_primitive(@variables) if @__variables_is_defined
       out
     end
 

--- a/rust/src/api/authentication.rs
+++ b/rust/src/api/authentication.rs
@@ -214,4 +214,11 @@ impl<'a> Authentication<'a> {
         .execute(self.cfg)
         .await
     }
+
+    /// Return information about the account associated with the current token
+    pub async fn whoami(&self) -> Result<WhoamiOut> {
+        crate::request::Request::new(http1::Method::GET, "/api/v1/auth/whoami")
+            .execute(self.cfg)
+            .await
+    }
 }

--- a/rust/src/models/authentication_source.rs
+++ b/rust/src/models/authentication_source.rs
@@ -1,0 +1,35 @@
+// this file is @generated
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// The authentication type of the current request
+#[derive(
+    Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize,
+)]
+pub enum AuthenticationSource {
+    #[default]
+    #[serde(rename = "OidcJwt")]
+    OidcJwt,
+    #[serde(rename = "SvixJwt")]
+    SvixJwt,
+    #[serde(rename = "RegionalAuthToken")]
+    RegionalAuthToken,
+    #[serde(rename = "GlobalAuthToken")]
+    GlobalAuthToken,
+    #[serde(rename = "Unknown")]
+    Unknown,
+}
+
+impl fmt::Display for AuthenticationSource {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let value = match self {
+            Self::OidcJwt => "OidcJwt",
+            Self::SvixJwt => "SvixJwt",
+            Self::RegionalAuthToken => "RegionalAuthToken",
+            Self::GlobalAuthToken => "GlobalAuthToken",
+            Self::Unknown => "Unknown",
+        };
+        f.write_str(value)
+    }
+}

--- a/rust/src/models/endpoint_transformation_out.rs
+++ b/rust/src/models/endpoint_transformation_out.rs
@@ -12,6 +12,9 @@ pub struct EndpointTransformationOut {
     #[serde(rename = "updatedAt")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub variables: Option<std::collections::HashMap<String, String>>,
 }
 
 impl EndpointTransformationOut {
@@ -20,6 +23,7 @@ impl EndpointTransformationOut {
             code: None,
             enabled: None,
             updated_at: None,
+            variables: None,
         }
     }
 }

--- a/rust/src/models/endpoint_transformation_patch.rs
+++ b/rust/src/models/endpoint_transformation_patch.rs
@@ -9,6 +9,9 @@ pub struct EndpointTransformationPatch {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "JsOption::is_undefined")]
+    pub variables: JsOption<std::collections::HashMap<String, String>>,
 }
 
 impl EndpointTransformationPatch {
@@ -16,6 +19,7 @@ impl EndpointTransformationPatch {
         Self {
             code: JsOption::Undefined,
             enabled: None,
+            variables: JsOption::Undefined,
         }
     }
 }

--- a/rust/src/models/mod.rs
+++ b/rust/src/models/mod.rs
@@ -17,6 +17,7 @@ pub mod application_in;
 pub mod application_out;
 pub mod application_patch;
 pub mod application_token_expire_in;
+pub mod authentication_source;
 pub mod azure_blob_storage_config;
 pub mod azure_blob_storage_patch_config;
 pub mod background_task_finished_event;
@@ -217,6 +218,7 @@ pub mod veriff_config;
 pub mod veriff_config_out;
 pub mod vgs_config;
 pub mod vgs_config_out;
+pub mod whoami_out;
 pub mod zoom_config;
 pub mod zoom_config_out;
 // not currently generated
@@ -244,6 +246,7 @@ pub use self::{
     application_out::ApplicationOut,
     application_patch::ApplicationPatch,
     application_token_expire_in::ApplicationTokenExpireIn,
+    authentication_source::AuthenticationSource,
     azure_blob_storage_config::AzureBlobStorageConfig,
     azure_blob_storage_patch_config::AzureBlobStoragePatchConfig,
     background_task_finished_event::BackgroundTaskFinishedEvent,
@@ -444,6 +447,7 @@ pub use self::{
     veriff_config_out::VeriffConfigOut,
     vgs_config::VgsConfig,
     vgs_config_out::VgsConfigOut,
+    whoami_out::WhoamiOut,
     zoom_config::ZoomConfig,
     zoom_config_out::ZoomConfigOut,
 };

--- a/rust/src/models/whoami_out.rs
+++ b/rust/src/models/whoami_out.rs
@@ -1,0 +1,47 @@
+// this file is @generated
+use serde::{Deserialize, Serialize};
+
+use super::authentication_source::AuthenticationSource;
+
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+pub struct WhoamiOut {
+    /// The dispatch application that the current token is limited to, if there
+    /// is one
+    #[serde(rename = "appId")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_id: Option<String>,
+
+    /// The environment ("organization") that the current token is attached to
+    #[serde(rename = "envId")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env_id: Option<String>,
+
+    /// The source of the current request's authentication
+    ///
+    /// This field is unstable and may change in the future.
+    #[serde(rename = "permissionSource")]
+    pub permission_source: AuthenticationSource,
+
+    /// The session associated with the current request
+    #[serde(rename = "sessionId")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+
+    /// The stream application that the current token is limited to, if there is
+    /// one
+    #[serde(rename = "streamAppId")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream_app_id: Option<String>,
+}
+
+impl WhoamiOut {
+    pub fn new(permission_source: AuthenticationSource) -> Self {
+        Self {
+            app_id: None,
+            env_id: None,
+            permission_source,
+            session_id: None,
+            stream_app_id: None,
+        }
+    }
+}

--- a/svix-cli/src/cmds/api/authentication.rs
+++ b/svix-cli/src/cmds/api/authentication.rs
@@ -287,6 +287,24 @@ pub enum AuthenticationCommands {
         #[clap(flatten)]
         options: AuthenticationRotateStreamPollerTokenOptions,
     },
+    /// Return information about the account associated with the current token
+    #[command(help_template = concat!(
+            "{about-with-newline}\n",
+            "{usage-heading} {usage}\n\n",
+            "Example: svix authentication whoami\n",
+            "{after-help}",
+            "\n",
+            "{all-args}",
+        ))]
+    #[command(after_help = "Example response:
+{
+  \"appId\": \"app_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"envId\": \"org_1srOrx2ZWZBpBUvZwXKQmoEYga2\",
+  \"permissionSource\": \"OidcJwt\",
+  \"sessionId\": \"user_1FB8\",
+  \"streamAppId\": \"strm_2yZwUhtgs5Ai8T9yRQJXA\"
+}\n")]
+    Whoami {},
 }
 
 impl AuthenticationCommands {
@@ -385,6 +403,10 @@ impl AuthenticationCommands {
                         Some(options.into()),
                     )
                     .await?;
+                crate::json::print_json_output(&resp, color_mode)?;
+            }
+            Self::Whoami {} => {
+                let resp = client.authentication().whoami().await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
         }

--- a/svix-cli/src/cmds/api/endpoint.rs
+++ b/svix-cli/src/cmds/api/endpoint.rs
@@ -644,7 +644,8 @@ pub enum EndpointCommands {
 {
   \"code\": \"...\",
   \"enabled\": true,
-  \"updatedAt\": \"2030-01-01T00:00:00Z\"
+  \"updatedAt\": \"2030-01-01T00:00:00Z\",
+  \"variables\": {\"key\": \"...\"}
 }\n")]
     TransformationGet { app_id: String, id: String },
     /// Set or unset the transformation code associated with this endpoint.
@@ -659,7 +660,8 @@ pub enum EndpointCommands {
     #[command(after_help = "Example body:
 {
   \"code\": \"function handler(webhook) { /* ... */ }\",
-  \"enabled\": true
+  \"enabled\": true,
+  \"variables\": {\"key\": \"...\"}
 }\n")]
     PatchTransformation {
         app_id: String,


### PR DESCRIPTION
The immediate goal is to expose the debugging `whoami` endpoint in the CLI and Rust library.

Pulled in the latest private openapi.json as `codegen/lib-openapi.json` then reran codegen.