### PR TITLE
Ignore RUSTSEC-2026-0173 until sea_orm drops the dep

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -17,6 +17,8 @@ ignore = [
     "RUSTSEC-2023-0071",
     # TODO: Wait for dependencies to upgrade off of proc-macro-error
     "RUSTSEC-2024-0370",
+    # TODO: Wait for dependencies (sea-orm) to upgrade off of proc-macro-error2
+    "RUSTSEC-2026-0173",
     # TODO: Wait for dependencies to upgrade off of paste
     "RUSTSEC-2024-0436",
     # rustls-pemfile is unmaintained, but we only use it for parsing system


### PR DESCRIPTION
See https://rustsec.org/advisories/RUSTSEC-2026-0173

We have the offending dep indirectly through sea_orm, so we can't drop the dep until sea_orm does. :'(