### PR TITLE
go: Add additional management APIs

### DIFF
--- a/codegen/codegen.toml
+++ b/codegen/codegen.toml
@@ -194,6 +194,9 @@ extra_codegen_args = [
     "--include-op-id=v1.management.authentication.expire-api-token",
     "--include-op-id=v1.management.authentication.patch-api-token",
     "--include-op-id=v1.endpoint.auto-config.update",
+    "--include-op-id=v1.management.environment-settings.get-otel-config",
+    "--include-op-id=v1.management.environment-settings.update-otel-config",
+    "--include-op-id=v1.management.environment-settings.delete-otel-config",
 ]
 [[go.task]]
 template = "templates/go/api_resource.go.jinja"
@@ -215,6 +218,9 @@ extra_codegen_args = [
     "--include-op-id=v1.management.authentication.expire-api-token",
     "--include-op-id=v1.management.authentication.patch-api-token",
     "--include-op-id=v1.endpoint.auto-config.update",
+    "--include-op-id=v1.management.environment-settings.get-otel-config",
+    "--include-op-id=v1.management.environment-settings.update-otel-config",
+    "--include-op-id=v1.management.environment-settings.delete-otel-config",
 ]
 
 

--- a/codegen/generated_files.json
+++ b/codegen/generated_files.json
@@ -490,6 +490,8 @@
         "go/models/ordering.go",
         "go/models/orum_io_config.go",
         "go/models/orum_io_config_out.go",
+        "go/models/otel_config.go",
+        "go/models/otel_config_out.go",
         "go/models/otel_tracing_patch_config.go",
         "go/models/panda_doc_config.go",
         "go/models/panda_doc_config_out.go",

--- a/go/internalapi/management_environment_settings.go
+++ b/go/internalapi/management_environment_settings.go
@@ -67,3 +67,54 @@ func (managementEnvironmentSettings *ManagementEnvironmentSettings) Patch(
 		&settingsInternalPatch,
 	)
 }
+
+// Get customer otel config.
+func (managementEnvironmentSettings *ManagementEnvironmentSettings) GetOtelConfig(
+	ctx context.Context,
+) (*models.OtelConfigOut, error) {
+	return internal.ExecuteRequest[any, models.OtelConfigOut](
+		ctx,
+		managementEnvironmentSettings.client,
+		"GET",
+		"/api/v1/management/environment-settings/customer-otel",
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+}
+
+// Update customer otel config.
+func (managementEnvironmentSettings *ManagementEnvironmentSettings) UpdateOtelConfig(
+	ctx context.Context,
+	otelConfig models.OtelConfig,
+) error {
+	_, err := internal.ExecuteRequest[models.OtelConfig, any](
+		ctx,
+		managementEnvironmentSettings.client,
+		"PUT",
+		"/api/v1/management/environment-settings/customer-otel",
+		nil,
+		nil,
+		nil,
+		&otelConfig,
+	)
+	return err
+}
+
+// Delete customer otel config.
+func (managementEnvironmentSettings *ManagementEnvironmentSettings) DeleteOtelConfig(
+	ctx context.Context,
+) error {
+	_, err := internal.ExecuteRequest[any, any](
+		ctx,
+		managementEnvironmentSettings.client,
+		"DELETE",
+		"/api/v1/management/environment-settings/customer-otel",
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	return err
+}

--- a/go/models/otel_config.go
+++ b/go/models/otel_config.go
@@ -1,0 +1,7 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type OtelConfig struct {
+	AdditionalHeaders *map[string]string `json:"additionalHeaders,omitempty"`
+	Url               string             `json:"url"`
+}

--- a/go/models/otel_config_out.go
+++ b/go/models/otel_config_out.go
@@ -1,0 +1,8 @@
+// Package svix this file is @generated DO NOT EDIT
+package models
+
+type OtelConfigOut struct {
+	AdditionalHeaders *map[string]string `json:"additionalHeaders,omitempty"`
+	SvixManaged       bool               `json:"svixManaged"`
+	Url               *string            `json:"url,omitempty"`
+}


### PR DESCRIPTION
Add additional internal management APIs for managing OTEL configuration. Needed by Terraform provider.
