### PR TITLE
py: make tests pass ruff and ty, and work better

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -22,12 +22,8 @@ jobs:
         working-directory: ./python
         run: uv sync
 
-      - name: Check typing on client tests
-        run: |
-          uv run mypy tests/test_client.py
-          uv run ty check tests/test_client.py
-        working-directory: ./python
-
       - name: Run Python tests
         run: uv run pytest -sv
+        env:
+          CI: '1'
         working-directory: ./python

--- a/python/.editorconfig
+++ b/python/.editorconfig
@@ -1,0 +1,8 @@
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+max_line_length = 88

--- a/python/scripts/lint.sh
+++ b/python/scripts/lint.sh
@@ -3,6 +3,9 @@
 set -ex
 
 mypy svix
-ty check svix
-ruff check svix
-ruff format --check svix
+ty check svix/
+ty check tests/
+ruff check svix/
+ruff check tests/
+ruff format --check svix/
+ruff format --check tests/

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,16 +1,20 @@
+import logging
 import os
 import shutil
+import typing as t
 from subprocess import CalledProcessError, check_output
 
 import pytest
 import requests
 from requests.adapters import HTTPAdapter
-from svix.api import Svix, SvixOptions
 from urllib3.util.retry import Retry
+
+from svix.api import Svix, SvixOptions
 
 SVIX_ORG_ID = "org_svix_python_tests"
 TOKEN = os.getenv("SVIX_TOKEN")
 SERVER_URL = os.getenv("SVIX_SERVER_URL")
+
 if not TOKEN and not SERVER_URL:
 
     def pytest_collection_modifyitems(config, items):
@@ -40,73 +44,81 @@ if not TOKEN and not SERVER_URL:
                 if item.module.__name__ == "tests.test_client":
                     item.add_marker(skipper)
 
-    @pytest.fixture(scope="session")
-    def docker_compose_command():
-        try:
-            # use docker compose v2 if available
-            check_output(["docker", "compose", "version"])
-            return "docker compose"
-        except Exception:
-            # fallback on v1 otherwise
-            return "docker-compose"
 
-    # `pytest-docker` reads this to override the location of the docker-compose.yml file
-    @pytest.fixture(scope="session")
-    def docker_compose_file():
-        return [
-            os.path.join(os.path.dirname(__file__), "../../server/docker-compose.yml"),
-            os.path.join(os.path.dirname(__file__), "docker-compose.override.yml"),
-        ]
+@pytest.fixture(scope="session")
+def docker_compose_command():
+    try:
+        # use docker compose v2 if available
+        check_output(["docker", "compose", "version"])
+        return "docker compose"
+    except Exception:
+        # fallback on v1 otherwise
+        return "docker-compose"
 
-    # `pytest-docker` will use this fixture to override the setup command
-    @pytest.fixture(scope="session")
-    def docker_setup():
-        # Don't include the default --build option in the setup
-        return ["up -d"]
 
-    @pytest.fixture(scope="session")
-    def docker_compose(docker_services):
-        return docker_services._docker_compose
+# `pytest-docker` reads this to override the location of the docker-compose.yml file
+@pytest.fixture(scope="session")
+def docker_compose_file():
+    return [
+        os.path.join(os.path.dirname(__file__), "../../server/docker-compose.yml"),
+        os.path.join(os.path.dirname(__file__), "docker-compose.override.yml"),
+    ]
 
-    @pytest.fixture(scope="session")
-    def httpserver_listen_address():
-        # Use IP address in the docker bridge network as server hostname in order for
-        # the svix server executed in a docker container to successfully send webhooks
-        # to the HTTP server executed on the host
+
+# `pytest-docker` will use this fixture to override the setup command
+@pytest.fixture(scope="session")
+def docker_setup():
+    # Don't include the default --build option in the setup
+    return ["up -d"]
+
+
+@pytest.fixture(scope="session")
+def docker_compose(docker_services):
+    return docker_services._docker_compose
+
+
+@pytest.fixture(scope="session")
+def is_ci() -> bool:
+    return os.environ.get("CI") is not None
+
+
+@pytest.fixture(scope="session")
+def httpserver_listen_address(is_ci):
+    if is_ci:
+        # host.docker.internal doesn't seem to work quite right in github actions,
+        # so hardcode this sketchy-ass IP address
         return ("172.17.0.1", 0)
+    else:
+        # however, 172.17.0.1 is only the host-local IP address for (commercial)
+        # docker for linux, so bind to 0.0.0.0 and then use host.docker.internal
+        # in the actual test on all other platforms
+        return ("0.0.0.0", 0)
+
+
+if not TOKEN and not SERVER_URL:
 
     @pytest.fixture(scope="session")
-    def svix_server_url(docker_services):
+    def svix_server_url(docker_services, docker_ip) -> str:
+        """Spawn a Svix server for the tests session using docker compose"""
         # svix server container exposes a free port to the docker host,
         # we use the docker network gateway IP in case the tests are also
         # executed in a container
         svix_server_port = docker_services.port_for("backend", 8071)
-        return f"http://172.17.0.1:{svix_server_port}"
-
-    @pytest.fixture(autouse=True, scope="session")
-    def svix_server(svix_server_url):
-        """Spawn a Svix server for the tests session using docker compose"""
+        url = f"http://{docker_ip}:{svix_server_port}"
         # wait for the svix backend service to be up and responding
         request_session = requests.Session()
         retries = Retry(
             total=10, backoff_factor=0.1, status_forcelist=[500, 502, 503, 504]
         )
         request_session.mount("http://", HTTPAdapter(max_retries=retries))
-        api_url = f"{svix_server_url}/api/v1/health/"
-        response = request_session.get(api_url)
-        assert response
+        api_url = f"{url}/api/v1/health/"
+        logging.debug("waiting for server at %s to be healthy...", api_url)
+        request_session.get(api_url).raise_for_status()
+        logging.debug("OK, we're up")
+        return url
 
-    @pytest.fixture(autouse=True)
-    def svix_wiper(docker_compose):
-        """Ensure stateless tests"""
-        yield
-        # wipe svix database after each test to ensure stateless tests
-        docker_compose.execute(
-            f"exec -T backend svix-server wipe --yes-i-know-what-im-doing {SVIX_ORG_ID}"
-        )
-
-    @pytest.fixture(scope="session")
-    def svix_api(svix_server_url, docker_compose):
+    @pytest.fixture
+    def svix_api(svix_server_url, docker_compose) -> t.Generator[Svix, None, None]:
         # generate bearer token to authorize communication with the svix server
         exec_output = docker_compose.execute(
             f"exec -T backend svix-server jwt generate {SVIX_ORG_ID}"
@@ -117,7 +129,27 @@ if not TOKEN and not SERVER_URL:
             .replace("\r", "")
             .replace("\n", "")
         )
-        return Svix(
+        yield Svix(
             svix_auth_token,
+            SvixOptions(server_url=svix_server_url),
+        )
+        # wipe svix database after each test to ensure stateless tests
+        docker_compose.execute(
+            f"exec -T backend svix-server wipe --yes-i-know-what-im-doing {SVIX_ORG_ID}"
+        )
+
+else:
+
+    @pytest.fixture(scope="session")
+    def svix_server_url() -> str:
+        """Use the existing svix server URL"""
+        assert SERVER_URL
+        return SERVER_URL
+
+    @pytest.fixture(scope="session")
+    def svix_api(svix_server_url) -> Svix:
+        assert TOKEN
+        return Svix(
+            TOKEN,
             SvixOptions(server_url=svix_server_url),
         )

--- a/python/tests/docker-compose.override.yml
+++ b/python/tests/docker-compose.override.yml
@@ -4,7 +4,10 @@ services:
     environment:
       SVIX_JWT_SECRET: "x"
       SVIX_ENDPOINT_HTTPS_ONLY: "false"
-      SVIX_WHITELIST_SUBNETS: "[127.0.0.1/32, 172.17.0.0/16]"
+      SVIX_WHITELIST_SUBNETS: "[127.0.0.1/32, 172.17.0.0/16, 0.250.250.0/24]"
+      SVIX_LOG_LEVEL: "trace"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
   pgbouncer:
     ports:
       - "8079:5432" # Needed for sqlx

--- a/python/tests/test_autoconfig.py
+++ b/python/tests/test_autoconfig.py
@@ -27,7 +27,13 @@ def test_decode_autoconfig_token_v1_parses_payload():
 
 
 def test_decode_autoconfig_token_v1_rejects_bad_prefix():
-    payload = {"aid": "a", "eid": "e", "surl": "https://x", "esec": "whsec_Zm9v", "tok": "t"}
+    payload = {
+        "aid": "a",
+        "eid": "e",
+        "surl": "https://x",
+        "esec": "whsec_Zm9v",
+        "tok": "t",
+    }
     raw = json.dumps(payload).encode()
     token = f"wrong_{base64.b64encode(raw).decode('ascii')}"
 
@@ -36,7 +42,9 @@ def test_decode_autoconfig_token_v1_rejects_bad_prefix():
 
 
 def test_decode_autoconfig_token_v1_rejects_invalid_json():
-    token = f"{_AUTOCONFIG_TOKEN_PREFIX_V1}{base64.b64encode(b'not json').decode('ascii')}"
+    token = (
+        f"{_AUTOCONFIG_TOKEN_PREFIX_V1}{base64.b64encode(b'not json').decode('ascii')}"
+    )
 
     with pytest.raises(AutoConfigError):
         _decode_autoconfig_token_v1(token)

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -1,3 +1,4 @@
+import hashlib
 import itertools
 import uuid
 from typing import Any, Dict, List, Optional
@@ -19,8 +20,11 @@ from svix.api import (
 from svix.webhooks import Webhook
 
 
-def _gen_uuid(name: str) -> str:
-    return str(uuid.uuid5(uuid.NAMESPACE_DNS, name))
+def _gen_uid(name: str) -> str:
+    hasher = hashlib.sha256()
+    hasher.update(name.encode("utf-8"))
+    hasher.update(str(uuid.uuid4()).encode("ascii"))
+    return hasher.hexdigest()
 
 
 @pytest.fixture
@@ -28,11 +32,14 @@ def svix_app_name() -> str:
     return "svix_python_tests"
 
 
-@pytest.fixture
-def event_type_schema() -> Dict[str, Any]:
+def event_type_name() -> str:
+    return f"event.{str(uuid.uuid4()).replace('-', '')}"
+
+
+def make_event_type_schema(event_type_name) -> Dict[str, Any]:
     return {
         "type": "object",
-        "title": "event.test",
+        "title": event_type_name,
         "description": "A dummy event type",
         "properties": {
             "value": {
@@ -94,15 +101,14 @@ def create_svix_endpoint(
 
 
 def test_svix_application_create(svix_api: Svix, svix_app_name: str) -> None:
-    svix_app_uid = _gen_uuid(svix_app_name)
+    svix_app_uid = _gen_uid(svix_app_name)
     app = create_svix_app(svix_api, svix_app_name, svix_app_uid)
     assert app.name == svix_app_name
     assert app.uid == svix_app_uid
 
 
-def test_svix_event_type_create(
-    svix_api: Svix, event_type_schema: Dict[str, Any]
-) -> None:
+def test_svix_event_type_create(svix_api: Svix) -> None:
+    event_type_schema = make_event_type_schema(event_type_name())
     event_type = create_svix_event_type(svix_api, event_type_schema)
     assert event_type.name == event_type_schema["title"]
     assert event_type.description == event_type_schema["description"]
@@ -133,16 +139,16 @@ def svix_endpoint_create_test_params_ids() -> List[str]:
 def test_svix_endpoint_create(
     svix_api: Svix,
     svix_app_name: str,
-    event_type_schema: Dict[str, Any],
     endpoint_url: str,
     with_channel: bool,
     with_metadata: bool,
     with_secret: bool,
 ) -> None:
-    svix_app_uid = _gen_uuid(svix_app_name)
+    svix_app_uid = _gen_uid(svix_app_name)
     app = create_svix_app(svix_api, svix_app_name, svix_app_uid)
+    event_type_schema = make_event_type_schema(event_type_name())
     event_type = create_svix_event_type(svix_api, event_type_schema)
-    endpoint_uid = _gen_uuid(endpoint_url)
+    endpoint_uid = _gen_uid(endpoint_url)
     channel = "test" if with_channel else None
     metadata = {"test": "test"} if with_metadata else None
     secret = "whsec_" + "e" * 32 if with_secret else None
@@ -174,18 +180,22 @@ def test_svix_endpoint_create(
 def test_svix_message_create(
     svix_api: Svix,
     svix_app_name: str,
-    event_type_schema: Dict[str, Any],
     httpserver: HTTPServer,
     with_channel: bool,
+    is_ci: bool,
 ) -> None:
-    svix_app_uid = _gen_uuid(svix_app_name)
+    svix_app_uid = _gen_uid(svix_app_name)
     create_svix_app(svix_api, svix_app_name, svix_app_uid)
+    event_type_schema = make_event_type_schema(event_type_name())
     event_type = create_svix_event_type(svix_api, event_type_schema)
 
     channel = "test" if with_channel else None
     endpoint_path = "/webhook/receiver/"
-    endpoint_url = httpserver.url_for(endpoint_path)
-    endpoint_uid = _gen_uuid(endpoint_url)
+    if is_ci:
+        endpoint_url = httpserver.url_for(endpoint_path)
+    else:
+        endpoint_url = f"http://host.docker.internal:{httpserver.port}{endpoint_path}"
+    endpoint_uid = _gen_uid(endpoint_url)
     create_svix_endpoint(
         svix_api,
         svix_app_uid,
@@ -217,7 +227,7 @@ def test_svix_message_create(
     ).respond_with_handler(webhook_handler)
 
     # send message and check it is received by local http server
-    with httpserver.wait() as waiting:
+    with httpserver.wait(stop_on_nohandler=True, timeout=10) as waiting:
         message_out = svix_api.message.create(
             svix_app_uid,
             MessageIn(

--- a/python/tests/test_httpretty.py
+++ b/python/tests/test_httpretty.py
@@ -1,18 +1,26 @@
+import httpretty
+
 import svix
-from svix.api import MessageListOptions,IngestSourceIn, CronConfig, ApplicationIn, ApplicationCreateOptions
+from svix.api import (
+    ApplicationCreateOptions,
+    ApplicationIn,
+    CronConfig,
+    IngestSourceIn,
+    MessageListOptions,
+)
 from svix.api.ingest_source import IngestSource
 
-import httpretty
 
 @httpretty.activate(verbose=True, allow_net_connect=False)
 def test_octothorpe_in_query_param():
-    svx = svix.Svix("token",svix.SvixOptions(server_url="http://test.example"))
+    svx = svix.Svix("token", svix.SvixOptions(server_url="http://test.example"))
     httpretty.register_uri(
         httpretty.GET,
         "http://test.example/api/v1/app/app_id/msg?tag=test%23test",
-        body='{"data":[],"iterator":null,"prevIterator":null,"done":true}'
+        body='{"data":[],"iterator":null,"prevIterator":null,"done":true}',
     )
-    svx.message.list("app_id",MessageListOptions(tag="test#test"))
+    svx.message.list("app_id", MessageListOptions(tag="test#test"))
+
 
 @httpretty.activate(verbose=True, allow_net_connect=False)
 def test_struct_enum_with_fields():
@@ -21,7 +29,14 @@ def test_struct_enum_with_fields():
     httpretty.register_uri(
         httpretty.POST,
         "http://test.example/ingest/api/v1/source",
-        body='{"type":"cron","config":{"content_type":"mendy/tired","payload":"@hello there","schedule":"* * * * *"},"id":"src_2yZwUhtgs5Ai8T9yRQJXA","uid":"unique-identifier","name":"string","ingestUrl":"http://example.com","createdAt":"2019-08-24T14:15:22Z","updatedAt":"2019-08-24T14:15:22Z","metadata":{ }}',
+        body=(
+            '{"type":"cron","config":{"content_type":"mendy/tired","payload":"@hello '
+            'there","schedule":"* * * * *"},"id":"src_2yZwUhtgs5Ai8T9yRQJXA","uid":"'
+            'unique-identifier","name":"string","ingestUrl":'
+            '"http://example.com","createdAt":"2019-08-24T14:15:22Z",'
+            '"updatedAt":"2019-08-24T14:15:22Z",'
+            '"metadata":{ }}'
+        ),
     )
     source_in = IngestSourceIn(
         name="name",
@@ -43,7 +58,11 @@ def test_struct_enum_without_fields():
     httpretty.register_uri(
         httpretty.POST,
         "http://test.example/ingest/api/v1/source",
-        body='{"type":"generic-webhook","id":"src_2yZwUhtgs5Ai8T9yRQJXA","uid":"unique-identifier","name":"string","ingestUrl":"http://example.com","createdAt":"2019-08-24T14:15:22Z","updatedAt":"2019-08-24T14:15:22Z","metadata":{ }}',
+        body=(
+            '{"type":"generic-webhook","id":"src_2yZwUhtgs5Ai8T9yRQJXA","uid":"unique-'
+            'identifier","name":"string","ingestUrl":"http://example.com","createdAt":'
+            '"2019-08-24T14:15:22Z","updatedAt":"2019-08-24T14:15:22Z","metadata":{ }}'
+        ),
     )
     source_in = IngestSourceIn(name="name", type="generic-webhook", config={})
 
@@ -52,13 +71,19 @@ def test_struct_enum_without_fields():
     assert isinstance(res.config, dict)
     assert res.config == {}
 
+
 @httpretty.activate(verbose=True, allow_net_connect=False)
 def test_idempotency_key_is_sent_for_create_request():
     svx = svix.Svix("token", svix.SvixOptions(server_url="http://test.example"))
     httpretty.register_uri(
         httpretty.POST,
         "http://test.example/api/v1/app",
-        body='{"uid":"unique-identifier","name":"My first application","rateLimit":0,"id":"app_1srOrx2ZWZBpBUvZwXKQmoEYga2","createdAt":"2019-08-24T14:15:22Z","updatedAt":"2019-08-24T14:15:22Z","metadata":{"property1":"string","property2":"string"}}'
+        body=(
+            '{"uid":"unique-identifier","name":"My first application","rateLimit":0,'
+            '"id":"app_1srOrx2ZWZBpBUvZwXKQmoEYga2","createdAt":"2019-08-24T14:15:22Z"'
+            ',"updatedAt":"2019-08-24T14:15:22Z","metadata":{"property1":"string",'
+            '"property2":"string"}}'
+        ),
     )
     svx.application.create(ApplicationIn(name="test app"))
 
@@ -73,19 +98,23 @@ def test_client_provided_idempotency_key_is_not_overridden():
     httpretty.register_uri(
         httpretty.POST,
         "http://test.example/api/v1/app",
-        body='{"uid":"unique-identifier","name":"My first application","rateLimit":0,"id":"app_1srOrx2ZWZBpBUvZwXKQmoEYga2","createdAt":"2019-08-24T14:15:22Z","updatedAt":"2019-08-24T14:15:22Z","metadata":{"property1":"string","property2":"string"}}'
+        body=(
+            '{"uid":"unique-identifier","name":"My first application","rateLimit":0'
+            ',"id":"app_1srOrx2ZWZBpBUvZwXKQmoEYga2","createdAt":"2019-08-24T14:15:'
+            '22Z","updatedAt":"2019-08-24T14:15:22Z","metadata":{"property1":"string"'
+            ',"property2":"string"}}'
+        ),
     )
 
     client_provided_key = "test-key-123"
     svx.application.create(
         ApplicationIn(name="test app"),
-        ApplicationCreateOptions(idempotency_key=client_provided_key)
+        ApplicationCreateOptions(idempotency_key=client_provided_key),
     )
 
     request = httpretty.latest_requests()[0]
     assert "idempotency-key" in request.headers
     assert request.headers["idempotency-key"] == client_provided_key
-
 
 
 @httpretty.activate(verbose=True, allow_net_connect=False)
@@ -94,8 +123,7 @@ def test_unknown_keys_are_ignored():
     httpretty.register_uri(
         httpretty.GET,
         "http://test.example/api/v1/app",
-        body='{"data":[],"done":true,"iterator":null,"prevIterator":null,"extra-key":"ignored"}'
+        body='{"data":[],"done":true,"iterator":null,"prevIterator":null,"extra-key":"ignored"}',
     )
-
 
     svx.application.list()

--- a/python/tests/test_kitchen_sink.py
+++ b/python/tests/test_kitchen_sink.py
@@ -1,4 +1,5 @@
 import os
+import typing as t
 
 import pytest
 
@@ -15,41 +16,44 @@ from svix.models import EndpointPatch
 TOKEN = os.getenv("SVIX_TOKEN")
 SERVER_URL = os.getenv("SVIX_SERVER_URL")
 
-CLIENT = (
-    Svix(TOKEN, SvixOptions(server_url=SERVER_URL))
-    if TOKEN is not None and SERVER_URL is not None
-    else None
-)
+
+@pytest.fixture
+def client() -> t.Optional[Svix]:
+    if TOKEN is not None and SERVER_URL is not None:
+        return Svix(TOKEN, SvixOptions(server_url=SERVER_URL))
+    else:
+        return None
 
 
-@pytest.mark.skipif(
-    CLIENT is None,
-    reason="SVIX_TOKEN and SVIX_SERVER_URL are required to run this test",
-)
-def test_endpoint_crud() -> None:
-    app = CLIENT.application.create(ApplicationIn(name="app"))
+def test_endpoint_crud(client) -> None:
+    if client is None:
+        # the version of pytest that works with python3.8 has a bug in its type
+        # annotations that reports pytest.skip() as taking 0 arguments
+        pytest.skip("$SVIX_TOKEN and $SVIX_SERVER_URL must be set to run this test")  # ty: ignore[too-many-positional-arguments]
+    app = client.application.create(ApplicationIn(name="app"))
     try:
-        CLIENT.event_type.create(
+        client.event_type.create(
             EventTypeIn(name="event.started", description="Something started")
         )
     except HttpError as e:
         assert e.status_code == 409, "conflicts are expected but other statuses are not"
     try:
-        CLIENT.event_type.create(
+        client.event_type.create(
             EventTypeIn(name="event.ended", description="Something ended")
         )
     except HttpError as e:
         assert e.status_code == 409, "conflicts are expected but other statuses are not"
 
-    ep = CLIENT.endpoint.create(
+    ep = client.endpoint.create(
         app.id, EndpointIn(url="https://example.svix.com/", channels=["ch0", "ch1"])
     )
     assert {s for s in ep.channels} == {"ch0", "ch1"}
-    ep_patched = CLIENT.endpoint.patch(
+    ep_patched = client.endpoint.patch(
         app.id, ep.id, EndpointPatch(filter_types=["event.started", "event.ended"])
     )
     assert {s for s in ep_patched.channels} == {"ch0", "ch1"}
     assert {s for s in ep_patched.filter_types} == {"event.started", "event.ended"}
 
-    # Should succeed without error if the deserialization handles empty response bodies correctly
-    CLIENT.endpoint.delete(app.id, ep.id)
+    # Should succeed without error if the deserialization handles empty response bodies
+    # correctly
+    client.endpoint.delete(app.id, ep.id)

--- a/python/tests/test_openapi.py
+++ b/python/tests/test_openapi.py
@@ -1,6 +1,7 @@
 import requests
 
+
 def test_openapi_json_is_available(svix_server_url: str) -> None:
     r = requests.get(f"{svix_server_url}/api/v1/openapi.json")
     assert r.status_code == 200
-    assert r.headers["content-type"] == 'application/json'
+    assert r.headers["content-type"] == "application/json"

--- a/python/tests/test_webhooks.py
+++ b/python/tests/test_webhooks.py
@@ -1,10 +1,11 @@
-import pytest
 import base64
-import typing as t
-import hmac
 import hashlib
-from math import floor
+import hmac
+import typing as t
 from datetime import datetime, timedelta, timezone
+from math import floor
+
+import pytest
 
 from svix.webhooks import Webhook, WebhookVerificationError
 
@@ -28,7 +29,7 @@ class PayloadForTesting:
     header: t.Dict[str, str]
 
     def __init__(self, timestamp: datetime = datetime.now(tz=timezone.utc)):
-        ts = str(floor(timestamp.timestamp()))
+        ts = floor(timestamp.timestamp())
         to_sign = f"{defaultMsgID}.{ts}.{defaultPayload}".encode()
         signature = base64.b64encode(
             hmac_data(base64.b64decode(defaultSecret), to_sign)
@@ -42,7 +43,7 @@ class PayloadForTesting:
         self.header = {
             "svix-id": defaultMsgID,
             "svix-signature": "v1," + signature,
-            "svix-timestamp": self.timestamp,
+            "svix-timestamp": str(self.timestamp),
         }
 
 
@@ -110,9 +111,9 @@ def test_valid_signature_is_valid_and_returns_json():
 def test_valid_unbranded_signature_is_valid_and_returns_json():
     testPayload = PayloadForTesting()
     unbrandedHeaders = {
-        "webhook-id": testPayload.header.get("svix-id"),
-        "webhook-signature": testPayload.header.get("svix-signature"),
-        "webhook-timestamp": testPayload.header.get("svix-timestamp"),
+        "webhook-id": testPayload.header["svix-id"],
+        "webhook-signature": testPayload.header["svix-signature"],
+        "webhook-timestamp": testPayload.header["svix-timestamp"],
     }
     testPayload.header = unbrandedHeaders
 
@@ -176,7 +177,7 @@ def test_signature_verification_with_and_without_prefix():
 def test_sign_function():
     key = "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw"
     msg_id = "msg_p5jXN8AQM9LWM0D4loKWxJek"
-    timestamp = datetime.utcfromtimestamp(1614265330)
+    timestamp = datetime.fromtimestamp(1614265330, tz=timezone.utc)
     payload = '{"test": 2432232314}'
     expected = "v1,g0hM9SsE+OTPJTGt/tmIKtSyZlE3uFJELVlNIOLJ1OE="
 

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -18,3 +18,9 @@ tmp/
 ## Docker-specific ignores
 Dockerfile
 .dockerignore
+docker-compose.yml
+docker-compose.override.yml
+
+# git stuff
+.git/
+.github/

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -35,16 +35,19 @@ services:
       POSTGRES_PASSWORD: postgres
 
   pgbouncer:
-    image: "docker.io/edoburu/pgbouncer:1.15.0"
+    image: "docker.io/edoburu/pgbouncer:v1.24.1-p1"
     healthcheck:
       test: "pg_isready -h localhost"
       interval: 30s
+      start_interval: 3s
+      start_period: 30s
       timeout: 10s
       retries: 3
     environment:
       DB_HOST: "postgres"
       DB_USER: "postgres"
       DB_PASSWORD: "postgres"
+      AUTH_TYPE: "trust"
       MAX_CLIENT_CONN: 500
     depends_on:
       postgres:


### PR DESCRIPTION
I'm optimistic that this will be the last Python client library change for a little while.

Changes:

 - Make all tests pass `ruff` and `ty`
 - Make tests that don't need the docker server not depend on it, so you can run `pytest tests/test_webhooks.py` quickly
 - Make client tests create a distinct event name and object UIDs for every test so that they work even if not running the wiper
 - Bump pgbouncer image to one that has an arm64 build for me
 - Use host.docker.internal instead of hardcoding an address from some specific version of docker when running locally (fixes tests on orbstack and probably podman)
 - Add an editorconfig for the python directory
 - Add some missing items to `.dockerignore`