### PR TITLE
rust: Default-related cleanup

### DIFF
--- a/codegen/templates/svix-cli/api_resource.rs.jinja
+++ b/codegen/templates/svix-cli/api_resource.rs.jinja
@@ -212,7 +212,7 @@ pub enum {{ resource_type_name }}Commands {
                 {% set body_schema_all_optional = body_schema.fields | selectattr("required") | length == 0 -%}
 
                 {{ op.request_body_schema_name | to_snake_case }}:
-                {% if body_schema_all_optional %}
+                {% if body_schema.kind == "struct" and body_schema_all_optional %}
                 Option<crate::json::JsonOf<{{ op.request_body_schema_name }}>>
                 {% else %}
                 crate::json::JsonOf<{{ op.request_body_schema_name }}>
@@ -293,7 +293,7 @@ impl {{ resource_type_name }}Commands {
                                     = body_schema.fields | selectattr("required") | length == 0 -%}
 
                                 {{ op.request_body_schema_name | to_snake_case }}
-                                {% if body_schema_all_optional -%}
+                                {% if body_schema.kind == "struct" and body_schema_all_optional -%}
                                     .unwrap_or_default()
                                 {% endif -%}
                                     .into_inner(),

--- a/rust/tests/it/kitchen_sink.rs
+++ b/rust/tests/it/kitchen_sink.rs
@@ -30,13 +30,7 @@ async fn test_endpoint_crud() {
 
     let app = client
         .application()
-        .create(
-            ApplicationIn {
-                name: "app".to_string(),
-                ..Default::default()
-            },
-            None,
-        )
+        .create(ApplicationIn::new("app".to_owned()), None)
         .await
         .unwrap();
 
@@ -44,9 +38,15 @@ async fn test_endpoint_crud() {
         .event_type()
         .create(
             EventTypeIn {
-                name: String::from("event.started"),
-                description: String::from("Something started"),
-                ..Default::default()
+                name: "event.started".to_owned(),
+                description: "Something started".to_owned(),
+                archived: None,
+                deprecated: None,
+                #[expect(deprecated)]
+                feature_flag: None,
+                feature_flags: None,
+                group_name: None,
+                schemas: None,
             },
             None,
         )
@@ -59,9 +59,15 @@ async fn test_endpoint_crud() {
         .event_type()
         .create(
             EventTypeIn {
-                name: String::from("event.ended"),
-                description: String::from("Something ended"),
-                ..Default::default()
+                name: "event.ended".to_owned(),
+                description: "Something ended".to_owned(),
+                archived: None,
+                deprecated: None,
+                #[expect(deprecated)]
+                feature_flag: None,
+                feature_flags: None,
+                group_name: None,
+                schemas: None,
             },
             None,
         )
@@ -76,8 +82,7 @@ async fn test_endpoint_crud() {
             app.id.clone(),
             EndpointIn {
                 channels: Some(vec![String::from("ch0"), String::from("ch1")]),
-                url: String::from("https://example.svix.com/"),
-                ..Default::default()
+                ..EndpointIn::new("https://example.svix.com/".to_owned())
             },
             None,
         )
@@ -101,7 +106,7 @@ async fn test_endpoint_crud() {
                     String::from("event.started"),
                     String::from("event.ended"),
                 ]),
-                ..Default::default()
+                ..EndpointPatch::new()
             },
         )
         .await
@@ -172,13 +177,7 @@ async fn test_default_retries() {
 
     let app = client
         .application()
-        .create(
-            ApplicationIn {
-                name: "app".to_string(),
-                ..Default::default()
-            },
-            None,
-        )
+        .create(ApplicationIn::new("app".to_owned()), None)
         .await;
     assert!(app.is_err());
 
@@ -222,13 +221,7 @@ async fn test_custom_retries() {
 
     let app = client
         .application()
-        .create(
-            ApplicationIn {
-                name: "app".to_string(),
-                ..Default::default()
-            },
-            None,
-        )
+        .create(ApplicationIn::new("app".to_owned()), None)
         .await;
     assert!(app.is_err());
 
@@ -274,13 +267,7 @@ async fn test_custom_retry_schedule() {
 
     let app = client
         .application()
-        .create(
-            ApplicationIn {
-                name: "app".to_string(),
-                ..Default::default()
-            },
-            None,
-        )
+        .create(ApplicationIn::new("app".to_owned()), None)
         .await;
     assert!(app.is_err());
 

--- a/rust/tests/it/model_serialization.rs
+++ b/rust/tests/it/model_serialization.rs
@@ -30,7 +30,8 @@ fn test_list_response_xxx_out() {
     let expected_model = ListResponseApplicationOut {
         data: vec![],
         done: true,
-        ..Default::default()
+        iterator: None,
+        prev_iterator: None,
     };
 
     assert_eq!(expected_model, loaded_json);
@@ -172,7 +173,7 @@ fn test_ingest_source_out() {
             name: "foo".to_owned(),
             uid: None,
             updated_at: "2006-01-02T15:04:05Z".to_owned(),
-            config: IngestSourceOutConfig::Segment(SegmentConfigOut::default()),
+            config: IngestSourceOutConfig::Segment(SegmentConfigOut::new()),
             metadata: HashMap::new(),
         },
     );

--- a/svix-cli/src/cmds/api/streaming_sink.rs
+++ b/svix-cli/src/cmds/api/streaming_sink.rs
@@ -121,7 +121,7 @@ pub enum StreamingSinkCommands {
 }\n")]
     Create {
         stream_id: String,
-        stream_sink_in: Option<crate::json::JsonOf<StreamSinkIn>>,
+        stream_sink_in: crate::json::JsonOf<StreamSinkIn>,
         #[clap(flatten)]
         options: StreamingSinkCreateOptions,
     },
@@ -185,7 +185,7 @@ pub enum StreamingSinkCommands {
     Update {
         stream_id: String,
         sink_id: String,
-        stream_sink_in: Option<crate::json::JsonOf<StreamSinkIn>>,
+        stream_sink_in: crate::json::JsonOf<StreamSinkIn>,
     },
     /// Delete a sink.
     #[command(help_template = concat!(
@@ -232,7 +232,7 @@ pub enum StreamingSinkCommands {
     Patch {
         stream_id: String,
         sink_id: String,
-        stream_sink_patch: Option<crate::json::JsonOf<StreamSinkPatch>>,
+        stream_sink_patch: crate::json::JsonOf<StreamSinkPatch>,
     },
     /// Set or unset the transformation code associated with this sink.
     #[command(help_template = concat!(
@@ -320,11 +320,7 @@ impl StreamingSinkCommands {
                 let resp = client
                     .streaming()
                     .sink()
-                    .create(
-                        stream_id,
-                        stream_sink_in.unwrap_or_default().into_inner(),
-                        Some(options.into()),
-                    )
+                    .create(stream_id, stream_sink_in.into_inner(), Some(options.into()))
                     .await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
@@ -340,11 +336,7 @@ impl StreamingSinkCommands {
                 let resp = client
                     .streaming()
                     .sink()
-                    .update(
-                        stream_id,
-                        sink_id,
-                        stream_sink_in.unwrap_or_default().into_inner(),
-                    )
+                    .update(stream_id, sink_id, stream_sink_in.into_inner())
                     .await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }
@@ -359,11 +351,7 @@ impl StreamingSinkCommands {
                 let resp = client
                     .streaming()
                     .sink()
-                    .patch(
-                        stream_id,
-                        sink_id,
-                        stream_sink_patch.unwrap_or_default().into_inner(),
-                    )
+                    .patch(stream_id, sink_id, stream_sink_patch.into_inner())
                     .await?;
                 crate::json::print_json_output(&resp, color_mode)?;
             }

--- a/svix-cli/src/cmds/seed.rs
+++ b/svix-cli/src/cmds/seed.rs
@@ -26,7 +26,7 @@ pub struct SeedArgs {
     options: SeedOptions,
 }
 
-#[derive(Debug, Serialize, Default)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct SeedOut {
     application: ApplicationOut,
@@ -49,10 +49,6 @@ pub async fn exec(
     args: SeedArgs,
     color_mode: colored_json::ColorMode,
 ) -> anyhow::Result<()> {
-    let mut seed_out = SeedOut {
-        ..Default::default()
-    };
-
     if args.options.reset {
         let confirmation = dialoguer::Confirm::new()
          .with_prompt("This will clear out all the applications and event types! Do you want to continue? ")
@@ -67,13 +63,15 @@ pub async fn exec(
         }
     }
 
-    let application_in = ApplicationIn {
-        name: "Test application".to_string(),
-        ..Default::default()
-    };
+    let application_in = ApplicationIn::new("Test application".to_owned());
     let application_out = client.application().create(application_in, None).await?;
 
-    seed_out.application = application_out.clone();
+    let mut seed_out = SeedOut {
+        application: application_out.clone(),
+        endpoints: Vec::new(),
+        event_types: Vec::new(),
+        messages: Vec::new(),
+    };
 
     let app_id = application_out.id;
 
@@ -97,8 +95,13 @@ pub async fn exec(
         let event_type_in = EventTypeIn {
             name: format!("user.{typ}"),
             description: "".to_string(),
-            schemas: Some(json!(schema_example())),
-            ..Default::default()
+            schemas: Some(schema_example()),
+            archived: None,
+            deprecated: None,
+            #[expect(deprecated)]
+            feature_flag: None,
+            feature_flags: None,
+            group_name: None,
         };
         let res = client.event_type().create(event_type_in, None).await;
 
@@ -153,28 +156,24 @@ async fn create_endpoint(client: Svix, app_id: String) -> anyhow::Result<Endpoin
         .await
         .context("Failed to get token from public api")?;
 
-    let endpoint_in = EndpointIn {
-        url: format!("https://play.svix.com/in/{}/", resp.token),
-        ..Default::default()
-    };
+    let endpoint_in = EndpointIn::new(format!("https://play.svix.com/in/{}/", resp.token));
     let endpoint_out = client.endpoint().create(app_id, endpoint_in, None).await?;
     Ok(endpoint_out)
 }
 
 async fn create_message(client: Svix, app_id: String) -> anyhow::Result<MessageOut> {
-    let event_type = USER_EVENT_TYPES
+    let event_type = *USER_EVENT_TYPES
         .choose(&mut rand::rng())
         .context("Couldn't pick a random event type while creating a message")?;
 
-    let message_in = MessageIn {
-        event_type: event_type.to_string(),
-        payload: json!({
+    let message_in = MessageIn::new(
+        event_type.to_owned(),
+        json!({
             "userId": "41376126-35bf-4eda-81ef-83d741b0e026",
             "firstName": "John",
             "lastName": "Doe",
         }),
-        ..Default::default()
-    };
+    );
 
     let message_out = client.message().create(app_id, message_in, None).await?;
     Ok(message_out)


### PR DESCRIPTION
A bunch of `Default` implementations that did not yield meaningful "default" values will be removed with SDK-v2. Drop usage of them ahead of the big SDK-v2 PR.