### PR TITLE
bump docker images for rust builds

### DIFF
--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -4,7 +4,7 @@
 # with `docker build -f bridge/Dockerfile .`
 
 # Base build
-FROM docker.io/rust:1.94-slim-trixie AS build
+FROM docker.io/rust:1.96-slim-trixie AS build
 
 SHELL ["/bin/bash", "-eux", "-o", "pipefail", "-c"]
 RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked --mount=target=/var/cache/apt,type=cache,sharing=locked <<EOF
@@ -62,7 +62,7 @@ RUN touch */src/lib.rs && touch */src/main.rs
 RUN cargo build --release --frozen
 
 # Production
-FROM docker.io/debian:trixie-slim AS prod
+FROM docker.io/debian:trixie-20260518-slim AS prod
 
 SHELL ["/bin/bash", "-eux", "-o", "pipefail", "-c"]
 RUN <<EOF

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,7 +6,7 @@
 # Using https://github.com/LukeMathWalker/cargo-chef for better layer caching
 
 # Base image for planner and build - keep in sync with .github/workflows/server-ci.yml
-FROM docker.io/rust:1.94-slim-trixie AS chef
+FROM docker.io/rust:1.96-slim-trixie AS chef
 RUN cargo install cargo-chef
 WORKDIR /app
 
@@ -49,7 +49,7 @@ COPY . .
 RUN cargo build --release --package svix-server --bin svix-server --frozen
 
 # Production
-FROM docker.io/debian:trixie-slim AS prod
+FROM docker.io/debian:trixie-20260518-slim AS prod
 
 SHELL ["/bin/bash", "-eux", "-o", "pipefail", "-c"]
 RUN <<EOF

--- a/svix-cli/Dockerfile
+++ b/svix-cli/Dockerfile
@@ -3,7 +3,7 @@
 # NOTE: this should be built from the root of `svix-webhooks`
 # with `docker build -f svix-cli/Dockerfile .`# Base build
 
-FROM docker.io/rust:1.94-slim-trixie AS build
+FROM docker.io/rust:1.96-slim-trixie AS build
 
 SHELL ["/bin/bash", "-eux", "-o", "pipefail", "-c"]
 RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked --mount=target=/var/cache/apt,type=cache,sharing=locked <<EOF
@@ -47,7 +47,7 @@ RUN touch src/main.rs
 RUN cargo build --release --frozen
 
 # Production
-FROM docker.io/debian:trixie-slim AS prod
+FROM docker.io/debian:trixie-20260518-slim AS prod
 
 SHELL ["/bin/bash", "-eux", "-o", "pipefail", "-c"]
 RUN <<EOF


### PR DESCRIPTION
Quick, we need to bump the svix version after this so that they can both be at 1.96.