### PR TITLE
server: switch to fork of sea-bae to remove proc-macro-error2 from dependencies

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -15,9 +15,6 @@ unused-ignored-advisory = "allow"
 ignore = [
     # TODO: Update dependencies that use rsa crate
     "RUSTSEC-2023-0071",
-    # TODO: Wait for dependencies to upgrade off of proc-macro-error (validator)
-    # and proc-macro-error2 (sea-orm/sea-bae)
-    "RUSTSEC-2024-0370",
     "RUSTSEC-2026-0173",
     # TODO: Wait for dependencies to upgrade off of paste
     "RUSTSEC-2024-0436",
@@ -81,6 +78,7 @@ allow-git = [
     "https://github.com/svix/omniqueue-rs.git",
     "https://github.com/svix/validator.git",
     "https://github.com/svix/rust-executable-metadata.git",
+    "https://github.com/svix-jbrown/sea-bae.git",
 ]
 # there are several projects in here, so it's okay if we don't use them all
 unused-allowed-source = "allow"

--- a/deny.toml
+++ b/deny.toml
@@ -76,7 +76,6 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
     "https://github.com/svix/hyper.git",
     "https://github.com/svix/omniqueue-rs.git",
-    "https://github.com/svix/validator.git",
     "https://github.com/svix/rust-executable-metadata.git",
     "https://github.com/svix-jbrown/sea-bae.git",
 ]

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -3777,16 +3777,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "proc-macro-error-attr3"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3794,18 +3784,6 @@ checksum = "34e4dd828515431dd6c4a030d26f7eaed7dd4778226e9d2bb968d65ca4ec3d4d"
 dependencies = [
  "proc-macro2",
  "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -4510,11 +4488,10 @@ dependencies = [
 [[package]]
 name = "sea-bae"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f694a6ab48f14bc063cfadff30ab551d3c7e46d8f81836c51989d548f44a2a25"
+source = "git+https://github.com/svix-jbrown/sea-bae.git?rev=a09fff7d57f626df1990d1c829053ba28435b1c3#a09fff7d57f626df1990d1c829053ba28435b1c3"
 dependencies = [
  "heck 0.4.1",
- "proc-macro-error2",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
  "syn",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -37,3 +37,5 @@ svix-server-derive = { opt-level = 0 }
 
 [patch.crates-io]
 hyper = { git = "https://github.com/svix/hyper.git", rev = "0b8b37910862f6da9cf08717f753c052f5c087fd" }
+# remove this override after https://github.com/SeaQL/sea-bae/pull/3 lands
+sea-bae = { git = "https://github.com/svix-jbrown/sea-bae.git", rev = "a09fff7d57f626df1990d1c829053ba28435b1c3" }


### PR DESCRIPTION
`proc-macro-error2` has a very annoying warning printed on every build under rust 1.97+. This removes our last user of proc-macro-error2 by switchign sea-bae to use https://github.com/SeaQL/sea-bae/pull/3.