### PR TITLE
test(js): Cover idempotency key reuse across POST retries

### DIFF
--- a/javascript/src/mockttp.test.ts
+++ b/javascript/src/mockttp.test.ts
@@ -470,6 +470,27 @@ test("mockttp tests", async (t) => {
     assert(idempotencyKey.startsWith("auto_"));
   });
 
+  await t.test("POST retry reuses the same auto idempotency key", async () => {
+    const endpointMock = await mockServer
+      .forPost("/api/v1/app")
+      .thenReply(500, `{"code":"500","detail":"asd"}`);
+    const svx = new Svix("token", {
+      serverUrl: mockServer.url,
+      numRetries: 2,
+    });
+
+    await assert.rejects(svx.application.create({ name: "test app" }), ApiException);
+
+    const requests = await endpointMock.getSeenRequests();
+    assert.equal(requests.length, 3);
+
+    const idempotencyKey = requests[0].headers["idempotency-key"] as string;
+    assert(idempotencyKey.startsWith("auto_"));
+
+    for (const request of requests) {
+      assert.equal(request.headers["idempotency-key"], idempotencyKey);
+    }
+  });
   await t.test("test client provided idempotency key is not overridden", async () => {
     const endpointMock = await mockServer
       .forPost("/api/v1/app")


### PR DESCRIPTION
## Summary

Adds regression coverage to ensure automatically generated idempotency keys are reused across POST retries.

## Motivation

The JavaScript SDK automatically generates an idempotency key for POST requests when one is not provided by the caller.

Retries currently reuse the same request headers, meaning the same auto-generated idempotency key is preserved across retry attempts. This behavior is important for safe retry semantics and helps avoid duplicate side effects when a request is retried after a transient failure.

This test documents and protects that existing behavior.

## Changes

- Added a test covering POST retries with automatic idempotency key generation.
- Verifies the same idempotency key is reused across all retry attempts.
- No production code changes.

## Test plan

```bash
cd javascript
npm test