### PR TITLE
docker: build CLI with wolfi instead of debian

### DIFF
--- a/bridge/scripts/check-deps.sh
+++ b/bridge/scripts/check-deps.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# this has to run under both bash on debian and busybox sh on alpine
+# this has to run under both bash on debian and busybox sh on alpine/wolfi
 
 BINPATH="$1"
 

--- a/bridge/scripts/check-deps.sh
+++ b/bridge/scripts/check-deps.sh
@@ -1,8 +1,10 @@
-#!/bin/bash
+#!/bin/sh
+
+# this has to run under both bash on debian and busybox sh on alpine
 
 BINPATH="$1"
 
-if [[ -z "$BINPATH" ]]; then
+if [ -z "$BINPATH" ]; then
     echo >&2 "Usage $0 path/to/binary"
     exit 2
 fi
@@ -13,6 +15,6 @@ MISSING="$(ldd "$BINPATH" | grep 'not found')"
 # There'll be 1 linebreak for the empty case. Anything else and it means we
 # caught some unexpected output from ldd.
 if [ "1" != "$(echo "$MISSING" | wc -l)" ]; then
-    echo -e "Binary $BINPATH missing dependencies:\n$MISSING"
+    printf "Binary %s missing dependencies:\n%s" "$BINPATH" "$MISSING"
     exit 1
 fi

--- a/svix-cli/.dockerignore
+++ b/svix-cli/.dockerignore
@@ -1,1 +1,2 @@
 */target/
+Dockerfile*

--- a/svix-cli/Dockerfile
+++ b/svix-cli/Dockerfile
@@ -3,22 +3,18 @@
 # NOTE: this should be built from the root of `svix-webhooks`
 # with `docker build -f svix-cli/Dockerfile .`# Base build
 
-FROM docker.io/rust:1.96-slim-trixie AS build
-
-SHELL ["/bin/bash", "-eux", "-o", "pipefail", "-c"]
-RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked --mount=target=/var/cache/apt,type=cache,sharing=locked <<EOF
-    export DEBIAN_FRONTEND=noninteractive
-    apt-get update -q
-    apt-get install -y \
-        build-essential=12.* \
-        checkinstall=1.* \
-        curl=8.* \
-        libssl-dev=* \
-        pkg-config=1.8.* \
-        zlib1g-dev=1:* \
-        cmake=3.* \
-        --no-install-recommends
+FROM cgr.dev/chainguard/wolfi-base@sha256:02dab76bd852a70556b5b2002195c8a5fdab77d323c433bf6642aab080489795 AS build
+SHELL ["/bin/sh", "-eux", "-c"]
+RUN --mount=target=/var/cache/apk,type=cache,sharing=locked --mount=target=/tmp,type=cache,sharing=locked <<EOF
+    apk add rust~1.96.1 \
+        build-base~1 \
+        openssl-dev~3.6 \
+        zlib-dev~1.3 \
+        cmake~4 \
+        shadow~4 \
+        git~2
 EOF
+RUN cargo install --locked cargo-sbom@0.10.0
 
 RUN <<EOF
     mkdir -p /app
@@ -30,48 +26,42 @@ EOF
 
 WORKDIR /app/svix-cli
 
-# Hack to enable docker caching
 COPY rust /app/rust
-COPY svix-cli/Cargo.toml .
-COPY svix-cli/Cargo.lock .
+COPY svix-cli /app/svix-cli
 
-RUN <<EOF
-    mkdir src
-    echo 'fn main() { println!("Dummy!"); }' > src/main.rs
-    cargo build --release
-    rm -rf src
-EOF
+RUN cargo build --release
+RUN cargo sbom > /app/svix-cli.spdx
+RUN strip target/release/svix
 
-COPY . /app
-RUN touch src/main.rs
-RUN cargo build --release --frozen
+# ensure that the check-deps.sh script never ends up in the real image
+FROM alpine:3.24 AS checker
+RUN mkdir /scripts
+COPY bridge/scripts/check-deps.sh /scripts/check-deps.sh
 
 # Production
-FROM docker.io/debian:trixie-20260713-slim AS prod
+FROM cgr.dev/chainguard/wolfi-base@sha256:02dab76bd852a70556b5b2002195c8a5fdab77d323c433bf6642aab080489795 AS prod
 
-SHELL ["/bin/bash", "-eux", "-o", "pipefail", "-c"]
-RUN <<EOF
-    mkdir -p /app
-    useradd appuser
-    chown -R appuser: /app
-    mkdir -p /home/appuser
-    chown -R appuser: /home/appuser
-EOF
+SHELL ["/bin/sh", "-eux", "-c"]
 
-RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked --mount=target=/var/cache/apt,type=cache,sharing=locked <<EOF
-    export DEBIAN_FRONTEND=noninteractive
-    apt-get update -q
-    apt-get install -y --no-install-recommends ca-certificates=20250419
+RUN --mount=target=/var/cache/apk,type=cache,sharing=locked --mount=target=/tmp,type=cache,sharing=locked <<EOF
+    apk add ca-certificates~20260413
     update-ca-certificates
 EOF
 
-USER appuser
+RUN <<EOF
+    mkdir -p /app
+    addgroup -S appgroup
+    adduser -G appgroup -S appuser
+    chown -R appuser:appgroup /app
+    mkdir -p /home/appuser
+    chown -R appuser:appgroup /home/appuser
+EOF
 
 COPY --chown=root:root --chmod=755 --from=build /app/svix-cli/target/release/svix /usr/local/bin/svix
-COPY bridge/scripts/check-deps.sh /usr/local/bin/check-deps.sh
+COPY --chown=root:root --chmod=444 --from=build /app/svix-cli.spdx /svix-cli.spdx
 
 # Verify all the dynamic libs we depend on are present in the runtime stage
-RUN /usr/local/bin/check-deps.sh /usr/local/bin/svix
+RUN --mount=type=bind,from=checker,source=/scripts,target=/scripts /scripts/check-deps.sh /usr/local/bin/svix
 
 LABEL org.opencontainers.image.authors="support@svix.com" \
       org.opencontainers.image.url="https://www.svix.com" \
@@ -80,6 +70,9 @@ LABEL org.opencontainers.image.authors="support@svix.com" \
       org.opencontainers.image.title="svix-webhooks, cli, oss" \
       org.opencontainers.image.vendor="Svix" \
       org.opencontainers.image.licenses="MIT" \
-      org.opencontainers.image.base.name="docker.io/debian:trixie"
+      org.opencontainers.image.base.name="cgr.dev/chainguard/wolfi-base" \
+      org.opencontainers.image.source=""
+
+USER appuser:appgroup
 
 CMD ["/usr/local/bin/svix"]


### PR DESCRIPTION
This is an alternative to #2471 that @svix-jplatte  suggested; rather than using alpine, it uses Chainguard's `wolfi`.

The image is a bit bigger than alpine (28MB instead of 22MB; entirely due to the fact that glibc is 6MB larger than musl libc), but it should be a lot faster due to using "real" glibc.

Also, 0 CVEs. :-)