### PR TITLE
Make svix::models public and use it in place of svix::api for model imports

### DIFF
--- a/bridge/svix-bridge-plugin-kafka/tests/it/kafka_consumer.rs
+++ b/bridge/svix-bridge-plugin-kafka/tests/it/kafka_consumer.rs
@@ -14,7 +14,7 @@ use svix_bridge_plugin_kafka::{KafkaConsumer, KafkaInputOpts};
 use svix_bridge_types::{
     CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions, SvixSenderOutputOpts,
     TransformationConfig, TransformerInput, TransformerInputFormat, TransformerJob,
-    TransformerOutput, svix::api::MessageIn,
+    TransformerOutput, svix::models::MessageIn,
 };
 use tracing::info;
 use wiremock::{

--- a/bridge/svix-bridge-plugin-queue/tests/it/gcp_pubsub_consumer.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/it/gcp_pubsub_consumer.rs
@@ -19,7 +19,7 @@ use svix_bridge_plugin_queue::{
 use svix_bridge_types::{
     CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions, SvixSenderOutputOpts,
     TransformationConfig, TransformerInput, TransformerInputFormat, TransformerJob,
-    TransformerOutput, svix::api::MessageIn,
+    TransformerOutput, svix::models::MessageIn,
 };
 use wiremock::{
     Mock, MockServer, ResponseTemplate,

--- a/bridge/svix-bridge-plugin-queue/tests/it/rabbitmq_consumer.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/it/rabbitmq_consumer.rs
@@ -16,7 +16,7 @@ use svix_bridge_plugin_queue::{
 use svix_bridge_types::{
     CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions, SvixSenderOutputOpts,
     TransformationConfig, TransformerInput, TransformerInputFormat, TransformerJob,
-    TransformerOutput, svix::api::MessageIn,
+    TransformerOutput, svix::models::MessageIn,
 };
 use wiremock::{
     Mock, MockServer, ResponseTemplate,

--- a/bridge/svix-bridge-plugin-queue/tests/it/redis_stream_consumer.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/it/redis_stream_consumer.rs
@@ -12,7 +12,7 @@ use svix_bridge_plugin_queue::{
 use svix_bridge_types::{
     CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions, SvixSenderOutputOpts,
     TransformationConfig, TransformerInput, TransformerInputFormat, TransformerJob,
-    TransformerOutput, svix::api::MessageIn,
+    TransformerOutput, svix::models::MessageIn,
 };
 use wiremock::{
     Mock, MockServer, ResponseTemplate,

--- a/bridge/svix-bridge-plugin-queue/tests/it/sqs_consumer.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/it/sqs_consumer.rs
@@ -15,7 +15,7 @@ use svix_bridge_plugin_queue::{
 use svix_bridge_types::{
     CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions, SvixSenderOutputOpts,
     TransformationConfig, TransformerInput, TransformerInputFormat, TransformerJob,
-    TransformerOutput, svix::api::MessageIn,
+    TransformerOutput, svix::models::MessageIn,
 };
 use wiremock::{
     Mock, MockServer, ResponseTemplate,

--- a/bridge/svix-bridge-types/src/lib.rs
+++ b/bridge/svix-bridge-types/src/lib.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 pub use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 pub use svix;
-use svix::api::{MessageIn, SvixOptions as _SvixOptions};
+use svix::{api::SvixOptions as _SvixOptions, models::MessageIn};
 use tokio::sync::{mpsc, oneshot};
 
 #[derive(Deserialize, Default, Eq, PartialEq, Copy, Clone)]

--- a/bridge/svix-bridge/src/webhook_receiver/mod.rs
+++ b/bridge/svix-bridge/src/webhook_receiver/mod.rs
@@ -10,8 +10,9 @@ use svix_bridge_types::{
     ForwardRequest, PollerInput, ReceiverOutput, TransformationConfig, TransformerInput,
     TransformerInputFormat, TransformerJob, TransformerOutput, TransformerTx, async_trait,
     svix::{
-        api::{MessagePollerConsumerPollOptions, PollingEndpointMessageOut, Svix},
+        api::{MessagePollerConsumerPollOptions, Svix},
         error::Error,
+        models::PollingEndpointMessageOut,
     },
 };
 use tracing::instrument;

--- a/codegen/templates/svix-cli/api_resource.rs.jinja
+++ b/codegen/templates/svix-cli/api_resource.rs.jinja
@@ -18,7 +18,9 @@
 } -%}
 
 use clap::{Args, Subcommand};
-use svix::api::*;
+use svix::api::Svix;
+#[allow(unused_imports)]
+use svix::models::*;
 
 {% for _, sub in resource.subresources | items -%}
 use super::{{ sub.name | to_snake_case }}::{{ sub.name | to_upper_camel_case }}Args;

--- a/rust/src/api/deprecated.rs
+++ b/rust/src/api/deprecated.rs
@@ -5,7 +5,7 @@ pub type MessageAttemptListOptions = super::MessageAttemptListByMsgOptions;
 #[deprecated = "Use MessageAttemptListAttemptedDestinationsOptions instead"]
 pub type ListOptions = super::MessageAttemptListAttemptedDestinationsOptions;
 #[deprecated = "Use AppUsageStatsIn instead"]
-pub type AggregateAppStatsOptions = super::AppUsageStatsIn;
+pub type AggregateAppStatsOptions = crate::models::AppUsageStatsIn;
 
 #[deprecated]
 #[derive(Default)]

--- a/rust/src/autoconfig.rs
+++ b/rust/src/autoconfig.rs
@@ -1,8 +1,8 @@
 use crate::{
-    api::{EndpointIn, EndpointOut, Svix, SvixOptions},
+    api::{Svix, SvixOptions},
     api_internal,
     error::Result,
-    models::SubscribeIn,
+    models::{EndpointIn, EndpointOut, SubscribeIn},
     webhooks::{HeaderMap, Webhook, WebhookError},
 };
 

--- a/rust/src/autoconfig_consumer.rs
+++ b/rust/src/autoconfig_consumer.rs
@@ -1,9 +1,12 @@
 use crate::{
-    api::{EndpointOut, Svix, SvixOptions},
+    api::{Svix, SvixOptions},
     api_internal,
     autoconfig::{decode_autoconfig_token_v1, AutoConfigError},
     error::Result,
-    models::{AutoConfigSinkType, PollerV2CommitIn, PollerV2PollOut, SinkInCommon, SubscribeIn},
+    models::{
+        AutoConfigSinkType, EndpointOut, PollerV2CommitIn, PollerV2PollOut, SinkInCommon,
+        SubscribeIn,
+    },
 };
 
 // Re-exported so callers can name and construct the `options` arguments of

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -20,7 +20,7 @@ pub mod autoconfig_consumer;
 mod connector;
 pub mod error;
 mod model_ext;
-mod models;
+pub mod models;
 mod request;
 pub mod webhooks;
 

--- a/rust/src/model_ext.rs
+++ b/rust/src/model_ext.rs
@@ -10,10 +10,7 @@ use std::str::FromStr;
 
 use serde_json::json;
 
-use crate::{
-    api::{ConnectorProduct, MessageStatus, Ordering, StatusCodeClass},
-    models::MessageIn,
-};
+use crate::models::{ConnectorProduct, MessageIn, MessageStatus, Ordering, StatusCodeClass};
 
 impl MessageIn {
     /// Create a new message with a raw string payload.

--- a/rust/tests/it/kitchen_sink.rs
+++ b/rust/tests/it/kitchen_sink.rs
@@ -1,8 +1,8 @@
 use js_option::JsOption;
 use std::{collections::HashSet, time::Duration};
 use svix::{
-    api::{ApplicationIn, EndpointIn, EndpointPatch, EventTypeIn},
     error::Error,
+    models::{ApplicationIn, EndpointIn, EndpointPatch, EventTypeIn},
 };
 use wiremock::{Mock, MockServer, ResponseTemplate};
 

--- a/rust/tests/it/model_serialization.rs
+++ b/rust/tests/it/model_serialization.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, fmt::Debug};
 
 use serde::de::DeserializeOwned;
 use serde_json::json;
-use svix::api::{
+use svix::models::{
     CronConfig, IngestSourceIn, IngestSourceInConfig, IngestSourceOut, IngestSourceOutConfig,
     ListResponseApplicationOut, SegmentConfig, SegmentConfigOut, SvixConfig, SvixConfigOut,
 };

--- a/rust/tests/it/wiremock_tests.rs
+++ b/rust/tests/it/wiremock_tests.rs
@@ -1,5 +1,8 @@
 use serde_json::json;
-use svix::api::{MessageIn, MessageListOptions, Svix, SvixOptions};
+use svix::{
+    api::{MessageListOptions, Svix, SvixOptions},
+    models::{ApplicationIn, MessageIn},
+};
 
 use wiremock::{
     matchers::{method, path, query_param},
@@ -70,7 +73,7 @@ async fn test_idempotency_key_is_sent_for_create_request() {
     mock_server
         .svix_client()
         .application()
-        .create(svix::api::ApplicationIn::new("test app".to_string()), None)
+        .create(ApplicationIn::new("test app".to_string()), None)
         .await
         .unwrap();
 
@@ -106,7 +109,7 @@ async fn test_client_provided_idempotency_key_is_not_overridden() {
         .svix_client()
         .application()
         .create(
-            svix::api::ApplicationIn::new("test app".to_string()),
+            ApplicationIn::new("test app".to_string()),
             Some(svix::api::ApplicationCreateOptions {
                 idempotency_key: Some(client_provided_key.to_string()),
             }),

--- a/svix-cli/src/cmds/api/application.rs
+++ b/svix-cli/src/cmds/api/application.rs
@@ -1,6 +1,8 @@
 // this file is @generated
 use clap::{Args, Subcommand};
-use svix::api::*;
+use svix::api::Svix;
+#[allow(unused_imports)]
+use svix::models::*;
 
 #[derive(Args, Clone)]
 pub struct ApplicationListOptions {

--- a/svix-cli/src/cmds/api/authentication.rs
+++ b/svix-cli/src/cmds/api/authentication.rs
@@ -1,6 +1,8 @@
 // this file is @generated
 use clap::{Args, Subcommand};
-use svix::api::*;
+use svix::api::Svix;
+#[allow(unused_imports)]
+use svix::models::*;
 
 #[derive(Args, Clone)]
 pub struct AuthenticationAppPortalAccessOptions {

--- a/svix-cli/src/cmds/api/connector.rs
+++ b/svix-cli/src/cmds/api/connector.rs
@@ -1,6 +1,8 @@
 // this file is @generated
 use clap::{Args, Subcommand};
-use svix::api::*;
+use svix::api::Svix;
+#[allow(unused_imports)]
+use svix::models::*;
 
 #[derive(Args, Clone)]
 pub struct ConnectorListOptions {

--- a/svix-cli/src/cmds/api/endpoint.rs
+++ b/svix-cli/src/cmds/api/endpoint.rs
@@ -1,6 +1,8 @@
 // this file is @generated
 use clap::{Args, Subcommand};
-use svix::api::*;
+use svix::api::Svix;
+#[allow(unused_imports)]
+use svix::models::*;
 
 #[derive(Args, Clone)]
 pub struct EndpointListOptions {

--- a/svix-cli/src/cmds/api/environment.rs
+++ b/svix-cli/src/cmds/api/environment.rs
@@ -1,6 +1,8 @@
 // this file is @generated
 use clap::{Args, Subcommand};
-use svix::api::*;
+use svix::api::Svix;
+#[allow(unused_imports)]
+use svix::models::*;
 
 #[derive(Args, Clone)]
 pub struct EnvironmentExportOptions {

--- a/svix-cli/src/cmds/api/event_type.rs
+++ b/svix-cli/src/cmds/api/event_type.rs
@@ -1,6 +1,8 @@
 // this file is @generated
 use clap::{Args, Subcommand};
-use svix::api::*;
+use svix::api::Svix;
+#[allow(unused_imports)]
+use svix::models::*;
 
 #[derive(Args, Clone)]
 pub struct EventTypeListOptions {

--- a/svix-cli/src/cmds/api/health.rs
+++ b/svix-cli/src/cmds/api/health.rs
@@ -1,6 +1,8 @@
 // this file is @generated
 use clap::{Args, Subcommand};
-use svix::api::*;
+use svix::api::Svix;
+#[allow(unused_imports)]
+use svix::models::*;
 
 #[derive(Args)]
 #[command(args_conflicts_with_subcommands = true, flatten_help = true)]

--- a/svix-cli/src/cmds/api/ingest.rs
+++ b/svix-cli/src/cmds/api/ingest.rs
@@ -1,6 +1,8 @@
 // this file is @generated
 use clap::{Args, Subcommand};
-use svix::api::*;
+use svix::api::Svix;
+#[allow(unused_imports)]
+use svix::models::*;
 
 use super::{ingest_endpoint::IngestEndpointArgs, ingest_source::IngestSourceArgs};
 #[derive(Args, Clone)]

--- a/svix-cli/src/cmds/api/ingest_endpoint.rs
+++ b/svix-cli/src/cmds/api/ingest_endpoint.rs
@@ -1,6 +1,8 @@
 // this file is @generated
 use clap::{Args, Subcommand};
-use svix::api::*;
+use svix::api::Svix;
+#[allow(unused_imports)]
+use svix::models::*;
 
 #[derive(Args, Clone)]
 pub struct IngestEndpointListOptions {

--- a/svix-cli/src/cmds/api/ingest_source.rs
+++ b/svix-cli/src/cmds/api/ingest_source.rs
@@ -1,6 +1,8 @@
 // this file is @generated
 use clap::{Args, Subcommand};
-use svix::api::*;
+use svix::api::Svix;
+#[allow(unused_imports)]
+use svix::models::*;
 
 #[derive(Args, Clone)]
 pub struct IngestSourceListOptions {

--- a/svix-cli/src/cmds/api/integration.rs
+++ b/svix-cli/src/cmds/api/integration.rs
@@ -1,6 +1,8 @@
 // this file is @generated
 use clap::{Args, Subcommand};
-use svix::api::*;
+use svix::api::Svix;
+#[allow(unused_imports)]
+use svix::models::*;
 
 #[derive(Args, Clone)]
 pub struct IntegrationListOptions {

--- a/svix-cli/src/cmds/api/message.rs
+++ b/svix-cli/src/cmds/api/message.rs
@@ -1,6 +1,8 @@
 // this file is @generated
 use clap::{Args, Subcommand};
-use svix::api::*;
+use svix::api::Svix;
+#[allow(unused_imports)]
+use svix::models::*;
 
 use super::message_poller::MessagePollerArgs;
 #[derive(Args, Clone)]

--- a/svix-cli/src/cmds/api/message_attempt.rs
+++ b/svix-cli/src/cmds/api/message_attempt.rs
@@ -1,6 +1,8 @@
 // this file is @generated
 use clap::{Args, Subcommand};
-use svix::api::*;
+use svix::api::Svix;
+#[allow(unused_imports)]
+use svix::models::*;
 
 #[derive(Args, Clone)]
 pub struct MessageAttemptListByEndpointOptions {

--- a/svix-cli/src/cmds/api/message_poller.rs
+++ b/svix-cli/src/cmds/api/message_poller.rs
@@ -1,6 +1,8 @@
 // this file is @generated
 use clap::{Args, Subcommand};
-use svix::api::*;
+use svix::api::Svix;
+#[allow(unused_imports)]
+use svix::models::*;
 
 #[derive(Args, Clone)]
 pub struct MessagePollerPollOptions {

--- a/svix-cli/src/cmds/api/operational_webhook.rs
+++ b/svix-cli/src/cmds/api/operational_webhook.rs
@@ -1,6 +1,8 @@
 // this file is @generated
 use clap::{Args, Subcommand};
-use svix::api::*;
+use svix::api::Svix;
+#[allow(unused_imports)]
+use svix::models::*;
 
 use super::operational_webhook_endpoint::OperationalWebhookEndpointArgs;
 

--- a/svix-cli/src/cmds/api/operational_webhook_endpoint.rs
+++ b/svix-cli/src/cmds/api/operational_webhook_endpoint.rs
@@ -1,6 +1,8 @@
 // this file is @generated
 use clap::{Args, Subcommand};
-use svix::api::*;
+use svix::api::Svix;
+#[allow(unused_imports)]
+use svix::models::*;
 
 #[derive(Args, Clone)]
 pub struct OperationalWebhookEndpointListOptions {

--- a/svix-cli/src/cmds/api/streaming.rs
+++ b/svix-cli/src/cmds/api/streaming.rs
@@ -1,6 +1,8 @@
 // this file is @generated
 use clap::{Args, Subcommand};
-use svix::api::*;
+use svix::api::Svix;
+#[allow(unused_imports)]
+use svix::models::*;
 
 use super::{
     streaming_event_type::StreamingEventTypeArgs, streaming_events::StreamingEventsArgs,

--- a/svix-cli/src/cmds/api/streaming_event_type.rs
+++ b/svix-cli/src/cmds/api/streaming_event_type.rs
@@ -1,6 +1,8 @@
 // this file is @generated
 use clap::{Args, Subcommand};
-use svix::api::*;
+use svix::api::Svix;
+#[allow(unused_imports)]
+use svix::models::*;
 
 #[derive(Args, Clone)]
 pub struct StreamingEventTypeListOptions {

--- a/svix-cli/src/cmds/api/streaming_events.rs
+++ b/svix-cli/src/cmds/api/streaming_events.rs
@@ -1,6 +1,8 @@
 // this file is @generated
 use clap::{Args, Subcommand};
-use svix::api::*;
+use svix::api::Svix;
+#[allow(unused_imports)]
+use svix::models::*;
 
 #[derive(Args, Clone)]
 pub struct StreamingEventsGetOptions {

--- a/svix-cli/src/cmds/api/streaming_sink.rs
+++ b/svix-cli/src/cmds/api/streaming_sink.rs
@@ -1,6 +1,8 @@
 // this file is @generated
 use clap::{Args, Subcommand};
-use svix::api::*;
+use svix::api::Svix;
+#[allow(unused_imports)]
+use svix::models::*;
 
 #[derive(Args, Clone)]
 pub struct StreamingSinkListOptions {

--- a/svix-cli/src/cmds/api/streaming_stream.rs
+++ b/svix-cli/src/cmds/api/streaming_stream.rs
@@ -1,6 +1,8 @@
 // this file is @generated
 use clap::{Args, Subcommand};
-use svix::api::*;
+use svix::api::Svix;
+#[allow(unused_imports)]
+use svix::models::*;
 
 #[derive(Args, Clone)]
 pub struct StreamingStreamListOptions {

--- a/svix-cli/src/cmds/seed.rs
+++ b/svix-cli/src/cmds/seed.rs
@@ -3,7 +3,12 @@ use clap::Args;
 use rand::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use svix::api::*;
+use svix::{
+    api::{EventTypeDeleteOptions, Svix},
+    models::{
+        ApplicationIn, ApplicationOut, EndpointIn, EndpointOut, EventTypeIn, MessageIn, MessageOut,
+    },
+};
 
 #[derive(Args)]
 struct SeedOptions {


### PR DESCRIPTION
Same as diom, other Svix SDKs.