### PR TITLE
rust: embed package metadata in binaries

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * CLI, Server, Bridge: Set OCI metadata on Docker images
+* CLI, Server, Bridge: Embed package metadata in compiled binaries on Linux
 
 ## Version 1.97.0
 * CLI: Ignore `EPIPE` when printing output

--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -3939,6 +3939,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-executable-metadata"
+version = "0.1.0"
+source = "git+https://github.com/svix/rust-executable-metadata?rev=7a32435fbdab53f33e6abab9c1ab500afef0a7a8#7a32435fbdab53f33e6abab9c1ab500afef0a7a8"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4609,6 +4618,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "reqwest",
+ "rust-executable-metadata",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/bridge/svix-bridge/Cargo.toml
+++ b/bridge/svix-bridge/Cargo.toml
@@ -44,6 +44,9 @@ tracing-opentelemetry = "0.33.0"
 tracing-subscriber = { workspace = true, features = ["fmt", "json"] }
 url = "2.5.4"
 
+[build-dependencies]
+rust-executable-metadata = { git = "https://github.com/svix/rust-executable-metadata", rev = "7a32435fbdab53f33e6abab9c1ab500afef0a7a8" }
+
 [dev-dependencies]
 chrono = "0.4"
 tower = "0.5.1"

--- a/bridge/svix-bridge/build.rs
+++ b/bridge/svix-bridge/build.rs
@@ -1,7 +1,4 @@
 fn main() {
-    // trigger recompilation when a new migration is added
-    println!("cargo:rerun-if-changed=migrations");
-
     println!("cargo:rerun-if-changed=build.rs");
 
     let mut package_metadata =

--- a/deny.toml
+++ b/deny.toml
@@ -80,6 +80,7 @@ allow-git = [
     "https://github.com/svix/hyper.git",
     "https://github.com/svix/omniqueue-rs.git",
     "https://github.com/svix/validator.git",
+    "https://github.com/svix/rust-executable-metadata.git",
 ]
 # there are several projects in here, so it's okay if we don't use them all
 unused-allowed-source = "allow"

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -4242,6 +4242,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-executable-metadata"
+version = "0.1.0"
+source = "git+https://github.com/svix/rust-executable-metadata?rev=7a32435fbdab53f33e6abab9c1ab500afef0a7a8#7a32435fbdab53f33e6abab9c1ab500afef0a7a8"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5295,6 +5304,7 @@ dependencies = [
  "redis",
  "regex",
  "reqwest",
+ "rust-executable-metadata",
  "schemars",
  "sea-orm",
  "sentry",

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -97,6 +97,9 @@ urlencoding = "2.1.2"
 # rewrite with a barely-useful changelog)
 validator = { git = "https://github.com/svix/validator.git", rev = "aebdc34a4ed72524902ff6d63397b9c435b0578f", features = ["derive"] }
 
+[build-dependencies]
+rust-executable-metadata = { git = "https://github.com/svix/rust-executable-metadata", rev = "7a32435fbdab53f33e6abab9c1ab500afef0a7a8" }
+
 [dev-dependencies]
 assert_matches = "1.5.0"
 axum-server = { version = "0.7.1", features = ["tls-openssl"] }

--- a/svix-cli/Cargo.lock
+++ b/svix-cli/Cargo.lock
@@ -1453,6 +1453,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-executable-metadata"
+version = "0.1.0"
+source = "git+https://github.com/svix/rust-executable-metadata?rev=7a32435fbdab53f33e6abab9c1ab500afef0a7a8#7a32435fbdab53f33e6abab9c1ab500afef0a7a8"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1806,6 +1815,7 @@ dependencies = [
  "open",
  "rand 0.9.4",
  "reqwest",
+ "rust-executable-metadata",
  "rustls",
  "serde",
  "serde_json",

--- a/svix-cli/Cargo.toml
+++ b/svix-cli/Cargo.toml
@@ -69,6 +69,9 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["std", "ansi", "fmt", "registry", "local-time"] }
 url = "2.5.4"
 
+[build-dependencies]
+rust-executable-metadata = { git = "https://github.com/svix/rust-executable-metadata", rev = "7a32435fbdab53f33e6abab9c1ab500afef0a7a8" }
+
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"

--- a/svix-cli/build.rs
+++ b/svix-cli/build.rs
@@ -1,7 +1,4 @@
 fn main() {
-    // trigger recompilation when a new migration is added
-    println!("cargo:rerun-if-changed=migrations");
-
     println!("cargo:rerun-if-changed=build.rs");
 
     let mut package_metadata =


### PR DESCRIPTION
This modifies OSS server, CLI, and bridge to embed package metadata into binaries when compiled on Linux (including in Docker).

Part of svix/monorepo-private#13574