### PR TITLE
Avoid deprecation about null values

### DIFF
--- a/php/src/Utils.php
+++ b/php/src/Utils.php
@@ -53,10 +53,14 @@ class Utils
         return $val;
     }
 
-    static function deserializeDt(mixed $data, string $key, bool $required, string $structName): \DateTimeImmutable
+    static function deserializeDt(mixed $data, string $key, bool $required, string $structName): ?\DateTimeImmutable
     {
 
         $val = Utils::getValFromJson($data, $key, $required, $structName);
+        if ($val === null) {
+            return null;
+        }
+
         return new \DateTimeImmutable($val);
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Hi @svix-jbrown ; I got recently the error
```
Deprecated: DateTimeImmutable::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated
```
Seems like the method `deserializeDt` doesn't handle null correctly

## Solution

Early null check
