### PR TITLE
python: fix template for struct enums

### DIFF
--- a/codegen/templates/python/types/struct_enum.py.jinja
+++ b/codegen/templates/python/types/struct_enum.py.jinja
@@ -10,7 +10,9 @@ from . {{ c | to_snake_case }} import {{ c | to_upper_camel_case }}
 {%- endfor %}
 
 class {{ type_name }}(BaseModel):
+    {%- if type.fields | length > 0 %}
     {% include "types/struct_fields.py.jinja" %}
+    {%- endif %}
     {{ type.discriminator_field }}: t.Union[
         {% for variant in type.variants -%}
             t.Literal["{{ variant.name }}"] {% if not loop.last %},{% endif %}


### PR DESCRIPTION
Fixes an issue where struct enums were generating incorrectly in Python if they had no other fields other than the discriminated union fields. 

That was because when it had no other fields, `{% include "types/struct_fields.py.jinja" %}` would just render `pass`, so the class was broken. 

This is failing in https://github.com/svix/svix-webhooks-private/pull/6475

```
##############python (3/6) | container logs python/svix/models/auto_config_sink_type.py:14:1: SyntaxError: unindent does not match any outer indentation level
python (3/6) | container logs    |
python (3/6) | container logs 12 | class AutoConfigSinkType(BaseModel):
python (3/6) | container logs 13 |         pass
python (3/6) | container logs 14 |     type: t.Union[
python (3/6) | container logs    | ^
python (3/6) | container logs 15 |         t.Literal["poller"] ,
python (3/6) | container logs 16 |         t.Literal["http"] 
python (3/6) | container logs    |
python (3/6) | container logs 
python (3/6) | container logs python/svix/models/auto_config_sink_type.py:18:1: SyntaxError: Unexpected indentation
python (3/6) | container logs    |
python (3/6) | container logs 16 |         t.Literal["http"] 
python (3/6) | container logs 17 |         ]
python (3/6) | container logs 18 |     config: t.Union[
python (3/6) | container logs    | ^
python (3/6) | container logs 19 |         
python (3/6) | container logs 20 |         SinkInCommon,EndpointIn
python (3/6) | container logs    |
python (3/6) | container logs 
python (3/6) | container logs Found 491 errors (489 fixed, 2 remaining).
python (3/6) | container logs 
python (3/6) | container logs 2026-06-03T17:27:44.265179Z DEBUG operation_from_openapi{path="/api/v1/app" method="post" op_id="v1.application.create"}: openapi_codegen::api::resources: ignoring get_if_exists query parameter
python (3/6) | container logs Error: `ruff` failed with exit code Some(1)
python (3/6) | subprocess exited with code 1 (run with DEBUG=yes to see extra logs)
##########################
```