### PR TITLE
python: Reuse httpx clients

### DIFF
--- a/codegen/templates/python/api_resource.py.jinja
+++ b/codegen/templates/python/api_resource.py.jinja
@@ -90,7 +90,7 @@ class {{ resource.name | to_upper_camel_case }}{% if is_async %}Async{% endif %}
     {%- set sub_type_name %}{{ sub.name | to_upper_camel_case }}{% if is_async %}Async{% endif %}{% endset %}
     @property
     def {{ name | to_snake_case }}(self) -> {{ sub_type_name }}:
-        return {{ sub_type_name }}(self._client)
+        return {{ sub_type_name }}(self._client, self._httpx_client)
 
     {% endfor %}
 

--- a/codegen/templates/python/api_resource.py.jinja
+++ b/codegen/templates/python/api_resource.py.jinja
@@ -6,7 +6,7 @@ import typing as t
 from datetime import datetime
 from dataclasses import dataclass
 from deprecated import deprecated
-from .common import ApiBase, BaseOptions, serialize_params
+from .common import ApiBaseAsync, ApiBaseSync, BaseOptions, serialize_params
 from .. import models
 
 {% for c in referenced_components -%}
@@ -84,7 +84,8 @@ class {{ resource_type_name }}{{ op.name | to_upper_camel_case }}Options(BaseOpt
 
 
 {% for is_async in [true, false] %}
-class {{ resource.name | to_upper_camel_case }}{% if is_async %}Async{% endif %}(ApiBase):
+{% set sync_bit %}{% if is_async %}Async{% else %}Sync{% endif %}{% endset -%}
+class {{ resource.name | to_upper_camel_case }}{% if is_async %}Async{% endif %}(ApiBase{{ sync_bit }}):
     {%- for name, sub in resource.subresources | items %}
     {%- set sub_type_name %}{{ sub.name | to_upper_camel_case }}{% if is_async %}Async{% endif %}{% endset %}
     @property

--- a/codegen/templates/python/summary.py.jinja
+++ b/codegen/templates/python/summary.py.jinja
@@ -4,6 +4,7 @@
 import typing as t
 import platform
 from dataclasses import field, dataclass
+import httpx
 
 {% for resource in api.resources %}
 from .{{ resource.name | to_snake_case }} import {{ resource.name | to_upper_camel_case }}, {{ resource.name | to_upper_camel_case }}Async
@@ -13,6 +14,7 @@ from .operational_webhook_endpoint import (
     OperationalWebhookEndpointAsync,
 )
 from .client import AuthenticatedClient
+from .common import _make_httpx_async_client, _make_httpx_client
 
 DEFAULT_SERVER_URL = "https://api.svix.com"
 
@@ -87,25 +89,37 @@ class ClientBase:
 
 
 class SvixAsync(ClientBase):
+    _httpx_client: httpx.AsyncClient
+
+    def __init__(self, auth_token: str, options: SvixOptions = SvixOptions()):
+        super().__init__(auth_token, options)
+        self._httpx_client = _make_httpx_async_client(self._client)
+
 {% for resource in api.resources %}
     @property
     def {{ resource.name | to_snake_case }}(self) -> {{ resource.name | to_upper_camel_case }}Async:
-        return {{ resource.name | to_upper_camel_case }}Async(self._client)
+        return {{ resource.name | to_upper_camel_case }}Async(self._client, self._httpx_client)
 {% endfor %}
     {# here for backwards compatibly #}
     @property
     def operational_webhook_endpoint(self) -> OperationalWebhookEndpointAsync:
-        return OperationalWebhookEndpointAsync(self._client)
+        return OperationalWebhookEndpointAsync(self._client, self._httpx_client)
 
 
 class Svix(ClientBase):
+    _httpx_client: httpx.Client
+
+    def __init__(self, auth_token: str, options: SvixOptions = SvixOptions()):
+        super().__init__(auth_token, options)
+        self._httpx_client = _make_httpx_client(self._client)
+
 {% for resource in api.resources %}
     @property
     def {{ resource.name | to_snake_case }}(self) -> {{ resource.name | to_upper_camel_case }}:
-        return {{ resource.name | to_upper_camel_case }}(self._client)
+        return {{ resource.name | to_upper_camel_case }}(self._client, self._httpx_client)
 {% endfor %}
 
     {# here for backwards compatibly #}
     @property
     def operational_webhook_endpoint(self) -> OperationalWebhookEndpoint:
-        return OperationalWebhookEndpoint(self._client)
+        return OperationalWebhookEndpoint(self._client, self._httpx_client)

--- a/python/svix/api/application.py
+++ b/python/svix/api/application.py
@@ -9,7 +9,7 @@ from ..models import (
     ApplicationPatch,
     ListResponseApplicationOut,
 )
-from .common import ApiBase, BaseOptions, serialize_params
+from .common import ApiBaseAsync, ApiBaseSync, BaseOptions, serialize_params
 
 
 @dataclass
@@ -52,7 +52,7 @@ class ApplicationCreateOptions(BaseOptions):
         )
 
 
-class ApplicationAsync(ApiBase):
+class ApplicationAsync(ApiBaseAsync):
     async def list(
         self, options: ApplicationListOptions = (ApplicationListOptions())
     ) -> ListResponseApplicationOut:
@@ -149,7 +149,7 @@ class ApplicationAsync(ApiBase):
         return ApplicationOut.model_validate(response.json())
 
 
-class Application(ApiBase):
+class Application(ApiBaseSync):
     def list(
         self, options: ApplicationListOptions = (ApplicationListOptions())
     ) -> ListResponseApplicationOut:

--- a/python/svix/api/authentication.py
+++ b/python/svix/api/authentication.py
@@ -14,7 +14,7 @@ from ..models import (
     StreamPortalAccessIn,
     StreamTokenExpireIn,
 )
-from .common import ApiBase, BaseOptions, serialize_params
+from .common import ApiBaseAsync, ApiBaseSync, BaseOptions, serialize_params
 
 
 @dataclass
@@ -113,7 +113,7 @@ class AuthenticationDashboardAccessOptions(BaseOptions):
         )
 
 
-class AuthenticationAsync(ApiBase):
+class AuthenticationAsync(ApiBaseAsync):
     async def app_portal_access(
         self,
         app_id: str,
@@ -291,7 +291,7 @@ class AuthenticationAsync(ApiBase):
         return ApiTokenOut.model_validate(response.json())
 
 
-class Authentication(ApiBase):
+class Authentication(ApiBaseSync):
     def app_portal_access(
         self,
         app_id: str,

--- a/python/svix/api/background_task.py
+++ b/python/svix/api/background_task.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 from .. import models
 from ..models import BackgroundTaskOut, ListResponseBackgroundTaskOut
-from .common import ApiBase, BaseOptions, serialize_params
+from .common import ApiBaseAsync, ApiBaseSync, BaseOptions, serialize_params
 
 
 @dataclass
@@ -32,7 +32,7 @@ class BackgroundTaskListOptions(BaseOptions):
         )
 
 
-class BackgroundTaskAsync(ApiBase):
+class BackgroundTaskAsync(ApiBaseAsync):
     async def list(
         self, options: BackgroundTaskListOptions = (BackgroundTaskListOptions())
     ) -> ListResponseBackgroundTaskOut:
@@ -58,7 +58,7 @@ class BackgroundTaskAsync(ApiBase):
         return BackgroundTaskOut.model_validate(response.json())
 
 
-class BackgroundTask(ApiBase):
+class BackgroundTask(ApiBaseSync):
     def list(
         self, options: BackgroundTaskListOptions = (BackgroundTaskListOptions())
     ) -> ListResponseBackgroundTaskOut:

--- a/python/svix/api/common.py
+++ b/python/svix/api/common.py
@@ -120,23 +120,13 @@ class ApiBase:
 class ApiBaseAsync(ApiBase):
     _httpx_client: httpx.AsyncClient
 
-    def __init__(self, client: AuthenticatedClient):
+    def __init__(
+        self,
+        client: AuthenticatedClient,
+        httpx_async_client: httpx.AsyncClient,
+    ):
         super().__init__(client)
-        if self._client.proxy is not None:
-            async_proxy_mounts = {
-                "http://": httpx.AsyncHTTPTransport(
-                    proxy=httpx.Proxy(self._client.proxy)
-                ),
-                "https://": httpx.AsyncHTTPTransport(
-                    proxy=httpx.Proxy(self._client.proxy)
-                ),
-            }
-        else:
-            async_proxy_mounts = None
-
-        self._httpx_client = httpx.AsyncClient(
-            mounts=async_proxy_mounts, cookies=self._client.get_cookies()
-        )
+        self._httpx_client = httpx_async_client
 
     async def _request_asyncio(
         self,
@@ -172,19 +162,9 @@ class ApiBaseAsync(ApiBase):
 class ApiBaseSync(ApiBase):
     _httpx_client: httpx.Client
 
-    def __init__(self, client: AuthenticatedClient):
+    def __init__(self, client: AuthenticatedClient, httpx_client: httpx.Client):
         super().__init__(client)
-        if self._client.proxy is not None:
-            proxy_mounts = {
-                "http://": httpx.HTTPTransport(proxy=httpx.Proxy(self._client.proxy)),
-                "https://": httpx.HTTPTransport(proxy=httpx.Proxy(self._client.proxy)),
-            }
-        else:
-            proxy_mounts = None
-
-        self._httpx_client = httpx.Client(
-            mounts=proxy_mounts, cookies=self._client.get_cookies()
-        )
+        self._httpx_client = httpx_client
 
     def _request_sync(
         self,
@@ -213,6 +193,30 @@ class ApiBaseSync(ApiBase):
             response = self._httpx_client.request(**httpx_kwargs)
 
         return _filter_response_for_errors_response(response)
+
+
+def _make_httpx_async_client(client: AuthenticatedClient) -> httpx.AsyncClient:
+    if client.proxy is not None:
+        async_proxy_mounts = {
+            "http://": httpx.AsyncHTTPTransport(proxy=httpx.Proxy(client.proxy)),
+            "https://": httpx.AsyncHTTPTransport(proxy=httpx.Proxy(client.proxy)),
+        }
+    else:
+        async_proxy_mounts = None
+
+    return httpx.AsyncClient(mounts=async_proxy_mounts, cookies=client.get_cookies())
+
+
+def _make_httpx_client(client: AuthenticatedClient) -> httpx.Client:
+    if client.proxy is not None:
+        proxy_mounts = {
+            "http://": httpx.HTTPTransport(proxy=httpx.Proxy(client.proxy)),
+            "https://": httpx.HTTPTransport(proxy=httpx.Proxy(client.proxy)),
+        }
+    else:
+        proxy_mounts = None
+
+    return httpx.Client(mounts=proxy_mounts, cookies=client.get_cookies())
 
 
 def _filter_response_for_errors_response(response: httpx.Response) -> httpx.Response:

--- a/python/svix/api/common.py
+++ b/python/svix/api/common.py
@@ -70,35 +70,9 @@ class PostOptions(BaseOptions):
 
 class ApiBase:
     _client: AuthenticatedClient
-    _httpx_client: httpx.Client
-    _httpx_async_client: httpx.AsyncClient
 
     def __init__(self, client: AuthenticatedClient) -> None:
         self._client = client
-
-        if self._client.proxy is not None:
-            proxy_mounts = {
-                "http://": httpx.HTTPTransport(proxy=httpx.Proxy(self._client.proxy)),
-                "https://": httpx.HTTPTransport(proxy=httpx.Proxy(self._client.proxy)),
-            }
-            async_proxy_mounts = {
-                "http://": httpx.AsyncHTTPTransport(
-                    proxy=httpx.Proxy(self._client.proxy)
-                ),
-                "https://": httpx.AsyncHTTPTransport(
-                    proxy=httpx.Proxy(self._client.proxy)
-                ),
-            }
-        else:
-            proxy_mounts = None
-            async_proxy_mounts = None
-
-        self._httpx_client = httpx.Client(
-            mounts=proxy_mounts, cookies=self._client.get_cookies()
-        )
-        self._httpx_async_client = httpx.AsyncClient(
-            mounts=async_proxy_mounts, cookies=self._client.get_cookies()
-        )
 
     def _get_httpx_kwargs(
         self,
@@ -142,6 +116,28 @@ class ApiBase:
 
         return httpx_kwargs
 
+
+class ApiBaseAsync(ApiBase):
+    _httpx_client: httpx.AsyncClient
+
+    def __init__(self, client: AuthenticatedClient):
+        super().__init__(client)
+        if self._client.proxy is not None:
+            async_proxy_mounts = {
+                "http://": httpx.AsyncHTTPTransport(
+                    proxy=httpx.Proxy(self._client.proxy)
+                ),
+                "https://": httpx.AsyncHTTPTransport(
+                    proxy=httpx.Proxy(self._client.proxy)
+                ),
+            }
+        else:
+            async_proxy_mounts = None
+
+        self._httpx_client = httpx.AsyncClient(
+            mounts=async_proxy_mounts, cookies=self._client.get_cookies()
+        )
+
     async def _request_asyncio(
         self,
         method: str,
@@ -160,7 +156,7 @@ class ApiBase:
             json_body=json_body,
         )
 
-        response = await self._httpx_async_client.request(**httpx_kwargs)
+        response = await self._httpx_client.request(**httpx_kwargs)
 
         for retry_count, sleep_time in enumerate(self._client.retry_schedule):
             if response.status_code < 500:
@@ -168,9 +164,27 @@ class ApiBase:
 
             await asyncio.sleep(sleep_time)
             httpx_kwargs["headers"]["svix-retry-count"] = str(retry_count)
-            response = await self._httpx_async_client.request(**httpx_kwargs)
+            response = await self._httpx_client.request(**httpx_kwargs)
 
         return _filter_response_for_errors_response(response)
+
+
+class ApiBaseSync(ApiBase):
+    _httpx_client: httpx.Client
+
+    def __init__(self, client: AuthenticatedClient):
+        super().__init__(client)
+        if self._client.proxy is not None:
+            proxy_mounts = {
+                "http://": httpx.HTTPTransport(proxy=httpx.Proxy(self._client.proxy)),
+                "https://": httpx.HTTPTransport(proxy=httpx.Proxy(self._client.proxy)),
+            }
+        else:
+            proxy_mounts = None
+
+        self._httpx_client = httpx.Client(
+            mounts=proxy_mounts, cookies=self._client.get_cookies()
+        )
 
     def _request_sync(
         self,

--- a/python/svix/api/connector.py
+++ b/python/svix/api/connector.py
@@ -10,7 +10,7 @@ from ..models import (
     ConnectorUpdate,
     ListResponseConnectorOut,
 )
-from .common import ApiBase, BaseOptions, serialize_params
+from .common import ApiBaseAsync, ApiBaseSync, BaseOptions, serialize_params
 
 
 @dataclass
@@ -46,7 +46,7 @@ class ConnectorCreateOptions(BaseOptions):
         )
 
 
-class ConnectorAsync(ApiBase):
+class ConnectorAsync(ApiBaseAsync):
     async def list(
         self, options: ConnectorListOptions = (ConnectorListOptions())
     ) -> ListResponseConnectorOut:
@@ -130,7 +130,7 @@ class ConnectorAsync(ApiBase):
         return ConnectorOut.model_validate(response.json())
 
 
-class Connector(ApiBase):
+class Connector(ApiBaseSync):
     def list(
         self, options: ConnectorListOptions = (ConnectorListOptions())
     ) -> ListResponseConnectorOut:

--- a/python/svix/api/endpoint.py
+++ b/python/svix/api/endpoint.py
@@ -29,7 +29,7 @@ from ..models import (
     ReplayIn,
     ReplayOut,
 )
-from .common import ApiBase, BaseOptions, serialize_params
+from .common import ApiBaseAsync, ApiBaseSync, BaseOptions, serialize_params
 
 
 @dataclass
@@ -139,7 +139,7 @@ class EndpointSendExampleOptions(BaseOptions):
         )
 
 
-class EndpointAsync(ApiBase):
+class EndpointAsync(ApiBaseAsync):
     async def list(
         self, app_id: str, options: EndpointListOptions = (EndpointListOptions())
     ) -> ListResponseEndpointOut:
@@ -520,7 +520,7 @@ class EndpointAsync(ApiBase):
         )
 
 
-class Endpoint(ApiBase):
+class Endpoint(ApiBaseSync):
     def list(
         self, app_id: str, options: EndpointListOptions = (EndpointListOptions())
     ) -> ListResponseEndpointOut:

--- a/python/svix/api/environment.py
+++ b/python/svix/api/environment.py
@@ -3,7 +3,7 @@ import typing as t
 from dataclasses import dataclass
 
 from ..models import EnvironmentIn, EnvironmentOut
-from .common import ApiBase, BaseOptions, serialize_params
+from .common import ApiBaseAsync, ApiBaseSync, BaseOptions, serialize_params
 
 
 @dataclass
@@ -30,7 +30,7 @@ class EnvironmentImportOptions(BaseOptions):
         )
 
 
-class EnvironmentAsync(ApiBase):
+class EnvironmentAsync(ApiBaseAsync):
     async def export(
         self, options: EnvironmentExportOptions = (EnvironmentExportOptions())
     ) -> EnvironmentOut:
@@ -68,7 +68,7 @@ class EnvironmentAsync(ApiBase):
         )
 
 
-class Environment(ApiBase):
+class Environment(ApiBaseSync):
     def export(
         self, options: EnvironmentExportOptions = (EnvironmentExportOptions())
     ) -> EnvironmentOut:

--- a/python/svix/api/event_type.py
+++ b/python/svix/api/event_type.py
@@ -12,7 +12,7 @@ from ..models import (
     EventTypeUpdate,
     ListResponseEventTypeOut,
 )
-from .common import ApiBase, BaseOptions, serialize_params
+from .common import ApiBaseAsync, ApiBaseSync, BaseOptions, serialize_params
 
 
 @dataclass
@@ -77,7 +77,7 @@ class EventTypeDeleteOptions(BaseOptions):
         )
 
 
-class EventTypeAsync(ApiBase):
+class EventTypeAsync(ApiBaseAsync):
     async def list(
         self, options: EventTypeListOptions = (EventTypeListOptions())
     ) -> ListResponseEventTypeOut:
@@ -198,7 +198,7 @@ class EventTypeAsync(ApiBase):
         return EventTypeOut.model_validate(response.json())
 
 
-class EventType(ApiBase):
+class EventType(ApiBaseSync):
     def list(
         self, options: EventTypeListOptions = (EventTypeListOptions())
     ) -> ListResponseEventTypeOut:

--- a/python/svix/api/health.py
+++ b/python/svix/api/health.py
@@ -1,14 +1,14 @@
 # This file is @generated
-from .common import ApiBase
+from .common import ApiBaseAsync, ApiBaseSync
 
 
-class HealthAsync(ApiBase):
+class HealthAsync(ApiBaseAsync):
     async def get(self) -> None:
         """Verify the API server is up and running."""
         await self._request_asyncio(method="get", path="/api/v1/health", path_params={})
 
 
-class Health(ApiBase):
+class Health(ApiBaseSync):
     def get(self) -> None:
         """Verify the API server is up and running."""
         self._request_sync(method="get", path="/api/v1/health", path_params={})

--- a/python/svix/api/ingest.py
+++ b/python/svix/api/ingest.py
@@ -29,11 +29,11 @@ class IngestDashboardOptions(BaseOptions):
 class IngestAsync(ApiBaseAsync):
     @property
     def endpoint(self) -> IngestEndpointAsync:
-        return IngestEndpointAsync(self._client)
+        return IngestEndpointAsync(self._client, self._httpx_client)
 
     @property
     def source(self) -> IngestSourceAsync:
-        return IngestSourceAsync(self._client)
+        return IngestSourceAsync(self._client, self._httpx_client)
 
     async def dashboard(
         self,
@@ -60,11 +60,11 @@ class IngestAsync(ApiBaseAsync):
 class Ingest(ApiBaseSync):
     @property
     def endpoint(self) -> IngestEndpoint:
-        return IngestEndpoint(self._client)
+        return IngestEndpoint(self._client, self._httpx_client)
 
     @property
     def source(self) -> IngestSource:
-        return IngestSource(self._client)
+        return IngestSource(self._client, self._httpx_client)
 
     def dashboard(
         self,

--- a/python/svix/api/ingest.py
+++ b/python/svix/api/ingest.py
@@ -3,7 +3,7 @@ import typing as t
 from dataclasses import dataclass
 
 from ..models import DashboardAccessOut, IngestSourceConsumerPortalAccessIn
-from .common import ApiBase, BaseOptions, serialize_params
+from .common import ApiBaseAsync, ApiBaseSync, BaseOptions, serialize_params
 from .ingest_endpoint import (
     IngestEndpoint,
     IngestEndpointAsync,
@@ -26,7 +26,7 @@ class IngestDashboardOptions(BaseOptions):
         )
 
 
-class IngestAsync(ApiBase):
+class IngestAsync(ApiBaseAsync):
     @property
     def endpoint(self) -> IngestEndpointAsync:
         return IngestEndpointAsync(self._client)
@@ -57,7 +57,7 @@ class IngestAsync(ApiBase):
         return DashboardAccessOut.model_validate(response.json())
 
 
-class Ingest(ApiBase):
+class Ingest(ApiBaseSync):
     @property
     def endpoint(self) -> IngestEndpoint:
         return IngestEndpoint(self._client)

--- a/python/svix/api/ingest_endpoint.py
+++ b/python/svix/api/ingest_endpoint.py
@@ -15,7 +15,7 @@ from ..models import (
     IngestEndpointUpdate,
     ListResponseIngestEndpointOut,
 )
-from .common import ApiBase, BaseOptions, serialize_params
+from .common import ApiBaseAsync, ApiBaseSync, BaseOptions, serialize_params
 
 
 @dataclass
@@ -61,7 +61,7 @@ class IngestEndpointRotateSecretOptions(BaseOptions):
         )
 
 
-class IngestEndpointAsync(ApiBase):
+class IngestEndpointAsync(ApiBaseAsync):
     async def list(
         self,
         source_id: str,
@@ -253,7 +253,7 @@ class IngestEndpointAsync(ApiBase):
         )
 
 
-class IngestEndpoint(ApiBase):
+class IngestEndpoint(ApiBaseSync):
     def list(
         self,
         source_id: str,

--- a/python/svix/api/ingest_source.py
+++ b/python/svix/api/ingest_source.py
@@ -9,7 +9,7 @@ from ..models import (
     ListResponseIngestSourceOut,
     RotateTokenOut,
 )
-from .common import ApiBase, BaseOptions, serialize_params
+from .common import ApiBaseAsync, ApiBaseSync, BaseOptions, serialize_params
 
 
 @dataclass
@@ -55,7 +55,7 @@ class IngestSourceRotateTokenOptions(BaseOptions):
         )
 
 
-class IngestSourceAsync(ApiBase):
+class IngestSourceAsync(ApiBaseAsync):
     async def list(
         self, options: IngestSourceListOptions = (IngestSourceListOptions())
     ) -> ListResponseIngestSourceOut:
@@ -147,7 +147,7 @@ class IngestSourceAsync(ApiBase):
         return RotateTokenOut.model_validate(response.json())
 
 
-class IngestSource(ApiBase):
+class IngestSource(ApiBaseSync):
     def list(
         self, options: IngestSourceListOptions = (IngestSourceListOptions())
     ) -> ListResponseIngestSourceOut:

--- a/python/svix/api/integration.py
+++ b/python/svix/api/integration.py
@@ -12,7 +12,7 @@ from ..models import (
     IntegrationUpdate,
     ListResponseIntegrationOut,
 )
-from .common import ApiBase, BaseOptions, serialize_params
+from .common import ApiBaseAsync, ApiBaseSync, BaseOptions, serialize_params
 
 
 @dataclass
@@ -58,7 +58,7 @@ class IntegrationRotateKeyOptions(BaseOptions):
         )
 
 
-class IntegrationAsync(ApiBase):
+class IntegrationAsync(ApiBaseAsync):
     async def list(
         self, app_id: str, options: IntegrationListOptions = (IntegrationListOptions())
     ) -> ListResponseIntegrationOut:
@@ -166,7 +166,7 @@ class IntegrationAsync(ApiBase):
         return IntegrationKeyOut.model_validate(response.json())
 
 
-class Integration(ApiBase):
+class Integration(ApiBaseSync):
     def list(
         self, app_id: str, options: IntegrationListOptions = (IntegrationListOptions())
     ) -> ListResponseIntegrationOut:

--- a/python/svix/api/message.py
+++ b/python/svix/api/message.py
@@ -145,7 +145,7 @@ def message_in_raw(
 class MessageAsync(ApiBaseAsync):
     @property
     def poller(self) -> MessagePollerAsync:
-        return MessagePollerAsync(self._client)
+        return MessagePollerAsync(self._client, self._httpx_client)
 
     async def list(
         self, app_id: str, options: MessageListOptions = (MessageListOptions())
@@ -296,7 +296,7 @@ class MessageAsync(ApiBaseAsync):
 class Message(ApiBaseSync):
     @property
     def poller(self) -> MessagePoller:
-        return MessagePoller(self._client)
+        return MessagePoller(self._client, self._httpx_client)
 
     def list(
         self, app_id: str, options: MessageListOptions = (MessageListOptions())

--- a/python/svix/api/message.py
+++ b/python/svix/api/message.py
@@ -11,7 +11,7 @@ from ..models import (
     MessagePrecheckIn,
     MessagePrecheckOut,
 )
-from .common import ApiBase, BaseOptions, serialize_params
+from .common import ApiBaseAsync, ApiBaseSync, BaseOptions, serialize_params
 from .message_poller import (
     MessagePoller,
     MessagePollerAsync,
@@ -142,7 +142,7 @@ def message_in_raw(
     )
 
 
-class MessageAsync(ApiBase):
+class MessageAsync(ApiBaseAsync):
     @property
     def poller(self) -> MessagePollerAsync:
         return MessagePollerAsync(self._client)
@@ -293,7 +293,7 @@ class MessageAsync(ApiBase):
         return ExpungeAllContentsOut.model_validate(response.json())
 
 
-class Message(ApiBase):
+class Message(ApiBaseSync):
     @property
     def poller(self) -> MessagePoller:
         return MessagePoller(self._client)

--- a/python/svix/api/message_attempt.py
+++ b/python/svix/api/message_attempt.py
@@ -11,7 +11,7 @@ from ..models import (
     ListResponseMessageEndpointOut,
     MessageAttemptOut,
 )
-from .common import ApiBase, BaseOptions, serialize_params
+from .common import ApiBaseAsync, ApiBaseSync, BaseOptions, serialize_params
 
 
 @dataclass
@@ -205,7 +205,7 @@ class MessageAttemptResendOptions(BaseOptions):
         )
 
 
-class MessageAttemptAsync(ApiBase):
+class MessageAttemptAsync(ApiBaseAsync):
     async def list_by_endpoint(
         self,
         app_id: str,
@@ -368,7 +368,7 @@ class MessageAttemptAsync(ApiBase):
         return EmptyResponse.model_validate(response.json())
 
 
-class MessageAttempt(ApiBase):
+class MessageAttempt(ApiBaseSync):
     def list_by_endpoint(
         self,
         app_id: str,

--- a/python/svix/api/message_poller.py
+++ b/python/svix/api/message_poller.py
@@ -8,7 +8,7 @@ from ..models import (
     PollingEndpointConsumerSeekOut,
     PollingEndpointOut,
 )
-from .common import ApiBase, BaseOptions, serialize_params
+from .common import ApiBaseAsync, ApiBaseSync, BaseOptions, serialize_params
 
 
 @dataclass
@@ -63,7 +63,7 @@ class MessagePollerConsumerPollOptions(BaseOptions):
         )
 
 
-class MessagePollerAsync(ApiBase):
+class MessagePollerAsync(ApiBaseAsync):
     async def poll(
         self,
         app_id: str,
@@ -135,7 +135,7 @@ class MessagePollerAsync(ApiBase):
         return PollingEndpointOut.model_validate(response.json())
 
 
-class MessagePoller(ApiBase):
+class MessagePoller(ApiBaseSync):
     def poll(
         self,
         app_id: str,

--- a/python/svix/api/operational_webhook.py
+++ b/python/svix/api/operational_webhook.py
@@ -1,18 +1,18 @@
 # This file is @generated
-from .common import ApiBase
+from .common import ApiBaseAsync, ApiBaseSync
 from .operational_webhook_endpoint import (
     OperationalWebhookEndpoint,
     OperationalWebhookEndpointAsync,
 )
 
 
-class OperationalWebhookAsync(ApiBase):
+class OperationalWebhookAsync(ApiBaseAsync):
     @property
     def endpoint(self) -> OperationalWebhookEndpointAsync:
         return OperationalWebhookEndpointAsync(self._client)
 
 
-class OperationalWebhook(ApiBase):
+class OperationalWebhook(ApiBaseSync):
     @property
     def endpoint(self) -> OperationalWebhookEndpoint:
         return OperationalWebhookEndpoint(self._client)

--- a/python/svix/api/operational_webhook.py
+++ b/python/svix/api/operational_webhook.py
@@ -9,10 +9,10 @@ from .operational_webhook_endpoint import (
 class OperationalWebhookAsync(ApiBaseAsync):
     @property
     def endpoint(self) -> OperationalWebhookEndpointAsync:
-        return OperationalWebhookEndpointAsync(self._client)
+        return OperationalWebhookEndpointAsync(self._client, self._httpx_client)
 
 
 class OperationalWebhook(ApiBaseSync):
     @property
     def endpoint(self) -> OperationalWebhookEndpoint:
-        return OperationalWebhookEndpoint(self._client)
+        return OperationalWebhookEndpoint(self._client, self._httpx_client)

--- a/python/svix/api/operational_webhook_endpoint.py
+++ b/python/svix/api/operational_webhook_endpoint.py
@@ -13,7 +13,7 @@ from ..models import (
     OperationalWebhookEndpointSecretOut,
     OperationalWebhookEndpointUpdate,
 )
-from .common import ApiBase, BaseOptions, serialize_params
+from .common import ApiBaseAsync, ApiBaseSync, BaseOptions, serialize_params
 
 
 @dataclass
@@ -59,7 +59,7 @@ class OperationalWebhookEndpointRotateSecretOptions(BaseOptions):
         )
 
 
-class OperationalWebhookEndpointAsync(ApiBase):
+class OperationalWebhookEndpointAsync(ApiBaseAsync):
     async def list(
         self,
         options: OperationalWebhookEndpointListOptions = (
@@ -204,7 +204,7 @@ class OperationalWebhookEndpointAsync(ApiBase):
         )
 
 
-class OperationalWebhookEndpoint(ApiBase):
+class OperationalWebhookEndpoint(ApiBaseSync):
     def list(
         self,
         options: OperationalWebhookEndpointListOptions = (

--- a/python/svix/api/statistics.py
+++ b/python/svix/api/statistics.py
@@ -3,7 +3,7 @@ import typing as t
 from dataclasses import dataclass
 
 from ..models import AggregateEventTypesOut, AppUsageStatsIn, AppUsageStatsOut
-from .common import ApiBase, BaseOptions, serialize_params
+from .common import ApiBaseAsync, ApiBaseSync, BaseOptions, serialize_params
 
 
 @dataclass
@@ -18,7 +18,7 @@ class StatisticsAggregateAppStatsOptions(BaseOptions):
         )
 
 
-class StatisticsAsync(ApiBase):
+class StatisticsAsync(ApiBaseAsync):
     async def aggregate_event_types(self) -> AggregateEventTypesOut:
         """Creates a background task to calculate the listed event types for all apps in the organization.
 
@@ -89,7 +89,7 @@ class StatisticsAsync(ApiBase):
         return AppUsageStatsOut.model_validate(response.json())
 
 
-class Statistics(ApiBase):
+class Statistics(ApiBaseSync):
     def aggregate_event_types(self) -> AggregateEventTypesOut:
         """Creates a background task to calculate the listed event types for all apps in the organization.
 

--- a/python/svix/api/streaming.py
+++ b/python/svix/api/streaming.py
@@ -22,19 +22,19 @@ from .streaming_stream import (
 class StreamingAsync(ApiBaseAsync):
     @property
     def event_type(self) -> StreamingEventTypeAsync:
-        return StreamingEventTypeAsync(self._client)
+        return StreamingEventTypeAsync(self._client, self._httpx_client)
 
     @property
     def events(self) -> StreamingEventsAsync:
-        return StreamingEventsAsync(self._client)
+        return StreamingEventsAsync(self._client, self._httpx_client)
 
     @property
     def sink(self) -> StreamingSinkAsync:
-        return StreamingSinkAsync(self._client)
+        return StreamingSinkAsync(self._client, self._httpx_client)
 
     @property
     def stream(self) -> StreamingStreamAsync:
-        return StreamingStreamAsync(self._client)
+        return StreamingStreamAsync(self._client, self._httpx_client)
 
     async def sink_transformation_get(
         self, stream_id: str, sink_id: str
@@ -92,19 +92,19 @@ class StreamingAsync(ApiBaseAsync):
 class Streaming(ApiBaseSync):
     @property
     def event_type(self) -> StreamingEventType:
-        return StreamingEventType(self._client)
+        return StreamingEventType(self._client, self._httpx_client)
 
     @property
     def events(self) -> StreamingEvents:
-        return StreamingEvents(self._client)
+        return StreamingEvents(self._client, self._httpx_client)
 
     @property
     def sink(self) -> StreamingSink:
-        return StreamingSink(self._client)
+        return StreamingSink(self._client, self._httpx_client)
 
     @property
     def stream(self) -> StreamingStream:
-        return StreamingStream(self._client)
+        return StreamingStream(self._client, self._httpx_client)
 
     def sink_transformation_get(
         self, stream_id: str, sink_id: str

--- a/python/svix/api/streaming.py
+++ b/python/svix/api/streaming.py
@@ -1,6 +1,6 @@
 # This file is @generated
 from ..models import EndpointHeadersOut, HttpSinkHeadersPatchIn, SinkTransformationOut
-from .common import ApiBase
+from .common import ApiBaseAsync, ApiBaseSync
 from .streaming_event_type import (
     StreamingEventType,
     StreamingEventTypeAsync,
@@ -19,7 +19,7 @@ from .streaming_stream import (
 )
 
 
-class StreamingAsync(ApiBase):
+class StreamingAsync(ApiBaseAsync):
     @property
     def event_type(self) -> StreamingEventTypeAsync:
         return StreamingEventTypeAsync(self._client)
@@ -89,7 +89,7 @@ class StreamingAsync(ApiBase):
         return EndpointHeadersOut.model_validate(response.json())
 
 
-class Streaming(ApiBase):
+class Streaming(ApiBaseSync):
     @property
     def event_type(self) -> StreamingEventType:
         return StreamingEventType(self._client)

--- a/python/svix/api/streaming_event_type.py
+++ b/python/svix/api/streaming_event_type.py
@@ -9,7 +9,7 @@ from ..models import (
     StreamEventTypeOut,
     StreamEventTypePatch,
 )
-from .common import ApiBase, BaseOptions, serialize_params
+from .common import ApiBaseAsync, ApiBaseSync, BaseOptions, serialize_params
 
 
 @dataclass
@@ -59,7 +59,7 @@ class StreamingEventTypeDeleteOptions(BaseOptions):
         )
 
 
-class StreamingEventTypeAsync(ApiBase):
+class StreamingEventTypeAsync(ApiBaseAsync):
     async def list(
         self, options: StreamingEventTypeListOptions = (StreamingEventTypeListOptions())
     ) -> ListResponseStreamEventTypeOut:
@@ -151,7 +151,7 @@ class StreamingEventTypeAsync(ApiBase):
         return StreamEventTypeOut.model_validate(response.json())
 
 
-class StreamingEventType(ApiBase):
+class StreamingEventType(ApiBaseSync):
     def list(
         self, options: StreamingEventTypeListOptions = (StreamingEventTypeListOptions())
     ) -> ListResponseStreamEventTypeOut:

--- a/python/svix/api/streaming_events.py
+++ b/python/svix/api/streaming_events.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from ..models import CreateStreamEventsIn, CreateStreamEventsOut, EventStreamOut
-from .common import ApiBase, BaseOptions, serialize_params
+from .common import ApiBaseAsync, ApiBaseSync, BaseOptions, serialize_params
 
 
 @dataclass
@@ -37,7 +37,7 @@ class StreamingEventsCreateOptions(BaseOptions):
         )
 
 
-class StreamingEventsAsync(ApiBase):
+class StreamingEventsAsync(ApiBaseAsync):
     async def get(
         self,
         stream_id: str,
@@ -81,7 +81,7 @@ class StreamingEventsAsync(ApiBase):
         return CreateStreamEventsOut.model_validate(response.json())
 
 
-class StreamingEvents(ApiBase):
+class StreamingEvents(ApiBaseSync):
     def get(
         self,
         stream_id: str,

--- a/python/svix/api/streaming_sink.py
+++ b/python/svix/api/streaming_sink.py
@@ -13,7 +13,7 @@ from ..models import (
     StreamSinkOut,
     StreamSinkPatch,
 )
-from .common import ApiBase, BaseOptions, serialize_params
+from .common import ApiBaseAsync, ApiBaseSync, BaseOptions, serialize_params
 
 
 @dataclass
@@ -59,7 +59,7 @@ class StreamingSinkRotateSecretOptions(BaseOptions):
         )
 
 
-class StreamingSinkAsync(ApiBase):
+class StreamingSinkAsync(ApiBaseAsync):
     async def list(
         self,
         stream_id: str,
@@ -210,7 +210,7 @@ class StreamingSinkAsync(ApiBase):
         return EmptyResponse.model_validate(response.json())
 
 
-class StreamingSink(ApiBase):
+class StreamingSink(ApiBaseSync):
     def list(
         self,
         stream_id: str,

--- a/python/svix/api/streaming_stream.py
+++ b/python/svix/api/streaming_stream.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 from .. import models
 from ..models import ListResponseStreamOut, StreamIn, StreamOut, StreamPatch
-from .common import ApiBase, BaseOptions, serialize_params
+from .common import ApiBaseAsync, ApiBaseSync, BaseOptions, serialize_params
 
 
 @dataclass
@@ -38,7 +38,7 @@ class StreamingStreamCreateOptions(BaseOptions):
         )
 
 
-class StreamingStreamAsync(ApiBase):
+class StreamingStreamAsync(ApiBaseAsync):
     async def list(
         self, options: StreamingStreamListOptions = (StreamingStreamListOptions())
     ) -> ListResponseStreamOut:
@@ -114,7 +114,7 @@ class StreamingStreamAsync(ApiBase):
         return StreamOut.model_validate(response.json())
 
 
-class StreamingStream(ApiBase):
+class StreamingStream(ApiBaseSync):
     def list(
         self, options: StreamingStreamListOptions = (StreamingStreamListOptions())
     ) -> ListResponseStreamOut:

--- a/python/svix/api/svix.py
+++ b/python/svix/api/svix.py
@@ -4,10 +4,13 @@ import platform
 import typing as t
 from dataclasses import dataclass, field
 
+import httpx
+
 from .application import Application, ApplicationAsync
 from .authentication import Authentication, AuthenticationAsync
 from .background_task import BackgroundTask, BackgroundTaskAsync
 from .client import AuthenticatedClient
+from .common import _make_httpx_async_client, _make_httpx_client
 from .connector import Connector, ConnectorAsync
 from .endpoint import Endpoint, EndpointAsync
 from .environment import Environment, EnvironmentAsync
@@ -98,132 +101,144 @@ class ClientBase:
 
 
 class SvixAsync(ClientBase):
+    _httpx_client: httpx.AsyncClient
+
+    def __init__(self, auth_token: str, options: SvixOptions = SvixOptions()):
+        super().__init__(auth_token, options)
+        self._httpx_client = _make_httpx_async_client(self._client)
+
     @property
     def application(self) -> ApplicationAsync:
-        return ApplicationAsync(self._client)
+        return ApplicationAsync(self._client, self._httpx_client)
 
     @property
     def authentication(self) -> AuthenticationAsync:
-        return AuthenticationAsync(self._client)
+        return AuthenticationAsync(self._client, self._httpx_client)
 
     @property
     def background_task(self) -> BackgroundTaskAsync:
-        return BackgroundTaskAsync(self._client)
+        return BackgroundTaskAsync(self._client, self._httpx_client)
 
     @property
     def connector(self) -> ConnectorAsync:
-        return ConnectorAsync(self._client)
+        return ConnectorAsync(self._client, self._httpx_client)
 
     @property
     def endpoint(self) -> EndpointAsync:
-        return EndpointAsync(self._client)
+        return EndpointAsync(self._client, self._httpx_client)
 
     @property
     def environment(self) -> EnvironmentAsync:
-        return EnvironmentAsync(self._client)
+        return EnvironmentAsync(self._client, self._httpx_client)
 
     @property
     def event_type(self) -> EventTypeAsync:
-        return EventTypeAsync(self._client)
+        return EventTypeAsync(self._client, self._httpx_client)
 
     @property
     def health(self) -> HealthAsync:
-        return HealthAsync(self._client)
+        return HealthAsync(self._client, self._httpx_client)
 
     @property
     def ingest(self) -> IngestAsync:
-        return IngestAsync(self._client)
+        return IngestAsync(self._client, self._httpx_client)
 
     @property
     def integration(self) -> IntegrationAsync:
-        return IntegrationAsync(self._client)
+        return IntegrationAsync(self._client, self._httpx_client)
 
     @property
     def message(self) -> MessageAsync:
-        return MessageAsync(self._client)
+        return MessageAsync(self._client, self._httpx_client)
 
     @property
     def message_attempt(self) -> MessageAttemptAsync:
-        return MessageAttemptAsync(self._client)
+        return MessageAttemptAsync(self._client, self._httpx_client)
 
     @property
     def operational_webhook(self) -> OperationalWebhookAsync:
-        return OperationalWebhookAsync(self._client)
+        return OperationalWebhookAsync(self._client, self._httpx_client)
 
     @property
     def statistics(self) -> StatisticsAsync:
-        return StatisticsAsync(self._client)
+        return StatisticsAsync(self._client, self._httpx_client)
 
     @property
     def streaming(self) -> StreamingAsync:
-        return StreamingAsync(self._client)
+        return StreamingAsync(self._client, self._httpx_client)
 
     @property
     def operational_webhook_endpoint(self) -> OperationalWebhookEndpointAsync:
-        return OperationalWebhookEndpointAsync(self._client)
+        return OperationalWebhookEndpointAsync(self._client, self._httpx_client)
 
 
 class Svix(ClientBase):
+    _httpx_client: httpx.Client
+
+    def __init__(self, auth_token: str, options: SvixOptions = SvixOptions()):
+        super().__init__(auth_token, options)
+        self._httpx_client = _make_httpx_client(self._client)
+
     @property
     def application(self) -> Application:
-        return Application(self._client)
+        return Application(self._client, self._httpx_client)
 
     @property
     def authentication(self) -> Authentication:
-        return Authentication(self._client)
+        return Authentication(self._client, self._httpx_client)
 
     @property
     def background_task(self) -> BackgroundTask:
-        return BackgroundTask(self._client)
+        return BackgroundTask(self._client, self._httpx_client)
 
     @property
     def connector(self) -> Connector:
-        return Connector(self._client)
+        return Connector(self._client, self._httpx_client)
 
     @property
     def endpoint(self) -> Endpoint:
-        return Endpoint(self._client)
+        return Endpoint(self._client, self._httpx_client)
 
     @property
     def environment(self) -> Environment:
-        return Environment(self._client)
+        return Environment(self._client, self._httpx_client)
 
     @property
     def event_type(self) -> EventType:
-        return EventType(self._client)
+        return EventType(self._client, self._httpx_client)
 
     @property
     def health(self) -> Health:
-        return Health(self._client)
+        return Health(self._client, self._httpx_client)
 
     @property
     def ingest(self) -> Ingest:
-        return Ingest(self._client)
+        return Ingest(self._client, self._httpx_client)
 
     @property
     def integration(self) -> Integration:
-        return Integration(self._client)
+        return Integration(self._client, self._httpx_client)
 
     @property
     def message(self) -> Message:
-        return Message(self._client)
+        return Message(self._client, self._httpx_client)
 
     @property
     def message_attempt(self) -> MessageAttempt:
-        return MessageAttempt(self._client)
+        return MessageAttempt(self._client, self._httpx_client)
 
     @property
     def operational_webhook(self) -> OperationalWebhook:
-        return OperationalWebhook(self._client)
+        return OperationalWebhook(self._client, self._httpx_client)
 
     @property
     def statistics(self) -> Statistics:
-        return Statistics(self._client)
+        return Statistics(self._client, self._httpx_client)
 
     @property
     def streaming(self) -> Streaming:
-        return Streaming(self._client)
+        return Streaming(self._client, self._httpx_client)
 
     @property
     def operational_webhook_endpoint(self) -> OperationalWebhookEndpoint:
-        return OperationalWebhookEndpoint(self._client)
+        return OperationalWebhookEndpoint(self._client, self._httpx_client)

--- a/python/svix/api_internal/common.py
+++ b/python/svix/api_internal/common.py
@@ -1,4 +1,4 @@
 # Shim to re-use common from the api package
-from ..api.common import ApiBase, BaseOptions, serialize_params
+from ..api.common import ApiBaseAsync, ApiBaseSync, BaseOptions, serialize_params
 
-__all__ = ["ApiBase", "BaseOptions", "serialize_params"]
+__all__ = ["ApiBaseAsync", "ApiBaseSync", "BaseOptions", "serialize_params"]

--- a/python/svix/api_internal/endpoint.py
+++ b/python/svix/api_internal/endpoint.py
@@ -12,7 +12,7 @@ from .endpoint_auto_config import (
 class EndpointAsync(ApiBaseAsync):
     @property
     def auto_config(self) -> EndpointAutoConfigAsync:
-        return EndpointAutoConfigAsync(self._client)
+        return EndpointAutoConfigAsync(self._client, self._httpx_client)
 
     @deprecated
     async def transformation_partial_update(
@@ -38,7 +38,7 @@ class EndpointAsync(ApiBaseAsync):
 class Endpoint(ApiBaseSync):
     @property
     def auto_config(self) -> EndpointAutoConfig:
-        return EndpointAutoConfig(self._client)
+        return EndpointAutoConfig(self._client, self._httpx_client)
 
     @deprecated
     def transformation_partial_update(

--- a/python/svix/api_internal/endpoint.py
+++ b/python/svix/api_internal/endpoint.py
@@ -2,14 +2,14 @@
 from deprecated import deprecated
 
 from ..models import EndpointTransformationIn
-from .common import ApiBase
+from .common import ApiBaseAsync, ApiBaseSync
 from .endpoint_auto_config import (
     EndpointAutoConfig,
     EndpointAutoConfigAsync,
 )
 
 
-class EndpointAsync(ApiBase):
+class EndpointAsync(ApiBaseAsync):
     @property
     def auto_config(self) -> EndpointAutoConfigAsync:
         return EndpointAutoConfigAsync(self._client)
@@ -35,7 +35,7 @@ class EndpointAsync(ApiBase):
         )
 
 
-class Endpoint(ApiBase):
+class Endpoint(ApiBaseSync):
     @property
     def auto_config(self) -> EndpointAutoConfig:
         return EndpointAutoConfig(self._client)

--- a/python/svix/api_internal/endpoint_auto_config.py
+++ b/python/svix/api_internal/endpoint_auto_config.py
@@ -1,9 +1,9 @@
 # This file is @generated
 from ..models import EndpointOut, SubscribeIn
-from .common import ApiBase
+from .common import ApiBaseAsync, ApiBaseSync
 
 
-class EndpointAutoConfigAsync(ApiBase):
+class EndpointAutoConfigAsync(ApiBaseAsync):
     async def update(
         self, app_id: str, endpoint_id: str, subscribe_in: SubscribeIn
     ) -> EndpointOut:
@@ -20,7 +20,7 @@ class EndpointAutoConfigAsync(ApiBase):
         return EndpointOut.model_validate(response.json())
 
 
-class EndpointAutoConfig(ApiBase):
+class EndpointAutoConfig(ApiBaseSync):
     def update(
         self, app_id: str, endpoint_id: str, subscribe_in: SubscribeIn
     ) -> EndpointOut:

--- a/python/svix/api_internal/message.py
+++ b/python/svix/api_internal/message.py
@@ -1,18 +1,18 @@
 # This file is @generated
-from .common import ApiBase
+from .common import ApiBaseAsync, ApiBaseSync
 from .message_pollerv2 import (
     MessagePollerv2,
     MessagePollerv2Async,
 )
 
 
-class MessageAsync(ApiBase):
+class MessageAsync(ApiBaseAsync):
     @property
     def pollerv2(self) -> MessagePollerv2Async:
         return MessagePollerv2Async(self._client)
 
 
-class Message(ApiBase):
+class Message(ApiBaseSync):
     @property
     def pollerv2(self) -> MessagePollerv2:
         return MessagePollerv2(self._client)

--- a/python/svix/api_internal/message.py
+++ b/python/svix/api_internal/message.py
@@ -9,10 +9,10 @@ from .message_pollerv2 import (
 class MessageAsync(ApiBaseAsync):
     @property
     def pollerv2(self) -> MessagePollerv2Async:
-        return MessagePollerv2Async(self._client)
+        return MessagePollerv2Async(self._client, self._httpx_client)
 
 
 class Message(ApiBaseSync):
     @property
     def pollerv2(self) -> MessagePollerv2:
-        return MessagePollerv2(self._client)
+        return MessagePollerv2(self._client, self._httpx_client)

--- a/python/svix/api_internal/message_pollerv2.py
+++ b/python/svix/api_internal/message_pollerv2.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 from .. import models
 from ..models import PollerV2CommitIn, PollerV2PollOut
-from .common import ApiBase, BaseOptions, serialize_params
+from .common import ApiBaseAsync, ApiBaseSync, BaseOptions, serialize_params
 
 
 @dataclass
@@ -36,7 +36,7 @@ class MessagePollerv2ConsumerCommitOptions(BaseOptions):
         )
 
 
-class MessagePollerv2Async(ApiBase):
+class MessagePollerv2Async(ApiBaseAsync):
     async def consumer_poll(
         self,
         app_id: str,
@@ -87,7 +87,7 @@ class MessagePollerv2Async(ApiBase):
         )
 
 
-class MessagePollerv2(ApiBase):
+class MessagePollerv2(ApiBaseSync):
     def consumer_poll(
         self,
         app_id: str,

--- a/python/svix/autoconfig.py
+++ b/python/svix/autoconfig.py
@@ -1,9 +1,11 @@
 import base64
 import typing as t
 
+import httpx
 import pydantic
 
 from .api.client import AuthenticatedClient
+from .api.common import _make_httpx_async_client, _make_httpx_client
 from .api.svix import Svix, SvixOptions
 from .api_internal.endpoint_auto_config import (
     EndpointAutoConfig,
@@ -66,6 +68,8 @@ class AutoConfig:
     _endpoint: EndpointIn
     _webhook: Webhook
     _client: AuthenticatedClient
+    _sync_api: t.Optional[EndpointAutoConfig]
+    _async_api: t.Optional[EndpointAutoConfigAsync]
 
     def __init__(self, token: str, endpoint: EndpointIn) -> None:
         content = _decode_autoconfig_token_v1(token)
@@ -86,14 +90,22 @@ class AutoConfig:
         self._client = svix._client
 
     def subscribe(self) -> EndpointOut:
-        return EndpointAutoConfig(self._client).update(
+        if self._sync_api is None:
+            httpx_client = _make_httpx_client(self._client)
+            self._sync_api = EndpointAutoConfig(self._client, httpx_client)
+
+        return self._sync_api.update(
             self._app_id,
             self._endpoint_id,
             SubscribeIn(endpoint=self._endpoint),
         )
 
     async def subscribe_async(self) -> EndpointOut:
-        return await EndpointAutoConfigAsync(self._client).update(
+        if self._async_api is None:
+            httpx_client = _make_httpx_async_client(self._client)
+            self._async_api = EndpointAutoConfigAsync(self._client, httpx_client)
+
+        return await self._async_api.update(
             self._app_id,
             self._endpoint_id,
             SubscribeIn(endpoint=self._endpoint),
@@ -108,6 +120,8 @@ class AutoConfigConsumer:
     _sink_id: str
     _sink_in: SinkInCommon
     _client: AuthenticatedClient
+    _httpx_client: t.Optional[httpx.Client]
+    _httpx_async_client: t.Optional[httpx.AsyncClient]
 
     def __init__(self, token: str, sink_in: SinkInCommon) -> None:
         content = _decode_autoconfig_token_v1(token)
@@ -128,14 +142,22 @@ class AutoConfigConsumer:
         )
 
     def subscribe(self) -> EndpointOut:
-        return EndpointAutoConfig(self._client).update(
+        if self._httpx_client is None:
+            self._httpx_client = _make_httpx_client(self._client)
+
+        return EndpointAutoConfig(self._client, self._httpx_client).update(
             self._app_id,
             self._sink_id,
             self._subscribe_in(),
         )
 
     async def subscribe_async(self) -> EndpointOut:
-        return await EndpointAutoConfigAsync(self._client).update(
+        if self._httpx_async_client is None:
+            self._httpx_async_client = _make_httpx_async_client(self._client)
+
+        return await EndpointAutoConfigAsync(
+            self._client, self._httpx_async_client
+        ).update(
             self._app_id,
             self._sink_id,
             self._subscribe_in(),
@@ -148,7 +170,10 @@ class AutoConfigConsumer:
             MessagePollerv2ConsumerPollOptions()
         ),
     ) -> PollerV2PollOut:
-        return MessagePollerv2(self._client).consumer_poll(
+        if self._httpx_client is None:
+            self._httpx_client = _make_httpx_client(self._client)
+
+        return MessagePollerv2(self._client, self._httpx_client).consumer_poll(
             self._app_id,
             self._sink_id,
             consumer_id,
@@ -162,7 +187,12 @@ class AutoConfigConsumer:
             MessagePollerv2ConsumerPollOptions()
         ),
     ) -> PollerV2PollOut:
-        return await MessagePollerv2Async(self._client).consumer_poll(
+        if self._httpx_async_client is None:
+            self._httpx_async_client = _make_httpx_async_client(self._client)
+
+        return await MessagePollerv2Async(
+            self._client, self._httpx_async_client
+        ).consumer_poll(
             self._app_id,
             self._sink_id,
             consumer_id,
@@ -177,7 +207,10 @@ class AutoConfigConsumer:
             MessagePollerv2ConsumerCommitOptions()
         ),
     ) -> None:
-        MessagePollerv2(self._client).consumer_commit(
+        if self._httpx_client is None:
+            self._httpx_client = _make_httpx_client(self._client)
+
+        MessagePollerv2(self._client, self._httpx_client).consumer_commit(
             self._app_id,
             self._sink_id,
             consumer_id,
@@ -193,7 +226,12 @@ class AutoConfigConsumer:
             MessagePollerv2ConsumerCommitOptions()
         ),
     ) -> None:
-        await MessagePollerv2Async(self._client).consumer_commit(
+        if self._httpx_async_client is None:
+            self._httpx_async_client = _make_httpx_async_client(self._client)
+
+        await MessagePollerv2Async(
+            self._client, self._httpx_async_client
+        ).consumer_commit(
             self._app_id,
             self._sink_id,
             consumer_id,

--- a/python/tests/test_httpretty.py
+++ b/python/tests/test_httpretty.py
@@ -9,7 +9,6 @@ from svix.api import (
     MessageIn,
     MessageListOptions,
 )
-from svix.api.ingest_source import IngestSource
 
 
 @httpretty.activate(verbose=True, allow_net_connect=False)
@@ -26,7 +25,6 @@ def test_octothorpe_in_query_param():
 @httpretty.activate(verbose=True, allow_net_connect=False)
 def test_struct_enum_with_fields():
     svx = svix.Svix("token", svix.SvixOptions(server_url="http://test.example"))
-    ingest_source = IngestSource(svx._client)
     httpretty.register_uri(
         httpretty.POST,
         "http://test.example/ingest/api/v1/source",
@@ -44,7 +42,7 @@ def test_struct_enum_with_fields():
         type="cron",
         config=CronConfig(content_type="asd", payload="asd", schedule="asd"),
     )
-    res = ingest_source.create(source_in)
+    res = svx.ingest.source.create(source_in)
     assert isinstance(res.config, CronConfig)
 
     assert res.config.content_type == "mendy/tired"
@@ -55,7 +53,6 @@ def test_struct_enum_with_fields():
 @httpretty.activate(verbose=True, allow_net_connect=False)
 def test_struct_enum_without_fields():
     svx = svix.Svix("token", svix.SvixOptions(server_url="http://test.example"))
-    ingest_source = IngestSource(svx._client)
     httpretty.register_uri(
         httpretty.POST,
         "http://test.example/ingest/api/v1/source",
@@ -67,7 +64,7 @@ def test_struct_enum_without_fields():
     )
     source_in = IngestSourceIn(name="name", type="generic-webhook", config={})
 
-    res = ingest_source.create(source_in)
+    res = svx.ingest.source.create(source_in)
 
     assert isinstance(res.config, dict)
     assert res.config == {}


### PR DESCRIPTION
Closes #2456.

I did some small refactorings to untangle the weird OpenAPI generator legacy, but kept the overall structure to keep the diff small. We should look into cleaning it up soon (I'll start in the SDK-v2 PR by prefixing things like `ApiBase`, `Client`, `ClientBase` with an underscore to make sure nobody relies on them without knowing they may go away).