### PR TITLE
Default expanded_statuses to true for some SDKs

### DIFF
--- a/codegen/templates/javascript/api_resource.ts.jinja
+++ b/codegen/templates/javascript/api_resource.ts.jinja
@@ -99,7 +99,10 @@ export class {{ resource_type_name }} {
             {% if op.query_params | length > 0 -%}
             request.setQueryParams({
                 {% for p in op.query_params -%}
-                "{{ p.name }}": options{% if not p.required %}?{% endif %}.{{ p.name | to_lower_camel_case }},
+                "{{ p.name }}": options{% if not p.required %}?{% endif %}.{{ p.name | to_lower_camel_case }}
+                    {#- HACK: default expanded_statuses to true, it only defaults to false
+                        server-side because of backwards-compatibility for old SDKs #}
+                    {%- if p.name == "expanded_statuses" %} ?? true{% endif %},
                 {% endfor -%}
             });
             {% endif -%}

--- a/codegen/templates/rust/api_extra/application_create.rs
+++ b/codegen/templates/rust/api_extra/application_create.rs
@@ -8,7 +8,7 @@ pub async fn get_or_create(
     let ApplicationCreateOptions { idempotency_key } = options.unwrap_or_default();
 
     crate::request::Request::new(http1::Method::POST, "/api/v1/app")
-        .with_query_param("get_if_exists", "true".to_owned())
+        .with_query_param("get_if_exists", true)
         .with_optional_header_param("idempotency-key", idempotency_key)
         .with_body_param(application_in)
         .execute(self.cfg)

--- a/csharp/Svix/SvixOptionsBase.cs
+++ b/csharp/Svix/SvixOptionsBase.cs
@@ -13,7 +13,15 @@ namespace Svix
             var dict = new Dictionary<string, string>();
             foreach (KeyValuePair<string, object?> entry in rawParams)
             {
-                if (entry.Value == null) { }
+                if (entry.Value == null)
+                {
+                    // HACK: default expanded_statuses to true, it only defaults to false
+                    //       server-side because of backwards-compatibility for old SDKs
+                    if (entry.Key == "expanded_statuses")
+                    {
+                        dict[entry.Key] = "true";
+                    }
+                }
                 else if (IsGenericList(entry.Value))
                 {
                     var list = (System.Collections.IEnumerable)entry.Value;

--- a/go/internal/svix_http_client.go
+++ b/go/internal/svix_http_client.go
@@ -210,6 +210,12 @@ func SerializeParamToMap(key string, val interface{}, d map[string]string, err *
 	}
 	// If val is null don't add it to the query params map
 	if val == nil || (reflect.ValueOf(val).Kind() == reflect.Ptr && reflect.ValueOf(val).IsNil()) {
+		// HACK: default expanded_statuses to true, it only defaults to false
+		//       server-side because of backwards-compatibility for old SDKs
+		if key == "expanded_statuses" {
+			d[key] = "true"
+		}
+
 		return
 	}
 
@@ -271,7 +277,7 @@ func serializeQueryOrHeaderParam(val interface{}, key string) (string, error) {
 		fallthrough
 	default:
 		return "", fmt.Errorf("can't serialize %s as a query param, key: %s", v.Kind().String(), key)
-
 	}
+
 	return value, nil
 }

--- a/javascript/src/api/messageAttempt.ts
+++ b/javascript/src/api/messageAttempt.ts
@@ -152,7 +152,7 @@ export class MessageAttempt {
       after: options?.after,
       with_content: options?.withContent,
       with_msg: options?.withMsg,
-      expanded_statuses: options?.expandedStatuses,
+      expanded_statuses: options?.expandedStatuses ?? true,
       event_types: options?.eventTypes,
     });
 
@@ -193,7 +193,7 @@ export class MessageAttempt {
       before: options?.before,
       after: options?.after,
       with_content: options?.withContent,
-      expanded_statuses: options?.expandedStatuses,
+      expanded_statuses: options?.expandedStatuses ?? true,
       event_types: options?.eventTypes,
     });
 
@@ -234,7 +234,7 @@ export class MessageAttempt {
       before: options?.before,
       after: options?.after,
       with_content: options?.withContent,
-      expanded_statuses: options?.expandedStatuses,
+      expanded_statuses: options?.expandedStatuses ?? true,
       event_types: options?.eventTypes,
     });
 
@@ -260,7 +260,7 @@ export class MessageAttempt {
     request.setPathParam("msg_id", msgId);
     request.setPathParam("attempt_id", attemptId);
     request.setQueryParams({
-      expanded_statuses: options?.expandedStatuses,
+      expanded_statuses: options?.expandedStatuses ?? true,
     });
 
     return request.send(this.requestCtx, MessageAttemptOutSerializer._fromJsonObject);

--- a/javascript/src/mockttp.test.ts
+++ b/javascript/src/mockttp.test.ts
@@ -36,7 +36,7 @@ test("mockttp tests", async (t) => {
     });
     const requests = await endpointMock.getSeenRequests();
     assert.equal(requests.length, 1);
-    assert(requests[0].url.endsWith("before=2025-02-16T21%3A38%3A21.977Z"));
+    assert(requests[0].url.includes("before=2025-02-16T21%3A38%3A21.977Z"));
   });
 
   await t.test("test Date request body", async () => {

--- a/rust/src/api/application.rs
+++ b/rust/src/api/application.rs
@@ -97,7 +97,7 @@ impl<'a> Application<'a> {
         let ApplicationCreateOptions { idempotency_key } = options.unwrap_or_default();
 
         crate::request::Request::new(http1::Method::POST, "/api/v1/app")
-            .with_query_param("get_if_exists", "true".to_owned())
+            .with_query_param("get_if_exists", true)
             .with_optional_header_param("idempotency-key", idempotency_key)
             .with_body_param(application_in)
             .execute(self.cfg)

--- a/rust/src/request.rs
+++ b/rust/src/request.rs
@@ -71,6 +71,10 @@ impl Request {
     ) -> Self {
         if let Some(value) = param {
             self.query_params.insert(name, value.encode());
+        } else if name == "expanded_statuses" {
+            // HACK: default expanded_statuses to true, it only defaults to false
+            //       server-side because of backwards-compatibility for old SDKs
+            self.query_params.insert(name, true.encode());
         }
         self
     }

--- a/rust/src/request.rs
+++ b/rust/src/request.rs
@@ -52,29 +52,25 @@ impl Request {
         self
     }
 
-    pub fn with_optional_header_param(
-        mut self,
-        basename: &'static str,
-        param: Option<String>,
-    ) -> Self {
+    pub fn with_optional_header_param(mut self, name: &'static str, param: Option<String>) -> Self {
         if let Some(value) = param {
-            self.header_params.insert(basename, value);
+            self.header_params.insert(name, value);
         }
         self
     }
 
-    pub fn with_query_param(mut self, basename: &'static str, param: impl QueryParamValue) -> Self {
-        self.query_params.insert(basename, param.encode());
+    pub fn with_query_param(mut self, name: &'static str, param: impl QueryParamValue) -> Self {
+        self.query_params.insert(name, param.encode());
         self
     }
 
     pub fn with_optional_query_param<T: QueryParamValue>(
         mut self,
-        basename: &'static str,
+        name: &'static str,
         param: Option<T>,
     ) -> Self {
         if let Some(value) = param {
-            self.query_params.insert(basename, value.encode());
+            self.query_params.insert(name, value.encode());
         }
         self
     }


### PR DESCRIPTION
## Motivation

Current versions of the SDKs support the `canceled` variant of message-status. There should be little to no reason not to set this to `true` for users, so change it to default-true.

## Solution

Just special-case the `expanded_statuses` parameter in each SDK, since that is the simplest way to get this done and fix user confusion. We could potentially replace this by a `default` in the OpenAPI spec (though only the one used to generate the SDKs, as it would be wrong to show a default of true in the docs) and changes to openapi-codegen + the jinja templates here to actually honor such a default.

Part of https://github.com/svix/monorepo-private/issues/13145.
