### PR TITLE
forbid empty webhook secrets

### DIFF
--- a/csharp/Svix/Exceptions/EmptyWebhookSecretException.cs
+++ b/csharp/Svix/Exceptions/EmptyWebhookSecretException.cs
@@ -1,0 +1,14 @@
+namespace Svix.Exceptions
+{
+    public class EmptyWebhookSecretException : Exception
+    {
+        public EmptyWebhookSecretException()
+            : base() { }
+
+        public EmptyWebhookSecretException(string message)
+            : base(message) { }
+
+        public EmptyWebhookSecretException(string message, Exception inner)
+            : base(message, inner) { }
+    }
+}

--- a/csharp/Svix/Exceptions/EmptyWebhookSecretException.cs
+++ b/csharp/Svix/Exceptions/EmptyWebhookSecretException.cs
@@ -1,6 +1,6 @@
 namespace Svix.Exceptions
 {
-    public class EmptyWebhookSecretException : Exception
+    public class EmptyWebhookSecretException : WebhookVerificationException
     {
         public EmptyWebhookSecretException()
             : base() { }

--- a/csharp/Svix/Webhook.cs
+++ b/csharp/Svix/Webhook.cs
@@ -35,11 +35,21 @@ namespace Svix
             }
 
             this.key = Convert.FromBase64String(key);
+
+            if (this.key == null || this.key.Length == 0)
+            {
+                throw new EmptyWebhookSecretException("Missing webhook secret");
+            }
         }
 
         public Webhook(byte[] key)
         {
             this.key = key;
+
+            if (this.key == null || this.key.Length == 0)
+            {
+                throw new EmptyWebhookSecretException("Missing webhook secret");
+            }
         }
 
         public void Verify(ReadOnlySpan<char> payload, WebHeaderCollection headers)

--- a/go/webhook.go
+++ b/go/webhook.go
@@ -27,6 +27,7 @@ var (
 	errNoMatchingSignature = fmt.Errorf("no matching signature found")
 	errMessageTooOld       = fmt.Errorf("message timestamp too old")
 	errMessageTooNew       = fmt.Errorf("message timestamp too new")
+	errEmptySecret         = fmt.Errorf("webhook secret may not be empty")
 )
 
 func NewWebhook(secret string) (*Webhook, error) {
@@ -34,12 +35,18 @@ func NewWebhook(secret string) (*Webhook, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(key) == 0 {
+		return nil, errEmptySecret
+	}
 	return &Webhook{
 		key: key,
 	}, nil
 }
 
 func NewWebhookRaw(secret []byte) (*Webhook, error) {
+	if len(secret) == 0 {
+		return nil, errEmptySecret
+	}
 	return &Webhook{
 		key: secret,
 	}, nil

--- a/go/webhook_test.go
+++ b/go/webhook_test.go
@@ -231,3 +231,24 @@ func TestWebhookSign(t *testing.T) {
 	}
 
 }
+
+func TestWebhookNoEmptySecrets(t *testing.T) {
+	_, err := svix.NewWebhook("")
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+}
+
+func TestWebhookNoEmptyPrefixedSecrets(t *testing.T) {
+	_, err := svix.NewWebhook("whsec_")
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+}
+
+func TestWebhookNewRawNoEmptyPrefixedSecrets(t *testing.T) {
+	_, err := svix.NewWebhookRaw([]byte(""))
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+}

--- a/java/lib/src/main/java/com/svix/AutoConfig.java
+++ b/java/lib/src/main/java/com/svix/AutoConfig.java
@@ -2,6 +2,7 @@ package com.svix;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.svix.exceptions.ApiException;
+import com.svix.exceptions.EmptyWebhookSecretException;
 import com.svix.exceptions.WebhookVerificationException;
 import com.svix.internalapi.EndpointAutoConfig;
 import com.svix.models.EndpointIn;
@@ -30,6 +31,8 @@ public final class AutoConfig {
         try {
             this.webhook = new Webhook(content.getEndpointSecret());
         } catch (IllegalArgumentException e) {
+            throw new InvalidTokenException(e);
+        } catch (EmptyWebhookSecretException e) {
             throw new InvalidTokenException(e);
         }
 

--- a/java/lib/src/main/java/com/svix/Webhook.java
+++ b/java/lib/src/main/java/com/svix/Webhook.java
@@ -1,15 +1,17 @@
 package com.svix;
 
+import com.svix.exceptions.EmptyWebhookSecretException;
+
 /**
  * A class for verifying and generating webhook signatures.
  */
 public final class Webhook extends WebhookBase {
 
-    public Webhook(final String secret) {
+    public Webhook(final String secret) throws EmptyWebhookSecretException {
         super(secret);
     }
 
-    public Webhook(final byte[] secret) {
+    public Webhook(final byte[] secret) throws EmptyWebhookSecretException {
         super(secret);
     }
 }

--- a/java/lib/src/main/java/com/svix/WebhookBase.java
+++ b/java/lib/src/main/java/com/svix/WebhookBase.java
@@ -34,7 +34,8 @@ abstract class WebhookBase {
 
     protected final byte[] key;
 
-    protected WebhookBase(final String secret) {
+    protected WebhookBase(final String secret)
+            throws EmptyWebhookSecretException {
         String sec = secret;
         if (sec.startsWith(WebhookBase.SECRET_PREFIX)) {
             sec = sec.substring(WebhookBase.SECRET_PREFIX.length());
@@ -45,7 +46,8 @@ abstract class WebhookBase {
         }
     }
 
-    protected WebhookBase(final byte[] secret) {
+    protected WebhookBase(final byte[] secret)
+            throws EmptyWebhookSecretException {
         this.key = secret;
         if (this.key.length == 0) {
             throw new EmptyWebhookSecretException("Webhook secret should not be empty");

--- a/java/lib/src/main/java/com/svix/WebhookBase.java
+++ b/java/lib/src/main/java/com/svix/WebhookBase.java
@@ -1,5 +1,6 @@
 package com.svix;
 
+import com.svix.exceptions.EmptyWebhookSecretException;
 import com.svix.exceptions.WebhookSigningException;
 import com.svix.exceptions.WebhookVerificationException;
 
@@ -39,10 +40,16 @@ abstract class WebhookBase {
             sec = sec.substring(WebhookBase.SECRET_PREFIX.length());
         }
         this.key = Base64.getDecoder().decode(sec);
+        if (this.key.length == 0) {
+            throw new EmptyWebhookSecretException("Webhook secret should not be empty");
+        }
     }
 
     protected WebhookBase(final byte[] secret) {
         this.key = secret;
+        if (this.key.length == 0) {
+            throw new EmptyWebhookSecretException("Webhook secret should not be empty");
+        }
     }
 
     public void verify(final String payload, final Map<String, List<String>> headers)

--- a/java/lib/src/main/java/com/svix/exceptions/EmptyWebhookSecretException.java
+++ b/java/lib/src/main/java/com/svix/exceptions/EmptyWebhookSecretException.java
@@ -1,0 +1,8 @@
+package com.svix.exceptions;
+
+public class EmptyWebhookSecretException extends Exception {
+
+    public EmptyWebhookSecretException(final String message) {
+        super(message);
+    }
+}

--- a/java/lib/src/main/java11/com/svix/Webhook.java
+++ b/java/lib/src/main/java11/com/svix/Webhook.java
@@ -1,5 +1,6 @@
 package com.svix;
 
+import com.svix.exceptions.EmptyWebhookSecretException;
 import com.svix.exceptions.WebhookVerificationException;
 
 import java.net.http.HttpHeaders;

--- a/java/lib/src/main/java11/com/svix/Webhook.java
+++ b/java/lib/src/main/java11/com/svix/Webhook.java
@@ -9,11 +9,11 @@ import java.net.http.HttpHeaders;
  */
 public final class Webhook extends WebhookBase {
 
-    public Webhook(final String secret) {
+    public Webhook(final String secret) throws EmptyWebhookSecretException {
         super(secret);
     }
 
-    public Webhook(final byte[] secret) {
+    public Webhook(final byte[] secret) throws EmptyWebhookSecretException {
         super(secret);
     }
 

--- a/java/lib/src/test/com/svix/test/WebhookTest.java
+++ b/java/lib/src/test/com/svix/test/WebhookTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 import com.svix.Webhook;
+import com.svix.exceptions.EmptyWebhookSecretException;
 import com.svix.exceptions.WebhookSigningException;
 import com.svix.exceptions.WebhookVerificationException;
 
@@ -26,7 +27,7 @@ public class WebhookTest {
     private static final int SECOND_IN_MS = 1000;
 
     @Test
-    public void verifyValidPayloadAndheader() throws WebhookVerificationException {
+    public void verifyValidPayloadAndheader() throws WebhookVerificationException, EmptyWebhookSecretException {
         TestPayload testPayload = new TestPayload(System.currentTimeMillis());
 
         Webhook webhook = new Webhook(testPayload.secret);
@@ -35,7 +36,7 @@ public class WebhookTest {
     }
 
     @Test
-    public void verifyValidBrandlessPayloadAndheader() throws WebhookVerificationException {
+    public void verifyValidBrandlessPayloadAndheader() throws WebhookVerificationException, EmptyWebhookSecretException {
         TestPayload testPayload = new TestPayload(System.currentTimeMillis());
         HashMap<String, ArrayList<String>> unbrandedHeaders =
                 new HashMap<String, ArrayList<String>>();
@@ -51,7 +52,7 @@ public class WebhookTest {
 
     @Test
     public void verifyValidPayloadWithMultipleSignaturesIsValid()
-            throws WebhookVerificationException {
+            throws WebhookVerificationException, EmptyWebhookSecretException {
         TestPayload testPayload = new TestPayload(System.currentTimeMillis());
         String[] sigs =
                 new String[] {
@@ -139,7 +140,7 @@ public class WebhookTest {
     }
 
     @Test
-    public void verifySecretWorksWithOrWithoutPrefix() throws WebhookVerificationException {
+    public void verifySecretWorksWithOrWithoutPrefix() throws WebhookVerificationException, EmptyWebhookSecretException  {
         TestPayload testPayload = new TestPayload(System.currentTimeMillis());
 
         Webhook webhook = new Webhook(testPayload.secret);
@@ -150,7 +151,7 @@ public class WebhookTest {
     }
 
     @Test
-    public void verifyWebhookSignWorks() throws WebhookSigningException {
+    public void verifyWebhookSignWorks() throws WebhookSigningException, EmptyWebhookSecretException  {
         String key = "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw";
         String msgId = "msg_p5jXN8AQM9LWM0D4loKWxJek";
         final long timestamp = 1614265330;
@@ -165,7 +166,7 @@ public class WebhookTest {
     private ThrowingRunnable verify(final TestPayload testPayload) {
         return new ThrowingRunnable() {
             @Override
-            public void run() throws WebhookVerificationException {
+            public void run() throws WebhookVerificationException, EmptyWebhookSecretException {
                 Webhook webhook = new Webhook(testPayload.secret);
                 webhook.verify(testPayload.payload, testPayload.headers());
             }

--- a/ruby/lib/svix/errors.rb
+++ b/ruby/lib/svix/errors.rb
@@ -14,4 +14,7 @@ module Svix
 
   class WebhookSigningError < SvixError
   end
+
+  class EmptyWebhookSecretError < SvixError
+  end
 end

--- a/ruby/lib/svix/webhook.rb
+++ b/ruby/lib/svix/webhook.rb
@@ -13,6 +13,10 @@ module Svix
       end
 
       @secret = Base64.decode64(secret)
+
+      if @secret.empty?
+        raise EmptyWebhookSecretError, "Webhook secret must not be blank"
+      end
     end
 
     def verify(payload, headers)

--- a/ruby/spec/webhook_spec.rb
+++ b/ruby/spec/webhook_spec.rb
@@ -37,6 +37,19 @@ class TestPayload
 end
 
 describe Svix::Webhook do
+  describe ".new" do
+    it "rejects empty webhook secrets" do
+      expect { Svix::Webhook.new("") }.to raise_error(Svix::EmptyWebhookSecretError)
+      expect { Svix::Webhook.new("whsec_") }.to raise_error(Svix::EmptyWebhookSecretError)
+    end
+  end
+
+  describe ".new_using_raw_bytes" do
+    it "rejects empty webhook secrets" do
+      expect { Svix::Webhook.new("") }.to raise_error(Svix::EmptyWebhookSecretError)
+    end
+  end
+
   it "missing id raises error" do
     testPayload = TestPayload.new
     testPayload.headers.delete("svix-id")

--- a/rust/src/webhooks.rs
+++ b/rust/src/webhooks.rs
@@ -9,6 +9,9 @@ pub enum WebhookError {
     #[error("invalid secret")]
     InvalidSecret(#[from] base64::DecodeError),
 
+    #[error("secret may not be blank")]
+    EmptySecret,
+
     #[error("invalid header {0}")]
     InvalidHeader(&'static str),
 
@@ -29,7 +32,13 @@ pub enum WebhookError {
 }
 
 pub struct Webhook {
-    key: Vec<u8>,
+    key: Box<[u8]>,
+}
+
+impl std::fmt::Debug for Webhook {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Webhook {{ key: [redacted] }}")
+    }
 }
 
 const PREFIX: &str = "whsec_";
@@ -47,11 +56,22 @@ impl Webhook {
         let secret = secret.strip_prefix(PREFIX).unwrap_or(secret);
         let key = base64::decode(secret)?;
 
-        Ok(Webhook { key })
+        if key.is_empty() {
+            return Err(WebhookError::EmptySecret);
+        }
+
+        Ok(Webhook {
+            key: key.into_boxed_slice(),
+        })
     }
 
     pub fn from_bytes(secret: Vec<u8>) -> Result<Self, WebhookError> {
-        Ok(Webhook { key: secret })
+        if secret.is_empty() {
+            return Err(WebhookError::EmptySecret);
+        }
+        Ok(Webhook {
+            key: secret.into_boxed_slice(),
+        })
     }
 
     pub fn verify<HM: HeaderMap>(&self, payload: &[u8], headers: &HM) -> Result<(), WebhookError> {
@@ -455,5 +475,18 @@ mod tests {
                 assert!(wh.verify(payload, &hdr_map).is_err());
             }
         }
+    }
+
+    #[test]
+    fn test_new_rejects_empty_secret() {
+        let secret = "".to_owned();
+        Webhook::new(&secret).expect_err("should fail for empty secret");
+        let secret = "whsec_".to_owned();
+        Webhook::new(&secret).expect_err("should fail for whsec_-prefixed empty secret");
+    }
+
+    #[test]
+    fn test_from_bytes_rejects_empty_secret() {
+        Webhook::from_bytes(vec![]).expect_err("should fail for empty secret");
     }
 }


### PR DESCRIPTION
This modifies all of the client libraries to reject empty webhook signing secrets, to make it harder to accidentally misconfigure them.

Same as standard-webhooks/standard-webhooks#286

Part of svix/monorepo-private#13164