### PR TITLE
rust: make http 0.2 dependency optional

### DIFF
--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -68,3 +68,12 @@ jobs:
 
       - name: Run tests
         run: cargo nextest run
+
+      - name: Run tests with http 0.2 support
+        run: cargo nextest run --features http02
+
+      - name: Run tests with all features
+        run: cargo nextest run --all-features
+
+      - name: Run tests with native-tls
+        run: cargo nextest run --no-default-features --features=http1,http2,native-tls

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,8 @@
 * Server: add `updatedAt` to `RecoverOut` (the response type for `v1.endpoint.recover`), matching the cloud version. Note that EE does not support incrementally checking background job status, so this always contains the timestamp at which the job was created
 * Server: add `gracePeriodSeconds` to `EndpointSecretRotateIn`, allowing users to customize how long the old key is still valid for (in a range from 0, which means immediate expiry, to 7 days)
 * Libs/Python: Bump minimum-supported Python interpreter version to 3.9
+* Libs/Rust: [`http` 0.2](https://crates.io/crates/http) is now an optional dependency; if you require integration with 0.2.x, please enable the `http02` feature
+* Libs/Rust: (minor breaking change) The `status` field of `svix::Error` is now a StatusCode from `http` 1.0 instead of `http` 0.2.
 
 ## Version 1.96.1
 * Libs/Java: Upgrade jackson dependency to v2.21.4

--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -4563,7 +4563,6 @@ version = "1.96.1"
 dependencies = [
  "base64 0.13.1",
  "hmac-sha256",
- "http 0.2.12",
  "http 1.4.1",
  "http-body-util",
  "hyper",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,15 +9,19 @@ repository = "https://github.com/svix/svix-webhooks"
 readme = "../README.md"
 license = "MIT"
 keywords = ["svix", "webhooks", "diahook"]
-categories = [
-    "development-tools",
-    "asynchronous",
-    "network-programming",
-    "web-programming",
-]
+categories = ["development-tools", "asynchronous", "network-programming", "web-programming"]
 include = ["src/**/*", "README.md"]
 # bump .github/workflows/rust-link.yml when changing this
 rust-version = "1.88"
+
+[package.metadata.cargo-public-api-crates]
+allowed = [
+    "http",
+    "serde",
+    "serde_json",
+    # Used in WebhookError, breaking change to remove from public API.
+    "base64",
+]
 
 [features]
 # openssl-sys keeps showing up in the CLI dep graph, breaking the build, even when
@@ -25,18 +29,23 @@ rust-version = "1.88"
 # Switcing the default to rustls properly culls it from the tree.
 default = ["http1", "rustls-tls"]
 
+# support HTTP/1
 http1 = ["hyper-util/http1", "hyper-rustls?/http1"]
+# support HTTP/2
 http2 = ["hyper-util/http2", "hyper-rustls?/http2"]
 native-tls = ["dep:hyper-tls"]
 rustls-tls = ["dep:hyper-rustls", "dep:rustls", "hyper-rustls?/rustls-native-certs"]
 svix_beta = []
 
+# support the http crate (version 0.2; version 1 is always supported)
+http02 = ["dep:http02"]
+
 [dependencies]
 base64 = "0.13"
 hmac-sha256 = "1"
-http02 = { package = "http", version = "0.2.0" }
-http1 = { package = "http", version = "1.0.0" }
 http-body-util = "0.1.0"
+http02 = { package = "http", version = "0.2.0", optional = true }
+http1 = { package = "http", version = "1.0.0" }
 hyper = "1.7.0"
 hyper-rustls = { version = "0.27.7", optional = true }
 hyper-tls = { version = "0.6.0", optional = true }
@@ -61,18 +70,9 @@ version_check = "0.9.5"
 nix = { version = "0.31", features = ["feature"] }
 
 [dev-dependencies]
-tokio = { version = "1.41.0", features = ["macros"] }
 regex = "1"
+tokio = { version = "1.41.0", features = ["macros"] }
 wiremock = "0.6.2, <0.6.5"
-
-[package.metadata.cargo-public-api-crates]
-allowed = [
-    "http",
-    "serde",
-    "serde_json",
-    # Used in WebhookError, breaking change to remove from public API.
-    "base64",
-]
 
 [lints.rust]
 # below clippy allow rule is for a lint that's not on stable yet 😒

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -6,8 +6,6 @@ use std::fmt;
 use http_body_util::BodyExt;
 use hyper::body::Incoming;
 
-use crate::http1_to_02_status_code;
-
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// The error type returned from the Svix API
@@ -32,12 +30,12 @@ impl Error {
                 let bytes = collected.to_bytes();
                 if status_code == http1::StatusCode::UNPROCESSABLE_ENTITY {
                     Self::Validation(HttpErrorContent {
-                        status: http02::StatusCode::UNPROCESSABLE_ENTITY,
+                        status: http1::StatusCode::UNPROCESSABLE_ENTITY,
                         payload: serde_json::from_slice(&bytes).ok(),
                     })
                 } else {
                     Error::Http(HttpErrorContent {
-                        status: http1_to_02_status_code(status_code),
+                        status: status_code,
                         payload: serde_json::from_slice(&bytes).ok(),
                     })
                 }
@@ -68,6 +66,6 @@ impl std::error::Error for Error {}
 
 #[derive(Debug, Clone)]
 pub struct HttpErrorContent<T> {
-    pub status: http02::StatusCode,
+    pub status: http1::StatusCode,
     pub payload: Option<T>,
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -36,10 +36,3 @@ pub struct Configuration {
 
     client: HyperClient<Connector, http_body_util::Full<Bytes>>,
 }
-
-/// Convert a `StatusCode` from the http crate v1 to one from the http crate
-/// v0.2.
-fn http1_to_02_status_code(code: http1::StatusCode) -> http02::StatusCode {
-    http02::StatusCode::from_u16(code.as_u16())
-        .expect("both versions of the http crate enforce the same numerical limits for StatusCode")
-}

--- a/rust/src/webhooks.rs
+++ b/rust/src/webhooks.rs
@@ -192,6 +192,7 @@ impl Webhook {
 /// `http` crate.
 pub trait HeaderMap: private::HeaderMapSealed {}
 
+#[cfg(feature = "http02")]
 impl HeaderMap for http02::HeaderMap {}
 impl HeaderMap for http1::HeaderMap {}
 
@@ -203,18 +204,40 @@ mod private {
     pub trait HeaderMapSealed {
         type HeaderValue: HeaderValueSealed;
         fn _get(&self, name: &str) -> Option<&Self::HeaderValue>;
+        #[cfg(test)]
+        fn _insert(&mut self, name: &'static str, val: Self::HeaderValue);
+        #[cfg(test)]
+        fn _new() -> Self;
     }
 
+    #[cfg(feature = "http02")]
     impl HeaderMapSealed for http02::HeaderMap {
         type HeaderValue = http02::HeaderValue;
         fn _get(&self, name: &str) -> Option<&Self::HeaderValue> {
             self.get(name)
         }
+        #[cfg(test)]
+        fn _insert(&mut self, name: &'static str, val: Self::HeaderValue) {
+            self.insert(name, val);
+        }
+        #[cfg(test)]
+        fn _new() -> Self {
+            Self::new()
+        }
     }
+
     impl HeaderMapSealed for http1::HeaderMap {
         type HeaderValue = http1::HeaderValue;
         fn _get(&self, name: &str) -> Option<&Self::HeaderValue> {
             self.get(name)
+        }
+        #[cfg(test)]
+        fn _insert(&mut self, name: &'static str, val: Self::HeaderValue) {
+            self.insert(name, val);
+        }
+        #[cfg(test)]
+        fn _new() -> Self {
+            Self::new()
         }
     }
 
@@ -222,6 +245,7 @@ mod private {
         fn _to_str(&self) -> Option<&str>;
     }
 
+    #[cfg(feature = "http02")]
     impl HeaderValueSealed for http02::HeaderValue {
         fn _to_str(&self) -> Option<&str> {
             self.to_str().ok()
@@ -236,30 +260,38 @@ mod private {
 
 #[cfg(test)]
 mod tests {
-    use http02::HeaderMap;
-
     use super::{
-        Webhook, SVIX_MSG_ID_KEY, SVIX_MSG_SIGNATURE_KEY, SVIX_MSG_TIMESTAMP_KEY,
-        UNBRANDED_MSG_ID_KEY, UNBRANDED_MSG_SIGNATURE_KEY, UNBRANDED_MSG_TIMESTAMP_KEY,
+        private::HeaderMapSealed, Webhook, SVIX_MSG_ID_KEY, SVIX_MSG_SIGNATURE_KEY,
+        SVIX_MSG_TIMESTAMP_KEY, UNBRANDED_MSG_ID_KEY, UNBRANDED_MSG_SIGNATURE_KEY,
+        UNBRANDED_MSG_TIMESTAMP_KEY,
     };
+    use std::{fmt::Debug, str::FromStr};
 
     fn now() -> i64 {
         std::time::UNIX_EPOCH.elapsed().unwrap().as_secs() as _
     }
 
-    fn get_svix_headers(msg_id: &str, signature: &str) -> HeaderMap {
-        let mut headers = HeaderMap::new();
-        headers.insert(SVIX_MSG_ID_KEY, msg_id.parse().unwrap());
-        headers.insert(SVIX_MSG_SIGNATURE_KEY, signature.parse().unwrap());
-        headers.insert(SVIX_MSG_TIMESTAMP_KEY, now().to_string().parse().unwrap());
+    fn get_svix_headers<H: super::HeaderMap>(msg_id: &str, signature: &str) -> H
+    where
+        <H as HeaderMapSealed>::HeaderValue: FromStr,
+        <<H as HeaderMapSealed>::HeaderValue as FromStr>::Err: Debug,
+    {
+        let mut headers = H::_new();
+        headers._insert(SVIX_MSG_ID_KEY, msg_id.parse().unwrap());
+        headers._insert(SVIX_MSG_SIGNATURE_KEY, signature.parse().unwrap());
+        headers._insert(SVIX_MSG_TIMESTAMP_KEY, now().to_string().parse().unwrap());
         headers
     }
 
-    fn get_unbranded_headers(msg_id: &str, signature: &str) -> HeaderMap {
-        let mut headers = HeaderMap::new();
-        headers.insert(UNBRANDED_MSG_ID_KEY, msg_id.parse().unwrap());
-        headers.insert(UNBRANDED_MSG_SIGNATURE_KEY, signature.parse().unwrap());
-        headers.insert(
+    fn get_unbranded_headers<H: super::HeaderMap>(msg_id: &str, signature: &str) -> H
+    where
+        <H as HeaderMapSealed>::HeaderValue: FromStr,
+        <<H as HeaderMapSealed>::HeaderValue as FromStr>::Err: Debug,
+    {
+        let mut headers = H::_new();
+        headers._insert(UNBRANDED_MSG_ID_KEY, msg_id.parse().unwrap());
+        headers._insert(UNBRANDED_MSG_SIGNATURE_KEY, signature.parse().unwrap());
+        headers._insert(
             UNBRANDED_MSG_TIMESTAMP_KEY,
             now().to_string().parse().unwrap(),
         );
@@ -288,11 +320,22 @@ mod tests {
         let wh = Webhook::new(&secret).unwrap();
 
         let signature = wh.sign(msg_id, now(), payload).unwrap();
-        for headers in [
-            get_svix_headers(msg_id, &signature),
-            get_unbranded_headers(msg_id, &signature),
-        ] {
-            wh.verify(payload, &headers).unwrap();
+        #[cfg(feature = "http02")]
+        {
+            for headers in [
+                get_svix_headers::<http02::HeaderMap>(msg_id, &signature),
+                get_unbranded_headers::<http02::HeaderMap>(msg_id, &signature),
+            ] {
+                wh.verify(payload, &headers).unwrap();
+            }
+        }
+        {
+            for headers in [
+                get_svix_headers::<http1::HeaderMap>(msg_id, &signature),
+                get_unbranded_headers::<http1::HeaderMap>(msg_id, &signature),
+            ] {
+                wh.verify(payload, &headers).unwrap();
+            }
         }
     }
 
@@ -304,11 +347,22 @@ mod tests {
         let wh = Webhook::new(&secret).unwrap();
 
         let signature = "v1,R3PTzyfHASBKHH98a7yexTwaJ4yNIcGhFQc1yuN+BPU=".to_owned();
-        for headers in [
-            get_svix_headers(msg_id, &signature),
-            get_unbranded_headers(msg_id, &signature),
-        ] {
-            assert!(wh.verify(payload, &headers).is_err());
+        #[cfg(feature = "http02")]
+        {
+            for headers in [
+                get_svix_headers::<http02::HeaderMap>(msg_id, &signature),
+                get_unbranded_headers::<http02::HeaderMap>(msg_id, &signature),
+            ] {
+                assert!(wh.verify(payload, &headers).is_err());
+            }
+        }
+        {
+            for headers in [
+                get_svix_headers::<http1::HeaderMap>(msg_id, &signature),
+                get_unbranded_headers::<http1::HeaderMap>(msg_id, &signature),
+            ] {
+                assert!(wh.verify(payload, &headers).is_err());
+            }
         }
     }
 
@@ -322,28 +376,56 @@ mod tests {
         let signature = wh.sign(msg_id, now(), payload).unwrap();
 
         // Just `v1,`
-        for mut headers in [
-            get_svix_headers(msg_id, &signature),
-            get_unbranded_headers(msg_id, &signature),
-        ] {
-            let partial = format!(
-                "{},",
-                signature.split(',').collect::<Vec<&str>>().first().unwrap()
-            );
-            headers.insert(SVIX_MSG_SIGNATURE_KEY, partial.parse().unwrap());
-            headers.insert(UNBRANDED_MSG_SIGNATURE_KEY, partial.parse().unwrap());
-            assert!(wh.verify(payload, &headers).is_err());
-        }
+        #[cfg(feature = "http02")]
+        {
+            for mut headers in [
+                get_svix_headers::<http02::HeaderMap>(msg_id, &signature),
+                get_unbranded_headers::<http02::HeaderMap>(msg_id, &signature),
+            ] {
+                let partial = format!(
+                    "{},",
+                    signature.split(',').collect::<Vec<&str>>().first().unwrap()
+                );
+                headers.insert(SVIX_MSG_SIGNATURE_KEY, partial.parse().unwrap());
+                headers.insert(UNBRANDED_MSG_SIGNATURE_KEY, partial.parse().unwrap());
+                assert!(wh.verify(payload, &headers).is_err());
+            }
 
-        // Non-empty but still partial signature (first few bytes)
-        for mut headers in [
-            get_svix_headers(msg_id, &signature),
-            get_unbranded_headers(msg_id, &signature),
-        ] {
-            let partial = &signature[0..8];
-            headers.insert(SVIX_MSG_SIGNATURE_KEY, partial.parse().unwrap());
-            headers.insert(UNBRANDED_MSG_SIGNATURE_KEY, partial.parse().unwrap());
-            assert!(wh.verify(payload, &headers).is_err());
+            // Non-empty but still partial signature (first few bytes)
+            for mut headers in [
+                get_svix_headers::<http02::HeaderMap>(msg_id, &signature),
+                get_unbranded_headers::<http02::HeaderMap>(msg_id, &signature),
+            ] {
+                let partial = &signature[0..8];
+                headers.insert(SVIX_MSG_SIGNATURE_KEY, partial.parse().unwrap());
+                headers.insert(UNBRANDED_MSG_SIGNATURE_KEY, partial.parse().unwrap());
+                assert!(wh.verify(payload, &headers).is_err());
+            }
+        }
+        {
+            for mut headers in [
+                get_svix_headers::<http1::HeaderMap>(msg_id, &signature),
+                get_unbranded_headers::<http1::HeaderMap>(msg_id, &signature),
+            ] {
+                let partial = format!(
+                    "{},",
+                    signature.split(',').collect::<Vec<&str>>().first().unwrap()
+                );
+                headers.insert(SVIX_MSG_SIGNATURE_KEY, partial.parse().unwrap());
+                headers.insert(UNBRANDED_MSG_SIGNATURE_KEY, partial.parse().unwrap());
+                assert!(wh.verify(payload, &headers).is_err());
+            }
+
+            // Non-empty but still partial signature (first few bytes)
+            for mut headers in [
+                get_svix_headers::<http1::HeaderMap>(msg_id, &signature),
+                get_unbranded_headers::<http1::HeaderMap>(msg_id, &signature),
+            ] {
+                let partial = &signature[0..8];
+                headers.insert(SVIX_MSG_SIGNATURE_KEY, partial.parse().unwrap());
+                headers.insert(UNBRANDED_MSG_SIGNATURE_KEY, partial.parse().unwrap());
+                assert!(wh.verify(payload, &headers).is_err());
+            }
         }
     }
 
@@ -356,35 +438,70 @@ mod tests {
 
         // Checks that timestamps that are in the future or too old are rejected by
         // `verify` but okay for `verify_ignoring_timestamp`.
-        for ts in [
-            now() - (super::TOLERANCE_IN_SECONDS as i64 + 1),
-            now() + (super::TOLERANCE_IN_SECONDS as i64 + 1),
-        ] {
+
+        #[cfg(feature = "http02")]
+        {
+            for ts in [
+                now() - (super::TOLERANCE_IN_SECONDS as i64 + 1),
+                now() + (super::TOLERANCE_IN_SECONDS as i64 + 1),
+            ] {
+                let signature = wh.sign(msg_id, ts, payload).unwrap();
+                let mut headers = get_svix_headers::<http02::HeaderMap>(msg_id, &signature);
+                headers.insert(
+                    super::SVIX_MSG_TIMESTAMP_KEY,
+                    ts.to_string().parse().unwrap(),
+                );
+
+                assert!(wh.verify(payload, &headers,).is_err());
+                // Timestamp tolerance is not considered in this case.
+                assert!(wh.verify_ignoring_timestamp(payload, &headers,).is_ok());
+            }
+
+            let ts = now();
             let signature = wh.sign(msg_id, ts, payload).unwrap();
-            let mut headers = get_svix_headers(msg_id, &signature);
+            let mut headers = get_svix_headers::<http02::HeaderMap>(msg_id, &signature);
             headers.insert(
                 super::SVIX_MSG_TIMESTAMP_KEY,
-                ts.to_string().parse().unwrap(),
+                // Timestamp mismatch!
+                (ts + 1).to_string().parse().unwrap(),
             );
 
+            // Both versions should reject the timestamp if it's not the same one used to
+            // produce the signature.
             assert!(wh.verify(payload, &headers,).is_err());
-            // Timestamp tolerance is not considered in this case.
-            assert!(wh.verify_ignoring_timestamp(payload, &headers,).is_ok());
+            assert!(wh.verify_ignoring_timestamp(payload, &headers,).is_err());
         }
+        {
+            for ts in [
+                now() - (super::TOLERANCE_IN_SECONDS as i64 + 1),
+                now() + (super::TOLERANCE_IN_SECONDS as i64 + 1),
+            ] {
+                let signature = wh.sign(msg_id, ts, payload).unwrap();
+                let mut headers = get_svix_headers::<http1::HeaderMap>(msg_id, &signature);
+                headers.insert(
+                    super::SVIX_MSG_TIMESTAMP_KEY,
+                    ts.to_string().parse().unwrap(),
+                );
 
-        let ts = now();
-        let signature = wh.sign(msg_id, ts, payload).unwrap();
-        let mut headers = get_svix_headers(msg_id, &signature);
-        headers.insert(
-            super::SVIX_MSG_TIMESTAMP_KEY,
-            // Timestamp mismatch!
-            (ts + 1).to_string().parse().unwrap(),
-        );
+                assert!(wh.verify(payload, &headers,).is_err());
+                // Timestamp tolerance is not considered in this case.
+                assert!(wh.verify_ignoring_timestamp(payload, &headers,).is_ok());
+            }
 
-        // Both versions should reject the timestamp if it's not the same one used to
-        // produce the signature.
-        assert!(wh.verify(payload, &headers,).is_err());
-        assert!(wh.verify_ignoring_timestamp(payload, &headers,).is_err());
+            let ts = now();
+            let signature = wh.sign(msg_id, ts, payload).unwrap();
+            let mut headers = get_svix_headers::<http1::HeaderMap>(msg_id, &signature);
+            headers.insert(
+                super::SVIX_MSG_TIMESTAMP_KEY,
+                // Timestamp mismatch!
+                (ts + 1).to_string().parse().unwrap(),
+            );
+
+            // Both versions should reject the timestamp if it's not the same one used to
+            // produce the signature.
+            assert!(wh.verify(payload, &headers,).is_err());
+            assert!(wh.verify_ignoring_timestamp(payload, &headers,).is_err());
+        }
     }
 
     #[test]
@@ -396,15 +513,30 @@ mod tests {
 
         let ts = -1;
         let signature = wh.sign(msg_id, ts, payload).unwrap();
-        let mut headers = get_svix_headers(msg_id, &signature);
-        headers.insert(
-            super::SVIX_MSG_TIMESTAMP_KEY,
-            ts.to_string().parse().unwrap(),
-        );
 
-        wh.verify(payload, &headers)
-            .expect_err("negative timestamp should not be allowed");
-        assert!(wh.verify_ignoring_timestamp(payload, &headers,).is_ok());
+        #[cfg(feature = "http02")]
+        {
+            let mut headers = get_svix_headers::<http02::HeaderMap>(msg_id, &signature);
+            headers.insert(
+                super::SVIX_MSG_TIMESTAMP_KEY,
+                ts.to_string().parse().unwrap(),
+            );
+
+            wh.verify(payload, &headers)
+                .expect_err("negative timestamp should not be allowed");
+            assert!(wh.verify_ignoring_timestamp(payload, &headers,).is_ok());
+        }
+        {
+            let mut headers = get_svix_headers::<http1::HeaderMap>(msg_id, &signature);
+            headers.insert(
+                super::SVIX_MSG_TIMESTAMP_KEY,
+                ts.to_string().parse().unwrap(),
+            );
+
+            wh.verify(payload, &headers)
+                .expect_err("negative timestamp should not be allowed");
+            assert!(wh.verify_ignoring_timestamp(payload, &headers,).is_ok());
+        }
     }
 
     #[test]
@@ -424,9 +556,15 @@ mod tests {
             "v1,9DfC1c3eeOrXB6w/5dIDydLNQaEyww5KalE5jLBZucE=",
         );
 
-        let headers = get_svix_headers(msg_id, &multi_sig);
-
-        wh.verify(payload, &headers).unwrap();
+        #[cfg(feature = "http02")]
+        {
+            let headers = get_svix_headers::<http02::HeaderMap>(msg_id, &multi_sig);
+            wh.verify(payload, &headers).unwrap();
+        }
+        {
+            let headers = get_svix_headers::<http1::HeaderMap>(msg_id, &multi_sig);
+            wh.verify(payload, &headers).unwrap();
+        }
     }
 
     #[test]
@@ -443,9 +581,15 @@ mod tests {
             "v1,9DfC1c3eeOrXB6w/5dIDydLNQaEyww5KalE5jLBZucE=",
         );
 
-        let headers = get_svix_headers(msg_id, &missing_sig);
-
-        assert!(wh.verify(payload, &headers).is_err());
+        #[cfg(feature = "http02")]
+        {
+            let headers = get_svix_headers::<http02::HeaderMap>(msg_id, &missing_sig);
+            assert!(wh.verify(payload, &headers).is_err());
+        }
+        {
+            let headers = get_svix_headers::<http1::HeaderMap>(msg_id, &missing_sig);
+            assert!(wh.verify(payload, &headers).is_err());
+        }
     }
 
     #[test]
@@ -456,27 +600,55 @@ mod tests {
         let wh = Webhook::new(&secret).unwrap();
 
         let signature = wh.sign(msg_id, now(), payload).unwrap();
-        for (mut hdr_map, hdrs) in [
-            (
-                get_svix_headers(msg_id, &signature),
-                [
-                    SVIX_MSG_ID_KEY,
-                    SVIX_MSG_SIGNATURE_KEY,
-                    SVIX_MSG_TIMESTAMP_KEY,
-                ],
-            ),
-            (
-                get_unbranded_headers(msg_id, &signature),
-                [
-                    UNBRANDED_MSG_ID_KEY,
-                    UNBRANDED_MSG_SIGNATURE_KEY,
-                    UNBRANDED_MSG_TIMESTAMP_KEY,
-                ],
-            ),
-        ] {
-            for hdr in hdrs {
-                hdr_map.remove(hdr);
-                assert!(wh.verify(payload, &hdr_map).is_err());
+        #[cfg(feature = "http02")]
+        {
+            for (mut hdr_map, hdrs) in [
+                (
+                    get_svix_headers::<http02::HeaderMap>(msg_id, &signature),
+                    [
+                        SVIX_MSG_ID_KEY,
+                        SVIX_MSG_SIGNATURE_KEY,
+                        SVIX_MSG_TIMESTAMP_KEY,
+                    ],
+                ),
+                (
+                    get_unbranded_headers::<http02::HeaderMap>(msg_id, &signature),
+                    [
+                        UNBRANDED_MSG_ID_KEY,
+                        UNBRANDED_MSG_SIGNATURE_KEY,
+                        UNBRANDED_MSG_TIMESTAMP_KEY,
+                    ],
+                ),
+            ] {
+                for hdr in hdrs {
+                    hdr_map.remove(hdr);
+                    assert!(wh.verify(payload, &hdr_map).is_err());
+                }
+            }
+        }
+        {
+            for (mut hdr_map, hdrs) in [
+                (
+                    get_svix_headers::<http1::HeaderMap>(msg_id, &signature),
+                    [
+                        SVIX_MSG_ID_KEY,
+                        SVIX_MSG_SIGNATURE_KEY,
+                        SVIX_MSG_TIMESTAMP_KEY,
+                    ],
+                ),
+                (
+                    get_unbranded_headers::<http1::HeaderMap>(msg_id, &signature),
+                    [
+                        UNBRANDED_MSG_ID_KEY,
+                        UNBRANDED_MSG_SIGNATURE_KEY,
+                        UNBRANDED_MSG_TIMESTAMP_KEY,
+                    ],
+                ),
+            ] {
+                for hdr in hdrs {
+                    hdr_map.remove(hdr);
+                    assert!(wh.verify(payload, &hdr_map).is_err());
+                }
             }
         }
     }

--- a/rust/tests/it/kitchen_sink.rs
+++ b/rust/tests/it/kitchen_sink.rs
@@ -13,7 +13,7 @@ fn check_for_conflict(e: Error) {
         Error::Http(e) => {
             assert_eq!(
                 e.status,
-                http02::StatusCode::CONFLICT,
+                http1::StatusCode::CONFLICT,
                 "conflicts are expected but other statuses are not"
             );
         }

--- a/svix-cli/Cargo.lock
+++ b/svix-cli/Cargo.lock
@@ -636,7 +636,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.1",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -679,17 +679,6 @@ checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
@@ -705,7 +694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.1",
+ "http",
 ]
 
 [[package]]
@@ -716,7 +705,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.1",
+ "http",
  "http-body",
  "pin-project-lite",
 ]
@@ -738,7 +727,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.1",
+ "http",
  "http-body",
  "httparse",
  "itoa",
@@ -754,7 +743,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.1",
+ "http",
  "hyper",
  "hyper-util",
  "log",
@@ -775,7 +764,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.1",
+ "http",
  "http-body",
  "hyper",
  "ipnet",
@@ -1377,7 +1366,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "h2",
- "http 1.4.1",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -1728,8 +1717,7 @@ version = "1.96.1"
 dependencies = [
  "base64 0.13.1",
  "hmac-sha256",
- "http 0.2.12",
- "http 1.4.1",
+ "http",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -1768,7 +1756,7 @@ dependencies = [
  "figment",
  "fs-err",
  "futures-util",
- "http 1.4.1",
+ "http",
  "idna_adapter",
  "indoc",
  "open",
@@ -2026,7 +2014,7 @@ dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
- "http 1.4.1",
+ "http",
  "http-body",
  "pin-project-lite",
  "tower",
@@ -2105,7 +2093,7 @@ checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.1",
+ "http",
  "httparse",
  "log",
  "rand",

--- a/svix-cli/Cargo.toml
+++ b/svix-cli/Cargo.toml
@@ -61,7 +61,7 @@ reqwest = { version = "0.13.2", features = ["rustls", "json", "charset", "http2"
 rustls = "0.23.34"
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
-svix = { path = "../rust" }
+svix = { path = "../rust", features = ["http1", "http2", "rustls-tls"] }
 tokio = { version = "1.42.0", features = ["macros", "time", "rt-multi-thread"] }
 tokio-tungstenite = { version = "0.28.0", features = ["rustls-tls-native-roots"] }
 toml = "0.8.19"


### PR DESCRIPTION
This changes the Rust library to make the http 0.2 dependency optional.

I recognize that this is a (very minor) breaking API change because it's in one `pub` field of one struct, so someone might be depending on the exact type (as opposed to just, I dunno, that it's `Debug` or calling `.is_success()`). I think that's such a minor edge case that it's not worth worrying about compared to making every consumer compile two independent copies of the `http` crate.