### PR TITLE
ruby: Default expanded_statuses to true

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unrelease
+* Libs/All: Enable server-side support of 'canceled' message-attempt status by default
+  * If you were previously comparing attempt statuses against 'success', note that the
+    result of the comparison will now change for messages canceled by a transformation script
+
 ## Version 1.94.0
 * Libs **(New)**: Webhooks AutoConfig SDK
 * Libs/Java: Restore compatibility with Java 1.8 in Webhooks verification

--- a/ruby/lib/svix/svix_http_client.rb
+++ b/ruby/lib/svix/svix_http_client.rb
@@ -101,7 +101,7 @@ module Svix
     private def encode_query_params(query_params = {})
       encoded_query_pairs = []
       query_params.each do |k, v|
-        unless v.nil?
+        if !v.nil?
           if v.kind_of?(Array)
             encoded_query_pairs.append("#{k}=" + CGI::escape(v.sort.join(",")))
           elsif v.kind_of?(Time)
@@ -109,6 +109,10 @@ module Svix
           else
             encoded_query_pairs.append("#{k}=#{CGI::escape(v)}")
           end
+        elsif k == "expanded_statuses"
+          # HACK: default expanded_statuses to true, it only defaults to false
+          #       server-side because of backwards-compatibility for old SDKs
+          encoded_query_pairs.append("#{k}=true")
         end
       end
 

--- a/ruby/spec/webmock_tests_spec.rb
+++ b/ruby/spec/webmock_tests_spec.rb
@@ -36,7 +36,7 @@ describe "API Client" do
 
     svx.message_attempt.list_by_endpoint("app_id", "endpoint_id", {tag: "#"})
 
-    expect(WebMock).to(have_requested(:get, "#{host}/api/v1/app/app_id/attempt/endpoint/endpoint_id?tag=%23"))
+    expect(WebMock).to(have_requested(:get, "#{host}/api/v1/app/app_id/attempt/endpoint/endpoint_id?expanded_statuses=true&tag=%23"))
   end
 
   it "test Date in query param" do
@@ -52,7 +52,7 @@ describe "API Client" do
     expect(WebMock).to(
       have_requested(
         :get,
-        "#{host}/api/v1/app/app_id/attempt/endpoint/endpoint_id?tag=%23&before=2025-02-26T20%3A35%3A43%2B00%3A00"
+        "#{host}/api/v1/app/app_id/attempt/endpoint/endpoint_id?expanded_statuses=true&tag=%23&before=2025-02-26T20%3A35%3A43%2B00%3A00"
       )
     )
   end
@@ -77,6 +77,7 @@ describe "API Client" do
 
   it "test Date response body" do
     stub_request(:get, "#{host}/api/v1/app/app_id/attempt/endpoint/endpoint_id")
+      .with(query: hash_including({}))
       .to_return(
         status: 200,
         body: ListResponseMessageAttemptOut_JSON
@@ -88,13 +89,14 @@ describe "API Client" do
     expect(WebMock).to(
       have_requested(
         :get,
-        "#{host}/api/v1/app/app_id/attempt/endpoint/endpoint_id"
+        "#{host}/api/v1/app/app_id/attempt/endpoint/endpoint_id?expanded_statuses=true"
       )
     )
   end
 
   it "test listResponseOut deserializes correctly" do
     stub_request(:get, "#{host}/api/v1/app/app_id/attempt/endpoint/endpoint_id")
+      .with(query: hash_including({}))
       .to_return(
         status: 200,
         body: "{\"data\":[],\"iterator\":null,\"prevIterator\":null,\"done\":true}"
@@ -104,7 +106,7 @@ describe "API Client" do
     expect(WebMock).to(
       have_requested(
         :get,
-        "#{host}/api/v1/app/app_id/attempt/endpoint/endpoint_id"
+        "#{host}/api/v1/app/app_id/attempt/endpoint/endpoint_id?expanded_statuses=true"
       )
     )
   end
@@ -202,6 +204,7 @@ describe "API Client" do
 
   it "integer enum deserialization" do
     stub_request(:get, "#{host}/api/v1/app/app_id/attempt/endpoint/endpoint_id")
+      .with(query: hash_including({}))
       .to_return(
         status: 200,
         body: ListResponseMessageAttemptOut_JSON
@@ -304,6 +307,7 @@ describe "API Client" do
 
   it "MessageAttemptOut without msg" do
     stub_request(:get, "#{host}/api/v1/app/app/attempt/endpoint/edp")
+      .with(query: hash_including({}))
       .to_return(
         status: 200,
         body: ListResponseMessageAttemptOut_without_msg_JSON


### PR DESCRIPTION
Last piece of #2338.
Closes https://github.com/svix/monorepo-private/issues/13145.