### PR TITLE
go: include the go runtime version in the user-agent string

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -2,6 +2,9 @@
 typ = "typ" # since type is a keyword in Rust
 ser = "ser" # Java com.fasterxml.jackson.databind.ser.std.StdSerializer
 
+[default.extend-identifiers]
+app_3Ead4bUeXzV2bCjMcrHYjHHzf1w = "app_3Ead4bUeXzV2bCjMcrHYjHHzf1w"  # iterator sample value
+
 [files]
 extend-exclude = [
     # False positives in randomly-generated strings

--- a/codegen/templates/go/summary.go.jinja
+++ b/codegen/templates/go/summary.go.jinja
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -57,7 +58,7 @@ func New(token string, options *SvixOptions) (*Svix, error) {
 	}
 
 	svixHttpClient.DefaultHeaders["Authorization"] = fmt.Sprintf("Bearer %s", token)
-	svixHttpClient.DefaultHeaders["User-Agent"] = fmt.Sprintf("svix-libs/%s/go", Version)
+	svixHttpClient.DefaultHeaders["User-Agent"] = fmt.Sprintf("svix-libs/%s/go go/%s", Version, runtime.Version())
 
 	svx := Svix{
 		client: &svixHttpClient,
@@ -73,11 +74,24 @@ func New(token string, options *SvixOptions) (*Svix, error) {
 
 // Add a custom suffix to the default user-agent
 //
+// The default user agent is `svix-libs/<version>/go go/<goversion>`.
 // The default user agent is `svix-libs/<version>/go`.
 // The suffix will be separated from the base user agent with a `/`
 //
 // The suffix must be less then 50 chars, And must match this regex `^[A-Za-z\d\.\-]+$`
+//
+// Deprecated: Please call the method with the same name instead of this free function.
 func SetUserAgentSuffix(s *Svix, userAgentSuffix string) error {
+	return s.SetUserAgentSuffix(userAgentSuffix)
+}
+
+// Add a custom suffix to the default user-agent
+//
+// The default user agent is `svix-libs/<version>/go`.
+// The suffix will be separated from the base user agent with a `/`
+//
+// The suffix must be less then 50 chars, And must match this regex `^[A-Za-z\d\.\-]+$`
+func (s Svix) SetUserAgentSuffix(userAgentSuffix string) error {
 	if len(userAgentSuffix) > 50 {
 		return fmt.Errorf("user agent suffix must be less then 50 chars")
 	}
@@ -86,7 +100,7 @@ func SetUserAgentSuffix(s *Svix, userAgentSuffix string) error {
 		return fmt.Errorf("invalid user agent suffix")
 	}
 
-	s.client.DefaultHeaders["User-Agent"] = fmt.Sprintf("svix-libs/%s/go/%s", Version, userAgentSuffix)
+	s.client.DefaultHeaders["User-Agent"] = fmt.Sprintf("svix-libs/%s/go/%s go/%s", Version, userAgentSuffix, runtime.Version())
 	return nil
 }
 

--- a/codegen/templates/go/summary.go.jinja
+++ b/codegen/templates/go/summary.go.jinja
@@ -75,8 +75,7 @@ func New(token string, options *SvixOptions) (*Svix, error) {
 // Add a custom suffix to the default user-agent
 //
 // The default user agent is `svix-libs/<version>/go go/<goversion>`.
-// The default user agent is `svix-libs/<version>/go`.
-// The suffix will be separated from the base user agent with a `/`
+// The suffix will be separated from the base svix-libs component of the user agent with a `/`
 //
 // The suffix must be less then 50 chars, And must match this regex `^[A-Za-z\d\.\-]+$`
 //
@@ -87,8 +86,8 @@ func SetUserAgentSuffix(s *Svix, userAgentSuffix string) error {
 
 // Add a custom suffix to the default user-agent
 //
-// The default user agent is `svix-libs/<version>/go`.
-// The suffix will be separated from the base user agent with a `/`
+// The default user agent is `svix-libs/<version>/go go/<goversion>`.
+// The suffix will be separated from the base svix-libs component of the user agent with a `/`
 //
 // The suffix must be less then 50 chars, And must match this regex `^[A-Za-z\d\.\-]+$`
 func (s Svix) SetUserAgentSuffix(userAgentSuffix string) error {

--- a/go/internalapi/internalapi.go
+++ b/go/internalapi/internalapi.go
@@ -4,6 +4,7 @@ package internalapi
 import (
 	"fmt"
 	"net/url"
+	"runtime"
 
 	"github.com/svix/svix-webhooks/go/internal"
 )
@@ -21,7 +22,7 @@ func New(token string, serverUrl *url.URL, debug bool, userAgentSuffix *string) 
 	svixHttpClient.Debug = debug
 
 	svixHttpClient.DefaultHeaders["Authorization"] = fmt.Sprintf("Bearer %s", token)
-	userAgent := fmt.Sprintf("svix-libs/%s/go", internal.Version)
+	userAgent := fmt.Sprintf("svix-libs/%s/go go/%s", internal.Version, runtime.Version())
 	if userAgentSuffix != nil {
 		userAgent = fmt.Sprintf("%s/%s", userAgent, *userAgentSuffix)
 	}

--- a/go/svix.go
+++ b/go/svix.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -69,7 +70,7 @@ func New(token string, options *SvixOptions) (*Svix, error) {
 	}
 
 	svixHttpClient.DefaultHeaders["Authorization"] = fmt.Sprintf("Bearer %s", token)
-	svixHttpClient.DefaultHeaders["User-Agent"] = fmt.Sprintf("svix-libs/%s/go", Version)
+	svixHttpClient.DefaultHeaders["User-Agent"] = fmt.Sprintf("svix-libs/%s/go go/%s", Version, runtime.Version())
 
 	svx := Svix{
 		client: &svixHttpClient,
@@ -96,11 +97,24 @@ func New(token string, options *SvixOptions) (*Svix, error) {
 
 // Add a custom suffix to the default user-agent
 //
+// The default user agent is `svix-libs/<version>/go go/<goversion>`.
 // The default user agent is `svix-libs/<version>/go`.
 // The suffix will be separated from the base user agent with a `/`
 //
 // The suffix must be less then 50 chars, And must match this regex `^[A-Za-z\d\.\-]+$`
+//
+// Deprecated: Please call the method with the same name instead of this free function.
 func SetUserAgentSuffix(s *Svix, userAgentSuffix string) error {
+	return s.SetUserAgentSuffix(userAgentSuffix)
+}
+
+// Add a custom suffix to the default user-agent
+//
+// The default user agent is `svix-libs/<version>/go`.
+// The suffix will be separated from the base user agent with a `/`
+//
+// The suffix must be less then 50 chars, And must match this regex `^[A-Za-z\d\.\-]+$`
+func (s Svix) SetUserAgentSuffix(userAgentSuffix string) error {
 	if len(userAgentSuffix) > 50 {
 		return fmt.Errorf("user agent suffix must be less then 50 chars")
 	}
@@ -109,7 +123,7 @@ func SetUserAgentSuffix(s *Svix, userAgentSuffix string) error {
 		return fmt.Errorf("invalid user agent suffix")
 	}
 
-	s.client.DefaultHeaders["User-Agent"] = fmt.Sprintf("svix-libs/%s/go/%s", Version, userAgentSuffix)
+	s.client.DefaultHeaders["User-Agent"] = fmt.Sprintf("svix-libs/%s/go/%s go/%s", Version, userAgentSuffix, runtime.Version())
 	return nil
 }
 

--- a/go/svix.go
+++ b/go/svix.go
@@ -98,8 +98,7 @@ func New(token string, options *SvixOptions) (*Svix, error) {
 // Add a custom suffix to the default user-agent
 //
 // The default user agent is `svix-libs/<version>/go go/<goversion>`.
-// The default user agent is `svix-libs/<version>/go`.
-// The suffix will be separated from the base user agent with a `/`
+// The suffix will be separated from the base svix-libs component of the user agent with a `/`
 //
 // The suffix must be less then 50 chars, And must match this regex `^[A-Za-z\d\.\-]+$`
 //
@@ -110,8 +109,8 @@ func SetUserAgentSuffix(s *Svix, userAgentSuffix string) error {
 
 // Add a custom suffix to the default user-agent
 //
-// The default user agent is `svix-libs/<version>/go`.
-// The suffix will be separated from the base user agent with a `/`
+// The default user agent is `svix-libs/<version>/go go/<goversion>`.
+// The suffix will be separated from the base svix-libs component of the user agent with a `/`
 //
 // The suffix must be less then 50 chars, And must match this regex `^[A-Za-z\d\.\-]+$`
 func (s Svix) SetUserAgentSuffix(userAgentSuffix string) error {

--- a/go/svix_test.go
+++ b/go/svix_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -934,4 +935,63 @@ func TestMsgInRaw(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+}
+
+func TestUserAgent(t *testing.T) {
+	ctx := context.Background()
+	svx := newMockClient()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("GET", "http://testapi.test/api/v1/app", func(r *http.Request) (*http.Response, error) {
+		defer r.Body.Close()
+		userAgent := r.Header.Get("User-Agent")
+
+		rxp := regexp.MustCompile("^svix-libs/[0-9.]+/go go/go[0-9.]+$")
+
+		if !rxp.Match([]byte(userAgent)) {
+			t.Errorf("Unexpected UA %s", userAgent)
+		}
+		return httpmock.NewStringResponse(200, "{\"data\": [], \"iterator\": \"app_3Ead4bUeXzV2bCjMcrHYjHHzf1w\", \"prevIterator\": \"-app_3Ead4bUeXzV2bCjMcrHYjHHzf1w\"}"), nil
+	})
+	_, err := svx.Application.List(ctx, nil)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestSetUserAgentSuffix(t *testing.T) {
+	ctx := context.Background()
+	svx := newMockClient()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("GET", "http://testapi.test/api/v1/app", func(r *http.Request) (*http.Response, error) {
+		defer r.Body.Close()
+		userAgent := r.Header.Get("User-Agent")
+
+		rxp := regexp.MustCompile("^svix-libs/[0-9.]+/go/foo go/go[0-9.]+$")
+
+		if !rxp.Match([]byte(userAgent)) {
+			t.Errorf("Unexpected UA %s", userAgent)
+		}
+		return httpmock.NewStringResponse(200, "{\"data\": [], \"iterator\": \"app_3Ead4bUeXzV2bCjMcrHYjHHzf1w\", \"prevIterator\": \"-app_3Ead4bUeXzV2bCjMcrHYjHHzf1w\"}"), nil
+	})
+	err := svx.SetUserAgentSuffix("foo")
+	if err != nil {
+		t.Error(err)
+	}
+	_, err = svx.Application.List(ctx, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	err = svx.SetUserAgentSuffix("g\nr")
+	if err == nil {
+		t.Errorf("expected invalid characters to fail")
+	}
+	err = svx.SetUserAgentSuffix("very long stringaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	if err == nil {
+		t.Errorf("expected invalid characters to fail")
+	}
+
 }


### PR DESCRIPTION
This concludes my patch sequence adding telemetry.