### PR TITLE
bridge: update edition to 2024

### DIFF
--- a/.justfile-common-rust
+++ b/.justfile-common-rust
@@ -8,7 +8,7 @@ fmt:
 
 # Run `cargo clippy` for the rfust codebase.
 clippy *args='':
-    cargo clippy --all-targets {{ args }} -- -D warnings
+    cargo clippy --all-targets --all-features {{ args }} -- -D warnings
 
 # Run lints (fmt and clippy)
 lint: fmt clippy && fmt

--- a/bridge/.justfile
+++ b/bridge/.justfile
@@ -12,4 +12,4 @@ run *args='':
 # Invokes `docker compose` with the testing configuration in the 'bridge' directory
 [no-exit-message]
 dc *args='':
-    docker compose -p svix-oss -f {{ HERE / "testing-docker-compose.yml" }} {{ args }}
+    docker compose -p svix-bridge -f {{ HERE / "testing-docker-compose.yml" }} {{ args }}

--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -4645,6 +4645,7 @@ name = "svix-bridge-plugin-queue"
 version = "1.96.1"
 dependencies = [
  "aws-config",
+ "aws-credential-types",
  "aws-sdk-sqs",
  "fastrand",
  "gcloud-googleapis",

--- a/bridge/svix-bridge-plugin-kafka/Cargo.toml
+++ b/bridge/svix-bridge-plugin-kafka/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "svix-bridge-plugin-kafka"
 version.workspace = true
-edition = "2021"
+edition = "2024"
 rust-version = "1.91"
 publish = false
 license.workspace = true

--- a/bridge/svix-bridge-plugin-kafka/src/config.rs
+++ b/bridge/svix-bridge-plugin-kafka/src/config.rs
@@ -1,10 +1,10 @@
 use rdkafka::{
-    consumer::StreamConsumer, error::KafkaResult, producer::FutureProducer, ClientConfig,
+    ClientConfig, consumer::StreamConsumer, error::KafkaResult, producer::FutureProducer,
 };
 use serde::Deserialize;
 use svix_bridge_types::{ReceiverOutput, SenderInput, SenderOutputOpts, TransformationConfig};
 
-use crate::{input::KafkaConsumer, KafkaProducer, Result};
+use crate::{KafkaProducer, Result, input::KafkaConsumer};
 
 #[derive(Clone, Deserialize)]
 #[serde(tag = "type")]
@@ -56,10 +56,10 @@ impl KafkaInputOpts {
             .set("enable.auto.commit", "false");
 
         security_protocol.apply(&mut config);
-        if let Some(debug_contexts) = debug_contexts {
-            if !debug_contexts.is_empty() {
-                config.set("debug", debug_contexts);
-            }
+        if let Some(debug_contexts) = debug_contexts
+            && !debug_contexts.is_empty()
+        {
+            config.set("debug", debug_contexts);
         }
 
         config.create()
@@ -106,10 +106,10 @@ impl KafkaOutputOpts {
         config.set("bootstrap.servers", bootstrap_brokers);
 
         security_protocol.apply(&mut config);
-        if let Some(debug_contexts) = debug_contexts {
-            if !debug_contexts.is_empty() {
-                config.set("debug", debug_contexts);
-            }
+        if let Some(debug_contexts) = debug_contexts
+            && !debug_contexts.is_empty()
+        {
+            config.set("debug", debug_contexts);
         }
 
         config.create()

--- a/bridge/svix-bridge-plugin-kafka/src/input.rs
+++ b/bridge/svix-bridge-plugin-kafka/src/input.rs
@@ -4,19 +4,19 @@ use std::{
 };
 
 use rdkafka::{
+    Message as _,
     consumer::{CommitMode, Consumer as _},
     error::KafkaError,
-    Message as _,
 };
 use svix_bridge_types::{
-    async_trait,
-    svix::api::{MessageCreateOptions, Svix},
     CreateMessageRequest, JsObject, SenderInput, SenderOutputOpts, TransformationConfig,
     TransformerInput, TransformerInputFormat, TransformerJob, TransformerOutput, TransformerTx,
+    async_trait,
+    svix::api::{MessageCreateOptions, Svix},
 };
 use tokio::task::spawn_blocking;
 
-use crate::{config::KafkaInputOpts, Error, Result};
+use crate::{Error, Result, config::KafkaInputOpts};
 
 pub struct KafkaConsumer {
     name: String,

--- a/bridge/svix-bridge-plugin-kafka/src/lib.rs
+++ b/bridge/svix-bridge-plugin-kafka/src/lib.rs
@@ -5,8 +5,8 @@ mod output;
 
 pub use self::{
     config::{
-        into_receiver_output, into_sender_input, KafkaInputOpts, KafkaOutputOpts,
-        KafkaSecurityProtocol,
+        KafkaInputOpts, KafkaOutputOpts, KafkaSecurityProtocol, into_receiver_output,
+        into_sender_input,
     },
     error::{Error, Result},
     input::KafkaConsumer,

--- a/bridge/svix-bridge-plugin-kafka/src/output.rs
+++ b/bridge/svix-bridge-plugin-kafka/src/output.rs
@@ -3,7 +3,7 @@ use rdkafka::{
     producer::{FutureProducer, FutureRecord},
     util::Timeout,
 };
-use svix_bridge_types::{async_trait, BoxError, ForwardRequest, ReceiverOutput};
+use svix_bridge_types::{BoxError, ForwardRequest, ReceiverOutput, async_trait};
 
 use crate::config::KafkaOutputOpts;
 

--- a/bridge/svix-bridge-plugin-kafka/tests/it/kafka_consumer.rs
+++ b/bridge/svix-bridge-plugin-kafka/tests/it/kafka_consumer.rs
@@ -5,24 +5,24 @@
 use std::time::Duration;
 
 use rdkafka::{
+    ClientConfig,
     producer::{FutureProducer, FutureRecord},
     util::Timeout,
-    ClientConfig,
 };
 use serde_json::json;
 use svix_bridge_plugin_kafka::{KafkaConsumer, KafkaInputOpts};
 use svix_bridge_types::{
-    svix::api::MessageIn, CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions,
-    SvixSenderOutputOpts, TransformationConfig, TransformerInput, TransformerInputFormat,
-    TransformerJob, TransformerOutput,
+    CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions, SvixSenderOutputOpts,
+    TransformationConfig, TransformerInput, TransformerInputFormat, TransformerJob,
+    TransformerOutput, svix::api::MessageIn,
 };
 use tracing::info;
 use wiremock::{
-    matchers::{body_partial_json, method},
     Mock, MockServer, ResponseTemplate,
+    matchers::{body_partial_json, method},
 };
 
-use crate::{create_topic, delete_topic, kafka_admin_client, BROKER_HOST};
+use crate::{BROKER_HOST, create_topic, delete_topic, kafka_admin_client};
 
 #[ctor::ctor]
 fn test_setup() {

--- a/bridge/svix-bridge-plugin-kafka/tests/it/kafka_producer.rs
+++ b/bridge/svix-bridge-plugin-kafka/tests/it/kafka_producer.rs
@@ -1,14 +1,14 @@
 use std::{sync::Arc, time::Duration};
 
 use rdkafka::{
-    consumer::{Consumer, StreamConsumer},
     ClientConfig, Message,
+    consumer::{Consumer, StreamConsumer},
 };
 use serde_json::json;
 use svix_bridge_plugin_kafka::{KafkaOutputOpts, KafkaProducer};
 use svix_bridge_types::{ForwardRequest, ReceiverOutput as _};
 
-use crate::{create_topic, delete_topic, kafka_admin_client, BROKER_HOST};
+use crate::{BROKER_HOST, create_topic, delete_topic, kafka_admin_client};
 
 /// Time to wait for the consumer to be properly listening.
 const LISTEN_WAIT_TIME: Duration = Duration::from_secs(8);

--- a/bridge/svix-bridge-plugin-kafka/tests/it/main.rs
+++ b/bridge/svix-bridge-plugin-kafka/tests/it/main.rs
@@ -1,8 +1,8 @@
 use rdkafka::{
+    ClientConfig,
     admin::{AdminClient, NewTopic, TopicReplication},
     client::DefaultClientContext,
     types::RDKafkaErrorCode,
-    ClientConfig,
 };
 
 /// These tests assume a "vanilla" kafka instance, using the default port, creds, exchange...
@@ -21,10 +21,9 @@ async fn create_topic(admin_client: &AdminClient<DefaultClientContext>, topic: &
     if let Err(e) = admin_client
         .create_topics(&[new_topic], &Default::default())
         .await
+        && e.rdkafka_error_code() != Some(RDKafkaErrorCode::TopicAlreadyExists)
     {
-        if e.rdkafka_error_code() != Some(RDKafkaErrorCode::TopicAlreadyExists) {
-            panic!("{e}");
-        }
+        panic!("failed to create Kafka topic: {e}");
     }
 }
 

--- a/bridge/svix-bridge-plugin-queue/Cargo.toml
+++ b/bridge/svix-bridge-plugin-queue/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "svix-bridge-plugin-queue"
 version.workspace = true
-edition = "2021"
+edition = "2024"
 rust-version = "1.91"
 publish = false
 license.workspace = true
@@ -24,6 +24,7 @@ features = ["gcp_pubsub", "rabbitmq", "redis", "sqs"]
 
 [dev-dependencies]
 aws-config = "1.8.12"
+aws-credential-types = "1.2"
 aws-sdk-sqs = { version = "1.97.0", default-features = false, features = ["default-https-client", "rt-tokio"] }
 fastrand = "2.0.1"
 gcloud-googleapis = "1.2.0"

--- a/bridge/svix-bridge-plugin-queue/src/gcp_pubsub/mod.rs
+++ b/bridge/svix-bridge-plugin-queue/src/gcp_pubsub/mod.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use omniqueue::{backends, DynConsumer, DynProducer};
+use omniqueue::{DynConsumer, DynProducer, backends};
 use serde::Deserialize;
 
 use crate::error::{Error, Result};

--- a/bridge/svix-bridge-plugin-queue/src/lib.rs
+++ b/bridge/svix-bridge-plugin-queue/src/lib.rs
@@ -2,8 +2,8 @@ use std::time::{Duration, Instant};
 
 use omniqueue::{Delivery, DynConsumer, QueueError};
 use svix_bridge_types::{
-    async_trait, svix::api::Svix, CreateMessageRequest, JsObject, TransformationConfig,
-    TransformerInput, TransformerInputFormat, TransformerJob, TransformerOutput, TransformerTx,
+    CreateMessageRequest, JsObject, TransformationConfig, TransformerInput, TransformerInputFormat,
+    TransformerJob, TransformerOutput, TransformerTx, async_trait, svix::api::Svix,
 };
 
 pub const PLUGIN_NAME: &str = env!("CARGO_PKG_NAME");

--- a/bridge/svix-bridge-plugin-queue/src/rabbitmq/mod.rs
+++ b/bridge/svix-bridge-plugin-queue/src/rabbitmq/mod.rs
@@ -1,4 +1,4 @@
-use omniqueue::{backends, DynConsumer, DynProducer};
+use omniqueue::{DynConsumer, DynProducer, backends};
 use serde::Deserialize;
 
 use crate::error::{Error, Result};

--- a/bridge/svix-bridge-plugin-queue/src/receiver_output/mod.rs
+++ b/bridge/svix-bridge-plugin-queue/src/receiver_output/mod.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use omniqueue::{DynProducer, QueueError};
-use svix_bridge_types::{async_trait, BoxError, ForwardRequest, ReceiverOutput};
+use svix_bridge_types::{BoxError, ForwardRequest, ReceiverOutput, async_trait};
 use tokio::sync::Mutex;
 
 use crate::{config::QueueOutputOpts, error::Result};

--- a/bridge/svix-bridge-plugin-queue/src/redis/mod.rs
+++ b/bridge/svix-bridge-plugin-queue/src/redis/mod.rs
@@ -1,4 +1,4 @@
-use omniqueue::{backends, DynConsumer, DynProducer};
+use omniqueue::{DynConsumer, DynProducer, backends};
 use serde::Deserialize;
 
 use crate::error::{Error, Result};

--- a/bridge/svix-bridge-plugin-queue/src/sender_input/mod.rs
+++ b/bridge/svix-bridge-plugin-queue/src/sender_input/mod.rs
@@ -1,10 +1,10 @@
 use omniqueue::DynConsumer;
 use svix_bridge_types::{
-    async_trait, svix::api::Svix, SenderInput, SenderOutputOpts, TransformationConfig,
-    TransformerTx,
+    SenderInput, SenderOutputOpts, TransformationConfig, TransformerTx, async_trait,
+    svix::api::Svix,
 };
 
-use crate::{config::QueueInputOpts, gcp_pubsub, rabbitmq, run_inner, sqs, Consumer};
+use crate::{Consumer, config::QueueInputOpts, gcp_pubsub, rabbitmq, run_inner, sqs};
 
 pub struct QueueSender {
     name: String,

--- a/bridge/svix-bridge-plugin-queue/src/sqs/mod.rs
+++ b/bridge/svix-bridge-plugin-queue/src/sqs/mod.rs
@@ -1,4 +1,4 @@
-use omniqueue::{backends, DynConsumer, DynProducer};
+use omniqueue::{DynConsumer, DynProducer, backends};
 use serde::Deserialize;
 
 use crate::error::{Error, Result};

--- a/bridge/svix-bridge-plugin-queue/tests/it/gcp_pubsub_consumer.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/it/gcp_pubsub_consumer.rs
@@ -3,7 +3,7 @@
 //!
 //! Use `run-tests.sh` to use the requisite environment for testing.
 
-use std::time::Duration;
+use std::{sync::Mutex, time::Duration};
 
 use gcloud_googleapis::pubsub::v1::{DeadLetterPolicy, PubsubMessage};
 use gcloud_pubsub::{
@@ -17,13 +17,13 @@ use svix_bridge_plugin_queue::{
     sender_input::QueueSender,
 };
 use svix_bridge_types::{
-    svix::api::MessageIn, CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions,
-    SvixSenderOutputOpts, TransformationConfig, TransformerInput, TransformerInputFormat,
-    TransformerJob, TransformerOutput,
+    CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions, SvixSenderOutputOpts,
+    TransformationConfig, TransformerInput, TransformerInputFormat, TransformerJob,
+    TransformerOutput, svix::api::MessageIn,
 };
 use wiremock::{
-    matchers::{body_partial_json, method},
     Mock, MockServer, ResponseTemplate,
+    matchers::{body_partial_json, method},
 };
 
 const DEFAULT_PUBSUB_EMULATOR_HOST: &str = "localhost:8085";
@@ -53,12 +53,20 @@ fn get_test_plugin(
     )
 }
 
+static ENV_VAR_NONSENSE_MUTEX: Mutex<()> = Mutex::new(());
+
 async fn mq_connection() -> Client {
+    let _guard = ENV_VAR_NONSENSE_MUTEX.lock();
     // The `Default` impl for `ClientConfig` looks for this env var. When set it branches for
     // local-mode use using the addr in the env var and a hardcoded project id of `local-project`.
     if std::env::var("PUBSUB_EMULATOR_HOST").is_err() {
-        std::env::set_var("PUBSUB_EMULATOR_HOST", DEFAULT_PUBSUB_EMULATOR_HOST);
+        // safety: this is unsafe and can panic if called from concurrent threads, but gcloud_pubsub
+        // doesn't provide any safe way to use an emulator. Sad day. At least it's only in tests?
+        unsafe {
+            std::env::set_var("PUBSUB_EMULATOR_HOST", DEFAULT_PUBSUB_EMULATOR_HOST);
+        }
     }
+    drop(_guard);
     Client::new(ClientConfig::default()).await.unwrap()
 }
 

--- a/bridge/svix-bridge-plugin-queue/tests/it/rabbitmq_consumer.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/it/rabbitmq_consumer.rs
@@ -5,8 +5,8 @@
 use std::time::Duration;
 
 use lapin::{
-    options::QueueDeclareOptions, types::FieldTable, Channel, Connection, ConnectionProperties,
-    Queue,
+    Channel, Connection, ConnectionProperties, Queue, options::QueueDeclareOptions,
+    types::FieldTable,
 };
 use serde_json::json;
 use svix_bridge_plugin_queue::{
@@ -14,13 +14,13 @@ use svix_bridge_plugin_queue::{
     sender_input::QueueSender,
 };
 use svix_bridge_types::{
-    svix::api::MessageIn, CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions,
-    SvixSenderOutputOpts, TransformationConfig, TransformerInput, TransformerInputFormat,
-    TransformerJob, TransformerOutput,
+    CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions, SvixSenderOutputOpts,
+    TransformationConfig, TransformerInput, TransformerInputFormat, TransformerJob,
+    TransformerOutput, svix::api::MessageIn,
 };
 use wiremock::{
-    matchers::{body_partial_json, method},
     Mock, MockServer, ResponseTemplate,
+    matchers::{body_partial_json, method},
 };
 
 fn get_test_plugin(

--- a/bridge/svix-bridge-plugin-queue/tests/it/rabbitmq_receiver.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/it/rabbitmq_receiver.rs
@@ -5,8 +5,8 @@
 use std::{fmt::Debug, time::Duration};
 
 use lapin::{
-    options::QueueDeclareOptions, types::FieldTable, Channel, Connection, ConnectionProperties,
-    Queue,
+    Channel, Connection, ConnectionProperties, Queue, options::QueueDeclareOptions,
+    types::FieldTable,
 };
 use serde_json::json;
 use svix_bridge_plugin_queue::config::{QueueForwarder, QueueOutputOpts, RabbitMqOutputOpts};

--- a/bridge/svix-bridge-plugin-queue/tests/it/redis_stream_consumer.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/it/redis_stream_consumer.rs
@@ -10,13 +10,13 @@ use svix_bridge_plugin_queue::{
     sender_input::QueueSender,
 };
 use svix_bridge_types::{
-    svix::api::MessageIn, CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions,
-    SvixSenderOutputOpts, TransformationConfig, TransformerInput, TransformerInputFormat,
-    TransformerJob, TransformerOutput,
+    CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions, SvixSenderOutputOpts,
+    TransformationConfig, TransformerInput, TransformerInputFormat, TransformerJob,
+    TransformerOutput, svix::api::MessageIn,
 };
 use wiremock::{
-    matchers::{body_partial_json, method},
     Mock, MockServer, ResponseTemplate,
+    matchers::{body_partial_json, method},
 };
 
 fn get_test_plugin(

--- a/bridge/svix-bridge-plugin-queue/tests/it/sqs_consumer.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/it/sqs_consumer.rs
@@ -5,6 +5,7 @@
 
 use std::time::Duration;
 
+use aws_config::Region;
 use aws_sdk_sqs::Client;
 use serde_json::json;
 use svix_bridge_plugin_queue::{
@@ -12,21 +13,16 @@ use svix_bridge_plugin_queue::{
     sender_input::QueueSender,
 };
 use svix_bridge_types::{
-    svix::api::MessageIn, CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions,
-    SvixSenderOutputOpts, TransformationConfig, TransformerInput, TransformerInputFormat,
-    TransformerJob, TransformerOutput,
+    CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions, SvixSenderOutputOpts,
+    TransformationConfig, TransformerInput, TransformerInputFormat, TransformerJob,
+    TransformerOutput, svix::api::MessageIn,
 };
 use wiremock::{
-    matchers::{body_partial_json, method},
     Mock, MockServer, ResponseTemplate,
+    matchers::{body_partial_json, method},
 };
 
 const ROOT_URL: &str = "http://localhost:9324";
-const DEFAULT_CFG: [(&str, &str); 3] = [
-    ("AWS_DEFAULT_REGION", "localhost"),
-    ("AWS_ACCESS_KEY_ID", "x"),
-    ("AWS_SECRET_ACCESS_KEY", "x"),
-];
 
 fn get_test_plugin(
     svix_url: String,
@@ -54,12 +50,16 @@ fn get_test_plugin(
 }
 
 async fn mq_connection() -> Client {
-    for (var, val) in &DEFAULT_CFG {
-        if std::env::var(var).is_err() {
-            std::env::set_var(var, val);
-        }
-    }
-    let config = aws_config::from_env().endpoint_url(ROOT_URL).load().await;
+    let config = aws_config::ConfigLoader::default()
+        .empty_test_environment()
+        .behavior_version(aws_config::BehaviorVersion::latest())
+        .credentials_provider(aws_credential_types::Credentials::new(
+            "x", "x", None, None, "testing",
+        ))
+        .region(Region::new("localhost"))
+        .endpoint_url(ROOT_URL)
+        .load()
+        .await;
     Client::new(&config)
 }
 

--- a/bridge/svix-bridge-types/Cargo.toml
+++ b/bridge/svix-bridge-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "svix-bridge-types"
 version.workspace = true
-edition = "2021"
+edition = "2024"
 rust-version = "1.91"
 publish = false
 license.workspace = true

--- a/bridge/svix-bridge/Cargo.toml
+++ b/bridge/svix-bridge/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "svix-bridge"
 version.workspace = true
-edition = "2021"
+edition = "2024"
 rust-version = "1.91"
 publish = false
 license.workspace = true

--- a/bridge/svix-bridge/src/config/mod.rs
+++ b/bridge/svix-bridge/src/config/mod.rs
@@ -10,8 +10,8 @@ use shellexpand::LookupError;
 use svix_bridge_plugin_kafka::{KafkaInputOpts, KafkaOutputOpts};
 use svix_bridge_plugin_queue::config::{QueueInputOpts, QueueOutputOpts};
 use svix_bridge_types::{
-    svix::api::Svix, ReceiverInputOpts, ReceiverOutput, SenderInput, SenderOutputOpts, SvixOptions,
-    TransformationConfig,
+    ReceiverInputOpts, ReceiverOutput, SenderInput, SenderOutputOpts, SvixOptions,
+    TransformationConfig, svix::api::Svix,
 };
 use tracing::Level;
 

--- a/bridge/svix-bridge/src/config/tests.rs
+++ b/bridge/svix-bridge/src/config/tests.rs
@@ -640,9 +640,10 @@ fn test_transformation_validation_bad_syntax_is_err() {
           token: "xxx"
     "#;
     let err = Config::from_src(src, None).err().unwrap();
-    assert!(err
-        .to_string()
-        .contains("failed to parse transformation for sender `bad xform`"))
+    assert!(
+        err.to_string()
+            .contains("failed to parse transformation for sender `bad xform`")
+    )
 }
 
 #[test]

--- a/bridge/svix-bridge/src/http_output.rs
+++ b/bridge/svix-bridge/src/http_output.rs
@@ -1,8 +1,8 @@
 use anyhow::Context;
-use axum::http::{header, HeaderMap, HeaderName, HeaderValue};
+use axum::http::{HeaderMap, HeaderName, HeaderValue, header};
 use indexmap::IndexMap;
 use serde::Deserialize;
-use svix_bridge_types::{async_trait, BoxError, ForwardRequest, ReceiverOutput};
+use svix_bridge_types::{BoxError, ForwardRequest, ReceiverOutput, async_trait};
 use url::Url;
 
 const BRIDGE_USER_AGENT: HeaderValue =

--- a/bridge/svix-bridge/src/main.rs
+++ b/bridge/svix-bridge/src/main.rs
@@ -7,11 +7,11 @@ use std::{
 use clap::Parser;
 use itertools::{Either, Itertools};
 use once_cell::sync::Lazy;
-use opentelemetry::{trace::TracerProvider as _, InstrumentationScope};
+use opentelemetry::{InstrumentationScope, trace::TracerProvider as _};
 use opentelemetry_otlp::WithExportConfig as _;
 use opentelemetry_sdk::{
-    metrics::{periodic_reader_with_async_runtime::PeriodicReader, SdkMeterProvider},
-    trace::{span_processor_with_async_runtime::BatchSpanProcessor, SdkTracerProvider},
+    metrics::{SdkMeterProvider, periodic_reader_with_async_runtime::PeriodicReader},
+    trace::{SdkTracerProvider, span_processor_with_async_runtime::BatchSpanProcessor},
 };
 use svix_bridge_types::{PollerInput, SenderInput, TransformerJob};
 use svix_ksuid::{KsuidLike as _, KsuidMs};

--- a/bridge/svix-bridge/src/runtime/mod.rs
+++ b/bridge/svix-bridge/src/runtime/mod.rs
@@ -4,9 +4,8 @@ use anyhow::Result;
 use deadpool::unmanaged::Pool;
 use deno_ast::{MediaType, ParseParams};
 use deno_core::{
-    serde_v8, url,
+    JsRuntime, serde_v8, url,
     v8::{self},
-    JsRuntime,
 };
 use svix_bridge_types::{JsObject, TransformerInput, TransformerOutput};
 use tokio::sync::oneshot;

--- a/bridge/svix-bridge/src/webhook_receiver/mod.rs
+++ b/bridge/svix-bridge/src/webhook_receiver/mod.rs
@@ -1,19 +1,18 @@
 use std::{convert::Infallible, net::SocketAddr, sync::Arc, time::Duration};
 
 use axum::{
+    Router,
     extract::{FromRequestParts, Path, State},
     http::{self, request},
     routing::{get, post},
-    Router,
 };
 use svix_bridge_types::{
-    async_trait,
+    ForwardRequest, PollerInput, ReceiverOutput, TransformationConfig, TransformerInput,
+    TransformerInputFormat, TransformerJob, TransformerOutput, TransformerTx, async_trait,
     svix::{
         api::{MessagePollerConsumerPollOptions, PollingEndpointMessageOut, Svix},
         error::Error,
     },
-    ForwardRequest, PollerInput, ReceiverOutput, TransformationConfig, TransformerInput,
-    TransformerInputFormat, TransformerJob, TransformerOutput, TransformerTx,
 };
 use tracing::instrument;
 use types::{IntegrationId, IntegrationState, InternalState, SerializableRequest, Unvalidated};

--- a/bridge/svix-bridge/src/webhook_receiver/tests.rs
+++ b/bridge/svix-bridge/src/webhook_receiver/tests.rs
@@ -6,9 +6,9 @@ use axum::{
 };
 use serde_json::json;
 use svix_bridge_types::{
-    async_trait, svix::webhooks::Webhook, BoxError, ForwardRequest, ReceiverOutput,
-    TransformationConfig, TransformerInput, TransformerInputFormat, TransformerJob,
-    TransformerOutput,
+    BoxError, ForwardRequest, ReceiverOutput, TransformationConfig, TransformerInput,
+    TransformerInputFormat, TransformerJob, TransformerOutput, async_trait,
+    svix::webhooks::Webhook,
 };
 use tower::{Service, ServiceExt};
 

--- a/bridge/svix-bridge/src/webhook_receiver/types.rs
+++ b/bridge/svix-bridge/src/webhook_receiver/types.rs
@@ -9,7 +9,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use svix_bridge_types::{
-    svix, ReceiverInputOpts, ReceiverOutput, TransformationConfig, TransformerTx, WebhookVerifier,
+    ReceiverInputOpts, ReceiverOutput, TransformationConfig, TransformerTx, WebhookVerifier, svix,
 };
 
 use super::verification::{NoVerifier, SvixVerifier, VerificationMethod, Verifier};


### PR DESCRIPTION
we already have an MSRV of Rust 1.91, and rust 2024 was added in 1.85. Might as well!

Probably the most annoying code in here is removing calls to `std::env::set_var` because it is indeed unsafe as used here.