### PR TITLE
server: replace validator 0.16 with validator 0.20

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -90,10 +90,10 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0487f8598afe49e6bc950a613a678bd962c4a6f431022ded62643c8b990301a"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -203,7 +203,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -214,7 +214,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -262,7 +262,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -274,7 +274,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -392,7 +392,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -409,7 +409,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -899,7 +899,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1121,7 +1121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1130,8 +1130,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -1145,7 +1155,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
@@ -1154,9 +1177,20 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1249,7 +1283,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1279,7 +1313,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn",
  "unicode-xid",
 ]
 
@@ -1322,7 +1356,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1424,7 +1458,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1440,7 +1474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1723,7 +1757,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2312,12 +2346,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "if_chain"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2348,7 +2376,7 @@ checksum = "c727f80bfa4a6c6e2508d2f05b6f4bfce242030bd88ed15ae5331c5b5d30fba7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2437,7 +2465,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2456,7 +2484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2870,7 +2898,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3004,7 +3032,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3248,7 +3276,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3395,7 +3423,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3510,7 +3538,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3572,7 +3600,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3727,7 +3755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3749,34 +3777,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error-attr3"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34e4dd828515431dd6c4a030d26f7eaed7dd4778226e9d2bb968d65ca4ec3d4d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3791,7 +3805,19 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro-error3"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee475e440453418ff1335189eddf7101ba502cd818ab7ae04209bc83aa925aa"
+dependencies = [
+ "proc-macro-error-attr3",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3811,7 +3837,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "version_check",
  "yansi",
 ]
@@ -3836,7 +3862,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4076,7 +4102,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4293,7 +4319,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4367,7 +4393,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4452,7 +4478,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4482,7 +4508,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4526,7 +4552,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.117",
+ "syn",
  "unicode-ident",
 ]
 
@@ -4732,7 +4758,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4743,7 +4769,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4791,7 +4817,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4926,7 +4952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5029,7 +5055,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5052,7 +5078,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.117",
+ "syn",
  "tokio",
  "url",
 ]
@@ -5328,18 +5354,7 @@ version = "1.97.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+ "syn",
 ]
 
 [[package]]
@@ -5370,7 +5385,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5423,7 +5438,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5452,7 +5467,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5463,7 +5478,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5565,7 +5580,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5813,7 +5828,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6065,42 +6080,31 @@ dependencies = [
 
 [[package]]
 name = "validator"
-version = "0.16.1"
-source = "git+https://github.com/svix/validator.git?rev=aebdc34a4ed72524902ff6d63397b9c435b0578f#aebdc34a4ed72524902ff6d63397b9c435b0578f"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
 dependencies = [
  "idna",
- "lazy_static",
+ "once_cell",
  "regex",
  "serde",
  "serde_derive",
  "serde_json",
- "tracing",
  "url",
  "validator_derive",
 ]
 
 [[package]]
 name = "validator_derive"
-version = "0.16.0"
-source = "git+https://github.com/svix/validator.git?rev=aebdc34a4ed72524902ff6d63397b9c435b0578f#aebdc34a4ed72524902ff6d63397b9c435b0578f"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240e4b81c20a1d6d50d1d7265c658dfbd204e8b9ac4d80f3c931f39462196335"
 dependencies = [
- "if_chain",
- "lazy_static",
- "proc-macro-error",
+ "darling 0.23.0",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
- "regex",
- "syn 1.0.109",
- "validator_types",
-]
-
-[[package]]
-name = "validator_types"
-version = "0.16.0"
-source = "git+https://github.com/svix/validator.git?rev=aebdc34a4ed72524902ff6d63397b9c435b0578f#aebdc34a4ed72524902ff6d63397b9c435b0578f"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -6228,7 +6232,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -6360,7 +6364,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6390,7 +6394,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6401,7 +6405,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6739,7 +6743,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap 2.14.0",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -6755,7 +6759,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -6848,7 +6852,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -92,10 +92,7 @@ tracing-opentelemetry = "0.33.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 url = { version = "2.2.2", features = ["serde"] }
 urlencoding = "2.1.2"
-# Forked version of 0.16 with a small fix and dependency upgrades, since we
-# haven't gotten around to doing a proper upgrade yet (0.17 is a large
-# rewrite with a barely-useful changelog)
-validator = { git = "https://github.com/svix/validator.git", rev = "aebdc34a4ed72524902ff6d63397b9c435b0578f", features = ["derive"] }
+validator = { version = "0.20.0", features = ["derive"] }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -107,17 +107,14 @@ fn validate_operational_webhook_url(url: &str) -> Result<(), ValidationError> {
 }
 
 #[derive(Clone, Debug, Deserialize, Validate)]
-#[validate(
-    schema(function = "validate_config_complete"),
-    skip_on_field_errors = false
-)]
+#[validate(schema(function = "validate_config_complete", skip_on_field_errors = false))]
 pub struct ConfigurationInner {
     /// The address to listen on
     pub listen_address: SocketAddr,
 
     /// The address to send operational webhooks to. When None, operational webhooks will not be
     /// sent. When Some, the API server with the given URL will be used to send operational webhooks.
-    #[validate(custom = "validate_operational_webhook_url")]
+    #[validate(custom(function = "validate_operational_webhook_url"))]
     pub operational_webhook_address: Option<String>,
 
     /// The main secret used by Svix. Used for client-side encryption of sensitive data, etc.

--- a/server/svix-server/src/v1/endpoints/application.rs
+++ b/server/svix-server/src/v1/endpoints/application.rs
@@ -49,7 +49,7 @@ fn application_name_example() -> &'static str {
 pub struct ApplicationIn {
     #[validate(
         length(min = 1, message = "Application names must be at least one character"),
-        custom = "validate_no_control_characters"
+        custom(function = "validate_no_control_characters")
     )]
     #[schemars(example = "application_name_example")]
     pub name: String,
@@ -70,7 +70,7 @@ pub struct ApplicationIn {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub throttle_rate: Option<u16>,
     /// Optional unique identifier for the application
-    #[validate]
+    #[validate(nested)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uid: Option<ApplicationUid>,
 
@@ -105,26 +105,26 @@ impl ModelIn for ApplicationIn {
 pub struct ApplicationPatch {
     #[serde(default, skip_serializing_if = "UnrequiredField::is_absent")]
     #[validate(
-        custom = "validate_name_length_patch",
-        custom = "validate_no_control_characters_unrequired"
+        custom(function = "validate_name_length_patch"),
+        custom(function = "validate_no_control_characters_unrequired")
     )]
     pub name: UnrequiredField<String>,
 
     /// Deprecated, use `throttleRate` instead.
     #[deprecated]
-    #[validate(custom = "validate_rate_limit_patch")]
+    #[validate(custom(function = "validate_rate_limit_patch"))]
     #[serde(default, skip_serializing_if = "UnrequiredNullableField::is_absent")]
     pub rate_limit: UnrequiredNullableField<u16>,
 
     /// Maximum messages per second to send to this application's endpoints.
     ///
     /// Outgoing messages will be throttled to this rate.
-    #[validate(custom = "validate_rate_limit_patch")]
+    #[validate(custom(function = "validate_rate_limit_patch"))]
     #[serde(default, skip_serializing_if = "UnrequiredNullableField::is_absent")]
     pub throttle_rate: UnrequiredNullableField<u16>,
 
     #[serde(default, skip_serializing_if = "UnrequiredNullableField::is_absent")]
-    #[validate]
+    #[validate(nested)]
     pub uid: UnrequiredNullableField<ApplicationUid>,
 
     #[serde(default, skip_serializing_if = "UnrequiredField::is_absent")]

--- a/server/svix-server/src/v1/endpoints/attempt.rs
+++ b/server/svix-server/src/v1/endpoints/attempt.rs
@@ -166,7 +166,7 @@ impl<'de> Deserialize<'de> for EndpointMessageOut {
 #[derive(Debug, Deserialize, Validate, JsonSchema)]
 pub struct ListAttemptedMessagesQueryParams {
     /// Filter response based on the channel
-    #[validate]
+    #[validate(nested)]
     channel: Option<EventChannel>,
     /// Filter response based on the delivery status
     status: Option<MessageStatus>,
@@ -450,7 +450,7 @@ pub struct ListAttemptsByEndpointQueryParams {
     /// Filter response based on the HTTP status code
     status_code_class: Option<StatusCodeClass>,
     /// Filter response based on the channel
-    #[validate]
+    #[validate(nested)]
     channel: Option<EventChannel>,
     /// Only include items created before a certain date
     before: Option<DateTime<Utc>>,
@@ -599,10 +599,10 @@ pub struct ListAttemptsByMsgQueryParams {
     /// Filter response based on the HTTP status code
     status_code_class: Option<StatusCodeClass>,
     /// Filter response based on the channel
-    #[validate]
+    #[validate(nested)]
     channel: Option<EventChannel>,
     /// Filter the attempts based on the attempted endpoint
-    #[validate]
+    #[validate(nested)]
     endpoint_id: Option<EndpointIdOrUid>,
     /// Only include items created before a certain date
     before: Option<DateTime<Utc>>,
@@ -800,7 +800,7 @@ async fn list_attempted_destinations(
 #[derive(Debug, Deserialize, Validate, JsonSchema)]
 pub struct ListAttemptsForEndpointQueryParams {
     /// Filter response based on the channel
-    #[validate]
+    #[validate(nested)]
     pub channel: Option<EventChannel>,
     /// Filter response based on the delivery status
     pub status: Option<MessageStatus>,
@@ -879,10 +879,10 @@ async fn list_attempts_for_endpoint(
 #[derive(Debug, Deserialize, Validate, JsonSchema)]
 pub struct AttemptListFetchQueryParams {
     /// Filter the attempts based on the attempted endpoint
-    #[validate]
+    #[validate(nested)]
     pub endpoint_id: Option<EndpointIdOrUid>,
     /// Filter response based on the channel
-    #[validate]
+    #[validate(nested)]
     pub channel: Option<EventChannel>,
     /// Filter response based on the delivery status
     pub status: Option<MessageStatus>,

--- a/server/svix-server/src/v1/endpoints/auth.rs
+++ b/server/svix-server/src/v1/endpoints/auth.rs
@@ -56,7 +56,7 @@ pub struct AppPortalAccessIn {
     ///
     /// If the application id or uid that is used in the path already exists,
     /// this argument is ignored.
-    #[validate]
+    #[validate(nested)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub application: Option<ApplicationIn>,
 }

--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -145,7 +145,7 @@ fn default_endpoint_version() -> Option<u16> {
 #[serde(rename_all = "camelCase")]
 pub struct EndpointIn {
     #[serde(default)]
-    #[validate(custom = "validate_no_control_characters")]
+    #[validate(custom(function = "validate_no_control_characters"))]
     #[schemars(example = "example_endpoint_description")]
     pub description: String,
 
@@ -166,11 +166,11 @@ pub struct EndpointIn {
     pub throttle_rate: Option<u16>,
 
     /// Optional unique identifier for the endpoint
-    #[validate]
+    #[validate(nested)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uid: Option<EndpointUid>,
 
-    #[validate(custom = "validate_url")]
+    #[validate(custom(function = "validate_url"))]
     #[schemars(url, length(min = 1, max = 65_536), example = "example_endpoint_url")]
     pub url: Url,
 
@@ -184,19 +184,19 @@ pub struct EndpointIn {
     #[schemars(example = "endpoint_disabled_default")]
     pub disabled: bool,
     #[serde(rename = "filterTypes")]
-    #[validate(custom = "validate_event_types_ids")]
-    #[validate]
+    #[validate(custom(function = "validate_event_types_ids"))]
+    #[validate(nested)]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(example = "example_filter_types", length(min = 1))]
     pub event_types_ids: Option<EventTypeNameSet>,
     /// List of message channels this endpoint listens to (omit for all)
-    #[validate(custom = "validate_channels_endpoint")]
-    #[validate]
+    #[validate(custom(function = "validate_channels_endpoint"))]
+    #[validate(nested)]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(example = "example_channel_set", length(min = 1, max = 10))]
     pub channels: Option<EventChannelSet>,
 
-    #[validate]
+    #[validate(nested)]
     #[serde(default)]
     #[serde(rename = "secret")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -256,7 +256,7 @@ impl ModelIn for EndpointIn {
 #[serde(rename_all = "camelCase")]
 struct EndpointUpdate {
     #[serde(default)]
-    #[validate(custom = "validate_no_control_characters")]
+    #[validate(custom(function = "validate_no_control_characters"))]
     #[schemars(example = "example_endpoint_description")]
     pub description: String,
 
@@ -277,11 +277,11 @@ struct EndpointUpdate {
     pub throttle_rate: Option<u16>,
 
     /// Optional unique identifier for the endpoint
-    #[validate]
+    #[validate(nested)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uid: Option<EndpointUid>,
 
-    #[validate(custom = "validate_url")]
+    #[validate(custom(function = "validate_url"))]
     #[schemars(url, length(min = 1, max = 65_536), example = "example_endpoint_url")]
     pub url: Url,
 
@@ -296,14 +296,14 @@ struct EndpointUpdate {
     pub disabled: bool,
 
     #[serde(rename = "filterTypes")]
-    #[validate(custom = "validate_event_types_ids")]
-    #[validate]
+    #[validate(custom(function = "validate_event_types_ids"))]
+    #[validate(nested)]
     #[schemars(example = "example_filter_types", length(min = 1))]
     pub event_types_ids: Option<EventTypeNameSet>,
 
     /// List of message channels this endpoint listens to (omit for all)
-    #[validate(custom = "validate_channels_endpoint")]
-    #[validate]
+    #[validate(custom(function = "validate_channels_endpoint"))]
+    #[validate(nested)]
     #[schemars(example = "example_channel_set", length(min = 1, max = 10))]
     pub channels: Option<EventChannelSet>,
 
@@ -381,32 +381,32 @@ impl EndpointUpdate {
 pub struct EndpointPatch {
     #[serde(default)]
     #[serde(skip_serializing_if = "UnrequiredField::is_absent")]
-    #[validate(custom = "validate_no_control_characters_unrequired")]
+    #[validate(custom(function = "validate_no_control_characters_unrequired"))]
     pub description: UnrequiredField<String>,
 
     /// Deprecated, use `throttleRate` instead.
     #[deprecated]
-    #[validate(custom = "validate_rate_limit_patch")]
+    #[validate(custom(function = "validate_rate_limit_patch"))]
     #[serde(default, skip_serializing_if = "UnrequiredNullableField::is_absent")]
     pub rate_limit: UnrequiredNullableField<u16>,
 
     /// Maximum messages per second to send to this endpoint.
     ///
     /// Outgoing messages will be throttled to this rate.
-    #[validate(custom = "validate_rate_limit_patch")]
+    #[validate(custom(function = "validate_rate_limit_patch"))]
     #[serde(default, skip_serializing_if = "UnrequiredNullableField::is_absent")]
     pub throttle_rate: UnrequiredNullableField<u16>,
 
-    #[validate]
+    #[validate(nested)]
     #[serde(default, skip_serializing_if = "UnrequiredNullableField::is_absent")]
     pub uid: UnrequiredNullableField<EndpointUid>,
 
-    #[validate(custom = "validate_url_unrequired")]
+    #[validate(custom(function = "validate_url_unrequired"))]
     #[serde(default)]
     pub url: UnrequiredField<Url>,
 
     #[deprecated]
-    #[validate(custom = "validate_minimum_version_patch")]
+    #[validate(custom(function = "validate_minimum_version_patch"))]
     #[schemars(range(min = 1), example = "example_endpoint_version")]
     #[serde(default)]
     pub version: UnrequiredField<u16>,
@@ -416,13 +416,13 @@ pub struct EndpointPatch {
     pub disabled: UnrequiredField<bool>,
 
     #[serde(default, rename = "filterTypes")]
-    #[validate(custom = "validate_event_types_ids_unrequired_nullable")]
-    #[validate]
+    #[validate(custom(function = "validate_event_types_ids_unrequired_nullable"))]
+    #[validate(nested)]
     #[serde(skip_serializing_if = "UnrequiredNullableField::is_absent")]
     pub event_types_ids: UnrequiredNullableField<EventTypeNameSet>,
 
-    #[validate(custom = "validate_channels_endpoint_unrequired_nullable")]
-    #[validate]
+    #[validate(custom(function = "validate_channels_endpoint_unrequired_nullable"))]
+    #[validate(nested)]
     #[serde(default, skip_serializing_if = "UnrequiredNullableField::is_absent")]
     pub channels: UnrequiredNullableField<EventChannelSet>,
 
@@ -580,7 +580,7 @@ impl From<(endpoint::Model, Metadata)> for EndpointOut {
 #[derive(Default, Clone, Debug, PartialEq, Eq, Validate, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct EndpointSecretRotateIn {
-    #[validate]
+    #[validate(nested)]
     #[serde(default)]
     key: Option<EndpointSecret>,
     /// How long the old secret will be valid for, in seconds.
@@ -697,7 +697,7 @@ fn endpoint_headers_patch_example() -> EndpointHeadersPatch {
 #[derive(Clone, Debug, PartialEq, Eq, Validate, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct EndpointHeadersPatchIn {
-    #[validate]
+    #[validate(nested)]
     #[schemars(example = "endpoint_headers_patch_example")]
     pub headers: EndpointHeadersPatch,
 }

--- a/server/svix-server/src/v1/endpoints/event_type.rs
+++ b/server/svix-server/src/v1/endpoints/event_type.rs
@@ -51,9 +51,9 @@ fn event_type_versioned_schemas_example() -> serde_json::Value {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Validate, ModelIn, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct EventTypeIn {
-    #[validate]
+    #[validate(nested)]
     pub name: EventTypeName,
-    #[validate(custom = "validate_no_control_characters")]
+    #[validate(custom(function = "validate_no_control_characters"))]
     #[schemars(example = "event_type_description_example")]
     pub description: String,
     #[serde(default, rename = "archived")]
@@ -94,7 +94,7 @@ impl ModelIn for EventTypeIn {
 #[derive(Clone, Debug, PartialEq, Deserialize, Validate, ModelIn, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 struct EventTypeUpdate {
-    #[validate(custom = "validate_no_control_characters")]
+    #[validate(custom(function = "validate_no_control_characters"))]
     #[schemars(example = "event_type_description_example")]
     description: String,
     #[serde(default, rename = "archived")]
@@ -134,7 +134,7 @@ impl ModelIn for EventTypeUpdate {
 #[serde(rename_all = "camelCase")]
 struct EventTypePatch {
     #[serde(default, skip_serializing_if = "UnrequiredField::is_absent")]
-    #[validate(custom = "validate_no_control_characters_unrequired")]
+    #[validate(custom(function = "validate_no_control_characters_unrequired"))]
     description: UnrequiredField<String>,
 
     #[serde(

--- a/server/svix-server/src/v1/endpoints/message.rs
+++ b/server/svix-server/src/v1/endpoints/message.rs
@@ -109,18 +109,18 @@ pub fn validate_raw_payload_is_object(payload: &RawPayload) -> Result<(), Valida
 #[serde(rename_all = "camelCase")]
 pub struct MessageIn {
     /// Optional unique identifier for the message
-    #[validate]
+    #[validate(nested)]
     #[serde(rename = "eventId", skip_serializing_if = "Option::is_none")]
     pub uid: Option<MessageUid>,
-    #[validate]
+    #[validate(nested)]
     pub event_type: EventTypeName,
-    #[validate(custom = "validate_raw_payload_is_object")]
+    #[validate(custom(function = "validate_raw_payload_is_object"))]
     #[serde(alias = "payload", alias = "data")]
     #[schemars(example = "example_payload")]
     pub payload: RawPayload,
     /// List of free-form identifiers that endpoints can filter by
-    #[validate(custom = "validate_channels_msg")]
-    #[validate]
+    #[validate(custom(function = "validate_channels_msg"))]
+    #[validate(nested)]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(example = "example_channel_set", length(min = 1, max = 5))]
     pub channels: Option<EventChannelSet>,
@@ -136,7 +136,7 @@ pub struct MessageIn {
     ///
     /// If the application id or uid that is used in the path already exists,
     /// this argument is ignored.
-    #[validate]
+    #[validate(nested)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub application: Option<ApplicationIn>,
 }
@@ -256,7 +256,7 @@ fn default_90() -> i64 {
 #[derive(Clone, Debug, Deserialize, Validate, JsonSchema)]
 pub struct ListMessagesQueryParams {
     /// Filter response based on the channel
-    #[validate]
+    #[validate(nested)]
     channel: Option<EventChannel>,
     /// Only include items created before a certain date
     before: Option<DateTime<Utc>>,

--- a/server/svix-server/src/v1/utils/mod.rs
+++ b/server/svix-server/src/v1/utils/mod.rs
@@ -58,22 +58,22 @@ static LIMITED_QUERY_DURATION: LazyLock<chrono::Duration> =
 #[derive(Clone, Debug, Deserialize, Validate, JsonSchema)]
 pub struct PaginationDescending<T: Validate + JsonSchema> {
     /// Limit the number of returned items
-    #[validate]
+    #[validate(nested)]
     #[serde(default = "default_limit")]
     pub limit: PaginationLimit,
     /// The iterator returned from a prior invocation
-    #[validate]
+    #[validate(nested)]
     pub iterator: Option<T>,
 }
 
 #[derive(Clone, Debug, Deserialize, Validate, JsonSchema)]
 pub struct Pagination<T: Validate + JsonSchema> {
     /// Limit the number of returned items
-    #[validate]
+    #[validate(nested)]
     #[serde(default = "default_limit")]
     pub limit: PaginationLimit,
     /// The iterator returned from a prior invocation
-    #[validate]
+    #[validate(nested)]
     pub iterator: Option<T>,
     /// The sorting order of the returned items
     pub order: Option<Ordering>,
@@ -473,7 +473,7 @@ pub fn validation_errors(
         .flat_map(|(k, v)| {
             // Add the next field to the location
             let mut loc = acc_path.clone();
-            loc.push(k.to_owned());
+            loc.push(k.into_owned());
 
             match v {
                 // If it's a [`validator::ValidationErrorsKind::Field`], then it will be a vector of
@@ -834,10 +834,10 @@ mod tests {
         #[validate(range(min = 10, message = "Below 10"))]
         a: u32,
 
-        #[validate]
+        #[validate(nested)]
         b: ValidationErrorTestStructInner,
 
-        #[validate]
+        #[validate(nested)]
         c: Vec<ValidationErrorTestStructInner>,
     }
 


### PR DESCRIPTION
My immediate goal is getting rid of proc-macro-error-2, which requires this upgrade.

Part of svix/monorepo-private#9089