### PR TITLE
rust: expose timeouts as dedicated error value

### DIFF
--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: © 2022 Svix Authors
 // SPDX-License-Identifier: MIT
 
-use std::fmt;
+use std::{fmt, time::Duration};
 
 use http_body_util::BodyExt;
 use hyper::body::Incoming;
@@ -15,6 +15,11 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     /// A generic error
     Generic(String),
+    /// A timeout, with the elapsed time and configured timeout value if known
+    Timeout {
+        elapsed: Option<Duration>,
+        timeout: Option<Duration>,
+    },
     /// Http Error
     Http(HttpErrorContent<crate::models::HttpErrorOut>),
     /// Http Validation Error
@@ -26,7 +31,11 @@ impl Error {
         Self::Generic(format!("{err:?}"))
     }
 
-    pub(crate) async fn from_response(status_code: http1::StatusCode, body: Incoming) -> Self {
+    pub(crate) async fn from_response(
+        status_code: http1::StatusCode,
+        body: Incoming,
+        timeout: Option<Duration>,
+    ) -> Self {
         match body.collect().await {
             Ok(collected) => {
                 let bytes = collected.to_bytes();
@@ -42,6 +51,11 @@ impl Error {
                     })
                 }
             }
+            Err(e) if e.is_timeout() => Self::Timeout {
+                // hyper doesn't give us the elapsed time by default
+                elapsed: None,
+                timeout,
+            },
             Err(e) => Self::Generic(e.to_string()),
         }
     }
@@ -58,6 +72,15 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Error::Generic(s) => s.fmt(f),
+            Self::Timeout {
+                elapsed: Some(elapsed),
+                timeout: Some(timeout),
+            } => format!("Request timeout after {elapsed:?} (timeout {timeout:?})").fmt(f),
+            Self::Timeout {
+                timeout: Some(timeout),
+                ..
+            } => format!("Request timeout (threshold {timeout:?})").fmt(f),
+            Self::Timeout { .. } => "Request timeout".fmt(f),
             Error::Http(e) => format!("Http error (status={}) {:?}", e.status, e.payload).fmt(f),
             Error::Validation(e) => format!("Validation error {:?}", e.payload).fmt(f),
         }

--- a/rust/src/request.rs
+++ b/rust/src/request.rs
@@ -134,7 +134,7 @@ impl Request {
 
             let status = response.status();
             if !status.is_success() {
-                Err(Error::from_response(status, response.into_body()).await)
+                Err(Error::from_response(status, response.into_body(), conf.timeout).await)
             } else if no_return_type {
                 Ok(None)
             } else {
@@ -149,11 +149,15 @@ impl Request {
         };
 
         loop {
+            let start = std::time::Instant::now();
             let request_fut = execute_request(request.clone());
             let res = if let Some(duration) = conf.timeout {
                 tokio::time::timeout(duration, request_fut)
                     .await
-                    .map_err(Error::generic)?
+                    .map_err(|_| Error::Timeout {
+                        elapsed: Some(start.elapsed()),
+                        timeout: Some(duration),
+                    })?
             } else {
                 request_fut.await
             };


### PR DESCRIPTION
`Error::Generic("Elapsed(())")` is *so* hard to debug. IMO, timeouts are annoying enough that you should always expose as much as you can.

This captures both the tokio overall-request timeout, and reqwest's slowloris-protection header timeouts.