### PR TITLE
cli: add timeout to config; add debugging command for config

### DIFF
--- a/svix-cli/src/config.rs
+++ b/svix-cli/src/config.rs
@@ -1,6 +1,7 @@
 use std::{
     io::Write,
     path::{Path, PathBuf},
+    time::Duration,
 };
 
 use anyhow::{Context as _, Result};
@@ -26,6 +27,9 @@ pub struct Config {
     pub relay_debug_hostname: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub relay_disable_security: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    timeout_milliseconds: Option<u32>,
 }
 
 fn create_config_file(path: &Path) -> Result<File> {
@@ -72,6 +76,11 @@ impl Config {
             server_url @ Some(_) => server_url,
             None => self.debug_url.as_deref(),
         }
+    }
+
+    pub fn timeout(&self) -> Option<Duration> {
+        self.timeout_milliseconds
+            .map(|s| Duration::from_millis(s as _))
     }
 }
 

--- a/svix-cli/src/main.rs
+++ b/svix-cli/src/main.rs
@@ -110,6 +110,8 @@ enum RootCommands {
     Seed(SeedArgs),
     /// Verifying and signing webhooks with the Svix signature scheme
     Signature(SignatureArgs),
+    /// Show the loaded CLI configuration, with all interpolated environment variables
+    ShowConfig,
     /// Get the version of the Svix CLI
     Version,
 }
@@ -197,6 +199,16 @@ async fn main() -> Result<()> {
             let client = get_client(&cfg?)?;
             cmds::seed::exec(&client, args, color_mode).await?;
         }
+        RootCommands::ShowConfig => {
+            eprintln!(
+                "Merged output of '{}' and SVIX_ environment variables:",
+                config::get_config_file_path()?.display()
+            );
+            let stdout = std::io::stdout();
+            let stdout = stdout.lock();
+            serde_json::to_writer_pretty(stdout, &cfg?)?;
+            println!();
+        }
     }
 
     Ok(())
@@ -214,7 +226,7 @@ fn get_client_options(cfg: &Config) -> Result<svix::api::SvixOptions> {
     Ok(svix::api::SvixOptions {
         debug: false,
         server_url: cfg.server_url().map(Into::into),
-        timeout: None,
+        timeout: cfg.timeout(),
         ..SvixOptions::default()
     })
 }


### PR DESCRIPTION
This lets you set a request timeout for the CLI. It defaults to unset, matching current behavior.

It also adds a `show-command` subcommand that runs after interpolating all the `SVIX_` magic variables.

<details open>

<summary>Example of timeout function:</summary>

```
$ env SVIX_TIMEOUT_MILLISECONDS=1 cargo run -- message create $APP_ID $PAYLOAD
Error: Request timeout after 1.711625ms (threshold 1ms)
```

</details>

<details open>

<summary>Example of config subcommand:</summary>

```
$ env SVIX_TIMEOUT_MILLISECONDS=100 cargo run -- show-config
Merged output of '/Users/jbrown/Library/Application Support/svix/config.toml' and SVIX_ environment variables:
{
  "debug_url": "http://localhost:8071",
  "relay_debug_hostname": "localhost:8060",
  "relay_disable_security": true,
  "timeout_milliseconds": 100
}
```

</details>