### PR TITLE
ci: Fix python release to include setup-uv

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -20,8 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
-        name: Install Python
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: '3.14'
 


### PR DESCRIPTION
Release of v1.95.0 failed due to uv not being set up: https://github.com/svix/svix-webhooks/actions/runs/26578580689/job/78304741004