### PR TITLE
server: add status_text to EndpointMessageOut in OSS

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Server: add `statusText` to `EndpointMessageOut` (the response type for `v1.message-attempt.list-attempted-messages`), matching the cloud version
 * Libs/Python: Bump minimum-supported Python interpreter version to 3.9
 
 ## Version 1.96.1

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -611,6 +611,9 @@
                     "status": {
                         "$ref": "#/components/schemas/MessageStatus"
                     },
+                    "statusText": {
+                        "$ref": "#/components/schemas/MessageStatusText"
+                    },
                     "timestamp": {
                         "format": "date-time",
                         "type": "string"
@@ -621,6 +624,7 @@
                     "id",
                     "payload",
                     "status",
+                    "statusText",
                     "timestamp"
                 ],
                 "type": "object"

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -110,6 +110,7 @@ pub struct EndpointMessageOut {
     #[serde(flatten)]
     pub msg: MessageOut,
     pub status: MessageStatus,
+    pub status_text: MessageStatusText,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_attempt: Option<DateTimeWithTimeZone>,
 }
@@ -135,6 +136,7 @@ impl EndpointMessageOut {
         EndpointMessageOut {
             msg: MessageOut::from_msg_and_payload(msg, msg_content, with_content),
             status,
+            status_text: status.into(),
             next_attempt: attempt.next_attempt,
         }
     }
@@ -151,6 +153,7 @@ impl<'de> Deserialize<'de> for EndpointMessageOut {
         Ok(Self {
             msg: serde_json::from_str(raw_value.get()).unwrap(),
             status: serde_json::from_str(rest.get("status").unwrap().get()).unwrap(),
+            status_text: serde_json::from_str(rest.get("statusText").unwrap().get()).unwrap(),
             next_attempt: rest
                 .get("next_attempt")
                 .map(|x| serde_json::from_str(x.get()).unwrap()),


### PR DESCRIPTION
This field was added to the cloud fork in svix/svix-webhooks-private#4646, and made it into the OpenAPI spec used to generate the client libraries in #2037, but was never actually added to the OSS server implementation. So you haven't been able to successfully do `list_attempted_messages` with a contemporary SDK against the OSS app since then.

Fixes #2385.