### PR TITLE
php: fix Webhook::fromRaw throwing ArgumentCountError

### DIFF
--- a/php/src/Webhook.php
+++ b/php/src/Webhook.php
@@ -8,8 +8,12 @@ class Webhook
     public const TOLERANCE = 5 * 60;
     private $secret;
 
-    public function __construct($secret)
+    public function __construct($secret = null)
     {
+        // fromRaw() constructs via `new self()` and sets the raw secret directly.
+        if ($secret === null) {
+            return;
+        }
         if (substr($secret, 0, strlen(Webhook::SECRET_PREFIX)) === Webhook::SECRET_PREFIX) {
             $secret = substr($secret, strlen(Webhook::SECRET_PREFIX));
         }

--- a/php/tests/WebhookTest.php
+++ b/php/tests/WebhookTest.php
@@ -20,6 +20,20 @@ final class WebhookTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testFromRawSignatureIsValidAndReturnsJson()
+    {
+        $testPayload = new TestPayload(time());
+
+        $wh = \Svix\Webhook::fromRaw(base64_decode($testPayload->secret));
+        $json = $wh->verify($testPayload->payload, $testPayload->header);
+
+        $this->assertEquals(
+            $json['test'],
+            2432232315,
+            "did not return expected json"
+        );
+    }
+
     public function testValidBrandlessSignatureIsValidAndReturnsJson()
     {
         $testPayload = new TestPayload(time());


### PR DESCRIPTION
## Motivation

`Svix\Webhook::fromRaw()` throws on every call, so there is currently no way to build a `Webhook` from a raw-bytes secret in the PHP library (the equivalent of `NewWebhookRaw` in Go, `new_using_raw_bytes` in Ruby, or `{ format: "raw" }` in JS). `fromRaw()` does `new self()`, but the constructor's `$secret` parameter is required, so it raises `ArgumentCountError` before it can set the secret:

```php
Svix\Webhook::fromRaw(base64_decode("MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw"));
// ArgumentCountError: Too few arguments to function Svix\Webhook::__construct(),
// 0 passed and exactly 1 expected
```

## Solution

Make the constructor's `$secret` optional with a `null` guard, so `new self()` succeeds and `fromRaw()` can set the raw secret directly. Callers that pass a secret are unaffected.

Added a test that builds a webhook via `fromRaw()` and verifies a signature against the existing test vector — it fails before this change with `ArgumentCountError` and passes after. Full suite is green (43 tests).