### PR TITLE
cli: ignore EPIPE

### DIFF
--- a/svix-cli/src/json.rs
+++ b/svix-cli/src/json.rs
@@ -1,7 +1,7 @@
 use std::{io::Read, str::FromStr};
 
 use anyhow::{Context, Error, Result};
-use colored_json::{Color, ColorMode, ToColoredJson};
+use colored_json::{Color, ColorMode, ColoredFormatter, PrettyFormatter};
 use serde::{de::DeserializeOwned, Serialize};
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -30,20 +30,38 @@ impl<T> JsonOf<T> {
     }
 }
 
+fn serialize_json<T, F>(val: &T, formatter: F) -> Result<()>
+where
+    T: Serialize,
+    F: serde_json::ser::Formatter,
+{
+    let stdout = std::io::stdout().lock();
+    let mut serializer = serde_json::Serializer::with_formatter(stdout, formatter);
+    match val.serialize(&mut serializer) {
+        Ok(_) => Ok(()),
+        Err(e) if matches!(e.io_error_kind(), Some(std::io::ErrorKind::BrokenPipe)) => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}
+
 pub fn print_json_output<T>(val: &T, color_mode: ColorMode) -> Result<()>
 where
     T: Serialize,
 {
-    let styler = colored_json::Styler {
-        integer_value: Color::Green.foreground(),
-        float_value: Color::Green.foreground(),
-        bool_value: Color::Yellow.foreground(),
-        nil_value: Color::Magenta.foreground(),
-        string_include_quotation: true,
-        ..Default::default()
-    };
-    let s = serde_json::to_string_pretty(val)?.to_colored_json_with_styler(color_mode, styler)?;
-
-    println!("{s}");
-    Ok(())
+    if color_mode.use_color() {
+        let styler = colored_json::Styler {
+            integer_value: Color::Green.foreground(),
+            float_value: Color::Green.foreground(),
+            bool_value: Color::Yellow.foreground(),
+            nil_value: Color::Magenta.foreground(),
+            string_include_quotation: true,
+            ..Default::default()
+        };
+        serialize_json(
+            val,
+            ColoredFormatter::with_styler(PrettyFormatter::new(), styler),
+        )
+    } else {
+        serialize_json(val, PrettyFormatter::new())
+    }
 }


### PR DESCRIPTION
This improves the CLI to ignore EPIPE when writing to stdout; basically the same as svix/diom#1286