### PR TITLE
py: fix matrix builds

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          python-version: ${{ matrix.python_version }}
+          python-version: ${{ matrix.python-version }}
 
       - name: Install deps
         working-directory: python/

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          python-version: ${{ matrix.python_version }}
+          python-version: ${{ matrix.python-version }}
 
       - name: Install deps
         working-directory: ./python

--- a/python/svix/api/common.py
+++ b/python/svix/api/common.py
@@ -123,7 +123,7 @@ class ApiBase:
         if headers.get("idempotency-key") is None and method.upper() == "POST":
             headers["idempotency-key"] = f"auto_{uuid.uuid4()}"
 
-        httpx_kwargs: dict[str, t.Any] = {
+        httpx_kwargs: t.Dict[str, t.Any] = {
             "method": method.upper(),
             "url": url,
             "headers": headers,

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -204,7 +204,7 @@ def test_svix_message_create(
         assert "Svix-Signature" in request.headers
 
         webhook = Webhook(secret)
-        headers: dict[str, str] = dict(request.headers.items())
+        headers: Dict[str, str] = dict(request.headers.items())
         received_payload = webhook.verify(request.data, headers)
         assert received_payload == payload
 


### PR DESCRIPTION
gah I hate github actions

I was reading the output in #2354 (which made no sense) and realized that GHA was pushing an empty string for `python-version`, and uv was just running with 3.12 for all of the builds.

I messed this up while editing #2350 