### PR TITLE
server: add gracePeriodSeconds to OSS endpoint secret rotation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,8 +3,9 @@
 ## Unreleased
 * Server: add `statusText` to `EndpointMessageOut` (the response type for `v1.message-attempt.list-attempted-messages`), matching the cloud version
 * Server: add `statusText` to `MessageEndpointOut` (the response type for `v1.message-attempt.list-attempted-destinations`), matching the cloud version
-* Server: add `canceled` to `EndpointStatsOut`, matching the cloud version. This is always 0 in the OSS server, which doesn't currently track message cancellations.
-* Server: add `updatedAt` to `RecoverOut` (the response type for `v1.endpoint.recover`), matching the cloud version. Note that EE does not support incrementally checking background job status, so this always contains the timestamp at which the job was created.
+* Server: add `canceled` to `EndpointStatsOut`, matching the cloud version. This is always 0 in the OSS server, which doesn't currently track message cancellations
+* Server: add `updatedAt` to `RecoverOut` (the response type for `v1.endpoint.recover`), matching the cloud version. Note that EE does not support incrementally checking background job status, so this always contains the timestamp at which the job was created
+* Server: add `gracePeriodSeconds` to `EndpointSecretRotateIn`, allowing users to customize how long the old key is still valid for (in a range from 0, which means immediate expiry, to 7 days)
 * Libs/Python: Bump minimum-supported Python interpreter version to 3.9
 
 ## Version 1.96.1

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -831,6 +831,15 @@
             },
             "EndpointSecretRotateIn": {
                 "properties": {
+                    "gracePeriodSeconds": {
+                        "default": 86400,
+                        "description": "How long the old secret will be valid for, in seconds.\n\nValid values are between 0 (immediate expiry) and 7 days. The default is 24 hours.",
+                        "format": "uint32",
+                        "maximum": 604800,
+                        "minimum": 0,
+                        "nullable": true,
+                        "type": "integer"
+                    },
                     "key": {
                         "default": null,
                         "description": "The endpoint's verification secret. If `null` is passed, a secret is automatically generated. Format: `base64` encoded random bytes optionally prefixed with `whsec_`. Recommended size: 24.",

--- a/server/svix-server/src/core/message_app.rs
+++ b/server/svix-server/src/core/message_app.rs
@@ -251,13 +251,11 @@ mod tests {
 
         let unexpired_old_key = ExpiringSigningKey {
             key: key.clone(),
-            expiration: Utc::now()
-                + chrono::Duration::hours(ExpiringSigningKeys::OLD_KEY_EXPIRY_HOURS),
+            expiration: Utc::now() + chrono::Duration::hours(1),
         };
         let expired_old_key = ExpiringSigningKey {
             key: key.clone(),
-            expiration: Utc::now()
-                - chrono::Duration::hours(ExpiringSigningKeys::OLD_KEY_EXPIRY_HOURS),
+            expiration: Utc::now() - chrono::Duration::hours(1),
         };
         let old_signing_keys = Some(ExpiringSigningKeys(vec![
             unexpired_old_key,

--- a/server/svix-server/src/core/types/mod.rs
+++ b/server/svix-server/src/core/types/mod.rs
@@ -641,7 +641,6 @@ json_wrapper!(ExpiringSigningKeys);
 
 impl ExpiringSigningKeys {
     pub const MAX_OLD_KEYS: usize = 10;
-    pub const OLD_KEY_EXPIRY_HOURS: i64 = 24;
 
     pub fn unexpired_keys(&self) -> impl Iterator<Item = &ExpiringSigningKey> {
         let now = Utc::now();
@@ -1114,6 +1113,12 @@ pub struct ExpiringSigningKey {
     #[serde(rename = "signingKey")]
     pub key: EndpointSecretInternal,
     pub expiration: DateTime<Utc>,
+}
+
+impl ExpiringSigningKey {
+    pub fn is_unexpired(&self) -> bool {
+        self.expiration > Utc::now()
+    }
 }
 
 const FORBIDDEN_KEYS: [&str; 19] = [

--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -583,6 +583,34 @@ pub struct EndpointSecretRotateIn {
     #[validate]
     #[serde(default)]
     key: Option<EndpointSecret>,
+    /// How long the old secret will be valid for, in seconds.
+    ///
+    /// Valid values are between 0 (immediate expiry) and 7 days.
+    /// The default is 24 hours.
+    #[serde(default)]
+    #[schemars(
+        default = "default_grace_period_seconds",
+        length(min = 0, max = 604_800)
+    )]
+    #[validate(range(
+        min = 0,
+        max = 604_800,
+        message = "Duration must be between 0 and 7 days"
+    ))]
+    pub grace_period_seconds: Option<u32>,
+}
+
+impl EndpointSecretRotateIn {
+    pub fn grace_period(&self) -> Duration {
+        Duration::seconds(
+            self.grace_period_seconds
+                .unwrap_or_else(default_grace_period_seconds) as _,
+        )
+    }
+}
+
+const fn default_grace_period_seconds() -> u32 {
+    86_400
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]

--- a/server/svix-server/src/v1/endpoints/endpoint/secrets.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/secrets.rs
@@ -46,6 +46,7 @@ pub fn rotate_key(
     current_data: SigningKeysData,
     new_key: Option<EndpointSecret>,
     cfg: &ConfigurationInner,
+    grace_period: Duration,
 ) -> Result<SigningKeysData> {
     let now = Utc::now();
     let last_key = current_data
@@ -53,26 +54,31 @@ pub fn rotate_key(
         .clone()
         .map(|current_key| ExpiringSigningKey {
             key: current_key,
-            expiration: now + Duration::hours(ExpiringSigningKeys::OLD_KEY_EXPIRY_HOURS),
+            expiration: now + grace_period,
         });
 
-    let unexpired_old_keys = current_data
+    let mut unexpired_old_keys = current_data
         .old_keys
         .as_ref()
-        .map(|k| k.unexpired_keys().cloned().collect::<Vec<_>>());
+        .map(|k| k.unexpired_keys().cloned().collect::<Vec<_>>())
+        .unwrap_or_default();
 
-    if let Some(old_keys) = &unexpired_old_keys {
-        if old_keys.len() + 1 > ExpiringSigningKeys::MAX_OLD_KEYS {
-            return Err(HttpError::bad_request(
-                Some("limit_reached".to_owned()),
-                Some(format!(
-                    "You can only rotate a key {} times within the last {} hours.",
-                    ExpiringSigningKeys::MAX_OLD_KEYS,
-                    ExpiringSigningKeys::OLD_KEY_EXPIRY_HOURS
-                )),
-            )
-            .into());
-        }
+    if let Some(last_key) = last_key.filter(|k| k.is_unexpired()) {
+        unexpired_old_keys.push(last_key)
+    }
+
+    unexpired_old_keys.sort_by_key(|x| x.expiration);
+
+    if unexpired_old_keys.len() > ExpiringSigningKeys::MAX_OLD_KEYS {
+        return Err(HttpError::bad_request(
+            Some("limit_reached".to_owned()),
+            Some(format!(
+                "You can only rotate a key {} times; please wait for old keys to expire. Your next key expires at {}.",
+                ExpiringSigningKeys::MAX_OLD_KEYS,
+                unexpired_old_keys.first().expect("we just checked that this is non-empty").expiration
+            )),
+        )
+        .into());
     }
 
     Ok(SigningKeysData {
@@ -81,12 +87,7 @@ pub fn rotate_key(
         } else {
             generate_secret(&cfg.encryption, &cfg.default_signature_type)?
         }),
-        old_keys: Some(ExpiringSigningKeys(
-            last_key
-                .into_iter()
-                .chain(unexpired_old_keys.unwrap_or_default())
-                .collect(),
-        )),
+        old_keys: Some(ExpiringSigningKeys(unexpired_old_keys)),
     })
 }
 
@@ -128,6 +129,8 @@ pub(super) async fn rotate_endpoint_secret(
         .await?
         .ok_or_else(|| HttpError::not_found(None, None))?;
 
+    let grace_period = data.grace_period();
+
     let new_data = rotate_key(
         SigningKeysData {
             current_key: Some(endp.key.clone()),
@@ -135,6 +138,7 @@ pub(super) async fn rotate_endpoint_secret(
         },
         data.key,
         &cfg,
+        grace_period,
     )?;
 
     let endp = endpoint::ActiveModel {


### PR DESCRIPTION
This matches svix/svix-webhooks-private#6604 + svix/svix-webhooks-private#6608. Part of svix/monorepo-private#13384.