### PR TITLE
codegen: Make ruby require_api macro recursive

### DIFF
--- a/codegen/templates/ruby/summary.rb.jinja
+++ b/codegen/templates/ruby/summary.rb.jinja
@@ -9,16 +9,16 @@ require "logger"
 
 {% macro require_api(resource) -%}
 require "svix/api/{{ resource.name | to_snake_case }}"
-{% endmacro -%}
+    {%- for _resource_name, resource in resource.subresources | items %}
+{{ require_api(resource) }}
+    {%- endfor %}
+{%- endmacro -%}
 
 
 # API
-{% for resource in api.resources -%}
-{{ require_api(resource) -}}
-    {% for _resource_name, resource in resource.subresources | items -%}
-{{ require_api(resource) -}}
-    {% endfor -%}
-{% endfor -%}
+{%- for resource in api.resources %}
+{{ require_api(resource) }}
+{%- endfor %}
 
 # Models
 {% for type in api.types -%}


### PR DESCRIPTION
Needed for SDK-v2 because it contains some subresources-of-subresources (e.g. `svix.ingest.endpoint.transformation`).