### PR TITLE
Rust SDK: Fix visibility of MessagePollerv2Consumer*Options

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -77,6 +77,10 @@ allowed = [
 [lints.rust]
 # below clippy allow rule is for a lint that's not on stable yet 😒
 unknown_lints = "allow"
+# Catch public APIs that reference types which cannot be named outside the
+# crate (e.g. `pub` types living in a private module). The default
+# `private_interfaces` lint misses these because the types are nominally `pub`.
+unnameable_types = "deny"
 
 [lints.clippy]
 all = { priority = -1, level = "warn" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -80,7 +80,7 @@ unknown_lints = "allow"
 # Catch public APIs that reference types which cannot be named outside the
 # crate (e.g. `pub` types living in a private module). The default
 # `private_interfaces` lint misses these because the types are nominally `pub`.
-unnameable_types = "deny"
+unnameable_types = "warn"
 
 [lints.clippy]
 all = { priority = -1, level = "warn" }

--- a/rust/src/autoconfig_consumer.rs
+++ b/rust/src/autoconfig_consumer.rs
@@ -6,6 +6,14 @@ use crate::{
     models::{AutoConfigSinkType, PollerV2CommitIn, PollerV2PollOut, SinkInCommon, SubscribeIn},
 };
 
+// Re-exported so callers can name and construct the `options` arguments of
+// `receive`/`commit`. The types are `pub` but live in the crate-private
+// `api_internal` module, so without this they would be reachable yet
+// unnameable.
+pub use crate::api_internal::message_pollerv2::{
+    MessagePollerv2ConsumerCommitOptions, MessagePollerv2ConsumerPollOptions,
+};
+
 pub struct AutoConfigConsumer {
     app_id: String,
     sink_id: String,

--- a/rust/src/model_ext.rs
+++ b/rust/src/model_ext.rs
@@ -1,5 +1,11 @@
 //! Extensions of the auto-generated "models" (schema structs).
 
+// The `*FromStrError` types below are the `Err` of public `FromStr` impls.
+// They are reachable but not nameable outside the crate; that is acceptable
+// here since they are trivial unit error structs with nothing to match on or
+// configure, so we don't surface them as named public API.
+#![allow(unnameable_types)]
+
 use std::str::FromStr;
 
 use serde_json::json;

--- a/rust/src/webhooks.rs
+++ b/rust/src/webhooks.rs
@@ -195,6 +195,10 @@ pub trait HeaderMap: private::HeaderMapSealed {}
 impl HeaderMap for http02::HeaderMap {}
 impl HeaderMap for http1::HeaderMap {}
 
+// Intentional sealed-trait pattern: these traits are reachable as supertrait
+// bounds of the public `HeaderMap`/`HeaderValue` traits but must not be
+// nameable or implementable downstream
+#[allow(unnameable_types)]
 mod private {
     pub trait HeaderMapSealed {
         type HeaderValue: HeaderValueSealed;


### PR DESCRIPTION
While trying to use the AutoConfigConsumer `receive` and `commit` methods (https://docs.rs/svix/1.96.0/svix/autoconfig_consumer/struct.AutoConfigConsumer.html), I was unable to use anything other than `None` for `options` field, because `MessagePollerv2ConsumerPollOptions` and `MessagePollerv2ConsumerCommitOptions` are in the `api_internal` module.

My guess is this wasn't intentional, so I tried to fix the issue and add a lint so issues like this would get caught in the future. (There were some places where the privacy was clearly intention, which I explicitly whitelisted).

I just did this for Rust, not the other languages. I don't know if the same issue impacts other SDKs.