### PR TITLE
go: Reduce scope of var err in generated API call methods

### DIFF
--- a/codegen/templates/go/api_resource.go.jinja
+++ b/codegen/templates/go/api_resource.go.jinja
@@ -123,9 +123,9 @@ func ({{ resource_self_name }} *{{ resource_type_name }}) {{ op.name | to_upper_
 	{% endif -%}
 
 	{% if op | has_query_or_header_params -%}
-	{% set used_err = true -%}
-	var err error
 	if o != nil {
+		var err error
+
 		{# header params -#}
 		{% if op.header_params | length > 0 -%}
 			{% for p in op.header_params -%}
@@ -153,7 +153,11 @@ func ({{ resource_self_name }} *{{ resource_type_name }}) {{ op.name | to_upper_
 	{% else -%}
 		{% set generic_ret_type -%}any,{{ ret_type }}{% endset -%}
 	{% endif -%}
-	{% if has_return %}return {% else %} _,err {% if not used_err%}:{% endif%}= {% endif %}internal.ExecuteRequest[{{ generic_ret_type }}](
+	{% if has_return -%}
+		return
+	{%- else -%}
+		_, err :=
+	{%- endif %} internal.ExecuteRequest[{{ generic_ret_type }}](
 		ctx,
 		{{ resource_self_name }}.client,
 		"{{ op.method | upper }}",

--- a/go/application.go
+++ b/go/application.go
@@ -44,8 +44,9 @@ func (application *Application) List(
 	o *ApplicationListOptions,
 ) (*models.ListResponseApplicationOut, error) {
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("exclude_apps_with_no_endpoints", o.ExcludeAppsWithNoEndpoints, queryMap, &err)
 		internal.SerializeParamToMap("exclude_apps_with_disabled_endpoints", o.ExcludeAppsWithDisabledEndpoints, queryMap, &err)
 		internal.SerializeParamToMap("exclude_apps_with_svix_play_endpoints", o.ExcludeAppsWithSvixPlayEndpoints, queryMap, &err)
@@ -78,8 +79,9 @@ func (application *Application) Create(
 		"get_if_exists": "false",
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err

--- a/go/authentication.go
+++ b/go/authentication.go
@@ -57,8 +57,9 @@ func (authentication *Authentication) AppPortalAccess(
 		"app_id": appId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
@@ -87,14 +88,15 @@ func (authentication *Authentication) ExpireAll(
 		"app_id": appId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return err
 		}
 	}
-	_, err = internal.ExecuteRequest[models.ApplicationTokenExpireIn, any](
+	_, err := internal.ExecuteRequest[models.ApplicationTokenExpireIn, any](
 		ctx,
 		authentication.client,
 		"POST",
@@ -144,14 +146,15 @@ func (authentication *Authentication) Logout(
 	o *AuthenticationLogoutOptions,
 ) error {
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return err
 		}
 	}
-	_, err = internal.ExecuteRequest[any, any](
+	_, err := internal.ExecuteRequest[any, any](
 		ctx,
 		authentication.client,
 		"POST",
@@ -172,14 +175,15 @@ func (authentication *Authentication) StreamLogout(
 	o *AuthenticationStreamLogoutOptions,
 ) error {
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return err
 		}
 	}
-	_, err = internal.ExecuteRequest[any, any](
+	_, err := internal.ExecuteRequest[any, any](
 		ctx,
 		authentication.client,
 		"POST",
@@ -203,8 +207,9 @@ func (authentication *Authentication) StreamPortalAccess(
 		"stream_id": streamId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
@@ -233,14 +238,15 @@ func (authentication *Authentication) StreamExpireAll(
 		"stream_id": streamId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return err
 		}
 	}
-	_, err = internal.ExecuteRequest[models.StreamTokenExpireIn, any](
+	_, err := internal.ExecuteRequest[models.StreamTokenExpireIn, any](
 		ctx,
 		authentication.client,
 		"POST",
@@ -288,8 +294,9 @@ func (authentication *Authentication) RotateStreamPollerToken(
 		"sink_id":   sinkId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err

--- a/go/background_task.go
+++ b/go/background_task.go
@@ -40,8 +40,9 @@ func (backgroundTask *BackgroundTask) List(
 	o *BackgroundTaskListOptions,
 ) (*models.ListResponseBackgroundTaskOut, error) {
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("status", o.Status, queryMap, &err)
 		internal.SerializeParamToMap("task", o.Task, queryMap, &err)
 		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)

--- a/go/connector.go
+++ b/go/connector.go
@@ -40,8 +40,9 @@ func (connector *Connector) List(
 	o *ConnectorListOptions,
 ) (*models.ListResponseConnectorOut, error) {
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
 		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
 		internal.SerializeParamToMap("order", o.Order, queryMap, &err)
@@ -69,8 +70,9 @@ func (connector *Connector) Create(
 	o *ConnectorCreateOptions,
 ) (*models.ConnectorOut, error) {
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err

--- a/go/endpoint.go
+++ b/go/endpoint.go
@@ -70,8 +70,9 @@ func (endpoint *Endpoint) List(
 		"app_id": appId,
 	}
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
 		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
 		internal.SerializeParamToMap("order", o.Order, queryMap, &err)
@@ -104,8 +105,9 @@ func (endpoint *Endpoint) Create(
 		"app_id": appId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
@@ -244,8 +246,9 @@ func (endpoint *Endpoint) BulkReplay(
 		"endpoint_id": endpointId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
@@ -362,8 +365,9 @@ func (endpoint *Endpoint) Recover(
 		"endpoint_id": endpointId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
@@ -411,8 +415,9 @@ func (endpoint *Endpoint) ReplayMissing(
 		"endpoint_id": endpointId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
@@ -470,14 +475,15 @@ func (endpoint *Endpoint) RotateSecret(
 		"endpoint_id": endpointId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return err
 		}
 	}
-	_, err = internal.ExecuteRequest[models.EndpointSecretRotateIn, any](
+	_, err := internal.ExecuteRequest[models.EndpointSecretRotateIn, any](
 		ctx,
 		endpoint.client,
 		"POST",
@@ -503,8 +509,9 @@ func (endpoint *Endpoint) SendExample(
 		"endpoint_id": endpointId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
@@ -534,8 +541,9 @@ func (endpoint *Endpoint) GetStats(
 		"endpoint_id": endpointId,
 	}
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("since", o.Since, queryMap, &err)
 		internal.SerializeParamToMap("until", o.Until, queryMap, &err)
 		if err != nil {

--- a/go/environment.go
+++ b/go/environment.go
@@ -35,8 +35,9 @@ func (environment *Environment) Export(
 	o *EnvironmentExportOptions,
 ) (*models.EnvironmentOut, error) {
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
@@ -66,14 +67,15 @@ func (environment *Environment) Import(
 	o *EnvironmentImportOptions,
 ) error {
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return err
 		}
 	}
-	_, err = internal.ExecuteRequest[models.EnvironmentIn, any](
+	_, err := internal.ExecuteRequest[models.EnvironmentIn, any](
 		ctx,
 		environment.client,
 		"POST",

--- a/go/event_type.go
+++ b/go/event_type.go
@@ -51,8 +51,9 @@ func (eventType *EventType) List(
 	o *EventTypeListOptions,
 ) (*models.ListResponseEventTypeOut, error) {
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
 		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
 		internal.SerializeParamToMap("order", o.Order, queryMap, &err)
@@ -85,8 +86,9 @@ func (eventType *EventType) Create(
 	o *EventTypeCreateOptions,
 ) (*models.EventTypeOut, error) {
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
@@ -115,8 +117,9 @@ func (eventType *EventType) ImportOpenapi(
 	o *EventTypeImportOpenapiOptions,
 ) (*models.EventTypeImportOpenApiOut, error) {
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
@@ -190,14 +193,15 @@ func (eventType *EventType) Delete(
 		"event_type_name": eventTypeName,
 	}
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("expunge", o.Expunge, queryMap, &err)
 		if err != nil {
 			return err
 		}
 	}
-	_, err = internal.ExecuteRequest[any, any](
+	_, err := internal.ExecuteRequest[any, any](
 		ctx,
 		eventType.client,
 		"DELETE",

--- a/go/ingest.go
+++ b/go/ingest.go
@@ -37,8 +37,9 @@ func (ingest *Ingest) Dashboard(
 		"source_id": sourceId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err

--- a/go/ingest_endpoint.go
+++ b/go/ingest_endpoint.go
@@ -46,8 +46,9 @@ func (ingestEndpoint *IngestEndpoint) List(
 		"source_id": sourceId,
 	}
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
 		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
 		internal.SerializeParamToMap("order", o.Order, queryMap, &err)
@@ -78,8 +79,9 @@ func (ingestEndpoint *IngestEndpoint) Create(
 		"source_id": sourceId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
@@ -251,14 +253,15 @@ func (ingestEndpoint *IngestEndpoint) RotateSecret(
 		"endpoint_id": endpointId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return err
 		}
 	}
-	_, err = internal.ExecuteRequest[models.IngestEndpointSecretIn, any](
+	_, err := internal.ExecuteRequest[models.IngestEndpointSecretIn, any](
 		ctx,
 		ingestEndpoint.client,
 		"POST",

--- a/go/ingest_source.go
+++ b/go/ingest_source.go
@@ -42,8 +42,9 @@ func (ingestSource *IngestSource) List(
 	o *IngestSourceListOptions,
 ) (*models.ListResponseIngestSourceOut, error) {
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
 		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
 		internal.SerializeParamToMap("order", o.Order, queryMap, &err)
@@ -70,8 +71,9 @@ func (ingestSource *IngestSource) Create(
 	o *IngestSourceCreateOptions,
 ) (*models.IngestSourceOut, error) {
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
@@ -166,8 +168,9 @@ func (ingestSource *IngestSource) RotateToken(
 		"source_id": sourceId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err

--- a/go/integration.go
+++ b/go/integration.go
@@ -46,8 +46,9 @@ func (integration *Integration) List(
 		"app_id": appId,
 	}
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
 		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
 		internal.SerializeParamToMap("order", o.Order, queryMap, &err)
@@ -78,8 +79,9 @@ func (integration *Integration) Create(
 		"app_id": appId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
@@ -201,8 +203,9 @@ func (integration *Integration) RotateKey(
 		"integ_id": integId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err

--- a/go/internalapi/management_authentication.go
+++ b/go/internalapi/management_authentication.go
@@ -37,8 +37,9 @@ func (managementAuthentication *ManagementAuthentication) CreateApiToken(
 		"env_id": envId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
@@ -92,14 +93,15 @@ func (managementAuthentication *ManagementAuthentication) ExpireApiToken(
 		"key_id": keyId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return err
 		}
 	}
-	_, err = internal.ExecuteRequest[models.ApiTokenExpireIn, any](
+	_, err := internal.ExecuteRequest[models.ApiTokenExpireIn, any](
 		ctx,
 		managementAuthentication.client,
 		"POST",

--- a/go/internalapi/management_environment.go
+++ b/go/internalapi/management_environment.go
@@ -38,8 +38,9 @@ func (managementEnvironment *ManagementEnvironment) List(
 	o *ManagementEnvironmentListOptions,
 ) (*models.ListResponseEnvironmentModelOut, error) {
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
 		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
 		internal.SerializeParamToMap("order", o.Order, queryMap, &err)
@@ -66,8 +67,9 @@ func (managementEnvironment *ManagementEnvironment) Create(
 	o *ManagementEnvironmentCreateOptions,
 ) (*models.EnvironmentModelOut, error) {
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err

--- a/go/message.go
+++ b/go/message.go
@@ -77,8 +77,9 @@ func (message *Message) List(
 		"app_id": appId,
 	}
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
 		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
 		internal.SerializeParamToMap("channel", o.Channel, queryMap, &err)
@@ -123,8 +124,9 @@ func (message *Message) Create(
 	}
 	queryMap := map[string]string{}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		internal.SerializeParamToMap("with_content", o.WithContent, queryMap, &err)
 		if err != nil {
@@ -169,8 +171,9 @@ func (message *Message) ExpungeAllContents(
 		"app_id": appId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
@@ -204,8 +207,9 @@ func (message *Message) Precheck(
 		"app_id": appId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
@@ -235,8 +239,9 @@ func (message *Message) Get(
 		"msg_id": msgId,
 	}
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("with_content", o.WithContent, queryMap, &err)
 		if err != nil {
 			return nil, err

--- a/go/message_attempt.go
+++ b/go/message_attempt.go
@@ -136,8 +136,9 @@ func (messageAttempt *MessageAttempt) ListByEndpoint(
 		"endpoint_id": endpointId,
 	}
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
 		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
 		internal.SerializeParamToMap("status", o.Status, queryMap, &err)
@@ -183,8 +184,9 @@ func (messageAttempt *MessageAttempt) ListByMsg(
 		"msg_id": msgId,
 	}
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
 		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
 		internal.SerializeParamToMap("status", o.Status, queryMap, &err)
@@ -232,8 +234,9 @@ func (messageAttempt *MessageAttempt) ListAttemptedMessages(
 		"endpoint_id": endpointId,
 	}
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
 		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
 		internal.SerializeParamToMap("channel", o.Channel, queryMap, &err)
@@ -274,8 +277,9 @@ func (messageAttempt *MessageAttempt) Get(
 		"attempt_id": attemptId,
 	}
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("expanded_statuses", o.ExpandedStatuses, queryMap, &err)
 		if err != nil {
 			return nil, err
@@ -336,8 +340,9 @@ func (messageAttempt *MessageAttempt) ListAttemptedDestinations(
 		"msg_id": msgId,
 	}
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
 		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
 		if err != nil {
@@ -370,8 +375,9 @@ func (messageAttempt *MessageAttempt) Resend(
 		"endpoint_id": endpointId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err

--- a/go/message_poller.go
+++ b/go/message_poller.go
@@ -54,8 +54,9 @@ func (messagePoller *MessagePoller) Poll(
 		"sink_id": sinkId,
 	}
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
 		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
 		internal.SerializeParamToMap("event_type", o.EventType, queryMap, &err)
@@ -92,8 +93,9 @@ func (messagePoller *MessagePoller) ConsumerPoll(
 		"consumer_id": consumerId,
 	}
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
 		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
 		if err != nil {
@@ -127,8 +129,9 @@ func (messagePoller *MessagePoller) ConsumerSeek(
 		"consumer_id": consumerId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err

--- a/go/operational_webhook_endpoint.go
+++ b/go/operational_webhook_endpoint.go
@@ -42,8 +42,9 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) List(
 	o *OperationalWebhookEndpointListOptions,
 ) (*models.ListResponseOperationalWebhookEndpointOut, error) {
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
 		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
 		internal.SerializeParamToMap("order", o.Order, queryMap, &err)
@@ -70,8 +71,9 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) Create(
 	o *OperationalWebhookEndpointCreateOptions,
 ) (*models.OperationalWebhookEndpointOut, error) {
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
@@ -229,14 +231,15 @@ func (operationalWebhookEndpoint *OperationalWebhookEndpoint) RotateSecret(
 		"endpoint_id": endpointId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return err
 		}
 	}
-	_, err = internal.ExecuteRequest[models.OperationalWebhookEndpointSecretIn, any](
+	_, err := internal.ExecuteRequest[models.OperationalWebhookEndpointSecretIn, any](
 		ctx,
 		operationalWebhookEndpoint.client,
 		"POST",

--- a/go/statistics.go
+++ b/go/statistics.go
@@ -52,8 +52,9 @@ func (statistics *Statistics) AggregateAppStats(
 	o *StatisticsAggregateAppStatsOptions,
 ) (*models.AppUsageStatsOut, error) {
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err

--- a/go/streaming_event_type.go
+++ b/go/streaming_event_type.go
@@ -45,8 +45,9 @@ func (streamingEventType *StreamingEventType) List(
 	o *StreamingEventTypeListOptions,
 ) (*models.ListResponseStreamEventTypeOut, error) {
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
 		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
 		internal.SerializeParamToMap("order", o.Order, queryMap, &err)
@@ -74,8 +75,9 @@ func (streamingEventType *StreamingEventType) Create(
 	o *StreamingEventTypeCreateOptions,
 ) (*models.StreamEventTypeOut, error) {
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
@@ -144,14 +146,15 @@ func (streamingEventType *StreamingEventType) Delete(
 		"name": name,
 	}
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("expunge", o.Expunge, queryMap, &err)
 		if err != nil {
 			return err
 		}
 	}
-	_, err = internal.ExecuteRequest[any, any](
+	_, err := internal.ExecuteRequest[any, any](
 		ctx,
 		streamingEventType.client,
 		"DELETE",

--- a/go/streaming_events.go
+++ b/go/streaming_events.go
@@ -42,8 +42,9 @@ func (streamingEvents *StreamingEvents) Create(
 		"stream_id": streamId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
@@ -75,8 +76,9 @@ func (streamingEvents *StreamingEvents) Get(
 		"sink_id":   sinkId,
 	}
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
 		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
 		internal.SerializeParamToMap("after", o.After, queryMap, &err)

--- a/go/streaming_sink.go
+++ b/go/streaming_sink.go
@@ -46,8 +46,9 @@ func (streamingSink *StreamingSink) List(
 		"stream_id": streamId,
 	}
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
 		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
 		internal.SerializeParamToMap("order", o.Order, queryMap, &err)
@@ -78,8 +79,9 @@ func (streamingSink *StreamingSink) Create(
 		"stream_id": streamId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err
@@ -227,8 +229,9 @@ func (streamingSink *StreamingSink) RotateSecret(
 		"sink_id":   sinkId,
 	}
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err

--- a/go/streaming_stream.go
+++ b/go/streaming_stream.go
@@ -38,8 +38,9 @@ func (streamingStream *StreamingStream) List(
 	o *StreamingStreamListOptions,
 ) (*models.ListResponseStreamOut, error) {
 	queryMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("limit", o.Limit, queryMap, &err)
 		internal.SerializeParamToMap("iterator", o.Iterator, queryMap, &err)
 		internal.SerializeParamToMap("order", o.Order, queryMap, &err)
@@ -66,8 +67,9 @@ func (streamingStream *StreamingStream) Create(
 	o *StreamingStreamCreateOptions,
 ) (*models.StreamOut, error) {
 	headerMap := map[string]string{}
-	var err error
 	if o != nil {
+		var err error
+
 		internal.SerializeParamToMap("idempotency-key", o.IdempotencyKey, headerMap, &err)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Small refactor towards https://github.com/svix/monorepo-private/issues/13162.