### PR TITLE
server: add status_text to MessageEndpointOut in OSS

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Server: add `statusText` to `EndpointMessageOut` (the response type for `v1.message-attempt.list-attempted-messages`), matching the cloud version
+* Server: add `statusText` to `MessageEndpointOut` (the response type for `v1.message-attempt.list-attempted-destinations`), matching the cloud version
 * Libs/Python: Bump minimum-supported Python interpreter version to 3.9
 
 ## Version 1.96.1

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1968,6 +1968,9 @@
                     "status": {
                         "$ref": "#/components/schemas/MessageStatus"
                     },
+                    "statusText": {
+                        "$ref": "#/components/schemas/MessageStatusText"
+                    },
                     "throttleRate": {
                         "description": "Maximum messages per second to send to this endpoint.\n\nOutgoing messages will be throttled to this rate.",
                         "format": "uint16",
@@ -2008,6 +2011,7 @@
                     "description",
                     "id",
                     "status",
+                    "statusText",
                     "updatedAt",
                     "url",
                     "version"

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -699,6 +699,7 @@ pub struct MessageEndpointOut {
     endpoint: super::endpoint::EndpointOutCommon,
     pub id: EndpointId,
     status: MessageStatus,
+    status_text: MessageStatusText,
     next_attempt: Option<DateTime<Utc>>,
 }
 
@@ -782,6 +783,7 @@ async fn list_attempted_destinations(
             Some(MessageEndpointOut {
                 id: msg_attempt.endp_id,
                 status: msg_attempt.status,
+                status_text: msg_attempt.status.into(),
                 next_attempt: msg_attempt.next_attempt.map(Into::into),
                 endpoint: endp.into(),
             })


### PR DESCRIPTION
This is essentially the same as #2408/#2385, but for `MessageEndpointOut` instead of `EndpointMessageout`.

Detected by using the script in #2411.