### PR TITLE
Add js, rs tests for client-wide handling of content mirroring

### DIFF
--- a/javascript/src/mockttp.test.ts
+++ b/javascript/src/mockttp.test.ts
@@ -19,6 +19,7 @@ const EndpointOut = `{"description":"string","rateLimit":0,"uid":"unique-identif
 const ValidationErrorOut = `{"detail":[{"loc":["string"],"msg":"string","type":"string"}]}`;
 const IngestSourceOutCron = `{"type":"cron","config":{"schedule":"hello","payload":"world"},"id":"src_2yZwUhtgs5Ai8T9yRQJXA","uid":"unique-identifier","name":"string","ingestUrl":"http://example.com","createdAt":"2019-08-24T14:15:22Z","updatedAt":"2019-08-24T14:15:22Z"}`;
 const IngestSourceOutGeneric = `{"type":"generic-webhook","config":{},"id":"src_2yZwUhtgs5Ai8T9yRQJXA","uid":"unique-identifier","name":"string","ingestUrl":"http://example.com","createdAt":"2019-08-24T14:15:22Z","updatedAt":"2019-08-24T14:15:22Z"}`;
+const MessageCreateNoContentOut = `{"channels":null,"deliverAt":null,"eventId":null,"eventType":"user.signup","id":"msg_2srOrx2ZWZBpBUvZwXKQmoEYga2","payload":{"m":"FILTERED"},"tags":null,"timestamp":"2026-06-08T09:25:17.864Z"}`;
 const mockServer = mockttp.getLocal();
 
 test("mockttp tests", async (t) => {
@@ -518,5 +519,26 @@ test("mockttp tests", async (t) => {
     const svx = new Svix("token", { serverUrl: mockServer.url, fetch: mockFetch });
     await svx.application.list({ order: Ordering.Ascending });
     assert(customFetchCalled);
+  });
+
+  await t.test("test create-message uses with_content=false by default", async () => {
+    const appId = "app_1srOrx2ZWZBpBUvZwXKQmoEYga2";
+    const endpointMock = await mockServer
+      .forPost(`/api/v1/app/${appId}/msg`)
+      .thenReply(202, MessageCreateNoContentOut);
+    const svx = new Svix("token.eu", { serverUrl: mockServer.url });
+
+    const eventType = "user.signup";
+    const payload = {
+      email: "test@example.com",
+      type: eventType,
+      username: "test_user",
+    };
+    const response = await svx.message.create(appId, { eventType, payload });
+    assert.equal(response.payload, payload);
+
+    const requests = await endpointMock.getSeenRequests();
+    assert.equal(requests.length, 1);
+    assert(requests[0].url.endsWith(`api/v1/app/${appId}/msg?with_content=false`));
   });
 });

--- a/rust/tests/it/wiremock_tests.rs
+++ b/rust/tests/it/wiremock_tests.rs
@@ -5,6 +5,22 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
+trait MockServerExt {
+    fn svix_client(&self) -> Svix;
+}
+
+impl MockServerExt for MockServer {
+    fn svix_client(&self) -> Svix {
+        Svix::new(
+            "token".to_owned(),
+            Some(SvixOptions {
+                server_url: Some(self.uri()),
+                ..Default::default()
+            }),
+        )
+    }
+}
+
 #[tokio::test]
 async fn test_urlencoded_octothorpe() {
     let mock_server = MockServer::start().await;
@@ -17,15 +33,9 @@ async fn test_urlencoded_octothorpe() {
         .mount(&mock_server)
         .await;
 
-    let svx = Svix::new(
-        "token".to_string(),
-        Some(SvixOptions {
-            server_url: Some(mock_server.uri()),
-            ..Default::default()
-        }),
-    );
-
-    svx.message()
+    mock_server
+        .svix_client()
+        .message()
         .list(
             "app_id".to_string(),
             Some(MessageListOptions {
@@ -56,15 +66,9 @@ async fn test_idempotency_key_is_sent_for_create_request() {
         .mount(&mock_server)
         .await;
 
-    let svx = Svix::new(
-        "token".to_string(),
-        Some(SvixOptions {
-            server_url: Some(mock_server.uri()),
-            ..Default::default()
-        }),
-    );
-
-    svx.application()
+    mock_server
+        .svix_client()
+        .application()
         .create(svix::api::ApplicationIn::new("test app".to_string()), None)
         .await
         .unwrap();
@@ -96,16 +100,10 @@ async fn test_client_provided_idempotency_key_is_not_overridden() {
         .mount(&mock_server)
         .await;
 
-    let svx = Svix::new(
-        "token".to_string(),
-        Some(SvixOptions {
-            server_url: Some(mock_server.uri()),
-            ..Default::default()
-        }),
-    );
-
     let client_provided_key = "test-key-123";
-    svx.application()
+    mock_server
+        .svix_client()
+        .application()
         .create(
             svix::api::ApplicationIn::new("test app".to_string()),
             Some(svix::api::ApplicationCreateOptions {
@@ -145,15 +143,12 @@ async fn test_unknown_keys_are_ignored() {
         .mount(&mock_server)
         .await;
 
-    let svx = Svix::new(
-        "token".to_string(),
-        Some(SvixOptions {
-            server_url: Some(mock_server.uri()),
-            ..Default::default()
-        }),
-    );
-
-    svx.application().list(None).await.unwrap();
+    mock_server
+        .svix_client()
+        .application()
+        .list(None)
+        .await
+        .unwrap();
 
     mock_server.verify().await;
 }

--- a/rust/tests/it/wiremock_tests.rs
+++ b/rust/tests/it/wiremock_tests.rs
@@ -1,7 +1,8 @@
-use svix::api::{MessageListOptions, Svix, SvixOptions};
+use serde_json::json;
+use svix::api::{MessageIn, MessageListOptions, Svix, SvixOptions};
 
 use wiremock::{
-    matchers::{method, path},
+    matchers::{method, path, query_param},
     Mock, MockServer, ResponseTemplate,
 };
 
@@ -150,5 +151,49 @@ async fn test_unknown_keys_are_ignored() {
         .await
         .unwrap();
 
+    mock_server.verify().await;
+}
+
+#[tokio::test]
+async fn test_cmg_with_content_default() {
+    let mock_server = MockServer::start().await;
+
+    let app_id = "app_1srOrx2ZWZBpBUvZwXKQmoEYga2";
+    let event_type = "user.signup";
+    let response_body = json!({
+        "channels": null,
+        "deliverAt": null,
+        "eventId": null,
+        "eventType": event_type,
+        "id": "msg_2srOrx2ZWZBpBUvZwXKQmoEYga2",
+        "payload": { "m": "FILTERED" },
+        "tags": null,
+        "timestamp": "2026-06-08T09:25:17.864Z"
+    });
+    Mock::given(method("POST"))
+        .and(path(format!("/api/v1/app/{app_id}/msg")))
+        .and(query_param("with_content", "false"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(response_body))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let payload = json!({
+        "email": "test@example.com",
+        "type": event_type,
+        "username": "test_user",
+    });
+    let response = mock_server
+        .svix_client()
+        .message()
+        .create(
+            app_id.to_owned(),
+            MessageIn::new(event_type.to_owned(), payload.clone()),
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.payload, payload);
     mock_server.verify().await;
 }


### PR DESCRIPTION
Part of https://github.com/svix/monorepo-private/issues/13162.