### PR TITLE
feat(ruby): support request_id on API requests

### DIFF
--- a/codegen/templates/ruby/api_extra/application_create.rb
+++ b/codegen/templates/ruby/api_extra/application_create.rb
@@ -8,8 +8,9 @@ def get_or_create(application_in, options = {})
       "get_if_exists" => "true"
     },
     headers: {
+      "x-request-id" => options["request_id"],
       "idempotency-key" => options["idempotency-key"]
-    },
+    }.compact,
     body: application_in
   )
   ApplicationOut.deserialize(res)

--- a/codegen/templates/ruby/api_extra/authentication_expire_all.rb
+++ b/codegen/templates/ruby/api_extra/authentication_expire_all.rb
@@ -4,8 +4,9 @@ def dashboard_access(app_id, options = {})
     "POST",
     "/api/v1/auth/dashboard-access/#{app_id}",
     headers: {
+      "x-request-id" => options["request_id"],
       "idempotency-key" => options["idempotency-key"]
-    }
+    }.compact
   )
   DashboardAccessOut.deserialize(res)
 end

--- a/codegen/templates/ruby/api_resource.rb.jinja
+++ b/codegen/templates/ruby/api_resource.rb.jinja
@@ -31,16 +31,12 @@ module Svix
       {%- if op.request_body_schema_name is defined -%}
       {{ op.request_body_schema_name | to_snake_case }},
       {%- endif -%}
-      {# header/query params -#}
-      {%- if op | has_query_or_header_params -%}
+      {# request options -#}
       options = {}
-      {%- endif -%}
     {% endset -%}
 
     def {{ op.name | to_snake_case }}({{ func_args | strip_trailing_comma }})
-      {% if op | has_query_or_header_params -%}
       options = options.transform_keys(&:to_s)
-      {% endif -%}
       {% if op.response_body_schema_name is defined -%}res = {% endif -%}
       @client.execute_request(
         "{{ op.method | upper }}",
@@ -52,13 +48,12 @@ module Svix
           {% endfor -%}
         },
         {% endif -%}
-        {% if op.header_params | length >0 -%}
         headers:{
+          "x-request-id" => options["request_id"],
           {% for p in op.header_params -%}
             "{{ p.name }}" => options["{{ p.name }}"],
           {% endfor -%}
-        },
-        {% endif -%}
+        }.compact{% if op.request_body_schema_name is defined %},{% endif %}
         {% if op.request_body_schema_name is defined -%}
         body: {{ op.request_body_schema_name | to_snake_case }},
         {% endif -%}

--- a/ruby/lib/svix/api/application.rb
+++ b/ruby/lib/svix/api/application.rb
@@ -21,7 +21,10 @@ module Svix
           "limit" => options["limit"],
           "iterator" => options["iterator"],
           "order" => options["order"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       ListResponseApplicationOut.deserialize(res)
     end
@@ -32,8 +35,9 @@ module Svix
         "POST",
         "/api/v1/app",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: application_in
       )
       ApplicationOut.deserialize(res)
@@ -49,41 +53,58 @@ module Svix
           "get_if_exists" => "true"
         },
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: application_in
       )
       ApplicationOut.deserialize(res)
     end
 
-    def get(app_id)
+    def get(app_id, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/api/v1/app/#{app_id}"
+        "/api/v1/app/#{app_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       ApplicationOut.deserialize(res)
     end
 
-    def update(app_id, application_in)
+    def update(app_id, application_in, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "PUT",
         "/api/v1/app/#{app_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: application_in
       )
       ApplicationOut.deserialize(res)
     end
 
-    def delete(app_id)
+    def delete(app_id, options = {})
+      options = options.transform_keys(&:to_s)
       @client.execute_request(
         "DELETE",
-        "/api/v1/app/#{app_id}"
+        "/api/v1/app/#{app_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
     end
 
-    def patch(app_id, application_patch)
+    def patch(app_id, application_patch, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "PATCH",
         "/api/v1/app/#{app_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: application_patch
       )
       ApplicationOut.deserialize(res)

--- a/ruby/lib/svix/api/authentication.rb
+++ b/ruby/lib/svix/api/authentication.rb
@@ -15,8 +15,9 @@ module Svix
         "POST",
         "/api/v1/auth/app-portal-access/#{app_id}",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: app_portal_access_in
       )
       AppPortalAccessOut.deserialize(res)
@@ -28,8 +29,9 @@ module Svix
         "POST",
         "/api/v1/auth/logout",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        }
+        }.compact
       )
     end
 
@@ -39,8 +41,9 @@ module Svix
         "POST",
         "/api/v1/auth/app/#{app_id}/expire-all",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: application_token_expire_in
       )
     end
@@ -51,8 +54,9 @@ module Svix
         "POST",
         "/api/v1/auth/dashboard-access/#{app_id}",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        }
+        }.compact
       )
       DashboardAccessOut.deserialize(res)
     end
@@ -63,8 +67,9 @@ module Svix
         "POST",
         "/api/v1/auth/stream-portal-access/#{stream_id}",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: stream_portal_access_in
       )
       AppPortalAccessOut.deserialize(res)
@@ -76,8 +81,9 @@ module Svix
         "POST",
         "/api/v1/auth/stream-logout",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        }
+        }.compact
       )
     end
 
@@ -87,8 +93,9 @@ module Svix
         "POST",
         "/api/v1/auth/stream/#{stream_id}/expire-all",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: stream_token_expire_in
       )
     end
@@ -99,17 +106,22 @@ module Svix
         "POST",
         "/api/v1/auth/stream/#{stream_id}/sink/#{sink_id}/poller/token/rotate",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: rotate_poller_token_in
       )
       ApiTokenOut.deserialize(res)
     end
 
-    def get_stream_poller_token(stream_id, sink_id)
+    def get_stream_poller_token(stream_id, sink_id, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/api/v1/auth/stream/#{stream_id}/sink/#{sink_id}/poller/token"
+        "/api/v1/auth/stream/#{stream_id}/sink/#{sink_id}/poller/token",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       ApiTokenOut.deserialize(res)
     end

--- a/ruby/lib/svix/api/background_task.rb
+++ b/ruby/lib/svix/api/background_task.rb
@@ -20,15 +20,22 @@ module Svix
           "limit" => options["limit"],
           "iterator" => options["iterator"],
           "order" => options["order"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       ListResponseBackgroundTaskOut.deserialize(res)
     end
 
-    def get(task_id)
+    def get(task_id, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/api/v1/background-task/#{task_id}"
+        "/api/v1/background-task/#{task_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       BackgroundTaskOut.deserialize(res)
     end

--- a/ruby/lib/svix/api/connector.rb
+++ b/ruby/lib/svix/api/connector.rb
@@ -19,7 +19,10 @@ module Svix
           "iterator" => options["iterator"],
           "order" => options["order"],
           "product_type" => options["product_type"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       ListResponseConnectorOut.deserialize(res)
     end
@@ -30,41 +33,58 @@ module Svix
         "POST",
         "/api/v1/connector",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: connector_in
       )
       ConnectorOut.deserialize(res)
     end
 
-    def get(connector_id)
+    def get(connector_id, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/api/v1/connector/#{connector_id}"
+        "/api/v1/connector/#{connector_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       ConnectorOut.deserialize(res)
     end
 
-    def update(connector_id, connector_update)
+    def update(connector_id, connector_update, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "PUT",
         "/api/v1/connector/#{connector_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: connector_update
       )
       ConnectorOut.deserialize(res)
     end
 
-    def delete(connector_id)
+    def delete(connector_id, options = {})
+      options = options.transform_keys(&:to_s)
       @client.execute_request(
         "DELETE",
-        "/api/v1/connector/#{connector_id}"
+        "/api/v1/connector/#{connector_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
     end
 
-    def patch(connector_id, connector_patch)
+    def patch(connector_id, connector_patch, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "PATCH",
         "/api/v1/connector/#{connector_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: connector_patch
       )
       ConnectorOut.deserialize(res)

--- a/ruby/lib/svix/api/endpoint.rb
+++ b/ruby/lib/svix/api/endpoint.rb
@@ -18,7 +18,10 @@ module Svix
           "limit" => options["limit"],
           "iterator" => options["iterator"],
           "order" => options["order"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       ListResponseEndpointOut.deserialize(res)
     end
@@ -29,50 +32,71 @@ module Svix
         "POST",
         "/api/v1/app/#{app_id}/endpoint",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: endpoint_in
       )
       EndpointOut.deserialize(res)
     end
 
-    def get(app_id, endpoint_id)
+    def get(app_id, endpoint_id, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/api/v1/app/#{app_id}/endpoint/#{endpoint_id}"
+        "/api/v1/app/#{app_id}/endpoint/#{endpoint_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       EndpointOut.deserialize(res)
     end
 
-    def update(app_id, endpoint_id, endpoint_update)
+    def update(app_id, endpoint_id, endpoint_update, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "PUT",
         "/api/v1/app/#{app_id}/endpoint/#{endpoint_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: endpoint_update
       )
       EndpointOut.deserialize(res)
     end
 
-    def delete(app_id, endpoint_id)
+    def delete(app_id, endpoint_id, options = {})
+      options = options.transform_keys(&:to_s)
       @client.execute_request(
         "DELETE",
-        "/api/v1/app/#{app_id}/endpoint/#{endpoint_id}"
+        "/api/v1/app/#{app_id}/endpoint/#{endpoint_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
     end
 
-    def patch(app_id, endpoint_id, endpoint_patch)
+    def patch(app_id, endpoint_id, endpoint_patch, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "PATCH",
         "/api/v1/app/#{app_id}/endpoint/#{endpoint_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: endpoint_patch
       )
       EndpointOut.deserialize(res)
     end
 
-    def get_secret(app_id, endpoint_id)
+    def get_secret(app_id, endpoint_id, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/api/v1/app/#{app_id}/endpoint/#{endpoint_id}/secret"
+        "/api/v1/app/#{app_id}/endpoint/#{endpoint_id}/secret",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       EndpointSecretOut.deserialize(res)
     end
@@ -83,48 +107,69 @@ module Svix
         "POST",
         "/api/v1/app/#{app_id}/endpoint/#{endpoint_id}/secret/rotate",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: endpoint_secret_rotate_in
       )
     end
 
-    def get_headers(app_id, endpoint_id)
+    def get_headers(app_id, endpoint_id, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/api/v1/app/#{app_id}/endpoint/#{endpoint_id}/headers"
+        "/api/v1/app/#{app_id}/endpoint/#{endpoint_id}/headers",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       EndpointHeadersOut.deserialize(res)
     end
 
-    def update_headers(app_id, endpoint_id, endpoint_headers_in)
+    def update_headers(app_id, endpoint_id, endpoint_headers_in, options = {})
+      options = options.transform_keys(&:to_s)
       @client.execute_request(
         "PUT",
         "/api/v1/app/#{app_id}/endpoint/#{endpoint_id}/headers",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: endpoint_headers_in
       )
     end
 
-    def patch_headers(app_id, endpoint_id, endpoint_headers_patch_in)
+    def patch_headers(app_id, endpoint_id, endpoint_headers_patch_in, options = {})
+      options = options.transform_keys(&:to_s)
       @client.execute_request(
         "PATCH",
         "/api/v1/app/#{app_id}/endpoint/#{endpoint_id}/headers",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: endpoint_headers_patch_in
       )
     end
 
-    def transformation_get(app_id, endpoint_id)
+    def transformation_get(app_id, endpoint_id, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/api/v1/app/#{app_id}/endpoint/#{endpoint_id}/transformation"
+        "/api/v1/app/#{app_id}/endpoint/#{endpoint_id}/transformation",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       EndpointTransformationOut.deserialize(res)
     end
 
-    def patch_transformation(app_id, endpoint_id, endpoint_transformation_patch)
+    def patch_transformation(app_id, endpoint_id, endpoint_transformation_patch, options = {})
+      options = options.transform_keys(&:to_s)
       @client.execute_request(
         "PATCH",
         "/api/v1/app/#{app_id}/endpoint/#{endpoint_id}/transformation",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: endpoint_transformation_patch
       )
     end
@@ -135,8 +180,9 @@ module Svix
         "POST",
         "/api/v1/app/#{app_id}/endpoint/#{endpoint_id}/replay-missing",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: replay_in
       )
       ReplayOut.deserialize(res)
@@ -148,8 +194,9 @@ module Svix
         "POST",
         "/api/v1/app/#{app_id}/endpoint/#{endpoint_id}/bulk-replay",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: bulk_replay_in
       )
       ReplayOut.deserialize(res)
@@ -163,7 +210,10 @@ module Svix
         query_params: {
           "since" => options["since"],
           "until" => options["until"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       EndpointStats.deserialize(res)
     end
@@ -174,8 +224,9 @@ module Svix
         "POST",
         "/api/v1/app/#{app_id}/endpoint/#{endpoint_id}/recover",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: recover_in
       )
       RecoverOut.deserialize(res)
@@ -187,17 +238,22 @@ module Svix
         "POST",
         "/api/v1/app/#{app_id}/endpoint/#{endpoint_id}/send-example",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: event_example_in
       )
       MessageOut.deserialize(res)
     end
 
-    def transformation_partial_update(app_id, endpoint_id, endpoint_transformation_in)
+    def transformation_partial_update(app_id, endpoint_id, endpoint_transformation_in, options = {})
+      options = options.transform_keys(&:to_s)
       @client.execute_request(
         "PATCH",
         "/api/v1/app/#{app_id}/endpoint/#{endpoint_id}/transformation",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: endpoint_transformation_in
       )
     end

--- a/ruby/lib/svix/api/environment.rb
+++ b/ruby/lib/svix/api/environment.rb
@@ -15,8 +15,9 @@ module Svix
         "POST",
         "/api/v1/environment/export",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        }
+        }.compact
       )
       EnvironmentOut.deserialize(res)
     end
@@ -27,8 +28,9 @@ module Svix
         "POST",
         "/api/v1/environment/import",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: environment_in
       )
     end

--- a/ruby/lib/svix/api/event_type.rb
+++ b/ruby/lib/svix/api/event_type.rb
@@ -20,7 +20,10 @@ module Svix
           "order" => options["order"],
           "include_archived" => options["include_archived"],
           "with_content" => options["with_content"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       ListResponseEventTypeOut.deserialize(res)
     end
@@ -31,8 +34,9 @@ module Svix
         "POST",
         "/api/v1/event-type",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: event_type_in
       )
       EventTypeOut.deserialize(res)
@@ -44,25 +48,34 @@ module Svix
         "POST",
         "/api/v1/event-type/import/openapi",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: event_type_import_open_api_in
       )
       EventTypeImportOpenApiOut.deserialize(res)
     end
 
-    def get(event_type_name)
+    def get(event_type_name, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/api/v1/event-type/#{event_type_name}"
+        "/api/v1/event-type/#{event_type_name}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       EventTypeOut.deserialize(res)
     end
 
-    def update(event_type_name, event_type_update)
+    def update(event_type_name, event_type_update, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "PUT",
         "/api/v1/event-type/#{event_type_name}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: event_type_update
       )
       EventTypeOut.deserialize(res)
@@ -75,14 +88,21 @@ module Svix
         "/api/v1/event-type/#{event_type_name}",
         query_params: {
           "expunge" => options["expunge"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
     end
 
-    def patch(event_type_name, event_type_patch)
+    def patch(event_type_name, event_type_patch, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "PATCH",
         "/api/v1/event-type/#{event_type_name}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: event_type_patch
       )
       EventTypeOut.deserialize(res)

--- a/ruby/lib/svix/api/health.rb
+++ b/ruby/lib/svix/api/health.rb
@@ -9,10 +9,14 @@ module Svix
       @client = client
     end
 
-    def get
+    def get(options = {})
+      options = options.transform_keys(&:to_s)
       @client.execute_request(
         "GET",
-        "/api/v1/health"
+        "/api/v1/health",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
     end
 

--- a/ruby/lib/svix/api/ingest.rb
+++ b/ruby/lib/svix/api/ingest.rb
@@ -19,8 +19,9 @@ module Svix
         "POST",
         "/ingest/api/v1/source/#{source_id}/dashboard",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: ingest_source_consumer_portal_access_in
       )
       DashboardAccessOut.deserialize(res)

--- a/ruby/lib/svix/api/ingest_endpoint.rb
+++ b/ruby/lib/svix/api/ingest_endpoint.rb
@@ -18,7 +18,10 @@ module Svix
           "limit" => options["limit"],
           "iterator" => options["iterator"],
           "order" => options["order"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       ListResponseIngestEndpointOut.deserialize(res)
     end
@@ -29,41 +32,58 @@ module Svix
         "POST",
         "/ingest/api/v1/source/#{source_id}/endpoint",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: ingest_endpoint_in
       )
       IngestEndpointOut.deserialize(res)
     end
 
-    def get(source_id, endpoint_id)
+    def get(source_id, endpoint_id, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/ingest/api/v1/source/#{source_id}/endpoint/#{endpoint_id}"
+        "/ingest/api/v1/source/#{source_id}/endpoint/#{endpoint_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       IngestEndpointOut.deserialize(res)
     end
 
-    def update(source_id, endpoint_id, ingest_endpoint_update)
+    def update(source_id, endpoint_id, ingest_endpoint_update, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "PUT",
         "/ingest/api/v1/source/#{source_id}/endpoint/#{endpoint_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: ingest_endpoint_update
       )
       IngestEndpointOut.deserialize(res)
     end
 
-    def delete(source_id, endpoint_id)
+    def delete(source_id, endpoint_id, options = {})
+      options = options.transform_keys(&:to_s)
       @client.execute_request(
         "DELETE",
-        "/ingest/api/v1/source/#{source_id}/endpoint/#{endpoint_id}"
+        "/ingest/api/v1/source/#{source_id}/endpoint/#{endpoint_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
     end
 
-    def get_secret(source_id, endpoint_id)
+    def get_secret(source_id, endpoint_id, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/ingest/api/v1/source/#{source_id}/endpoint/#{endpoint_id}/secret"
+        "/ingest/api/v1/source/#{source_id}/endpoint/#{endpoint_id}/secret",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       IngestEndpointSecretOut.deserialize(res)
     end
@@ -74,40 +94,57 @@ module Svix
         "POST",
         "/ingest/api/v1/source/#{source_id}/endpoint/#{endpoint_id}/secret/rotate",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: ingest_endpoint_secret_in
       )
     end
 
-    def get_headers(source_id, endpoint_id)
+    def get_headers(source_id, endpoint_id, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/ingest/api/v1/source/#{source_id}/endpoint/#{endpoint_id}/headers"
+        "/ingest/api/v1/source/#{source_id}/endpoint/#{endpoint_id}/headers",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       IngestEndpointHeadersOut.deserialize(res)
     end
 
-    def update_headers(source_id, endpoint_id, ingest_endpoint_headers_in)
+    def update_headers(source_id, endpoint_id, ingest_endpoint_headers_in, options = {})
+      options = options.transform_keys(&:to_s)
       @client.execute_request(
         "PUT",
         "/ingest/api/v1/source/#{source_id}/endpoint/#{endpoint_id}/headers",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: ingest_endpoint_headers_in
       )
     end
 
-    def get_transformation(source_id, endpoint_id)
+    def get_transformation(source_id, endpoint_id, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/ingest/api/v1/source/#{source_id}/endpoint/#{endpoint_id}/transformation"
+        "/ingest/api/v1/source/#{source_id}/endpoint/#{endpoint_id}/transformation",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       IngestEndpointTransformationOut.deserialize(res)
     end
 
-    def set_transformation(source_id, endpoint_id, ingest_endpoint_transformation_patch)
+    def set_transformation(source_id, endpoint_id, ingest_endpoint_transformation_patch, options = {})
+      options = options.transform_keys(&:to_s)
       @client.execute_request(
         "PATCH",
         "/ingest/api/v1/source/#{source_id}/endpoint/#{endpoint_id}/transformation",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: ingest_endpoint_transformation_patch
       )
     end

--- a/ruby/lib/svix/api/ingest_source.rb
+++ b/ruby/lib/svix/api/ingest_source.rb
@@ -18,7 +18,10 @@ module Svix
           "limit" => options["limit"],
           "iterator" => options["iterator"],
           "order" => options["order"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       ListResponseIngestSourceOut.deserialize(res)
     end
@@ -29,34 +32,47 @@ module Svix
         "POST",
         "/ingest/api/v1/source",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: ingest_source_in
       )
       IngestSourceOut.deserialize(res)
     end
 
-    def get(source_id)
+    def get(source_id, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/ingest/api/v1/source/#{source_id}"
+        "/ingest/api/v1/source/#{source_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       IngestSourceOut.deserialize(res)
     end
 
-    def update(source_id, ingest_source_in)
+    def update(source_id, ingest_source_in, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "PUT",
         "/ingest/api/v1/source/#{source_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: ingest_source_in
       )
       IngestSourceOut.deserialize(res)
     end
 
-    def delete(source_id)
+    def delete(source_id, options = {})
+      options = options.transform_keys(&:to_s)
       @client.execute_request(
         "DELETE",
-        "/ingest/api/v1/source/#{source_id}"
+        "/ingest/api/v1/source/#{source_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
     end
 
@@ -66,8 +82,9 @@ module Svix
         "POST",
         "/ingest/api/v1/source/#{source_id}/token/rotate",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        }
+        }.compact
       )
       RotateTokenOut.deserialize(res)
     end

--- a/ruby/lib/svix/api/integration.rb
+++ b/ruby/lib/svix/api/integration.rb
@@ -18,7 +18,10 @@ module Svix
           "limit" => options["limit"],
           "iterator" => options["iterator"],
           "order" => options["order"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       ListResponseIntegrationOut.deserialize(res)
     end
@@ -29,34 +32,47 @@ module Svix
         "POST",
         "/api/v1/app/#{app_id}/integration",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: integration_in
       )
       IntegrationOut.deserialize(res)
     end
 
-    def get(app_id, integ_id)
+    def get(app_id, integ_id, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/api/v1/app/#{app_id}/integration/#{integ_id}"
+        "/api/v1/app/#{app_id}/integration/#{integ_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       IntegrationOut.deserialize(res)
     end
 
-    def update(app_id, integ_id, integration_update)
+    def update(app_id, integ_id, integration_update, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "PUT",
         "/api/v1/app/#{app_id}/integration/#{integ_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: integration_update
       )
       IntegrationOut.deserialize(res)
     end
 
-    def delete(app_id, integ_id)
+    def delete(app_id, integ_id, options = {})
+      options = options.transform_keys(&:to_s)
       @client.execute_request(
         "DELETE",
-        "/api/v1/app/#{app_id}/integration/#{integ_id}"
+        "/api/v1/app/#{app_id}/integration/#{integ_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
     end
 
@@ -66,16 +82,21 @@ module Svix
         "POST",
         "/api/v1/app/#{app_id}/integration/#{integ_id}/key/rotate",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        }
+        }.compact
       )
       IntegrationKeyOut.deserialize(res)
     end
 
-    def get_key(app_id, integ_id)
+    def get_key(app_id, integ_id, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/api/v1/app/#{app_id}/integration/#{integ_id}/key"
+        "/api/v1/app/#{app_id}/integration/#{integ_id}/key",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       IntegrationKeyOut.deserialize(res)
     end

--- a/ruby/lib/svix/api/message.rb
+++ b/ruby/lib/svix/api/message.rb
@@ -53,7 +53,10 @@ module Svix
           "with_content" => options["with_content"],
           "tag" => options["tag"],
           "event_types" => options["event_types"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       ListResponseMessageOut.deserialize(res)
     end
@@ -67,8 +70,9 @@ module Svix
           "with_content" => options["with_content"]
         },
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: message_in
       )
       MessageOut.deserialize(res)
@@ -80,8 +84,9 @@ module Svix
         "POST",
         "/api/v1/app/#{app_id}/msg/precheck/active",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: message_precheck_in
       )
       MessagePrecheckOut.deserialize(res)
@@ -94,15 +99,22 @@ module Svix
         "/api/v1/app/#{app_id}/msg/#{msg_id}",
         query_params: {
           "with_content" => options["with_content"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       MessageOut.deserialize(res)
     end
 
-    def expunge_content(app_id, msg_id)
+    def expunge_content(app_id, msg_id, options = {})
+      options = options.transform_keys(&:to_s)
       @client.execute_request(
         "DELETE",
-        "/api/v1/app/#{app_id}/msg/#{msg_id}/content"
+        "/api/v1/app/#{app_id}/msg/#{msg_id}/content",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
     end
 
@@ -112,8 +124,9 @@ module Svix
         "POST",
         "/api/v1/app/#{app_id}/msg/expunge-all-contents",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        }
+        }.compact
       )
       ExpungeAllContentsOut.deserialize(res)
     end

--- a/ruby/lib/svix/api/message_attempt.rb
+++ b/ruby/lib/svix/api/message_attempt.rb
@@ -27,7 +27,10 @@ module Svix
           "with_msg" => options["with_msg"],
           "expanded_statuses" => options["expanded_statuses"],
           "event_types" => options["event_types"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       ListResponseMessageAttemptOut.deserialize(res)
     end
@@ -50,7 +53,10 @@ module Svix
           "with_content" => options["with_content"],
           "expanded_statuses" => options["expanded_statuses"],
           "event_types" => options["event_types"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       ListResponseMessageAttemptOut.deserialize(res)
     end
@@ -71,7 +77,10 @@ module Svix
           "with_content" => options["with_content"],
           "expanded_statuses" => options["expanded_statuses"],
           "event_types" => options["event_types"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       ListResponseEndpointMessageOut.deserialize(res)
     end
@@ -84,7 +93,10 @@ module Svix
         query_params: {
           "limit" => options["limit"],
           "iterator" => options["iterator"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       ListResponseMessageEndpointOut.deserialize(res)
     end
@@ -96,15 +108,22 @@ module Svix
         "/api/v1/app/#{app_id}/msg/#{msg_id}/attempt/#{attempt_id}",
         query_params: {
           "expanded_statuses" => options["expanded_statuses"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       MessageAttemptOut.deserialize(res)
     end
 
-    def expunge_content(app_id, msg_id, attempt_id)
+    def expunge_content(app_id, msg_id, attempt_id, options = {})
+      options = options.transform_keys(&:to_s)
       @client.execute_request(
         "DELETE",
-        "/api/v1/app/#{app_id}/msg/#{msg_id}/attempt/#{attempt_id}/content"
+        "/api/v1/app/#{app_id}/msg/#{msg_id}/attempt/#{attempt_id}/content",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
     end
 
@@ -114,8 +133,9 @@ module Svix
         "POST",
         "/api/v1/app/#{app_id}/msg/#{msg_id}/endpoint/#{endpoint_id}/resend",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        }
+        }.compact
       )
       EmptyResponse.deserialize(res)
     end

--- a/ruby/lib/svix/api/message_poller.rb
+++ b/ruby/lib/svix/api/message_poller.rb
@@ -20,7 +20,10 @@ module Svix
           "event_type" => options["event_type"],
           "channel" => options["channel"],
           "after" => options["after"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       PollingEndpointOut.deserialize(res)
     end
@@ -31,8 +34,9 @@ module Svix
         "POST",
         "/api/v1/app/#{app_id}/poller/#{sink_id}/consumer/#{consumer_id}/seek",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: polling_endpoint_consumer_seek_in
       )
       PollingEndpointConsumerSeekOut.deserialize(res)
@@ -46,7 +50,10 @@ module Svix
         query_params: {
           "limit" => options["limit"],
           "iterator" => options["iterator"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       PollingEndpointOut.deserialize(res)
     end

--- a/ruby/lib/svix/api/operational_webhook_endpoint.rb
+++ b/ruby/lib/svix/api/operational_webhook_endpoint.rb
@@ -18,7 +18,10 @@ module Svix
           "limit" => options["limit"],
           "iterator" => options["iterator"],
           "order" => options["order"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       ListResponseOperationalWebhookEndpointOut.deserialize(res)
     end
@@ -29,41 +32,58 @@ module Svix
         "POST",
         "/api/v1/operational-webhook/endpoint",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: operational_webhook_endpoint_in
       )
       OperationalWebhookEndpointOut.deserialize(res)
     end
 
-    def get(endpoint_id)
+    def get(endpoint_id, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/api/v1/operational-webhook/endpoint/#{endpoint_id}"
+        "/api/v1/operational-webhook/endpoint/#{endpoint_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       OperationalWebhookEndpointOut.deserialize(res)
     end
 
-    def update(endpoint_id, operational_webhook_endpoint_update)
+    def update(endpoint_id, operational_webhook_endpoint_update, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "PUT",
         "/api/v1/operational-webhook/endpoint/#{endpoint_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: operational_webhook_endpoint_update
       )
       OperationalWebhookEndpointOut.deserialize(res)
     end
 
-    def delete(endpoint_id)
+    def delete(endpoint_id, options = {})
+      options = options.transform_keys(&:to_s)
       @client.execute_request(
         "DELETE",
-        "/api/v1/operational-webhook/endpoint/#{endpoint_id}"
+        "/api/v1/operational-webhook/endpoint/#{endpoint_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
     end
 
-    def get_secret(endpoint_id)
+    def get_secret(endpoint_id, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/api/v1/operational-webhook/endpoint/#{endpoint_id}/secret"
+        "/api/v1/operational-webhook/endpoint/#{endpoint_id}/secret",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       OperationalWebhookEndpointSecretOut.deserialize(res)
     end
@@ -74,24 +94,33 @@ module Svix
         "POST",
         "/api/v1/operational-webhook/endpoint/#{endpoint_id}/secret/rotate",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: operational_webhook_endpoint_secret_in
       )
     end
 
-    def get_headers(endpoint_id)
+    def get_headers(endpoint_id, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/api/v1/operational-webhook/endpoint/#{endpoint_id}/headers"
+        "/api/v1/operational-webhook/endpoint/#{endpoint_id}/headers",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       OperationalWebhookEndpointHeadersOut.deserialize(res)
     end
 
-    def update_headers(endpoint_id, operational_webhook_endpoint_headers_in)
+    def update_headers(endpoint_id, operational_webhook_endpoint_headers_in, options = {})
+      options = options.transform_keys(&:to_s)
       @client.execute_request(
         "PUT",
         "/api/v1/operational-webhook/endpoint/#{endpoint_id}/headers",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: operational_webhook_endpoint_headers_in
       )
     end

--- a/ruby/lib/svix/api/statistics.rb
+++ b/ruby/lib/svix/api/statistics.rb
@@ -9,10 +9,14 @@ module Svix
       @client = client
     end
 
-    def aggregate_event_types
+    def aggregate_event_types(options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "PUT",
-        "/api/v1/stats/usage/event-types"
+        "/api/v1/stats/usage/event-types",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       AggregateEventTypesOut.deserialize(res)
     end
@@ -23,8 +27,9 @@ module Svix
         "POST",
         "/api/v1/stats/usage/app",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: app_usage_stats_in
       )
       AppUsageStatsOut.deserialize(res)

--- a/ruby/lib/svix/api/streaming.rb
+++ b/ruby/lib/svix/api/streaming.rb
@@ -17,26 +17,38 @@ module Svix
       @stream = StreamingStream.new(client)
     end
 
-    def sink_transformation_get(stream_id, sink_id)
+    def sink_transformation_get(stream_id, sink_id, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/api/v1/stream/#{stream_id}/sink/#{sink_id}/transformation"
+        "/api/v1/stream/#{stream_id}/sink/#{sink_id}/transformation",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       SinkTransformationOut.deserialize(res)
     end
 
-    def sink_headers_get(stream_id, sink_id)
+    def sink_headers_get(stream_id, sink_id, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/api/v1/stream/#{stream_id}/sink/#{sink_id}/headers"
+        "/api/v1/stream/#{stream_id}/sink/#{sink_id}/headers",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       EndpointHeadersOut.deserialize(res)
     end
 
-    def sink_headers_patch(stream_id, sink_id, http_sink_headers_patch_in)
+    def sink_headers_patch(stream_id, sink_id, http_sink_headers_patch_in, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "PATCH",
         "/api/v1/stream/#{stream_id}/sink/#{sink_id}/headers",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: http_sink_headers_patch_in
       )
       EndpointHeadersOut.deserialize(res)

--- a/ruby/lib/svix/api/streaming_event_type.rb
+++ b/ruby/lib/svix/api/streaming_event_type.rb
@@ -19,7 +19,10 @@ module Svix
           "iterator" => options["iterator"],
           "order" => options["order"],
           "include_archived" => options["include_archived"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       ListResponseStreamEventTypeOut.deserialize(res)
     end
@@ -30,25 +33,34 @@ module Svix
         "POST",
         "/api/v1/stream/event-type",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: stream_event_type_in
       )
       StreamEventTypeOut.deserialize(res)
     end
 
-    def get(name)
+    def get(name, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/api/v1/stream/event-type/#{name}"
+        "/api/v1/stream/event-type/#{name}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       StreamEventTypeOut.deserialize(res)
     end
 
-    def update(name, stream_event_type_in)
+    def update(name, stream_event_type_in, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "PUT",
         "/api/v1/stream/event-type/#{name}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: stream_event_type_in
       )
       StreamEventTypeOut.deserialize(res)
@@ -61,14 +73,21 @@ module Svix
         "/api/v1/stream/event-type/#{name}",
         query_params: {
           "expunge" => options["expunge"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
     end
 
-    def patch(name, stream_event_type_patch)
+    def patch(name, stream_event_type_patch, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "PATCH",
         "/api/v1/stream/event-type/#{name}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: stream_event_type_patch
       )
       StreamEventTypeOut.deserialize(res)

--- a/ruby/lib/svix/api/streaming_events.rb
+++ b/ruby/lib/svix/api/streaming_events.rb
@@ -18,7 +18,10 @@ module Svix
           "limit" => options["limit"],
           "iterator" => options["iterator"],
           "after" => options["after"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       EventStreamOut.deserialize(res)
     end
@@ -29,8 +32,9 @@ module Svix
         "POST",
         "/api/v1/stream/#{stream_id}/events",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: create_stream_events_in
       )
       CreateStreamEventsOut.deserialize(res)

--- a/ruby/lib/svix/api/streaming_sink.rb
+++ b/ruby/lib/svix/api/streaming_sink.rb
@@ -18,7 +18,10 @@ module Svix
           "limit" => options["limit"],
           "iterator" => options["iterator"],
           "order" => options["order"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       ListResponseStreamSinkOut.deserialize(res)
     end
@@ -29,59 +32,84 @@ module Svix
         "POST",
         "/api/v1/stream/#{stream_id}/sink",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: stream_sink_in
       )
       StreamSinkOut.deserialize(res)
     end
 
-    def get(stream_id, sink_id)
+    def get(stream_id, sink_id, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/api/v1/stream/#{stream_id}/sink/#{sink_id}"
+        "/api/v1/stream/#{stream_id}/sink/#{sink_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       StreamSinkOut.deserialize(res)
     end
 
-    def update(stream_id, sink_id, stream_sink_in)
+    def update(stream_id, sink_id, stream_sink_in, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "PUT",
         "/api/v1/stream/#{stream_id}/sink/#{sink_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: stream_sink_in
       )
       StreamSinkOut.deserialize(res)
     end
 
-    def delete(stream_id, sink_id)
+    def delete(stream_id, sink_id, options = {})
+      options = options.transform_keys(&:to_s)
       @client.execute_request(
         "DELETE",
-        "/api/v1/stream/#{stream_id}/sink/#{sink_id}"
+        "/api/v1/stream/#{stream_id}/sink/#{sink_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
     end
 
-    def patch(stream_id, sink_id, stream_sink_patch)
+    def patch(stream_id, sink_id, stream_sink_patch, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "PATCH",
         "/api/v1/stream/#{stream_id}/sink/#{sink_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: stream_sink_patch
       )
       StreamSinkOut.deserialize(res)
     end
 
-    def transformation_partial_update(stream_id, sink_id, sink_transform_in)
+    def transformation_partial_update(stream_id, sink_id, sink_transform_in, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "PATCH",
         "/api/v1/stream/#{stream_id}/sink/#{sink_id}/transformation",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: sink_transform_in
       )
       EmptyResponse.deserialize(res)
     end
 
-    def get_secret(stream_id, sink_id)
+    def get_secret(stream_id, sink_id, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/api/v1/stream/#{stream_id}/sink/#{sink_id}/secret"
+        "/api/v1/stream/#{stream_id}/sink/#{sink_id}/secret",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       SinkSecretOut.deserialize(res)
     end
@@ -92,8 +120,9 @@ module Svix
         "POST",
         "/api/v1/stream/#{stream_id}/sink/#{sink_id}/secret/rotate",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: endpoint_secret_rotate_in
       )
       EmptyResponse.deserialize(res)

--- a/ruby/lib/svix/api/streaming_stream.rb
+++ b/ruby/lib/svix/api/streaming_stream.rb
@@ -18,7 +18,10 @@ module Svix
           "limit" => options["limit"],
           "iterator" => options["iterator"],
           "order" => options["order"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       ListResponseStreamOut.deserialize(res)
     end
@@ -29,41 +32,58 @@ module Svix
         "POST",
         "/api/v1/stream",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: stream_in
       )
       StreamOut.deserialize(res)
     end
 
-    def get(stream_id)
+    def get(stream_id, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "GET",
-        "/api/v1/stream/#{stream_id}"
+        "/api/v1/stream/#{stream_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       StreamOut.deserialize(res)
     end
 
-    def update(stream_id, stream_in)
+    def update(stream_id, stream_in, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "PUT",
         "/api/v1/stream/#{stream_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: stream_in
       )
       StreamOut.deserialize(res)
     end
 
-    def delete(stream_id)
+    def delete(stream_id, options = {})
+      options = options.transform_keys(&:to_s)
       @client.execute_request(
         "DELETE",
-        "/api/v1/stream/#{stream_id}"
+        "/api/v1/stream/#{stream_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
     end
 
-    def patch(stream_id, stream_patch)
+    def patch(stream_id, stream_patch, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "PATCH",
         "/api/v1/stream/#{stream_id}",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: stream_patch
       )
       StreamOut.deserialize(res)

--- a/ruby/lib/svix/api_internal/endpoint.rb
+++ b/ruby/lib/svix/api_internal/endpoint.rb
@@ -11,10 +11,14 @@ module Svix
       @auto_config = EndpointAutoConfig.new(client)
     end
 
-    def transformation_partial_update(app_id, endpoint_id, endpoint_transformation_in)
+    def transformation_partial_update(app_id, endpoint_id, endpoint_transformation_in, options = {})
+      options = options.transform_keys(&:to_s)
       @client.execute_request(
         "PATCH",
         "/api/v1/app/#{app_id}/endpoint/#{endpoint_id}/transformation",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: endpoint_transformation_in
       )
     end

--- a/ruby/lib/svix/api_internal/endpoint_auto_config.rb
+++ b/ruby/lib/svix/api_internal/endpoint_auto_config.rb
@@ -9,10 +9,14 @@ module Svix
       @client = client
     end
 
-    def update(app_id, endpoint_id, subscribe_in)
+    def update(app_id, endpoint_id, subscribe_in, options = {})
+      options = options.transform_keys(&:to_s)
       res = @client.execute_request(
         "PUT",
         "/api/v1/app/#{app_id}/endpoint/#{endpoint_id}/auto-config",
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact,
         body: subscribe_in
       )
       EndpointOut.deserialize(res)

--- a/ruby/lib/svix/api_internal/message_pollerv2.rb
+++ b/ruby/lib/svix/api_internal/message_pollerv2.rb
@@ -18,7 +18,10 @@ module Svix
           "limit" => options["limit"],
           "lease_duration_ms" => options["lease_duration_ms"],
           "starting_position" => options["starting_position"]
-        }
+        },
+        headers: {
+          "x-request-id" => options["request_id"]
+        }.compact
       )
       PollerV2PollOut.deserialize(res)
     end
@@ -29,8 +32,9 @@ module Svix
         "POST",
         "/api/v1/app/#{app_id}/polling-endpoint/#{sink_id}/consumer/#{consumer_id}/commit",
         headers: {
+          "x-request-id" => options["request_id"],
           "idempotency-key" => options["idempotency-key"]
-        },
+        }.compact,
         body: poller_v2_commit_in
       )
     end

--- a/ruby/spec/webmock_tests_spec.rb
+++ b/ruby/spec/webmock_tests_spec.rb
@@ -167,6 +167,63 @@ describe "API Client" do
     )
   end
 
+  it "test request_id is sent for request with existing options" do
+    stub_request(:post, "#{host}/api/v1/app/app_id/msg")
+      .to_return(
+        status: 200,
+        body: MessageOut_JSON
+      )
+
+    svx.message.create("app_id", Svix::MessageIn.new(event_type: "event.type"), {request_id: "REQ-123"})
+    expect(WebMock).to(
+      have_requested(
+        :post,
+        "#{host}/api/v1/app/app_id/msg"
+      )
+        .with(
+          headers: {
+            "x-request-id" => "REQ-123"
+          }
+        )
+    )
+  end
+
+  it "test request_id is sent for request without existing options" do
+    stub_request(:delete, "#{host}/api/v1/app/app_id")
+      .to_return(
+        status: 204
+      )
+
+    svx.application.delete("app_id", {request_id: "REQ-456"})
+    expect(WebMock).to(
+      have_requested(
+        :delete,
+        "#{host}/api/v1/app/app_id"
+      )
+        .with(
+          headers: {
+            "x-request-id" => "REQ-456"
+          }
+        )
+    )
+  end
+
+  it "does not send request_id header when option is omitted" do
+    stub_request(:delete, "#{host}/api/v1/app/app_id")
+      .to_return(
+        status: 204
+      )
+
+    svx.application.delete("app_id")
+    expect(WebMock).to(
+      have_requested(
+        :delete,
+        "#{host}/api/v1/app/app_id"
+      )
+        .with { |request| !request.headers.key?("x-request-id") }
+    )
+  end
+
   it "no body in response does not return anything" do
     stub_request(:delete, "#{host}/api/v1/app/app_id")
       .to_return(


### PR DESCRIPTION
## Summary

Adds Ruby SDK support for a caller-provided `request_id` option, sent as the `X-Request-Id` header for Svix API requests.

## Motivation

Svix server traces already support `x-request-id` and fall back to the SDK-generated `svix-req-id`. The Ruby SDK currently sends the internal `svix-req-id`, but callers cannot attach their own request id for end-to-end request correlation.

This addresses #2395.

## Changes

- Updates the Ruby API generator so generated API methods accept optional `options = {}`.
- Sends `options["request_id"]` as the `X-Request-Id` header on generated Ruby API requests.
- Uses `.compact` on generated header hashes so omitted `request_id` values are not sent.
- Updates Ruby extra API templates that define custom request helpers.
- Adds WebMock coverage for:
  - a method that already accepted options (`message.create`)
  - a method that previously did not accept options (`application.delete`)
  - omitted `request_id` not sending `X-Request-Id`

## Test plan

```bash
git diff --check