### PR TITLE
rust: add rustc version and platform to the user-agent string

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,4 +19,5 @@
 /ruby/lib/svix/api/** linguist-generated
 /ruby/lib/svix/models/** linguist-generated
 /rust/src/api/** linguist-generated
+/rust/src/api/client.rs -linguist-generated
 /rust/src/models/** linguist-generated

--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -2977,6 +2977,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4648,6 +4660,7 @@ dependencies = [
  "hyper-util",
  "itertools 0.14.0",
  "js_option",
+ "nix",
  "percent-encoding",
  "rand 0.9.4",
  "rustls",
@@ -4660,6 +4673,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "version_check",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -43,6 +43,7 @@ hyper-tls = { version = "0.6.0", optional = true }
 hyper-util = { version = "0.1.16", features = ["client", "client-legacy", "tokio"] }
 itertools = "0.14.0"
 js_option = "0.1.1"
+nix = "0.31"
 percent-encoding = "2.3.1"
 rand = "0.9.0"
 rustls = { version = "0.23.31", optional = true }
@@ -55,9 +56,14 @@ tower-service = "0.3.3"
 tracing = { version = "0.1.41", default-features = false }
 url = "2.2"
 uuid = { version = "1", features = ["v4"] }
+version_check = "0.9.5"
+
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.31", features = ["feature"] }
 
 [dev-dependencies]
 tokio = { version = "1.41.0", features = ["macros"] }
+regex = "1"
 wiremock = "0.6.2, <0.6.5"
 
 [package.metadata.cargo-public-api-crates]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -43,7 +43,6 @@ hyper-tls = { version = "0.6.0", optional = true }
 hyper-util = { version = "0.1.16", features = ["client", "client-legacy", "tokio"] }
 itertools = "0.14.0"
 js_option = "0.1.1"
-nix = "0.31"
 percent-encoding = "2.3.1"
 rand = "0.9.0"
 rustls = { version = "0.23.31", optional = true }

--- a/rust/src/api/client.rs
+++ b/rust/src/api/client.rs
@@ -67,8 +67,23 @@ impl Svix {
     pub fn new(token: String, options: Option<SvixOptions>) -> Self {
         let options = options.unwrap_or_default();
 
+        let mut user_agent_fields = vec![format!("svix-libs/{CRATE_VERSION}/rust")];
+
+        if let Some(rustc) = version_check::Version::read() {
+            user_agent_fields.push(format!("rust/{rustc}"));
+        }
+
+        #[cfg(unix)]
+        if let Ok(uname) = nix::sys::utsname::uname() {
+            user_agent_fields.push(format!(
+                "{}/{}",
+                uname.sysname().to_string_lossy(),
+                uname.machine().to_string_lossy()
+            ));
+        }
+
         let cfg = Arc::new(Configuration {
-            user_agent: Some(format!("svix-libs/{CRATE_VERSION}/rust")),
+            user_agent: Some(user_agent_fields.join(" ")),
             client: HyperClient::builder(TokioExecutor::new())
                 .build(crate::make_connector(options.proxy_address)),
             timeout: options.timeout,
@@ -136,5 +151,18 @@ mod tests {
         let message_api = svix.message();
         let fut = message_api.expunge_content(String::new(), String::new());
         require_send_sync(fut);
+    }
+
+    #[test]
+    fn test_user_agent() {
+        let svix = Svix::new(String::new(), None);
+        let re =
+            regex::Regex::new(r"^svix-libs/[0-9.]+/rust rust/1\.[0-9.]+ [^ ]+/[^ ]+$").unwrap();
+        let ua = svix
+            .cfg
+            .user_agent
+            .as_ref()
+            .expect("user_agent must be set");
+        assert!(re.is_match(ua));
     }
 }

--- a/svix-cli/Cargo.lock
+++ b/svix-cli/Cargo.lock
@@ -1082,6 +1082,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1724,6 +1736,7 @@ dependencies = [
  "hyper-util",
  "itertools",
  "js_option",
+ "nix",
  "percent-encoding",
  "rand",
  "rustls",
@@ -1736,6 +1749,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "version_check",
 ]
 
 [[package]]


### PR DESCRIPTION
Basically the same as #2365.

I'm sort of the least interested in this one, because the Rust client has the least behavioral dependence on the platform, but it seems worth including for completeness.

<details>

<summary>dependency review</summary>

 - adds [`version_check`](https://crates.io/crates/version_check) as a direct dependency, which was already an indirect dependency. Apache-2.0/MIT license, actively maintained
 - adds [`nix`](https://crates.io/crates/nix) as a dependency, which every other rust program on the planet has. MIT license, actively maintained.

</details>