### PR TITLE
Fix whitespace issue in JS codegen template

### DIFF
--- a/codegen/templates/javascript/types/struct_enum.ts.jinja
+++ b/codegen/templates/javascript/types/struct_enum.ts.jinja
@@ -56,8 +56,8 @@ export const {{ type.name | to_upper_camel_case }}Serializer = {
                 {%- else %}
                 case '{{ variant.name }}':
                     return {}
-                {%- endif -%}
-            {%- endfor -%}
+                {%- endif %}
+            {%- endfor %}
                 default:
                     throw new Error(`Unexpected {{ type.discriminator_field }}: ${ {{ disc_field_name}} }`);
             }


### PR DESCRIPTION
This doesn't change anything for the spec currently checked-in, but solves an issue we encountered internally.
