### PR TITLE
cli: support using svix listen with an existing token

### DIFF
--- a/svix-cli/src/cmds/listen.rs
+++ b/svix-cli/src/cmds/listen.rs
@@ -1,12 +1,15 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::Args;
 
-use crate::config::{get_config_file_path, Config};
+use crate::config::Config;
 
 #[derive(Args)]
 pub struct ListenArgs {
     /// The local URL to forward webhooks to
     url: url::Url,
+    /// Connect to an existing Play token instead of creating a new one
+    #[arg(long)]
+    token: Option<String>,
     /// Disable TLS certificate verification when connecting to the local URL
     #[arg(long)]
     disable_tls_verification: bool,
@@ -14,26 +17,17 @@ pub struct ListenArgs {
 
 impl ListenArgs {
     pub async fn exec(self, cfg: &Config) -> Result<()> {
-        let token = match cfg.relay_token.as_ref() {
+        let (token, allow_token_rotation) = match self.token {
+            Some(token) => (token, false),
             None => {
                 let token = crate::relay::token::generate_token()?;
-                let mut updated_cfg = cfg.clone();
-                updated_cfg.relay_token = Some(token.clone());
-
-                let cfg_path = get_config_file_path()?;
-                if let Err(e) = updated_cfg.save_to_disk(&cfg_path).context(format!(
-                    "failed to save relay token to config file at `{}`",
-                    cfg_path.display()
-                )) {
-                    eprintln!("{e:#}");
-                }
-                token
+                (token, true)
             }
-            Some(token) => token.clone(),
         };
         crate::relay::listen(
             self.url,
             token,
+            allow_token_rotation,
             cfg.relay_debug_hostname.as_deref(),
             cfg.relay_disable_security.unwrap_or_default(),
             self.disable_tls_verification,

--- a/svix-cli/src/cmds/listen.rs
+++ b/svix-cli/src/cmds/listen.rs
@@ -8,7 +8,7 @@ pub struct ListenArgs {
     /// The local URL to forward webhooks to
     url: url::Url,
     /// Connect to an existing Play token instead of creating a new one
-    #[arg(long)]
+    #[arg(long, short)]
     token: Option<String>,
     /// Disable TLS certificate verification when connecting to the local URL
     #[arg(long)]

--- a/svix-cli/src/cmds/listen.rs
+++ b/svix-cli/src/cmds/listen.rs
@@ -21,7 +21,7 @@ impl ListenArgs {
             Some(token) => (token, false),
             None => {
                 let token = crate::relay::token::generate_token()?;
-                (token, true)
+                (format!("c_{token}"), true)
             }
         };
         crate::relay::listen(

--- a/svix-cli/src/config.rs
+++ b/svix-cli/src/config.rs
@@ -21,8 +21,6 @@ pub struct Config {
     debug_url: Option<String>,
 
     // Relay stuff relates to the `listen` command.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub relay_token: Option<String>,
     #[serde(alias = "relay_debug_url")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub relay_debug_hostname: Option<String>,

--- a/svix-cli/src/relay/mod.rs
+++ b/svix-cli/src/relay/mod.rs
@@ -256,7 +256,7 @@ pub async fn listen(
             eprintln!("Failed to connect to Webhook Relay: {e:#}");
             if e.downcast_ref::<TokenInUse>().is_some() && allow_token_rotation {
                 eprintln!("Generating a new token for this session.");
-                client.token = generate_token()?;
+                client.token = format!("c_{}", generate_token()?);
             }
         } else {
             eprintln!("Failed to connect to Webhook Relay");

--- a/svix-cli/src/relay/mod.rs
+++ b/svix-cli/src/relay/mod.rs
@@ -213,13 +213,13 @@ impl Client {
 pub async fn listen(
     local_url: url::Url,
     relay_token: String,
+    allow_token_rotation: bool,
     relay_debug_url: Option<&str>,
     relay_disable_security: bool,
     disable_tls_verification: bool,
 ) -> Result<()> {
     let scheme = if relay_disable_security { "ws" } else { "wss" };
     let api_host = relay_debug_url.unwrap_or(DEFAULT_API_HOST);
-    let token = format!("c_{relay_token}");
 
     let websocket_url = format!("{scheme}://{api_host}/{API_PREFIX}/listen/").parse()?;
 
@@ -228,7 +228,7 @@ pub async fn listen(
         .build()?;
 
     let mut client = Client {
-        token,
+        token: relay_token,
         websocket_url,
         local_url,
         http_client,
@@ -254,12 +254,9 @@ pub async fn listen(
 
         if let Err(e) = client.connect(show_welcome_message).await {
             eprintln!("Failed to connect to Webhook Relay: {e:#}");
-            if e.downcast_ref::<TokenInUse>().is_some() {
+            if e.downcast_ref::<TokenInUse>().is_some() && allow_token_rotation {
                 eprintln!("Generating a new token for this session.");
-                client.token = {
-                    let relay_token = generate_token()?;
-                    format!("c_{relay_token}")
-                };
+                client.token = generate_token()?;
             }
         } else {
             eprintln!("Failed to connect to Webhook Relay");


### PR DESCRIPTION
Allow using `svix listen --token <token> <local-url>` to connect to an existing Play session. Remove the config variable, since it makes no sense now