### PR TITLE
gha: switch docker/github-builder to our fork temporarily

### DIFF
--- a/.github/workflows/bridge-release.yml
+++ b/.github/workflows/bridge-release.yml
@@ -63,7 +63,8 @@ jobs:
 
   build:
     needs: [get-version]
-    uses: docker/github-builder/.github/workflows/build.yml@v1
+    # TODO: switch back to docker/github-builder after https://github.com/docker/github-builder/pull/256 is landed
+    uses: svix-jbrown/github-builder/.github/workflows/build.yml@849c76fdd485958f58aff3ef1222ddfb8dcf4c3b # 849c76fdd485958f58aff3ef1222ddfb8dcf4c3b
     permissions:
       contents: read # to fetch the repository content
       id-token: write # for signing attestation(s) with GitHub OIDC Token

--- a/.github/workflows/cli-docker-release.yml
+++ b/.github/workflows/cli-docker-release.yml
@@ -29,7 +29,8 @@ jobs:
       version: ${{ steps.get-version-number.outputs.tag }}
   build:
     needs: [get-version]
-    uses: docker/github-builder/.github/workflows/build.yml@v1
+    # TODO: switch back to docker/github-builder after https://github.com/docker/github-builder/pull/256 is landed
+    uses: svix-jbrown/github-builder/.github/workflows/build.yml@849c76fdd485958f58aff3ef1222ddfb8dcf4c3b # 849c76fdd485958f58aff3ef1222ddfb8dcf4c3b
     permissions:
       contents: read # to fetch the repository content
       id-token: write # for signing attestation(s) with GitHub OIDC Token

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -52,7 +52,8 @@ jobs:
 
   build:
     needs: [get-version]
-    uses: docker/github-builder/.github/workflows/build.yml@v1
+    # TODO: switch back to docker/github-builder after https://github.com/docker/github-builder/pull/256 is landed
+    uses: svix-jbrown/github-builder/.github/workflows/build.yml@849c76fdd485958f58aff3ef1222ddfb8dcf4c3b # 849c76fdd485958f58aff3ef1222ddfb8dcf4c3b
     permissions:
       contents: read # to fetch the repository content
       id-token: write # for signing attestation(s) with GitHub OIDC Token


### PR DESCRIPTION
`build.yml` doesn't actually honor `meta-labels` (which we started passing in #2457); see docker/github-builder#255. For now, switch to my fork which adds the missing input.