### PR TITLE
server: update crossbeam-epoch for RUSTSEC-2026-0204

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1063,9 +1063,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
[RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204.html). Seems unlikely to affect us since I don't think we ever Display a crossbeam smart pointer, but might as well bump