### PR TITLE
dotnet: include .NET runtime version in the user-agent for the csharp client library

### DIFF
--- a/csharp/Svix.Tests/WiremockTests.cs
+++ b/csharp/Svix.Tests/WiremockTests.cs
@@ -165,7 +165,7 @@ namespace Svix.Tests
                 "svix-libs/",
                 stub.LogEntries[0].RequestMessage.Headers["User-Agent"][0]
             );
-            Assert.Contains("dotnet/4", stub.LogEntries[0].RequestMessage.Headers["User-Agent"][0]);
+            Assert.Contains("dotnet/v", stub.LogEntries[0].RequestMessage.Headers["User-Agent"][0]);
         }
 
         [Fact]

--- a/csharp/Svix.Tests/WiremockTests.cs
+++ b/csharp/Svix.Tests/WiremockTests.cs
@@ -165,10 +165,7 @@ namespace Svix.Tests
                 "svix-libs/",
                 stub.LogEntries[0].RequestMessage.Headers["User-Agent"][0]
             );
-            Assert.Contains(
-                "dotnet/4",
-                stub.LogEntries[0].RequestMessage.Headers["User-Agent"][0]
-            );
+            Assert.Contains("dotnet/4", stub.LogEntries[0].RequestMessage.Headers["User-Agent"][0]);
         }
 
         [Fact]

--- a/csharp/Svix.Tests/WiremockTests.cs
+++ b/csharp/Svix.Tests/WiremockTests.cs
@@ -165,6 +165,10 @@ namespace Svix.Tests
                 "svix-libs/",
                 stub.LogEntries[0].RequestMessage.Headers["User-Agent"][0]
             );
+            Assert.Contains(
+                "dotnet/4",
+                stub.LogEntries[0].RequestMessage.Headers["User-Agent"][0]
+            );
         }
 
         [Fact]

--- a/csharp/Svix/Svix.csproj
+++ b/csharp/Svix/Svix.csproj
@@ -16,5 +16,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Polly" Version="7.2.3" />
+    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/csharp/Svix/SvixClient.cs
+++ b/csharp/Svix/SvixClient.cs
@@ -87,7 +87,7 @@ namespace Svix
                 ?? new SvixHttpClient(
                     token,
                     opts.RetryScheduleMilliseconds,
-                    $"svix-libs/{Version.version}/csharp",
+                    $"svix-libs/{Version.version}/csharp dotnet/{Environment.Version.ToString()}",
                     opts.ServerUrl ?? Utils.DEFAULT_SERVER_URL
                 );
         }

--- a/csharp/Svix/SvixClient.cs
+++ b/csharp/Svix/SvixClient.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using System.Runtime.InteropServices;
 
 namespace Svix
 {
@@ -87,7 +88,7 @@ namespace Svix
                 ?? new SvixHttpClient(
                     token,
                     opts.RetryScheduleMilliseconds,
-                    $"svix-libs/{Version.version}/csharp dotnet/{Environment.Version.ToString()}",
+                    $"svix-libs/{Version.version}/csharp dotnet/{RuntimeEnvironment.GetSystemVersion().ToString()}",
                     opts.ServerUrl ?? Utils.DEFAULT_SERVER_URL
                 );
         }

--- a/csharp/Svix/SvixClient.cs
+++ b/csharp/Svix/SvixClient.cs
@@ -1,5 +1,5 @@
-using Microsoft.Extensions.Logging;
 using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
 
 namespace Svix
 {


### PR DESCRIPTION
Basically the same as #2365.