### PR TITLE
csharp: Accept a valid signature when it is last in a multi-sig header

### DIFF
--- a/csharp/Svix.Tests/WebhookTest.cs
+++ b/csharp/Svix.Tests/WebhookTest.cs
@@ -213,6 +213,23 @@ namespace Svix.Tests
         }
 
         [Fact]
+        public void TestMultiSigPayloadValidSignatureLastIsValid()
+        {
+            var testPayload = new TestPayload(DateTimeOffset.UtcNow);
+
+            string[] sigs = new string[]
+            {
+                "v1,Ceo5qEr07ixe2NLpvHk3FH9bwy/WavXrAFQ/9tdO6mc=",
+                testPayload.headers.Get(TestPayload.SVIX_SIGNATURE_HEADER_KEY), // valid signature, last
+            };
+            testPayload.headers.Set(TestPayload.SVIX_SIGNATURE_HEADER_KEY, String.Join(" ", sigs));
+
+            var wh = new Webhook(testPayload.secret);
+
+            wh.Verify(testPayload.payload, testPayload.headers);
+        }
+
+        [Fact]
         public void TestSignatureVerificationWorksWithoutPrefix()
         {
             var testPayload = new TestPayload(DateTimeOffset.UtcNow);

--- a/csharp/Svix/Webhook.cs
+++ b/csharp/Svix/Webhook.cs
@@ -105,14 +105,20 @@ namespace Svix
             expectedSignature = expectedSignature.Slice(0, charsWritten);
 
             var signaturePtr = msgSignature;
-            var spaceIndex = signaturePtr.IndexOf(' ');
-            do
+            while (!signaturePtr.IsEmpty)
             {
-                var versionedSignature =
-                    spaceIndex < 0 ? msgSignature : signaturePtr.Slice(0, spaceIndex);
-
-                signaturePtr = signaturePtr.Slice(spaceIndex + 1);
-                spaceIndex = signaturePtr.IndexOf(' ');
+                var spaceIndex = signaturePtr.IndexOf(' ');
+                ReadOnlySpan<char> versionedSignature;
+                if (spaceIndex < 0)
+                {
+                    versionedSignature = signaturePtr;
+                    signaturePtr = ReadOnlySpan<char>.Empty;
+                }
+                else
+                {
+                    versionedSignature = signaturePtr.Slice(0, spaceIndex);
+                    signaturePtr = signaturePtr.Slice(spaceIndex + 1);
+                }
 
                 var commaIndex = versionedSignature.IndexOf(',');
                 if (commaIndex < 0)
@@ -129,7 +135,7 @@ namespace Svix
                 {
                     return;
                 }
-            } while (spaceIndex >= 0);
+            }
 
             throw new WebhookVerificationException("No matching signature found");
         }


### PR DESCRIPTION
## What's broken
In the C# SDK, `Webhook.Verify` silently drops the **last** signature in a space-separated `svix-signature`/`webhook-signature` header. If the only signature matching your secret is last in the list, verification throws `WebhookVerificationException("No matching signature found")` and a legitimate webhook is rejected. Multiple signatures in one header occur in normal operation during signing-secret rotation, so this rejects valid traffic.

## Why it happens
The signature loop is a `do { ... } while (spaceIndex >= 0)` that computes the current segment from the previous iteration's `spaceIndex` and updates `spaceIndex` inside the body. When the second-to-last segment is processed, `spaceIndex` becomes `-1`, so the loop exits before the final segment is ever evaluated. The existing `TestMultiSigPayloadIsValid` doesn't catch it because its valid signature sits in the middle of the list, never last.

## Fix
Replace the `do/while` with a `while (!signaturePtr.IsEmpty)` loop that recomputes the next space boundary from the remaining span on each iteration and handles the trailing segment explicitly. Behavior is otherwise identical (same `v1` filtering and `SecureCompare`).

## Test
Added `TestMultiSigPayloadValidSignatureLastIsValid`, which places the valid signature last of two. It fails before the change (`No matching signature found`) and passes after; the full webhook suite stays green (18/18).
