### PR TITLE
Python: AutoConfigConsumer fixes

### DIFF
--- a/codegen/templates/python/types/struct_enum.py.jinja
+++ b/codegen/templates/python/types/struct_enum.py.jinja
@@ -28,6 +28,12 @@ class {{ type_name }}(BaseModel):
     def validate_model(
         cls, data: t.Any, handler: ModelWrapValidatorHandler[Self]
     ) -> Self:
+        {# `data` is a mapping on construction, but an already-built model
+           instance when pydantic re-validates this nested model (e.g. when it
+           is a field of another model). An instance is already correctly
+           typed, so skip the mapping-only content-field massaging below. -#}
+        if not isinstance(data, dict):
+            return handler(data)
         {# sadly this is needed because of pydantic -#}
         if "{{ type.content_field }}" not in data:
             data["{{ type.content_field }}"] = {}

--- a/codegen/templates/python/types/struct_enum.py.jinja
+++ b/codegen/templates/python/types/struct_enum.py.jinja
@@ -32,7 +32,7 @@ class {{ type_name }}(BaseModel):
            instance when pydantic re-validates this nested model (e.g. when it
            is a field of another model). An instance is already correctly
            typed, so skip the mapping-only content-field massaging below. -#}
-        if not isinstance(data, dict):
+        if isinstance(data, cls):
             return handler(data)
         {# sadly this is needed because of pydantic -#}
         if "{{ type.content_field }}" not in data:

--- a/python/svix/autoconfig.py
+++ b/python/svix/autoconfig.py
@@ -47,6 +47,11 @@ def _decode_autoconfig_token_v1(token: str) -> _AutoConfigTokenContentV1:
     if not token.startswith(_AUTOCONFIG_TOKEN_PREFIX_V1):
         raise AutoConfigError("invalid token")
     b64 = token[len(_AUTOCONFIG_TOKEN_PREFIX_V1) :]
+    # The server emits the token with standard-but-unpadded base64
+    # (Rust `STANDARD_NO_PAD`), so re-add the padding that Python's strict
+    # `b64decode` requires. (Other SDKs decode via padding-tolerant
+    # primitives, e.g. Node's `Buffer.from(b64, "base64")`.)
+    b64 += "=" * (-len(b64) % 4)
     try:
         decoded = base64.b64decode(b64)
     except Exception as exc:

--- a/python/svix/autoconfig.py
+++ b/python/svix/autoconfig.py
@@ -49,7 +49,9 @@ def _decode_autoconfig_token_v1(token: str) -> _AutoConfigTokenContentV1:
     b64 = token[len(_AUTOCONFIG_TOKEN_PREFIX_V1) :]
     # Ensure b64 has padding, which is required by the python base64 module
     try:
-        decoded = base64.b64decode(b64 + "===") # trick from https://stackoverflow.com/a/49459036
+        decoded = base64.b64decode(
+            b64 + "==="
+        )  # trick from https://stackoverflow.com/a/49459036
     except Exception as exc:
         raise AutoConfigError("invalid token") from exc
     try:

--- a/python/svix/autoconfig.py
+++ b/python/svix/autoconfig.py
@@ -47,13 +47,9 @@ def _decode_autoconfig_token_v1(token: str) -> _AutoConfigTokenContentV1:
     if not token.startswith(_AUTOCONFIG_TOKEN_PREFIX_V1):
         raise AutoConfigError("invalid token")
     b64 = token[len(_AUTOCONFIG_TOKEN_PREFIX_V1) :]
-    # The server emits the token with standard-but-unpadded base64
-    # (Rust `STANDARD_NO_PAD`), so re-add the padding that Python's strict
-    # `b64decode` requires. (Other SDKs decode via padding-tolerant
-    # primitives, e.g. Node's `Buffer.from(b64, "base64")`.)
-    b64 += "=" * (-len(b64) % 4)
+    # Ensure b64 has padding, which is required by the python base64 module
     try:
-        decoded = base64.b64decode(b64)
+        decoded = base64.b64decode(b64 + "===") # trick from https://stackoverflow.com/a/49459036
     except Exception as exc:
         raise AutoConfigError("invalid token") from exc
     try:

--- a/python/svix/models/auto_config_sink_type.py
+++ b/python/svix/models/auto_config_sink_type.py
@@ -18,6 +18,8 @@ class AutoConfigSinkType(BaseModel):
     def validate_model(
         cls, data: t.Any, handler: ModelWrapValidatorHandler[Self]
     ) -> Self:
+        if not isinstance(data, dict):
+            return handler(data)
         if "config" not in data:
             data["config"] = {}
         output = handler(data)

--- a/python/svix/models/auto_config_sink_type.py
+++ b/python/svix/models/auto_config_sink_type.py
@@ -18,7 +18,7 @@ class AutoConfigSinkType(BaseModel):
     def validate_model(
         cls, data: t.Any, handler: ModelWrapValidatorHandler[Self]
     ) -> Self:
-        if not isinstance(data, dict):
+        if isinstance(data, cls):
             return handler(data)
         if "config" not in data:
             data["config"] = {}

--- a/python/svix/models/ingest_source_in.py
+++ b/python/svix/models/ingest_source_in.py
@@ -115,7 +115,7 @@ class IngestSourceIn(BaseModel):
     def validate_model(
         cls, data: t.Any, handler: ModelWrapValidatorHandler[Self]
     ) -> Self:
-        if not isinstance(data, dict):
+        if isinstance(data, cls):
             return handler(data)
         if "config" not in data:
             data["config"] = {}

--- a/python/svix/models/ingest_source_in.py
+++ b/python/svix/models/ingest_source_in.py
@@ -115,6 +115,8 @@ class IngestSourceIn(BaseModel):
     def validate_model(
         cls, data: t.Any, handler: ModelWrapValidatorHandler[Self]
     ) -> Self:
+        if not isinstance(data, dict):
+            return handler(data)
         if "config" not in data:
             data["config"] = {}
         output = handler(data)

--- a/python/svix/models/ingest_source_out.py
+++ b/python/svix/models/ingest_source_out.py
@@ -125,7 +125,7 @@ class IngestSourceOut(BaseModel):
     def validate_model(
         cls, data: t.Any, handler: ModelWrapValidatorHandler[Self]
     ) -> Self:
-        if not isinstance(data, dict):
+        if isinstance(data, cls):
             return handler(data)
         if "config" not in data:
             data["config"] = {}

--- a/python/svix/models/ingest_source_out.py
+++ b/python/svix/models/ingest_source_out.py
@@ -125,6 +125,8 @@ class IngestSourceOut(BaseModel):
     def validate_model(
         cls, data: t.Any, handler: ModelWrapValidatorHandler[Self]
     ) -> Self:
+        if not isinstance(data, dict):
+            return handler(data)
         if "config" not in data:
             data["config"] = {}
         output = handler(data)

--- a/python/svix/models/stream_sink_in.py
+++ b/python/svix/models/stream_sink_in.py
@@ -88,6 +88,8 @@ class StreamSinkIn(BaseModel):
     def validate_model(
         cls, data: t.Any, handler: ModelWrapValidatorHandler[Self]
     ) -> Self:
+        if not isinstance(data, dict):
+            return handler(data)
         if "config" not in data:
             data["config"] = {}
         output = handler(data)

--- a/python/svix/models/stream_sink_in.py
+++ b/python/svix/models/stream_sink_in.py
@@ -88,7 +88,7 @@ class StreamSinkIn(BaseModel):
     def validate_model(
         cls, data: t.Any, handler: ModelWrapValidatorHandler[Self]
     ) -> Self:
-        if not isinstance(data, dict):
+        if isinstance(data, cls):
             return handler(data)
         if "config" not in data:
             data["config"] = {}

--- a/python/svix/models/stream_sink_out.py
+++ b/python/svix/models/stream_sink_out.py
@@ -90,7 +90,7 @@ class StreamSinkOut(BaseModel):
     def validate_model(
         cls, data: t.Any, handler: ModelWrapValidatorHandler[Self]
     ) -> Self:
-        if not isinstance(data, dict):
+        if isinstance(data, cls):
             return handler(data)
         if "config" not in data:
             data["config"] = {}

--- a/python/svix/models/stream_sink_out.py
+++ b/python/svix/models/stream_sink_out.py
@@ -90,6 +90,8 @@ class StreamSinkOut(BaseModel):
     def validate_model(
         cls, data: t.Any, handler: ModelWrapValidatorHandler[Self]
     ) -> Self:
+        if not isinstance(data, dict):
+            return handler(data)
         if "config" not in data:
             data["config"] = {}
         output = handler(data)

--- a/python/svix/models/stream_sink_patch.py
+++ b/python/svix/models/stream_sink_patch.py
@@ -76,7 +76,7 @@ class StreamSinkPatch(BaseModel):
     def validate_model(
         cls, data: t.Any, handler: ModelWrapValidatorHandler[Self]
     ) -> Self:
-        if not isinstance(data, dict):
+        if isinstance(data, cls):
             return handler(data)
         if "config" not in data:
             data["config"] = {}

--- a/python/svix/models/stream_sink_patch.py
+++ b/python/svix/models/stream_sink_patch.py
@@ -76,6 +76,8 @@ class StreamSinkPatch(BaseModel):
     def validate_model(
         cls, data: t.Any, handler: ModelWrapValidatorHandler[Self]
     ) -> Self:
+        if not isinstance(data, dict):
+            return handler(data)
         if "config" not in data:
             data["config"] = {}
         output = handler(data)

--- a/python/tests/test_autoconfig.py
+++ b/python/tests/test_autoconfig.py
@@ -19,8 +19,10 @@ def _make_token(**overrides) -> str:
         "tok": "sk_test_xyz",
     }
     payload.update(overrides)
-    raw = json.dumps(payload).encode()
-    return f"{_AUTOCONFIG_TOKEN_PREFIX_V1}{base64.b64encode(raw).decode('ascii')}"
+    raw = json.dumps(payload).encode("utf-8")
+    # Strip padding so the token emulates the server's unpadded output.
+    b64 = base64.b64encode(raw).decode("ascii").replace("=", "")
+    return f"{_AUTOCONFIG_TOKEN_PREFIX_V1}{b64}"
 
 
 def test_decode_autoconfig_token_v1_parses_payload():

--- a/python/tests/test_autoconfig.py
+++ b/python/tests/test_autoconfig.py
@@ -3,8 +3,24 @@ import json
 
 import pytest
 
-from svix import AutoConfigError
+from svix import AutoConfigConsumer, AutoConfigError
 from svix.autoconfig import _AUTOCONFIG_TOKEN_PREFIX_V1, _decode_autoconfig_token_v1
+from svix.models import SinkInCommon
+from svix.models.auto_config_sink_type import AutoConfigSinkType
+from svix.models.subscribe_in import SubscribeIn
+
+
+def _make_token(**overrides) -> str:
+    payload = {
+        "aid": "app_1",
+        "eid": "ep_2",
+        "surl": "https://api.example.test",
+        "esec": "whsec_Zm9v",
+        "tok": "sk_test_xyz",
+    }
+    payload.update(overrides)
+    raw = json.dumps(payload).encode()
+    return f"{_AUTOCONFIG_TOKEN_PREFIX_V1}{base64.b64encode(raw).decode('ascii')}"
 
 
 def test_decode_autoconfig_token_v1_parses_payload():
@@ -48,3 +64,30 @@ def test_decode_autoconfig_token_v1_rejects_invalid_json():
 
     with pytest.raises(AutoConfigError):
         _decode_autoconfig_token_v1(token)
+
+
+def test_auto_config_sink_type_revalidates_when_nested():
+    # Regression: nesting an already-built AutoConfigSinkType inside another
+    # model re-runs its wrap validator with a model instance (not a dict),
+    # which used to raise TypeError on `data["config"] = {}`.
+    sink = AutoConfigSinkType(type="poller", config=SinkInCommon(filter_types=["a"]))
+    subscribe_in = SubscribeIn(sink=sink)
+
+    assert subscribe_in.sink is not None
+    assert isinstance(subscribe_in.sink.config, SinkInCommon)
+    assert subscribe_in.sink.config.filter_types == ["a"]
+
+
+def test_auto_config_consumer_subscribe_in_payload():
+    consumer = AutoConfigConsumer(
+        _make_token(), SinkInCommon(filter_types=["issue.opened"])
+    )
+    subscribe_in = consumer._subscribe_in()
+
+    assert subscribe_in.sink is not None
+    assert subscribe_in.sink.type == "poller"
+    assert isinstance(subscribe_in.sink.config, SinkInCommon)
+    assert (
+        subscribe_in.model_dump_json(exclude_unset=True, by_alias=True)
+        == '{"sink":{"type":"poller","config":{"filterTypes":["issue.opened"]}}}'
+    )


### PR DESCRIPTION
I was trying to set up AutoConfigConsumer for the `svix-hermes` plugin and hit this problem. I let Claude take a look while I was working on other stuff

---

Two bugs prevented the polling `AutoConfigConsumer` from working in the Python SDK:

1. **`subscribe()` crashed** with `TypeError: 'AutoConfigSinkType' object does not support item assignment`. The struct-enum wrap-validator did `data["config"] = {}` assuming a dict, but pydantic hands it a model instance when re-validating a nested struct-enum (exactly what `SubscribeIn(sink=…)` triggers). Guarded with `if not isinstance(data, dict): return handler(data)`.

2. **Tokens failed to decode** with "Incorrect padding". The server emits tokens as unpadded base64 (`STANDARD_NO_PAD`), but the decoder used strict `base64.b64decode`. Other SDKs work via padding-tolerant primitives (e.g. Node's `Buffer.from`). Re-add padding before decoding.
