### PR TITLE
server: add canceled to OSS EndpointStatsOut

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 * Server: add `statusText` to `EndpointMessageOut` (the response type for `v1.message-attempt.list-attempted-messages`), matching the cloud version
 * Server: add `statusText` to `MessageEndpointOut` (the response type for `v1.message-attempt.list-attempted-destinations`), matching the cloud version
+* Server: add `canceled` to `EndpointStatsOut`, matching the cloud version. This is always 0 in the OSS server, which doesn't currently track message cancellations.
 * Libs/Python: Bump minimum-supported Python interpreter version to 3.9
 
 ## Version 1.96.1

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -844,6 +844,10 @@
             },
             "EndpointStats": {
                 "properties": {
+                    "canceled": {
+                        "format": "int64",
+                        "type": "integer"
+                    },
                     "fail": {
                         "format": "int64",
                         "type": "integer"
@@ -862,6 +866,7 @@
                     }
                 },
                 "required": [
+                    "canceled",
                     "fail",
                     "pending",
                     "sending",

--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -743,6 +743,7 @@ pub struct EndpointStatsOut {
     pub pending: i64,
     pub sending: i64,
     pub fail: i64,
+    pub canceled: i64,
 }
 
 #[derive(Debug, FromQueryResult)]
@@ -788,6 +789,7 @@ async fn endpoint_stats(
         pending: query_out.remove(&MessageStatus::Pending).unwrap_or(0),
         fail: query_out.remove(&MessageStatus::Fail).unwrap_or(0),
         sending: query_out.remove(&MessageStatus::Sending).unwrap_or(0),
+        canceled: 0,
     }))
 }
 


### PR DESCRIPTION
This is similar to #2408; this field was added as required in the cloud version in #2298, but isn't emitted by OSS, so the client libraries can't be used against the OSS endpoint stats endpoint.

Discovered using the tool from #2411.