### PR TITLE
Fix bump_version regex for pyproject.toml

### DIFF
--- a/tools/bump_version.py
+++ b/tools/bump_version.py
@@ -134,7 +134,7 @@ VERSION_FILES = [
     ),
     VersionFile(
         "python/pyproject.toml",
-        [r'(version\s*=\s*")([^"]*)(")', ],
+        [r'(\[project\][\s\S]*?\nversion\s*=\s*")([^"]*)(")', ],
     ),
     # Ruby
     VersionFile(


### PR DESCRIPTION
Tripped me up in #2359.