### PR TITLE
Backwards-compatibly rename filterTypes => eventTypes

### DIFF
--- a/server/openapi.json
+++ b/server/openapi.json
@@ -460,7 +460,7 @@
                         "example": false,
                         "type": "boolean"
                     },
-                    "filterTypes": {
+                    "eventTypes": {
                         "example": [
                             "user.signup",
                             "user.deleted"
@@ -642,7 +642,7 @@
                         "example": false,
                         "type": "boolean"
                     },
-                    "filterTypes": {
+                    "eventTypes": {
                         "example": [
                             "user.signup",
                             "user.deleted"
@@ -741,7 +741,7 @@
                     "disabled": {
                         "type": "boolean"
                     },
-                    "filterTypes": {
+                    "eventTypes": {
                         "items": {
                             "example": "user.signup",
                             "maxLength": 256,
@@ -908,7 +908,7 @@
                         "example": false,
                         "type": "boolean"
                     },
-                    "filterTypes": {
+                    "eventTypes": {
                         "example": [
                             "user.signup",
                             "user.deleted"
@@ -1834,7 +1834,7 @@
                         "example": false,
                         "type": "boolean"
                     },
-                    "filterTypes": {
+                    "eventTypes": {
                         "example": [
                             "user.signup",
                             "user.deleted"

--- a/server/svix-server/src/core/message_app.rs
+++ b/server/svix-server/src/core/message_app.rs
@@ -137,7 +137,7 @@ impl CreateMessageApp {
                         || (
                             // If an endpoint has event types and it matches ours, or has no event types
                             endpoint
-                                .event_types_ids
+                                .event_types
                                 .as_ref()
                                 .map(|x| x.0.contains(event_type))
                                 .unwrap_or(true)
@@ -165,7 +165,14 @@ pub struct CreateMessageEndpoint {
     pub id: EndpointId,
     pub url: String,
     pub key: EndpointSecretInternal,
-    pub event_types_ids: Option<EventTypeNameSet>,
+    #[serde(
+        // backwards compat
+        rename = "event_types_ids",
+        // in case we ever start cleaning up old stuff
+        // (we'll have to figure out how to do the migration though)
+        alias = "event_types"
+    )]
+    pub event_types: Option<EventTypeNameSet>,
     pub channels: Option<EventChannelSet>,
     pub rate_limit: Option<u16>,
     // Same type as the `DateTimeWithTimeZone from SeaORM used in the endpoint model
@@ -203,7 +210,7 @@ impl TryFrom<endpoint::Model> for CreateMessageEndpoint {
             url: m.url,
             key: m.key,
             old_signing_keys: m.old_keys,
-            event_types_ids: m.event_types_ids,
+            event_types: m.event_types_ids,
             channels: m.channels,
             rate_limit: m
                 .rate_limit
@@ -267,7 +274,7 @@ mod tests {
             url: "".to_string(),
             key,
             old_signing_keys,
-            event_types_ids: None,
+            event_types: None,
             channels: None,
             rate_limit: None,
             first_failure_at: None,

--- a/server/svix-server/src/v1/endpoints/endpoint/crud.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/crud.rs
@@ -348,7 +348,7 @@ async fn validate_event_types(
             .collect::<Vec<&str>>()
             .join(", ");
         Err(HttpError::unprocessable_entity(vec![ValidationErrorItem {
-            loc: vec!["body".to_owned(), "filterTypes".to_owned()],
+            loc: vec!["body".to_owned(), "eventTypes".to_owned()],
             msg: format!("The following event types don't exist: {missing}"),
             ty: "value_error".to_owned(),
         }])

--- a/server/svix-server/src/v1/endpoints/endpoint/crud.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/crud.rs
@@ -124,8 +124,8 @@ pub(super) async fn create_endpoint(
     permissions::Application { app }: permissions::Application,
     ValidatedJson(data): ValidatedJson<EndpointIn>,
 ) -> Result<JsonStatus<201, EndpointOut>> {
-    if let Some(ref event_types_ids) = data.event_types_ids {
-        validate_event_types(db, event_types_ids, &app.org_id).await?;
+    if let Some(event_types) = &data.event_types {
+        validate_event_types(db, event_types, &app.org_id).await?;
     }
     validate_endpoint_url(&data.url, cfg.endpoint_https_only)?;
 
@@ -199,8 +199,8 @@ pub(super) async fn update_endpoint(
     permissions::Application { app }: permissions::Application,
     ValidatedJson(mut data): ValidatedJson<EndpointUpdate>,
 ) -> Result<JsonStatusUpsert<EndpointOut>> {
-    if let Some(ref event_types_ids) = data.event_types_ids {
-        validate_event_types(db, event_types_ids, &app.org_id).await?;
+    if let Some(event_types) = &data.event_types {
+        validate_event_types(db, event_types, &app.org_id).await?;
     }
     validate_endpoint_url(&data.url, cfg.endpoint_https_only)?;
 
@@ -238,8 +238,8 @@ pub(super) async fn patch_endpoint(
     permissions::Application { app }: permissions::Application,
     ValidatedJson(data): ValidatedJson<EndpointPatch>,
 ) -> Result<Json<EndpointOut>> {
-    if let UnrequiredNullableField::Some(ref event_types_ids) = data.event_types_ids {
-        validate_event_types(db, event_types_ids, &app.org_id).await?;
+    if let UnrequiredNullableField::Some(event_types) = &data.event_types {
+        validate_event_types(db, event_types, &app.org_id).await?;
     }
     if let UnrequiredField::Some(url) = &data.url {
         validate_endpoint_url(url, cfg.endpoint_https_only)?;

--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -56,8 +56,8 @@ use crate::{
 pub fn validate_event_types_ids(event_types_ids: &EventTypeNameSet) -> Result<(), ValidationError> {
     if event_types_ids.0.is_empty() {
         Err(validation_error(
-            Some("filterTypes"),
-            Some("filterTypes can't be empty, it must have at least one item."),
+            Some("eventTypes"),
+            Some("eventTypes can't be empty, it must have at least one item."),
         ))
     } else {
         Ok(())
@@ -183,12 +183,14 @@ pub struct EndpointIn {
     #[serde(default)]
     #[schemars(example = "endpoint_disabled_default")]
     pub disabled: bool,
-    #[serde(rename = "filterTypes")]
+
+    #[serde(alias = "filterTypes")]
     #[validate(custom(function = "validate_event_types_ids"))]
     #[validate(nested)]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(example = "example_filter_types", length(min = 1))]
     pub event_types: Option<EventTypeNameSet>,
+
     /// List of message channels this endpoint listens to (omit for all)
     #[validate(custom(function = "validate_channels_endpoint"))]
     #[validate(nested)]
@@ -295,7 +297,7 @@ struct EndpointUpdate {
     #[schemars(example = "endpoint_disabled_default")]
     pub disabled: bool,
 
-    #[serde(rename = "filterTypes")]
+    #[serde(alias = "filterTypes")]
     #[validate(custom(function = "validate_event_types_ids"))]
     #[validate(nested)]
     #[schemars(example = "example_filter_types", length(min = 1))]
@@ -415,7 +417,7 @@ pub struct EndpointPatch {
     #[serde(skip_serializing_if = "UnrequiredField::is_absent")]
     pub disabled: UnrequiredField<bool>,
 
-    #[serde(default, rename = "filterTypes")]
+    #[serde(default, alias = "filterTypes")]
     #[validate(custom(function = "validate_event_types_ids_unrequired_nullable"))]
     #[validate(nested)]
     #[serde(skip_serializing_if = "UnrequiredNullableField::is_absent")]
@@ -528,9 +530,12 @@ pub struct EndpointOutCommon {
         default = "endpoint_disabled_default"
     )]
     pub disabled: bool,
-    #[serde(rename = "filterTypes")]
     #[schemars(example = "example_filter_types", length(min = 1))]
     pub event_types: Option<EventTypeNameSet>,
+    /// Deprecated alias of `event_types`.
+    #[serde(rename = "filterTypes")]
+    #[schemars(skip)]
+    pub filter_types: Option<EventTypeNameSet>,
     /// List of message channels this endpoint listens to (omit for all)
     #[schemars(example = "example_channel_set", length(min = 1, max = 10))]
     pub channels: Option<EventChannelSet>,
@@ -549,7 +554,8 @@ impl From<endpoint::Model> for EndpointOutCommon {
             url: model.url,
             version: model.version as u16,
             disabled: model.disabled,
-            event_types: model.event_types_ids,
+            event_types: model.event_types_ids.clone(),
+            filter_types: model.event_types_ids,
             channels: model.channels,
             created_at: model.created_at.into(),
             updated_at: model.updated_at.into(),

--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -188,7 +188,7 @@ pub struct EndpointIn {
     #[validate(nested)]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(example = "example_filter_types", length(min = 1))]
-    pub event_types_ids: Option<EventTypeNameSet>,
+    pub event_types: Option<EventTypeNameSet>,
     /// List of message channels this endpoint listens to (omit for all)
     #[validate(custom(function = "validate_channels_endpoint"))]
     #[validate(nested)]
@@ -235,7 +235,7 @@ impl ModelIn for EndpointIn {
             url,
             version,
             disabled,
-            event_types_ids,
+            event_types: event_types_ids,
             channels,
             key: _,
             metadata: _,
@@ -299,7 +299,7 @@ struct EndpointUpdate {
     #[validate(custom(function = "validate_event_types_ids"))]
     #[validate(nested)]
     #[schemars(example = "example_filter_types", length(min = 1))]
-    pub event_types_ids: Option<EventTypeNameSet>,
+    pub event_types: Option<EventTypeNameSet>,
 
     /// List of message channels this endpoint listens to (omit for all)
     #[validate(custom(function = "validate_channels_endpoint"))]
@@ -325,7 +325,7 @@ impl ModelIn for EndpointUpdate {
             url,
             version,
             disabled,
-            event_types_ids,
+            event_types: event_types_ids,
             channels,
             metadata: _,
         } = self;
@@ -353,7 +353,7 @@ impl EndpointUpdate {
             url,
             version,
             disabled,
-            event_types_ids,
+            event_types: event_types_ids,
             channels,
             metadata,
         } = self;
@@ -367,7 +367,7 @@ impl EndpointUpdate {
             url,
             version,
             disabled,
-            event_types_ids,
+            event_types: event_types_ids,
             channels,
             metadata,
 
@@ -419,7 +419,7 @@ pub struct EndpointPatch {
     #[validate(custom(function = "validate_event_types_ids_unrequired_nullable"))]
     #[validate(nested)]
     #[serde(skip_serializing_if = "UnrequiredNullableField::is_absent")]
-    pub event_types_ids: UnrequiredNullableField<EventTypeNameSet>,
+    pub event_types: UnrequiredNullableField<EventTypeNameSet>,
 
     #[validate(custom(function = "validate_channels_endpoint_unrequired_nullable"))]
     #[validate(nested)]
@@ -445,7 +445,7 @@ impl ModelIn for EndpointPatch {
             url,
             version,
             disabled,
-            event_types_ids,
+            event_types: event_types_ids,
             channels,
             metadata: _,
         } = self;
@@ -530,7 +530,7 @@ pub struct EndpointOutCommon {
     pub disabled: bool,
     #[serde(rename = "filterTypes")]
     #[schemars(example = "example_filter_types", length(min = 1))]
-    pub event_types_ids: Option<EventTypeNameSet>,
+    pub event_types: Option<EventTypeNameSet>,
     /// List of message channels this endpoint listens to (omit for all)
     #[schemars(example = "example_channel_set", length(min = 1, max = 10))]
     pub channels: Option<EventChannelSet>,
@@ -549,7 +549,7 @@ impl From<endpoint::Model> for EndpointOutCommon {
             url: model.url,
             version: model.version as u16,
             disabled: model.disabled,
-            event_types_ids: model.event_types_ids,
+            event_types: model.event_types_ids,
             channels: model.channels,
             created_at: model.created_at.into(),
             updated_at: model.updated_at.into(),

--- a/server/svix-server/src/v1/endpoints/endpoint/mod.rs
+++ b/server/svix-server/src/v1/endpoints/endpoint/mod.rs
@@ -997,42 +997,42 @@ mod tests {
     #[test]
     fn test_endpoint_in_validation() {
         let invalid_1: EndpointIn = serde_json::from_value(json!({
-             "version": VERSION_INVALID,
-             "url": URL_VALID
+            "version": VERSION_INVALID,
+            "url": URL_VALID
         }))
         .unwrap();
 
         let invalid_2: EndpointIn = serde_json::from_value(json!({
-             "version": VERSION_VALID,
-             "url": URL_VALID,
-             "channels": EVENT_CHANNELS_INVALID
+            "version": VERSION_VALID,
+            "url": URL_VALID,
+            "channels": EVENT_CHANNELS_INVALID
         }))
         .unwrap();
 
         let invalid_3: EndpointIn = serde_json::from_value(json!({
-             "version": VERSION_VALID,
-             "url": URL_VALID,
-             "rateLimit": RATE_LIMIT_INVALID
+            "version": VERSION_VALID,
+            "url": URL_VALID,
+            "rateLimit": RATE_LIMIT_INVALID
         }))
         .unwrap();
 
         let invalid_4: EndpointIn = serde_json::from_value(json!({
-             "version": VERSION_VALID,
-             "url": URL_VALID,
-             "uid": ENDPOINT_ID_INVALID
+            "version": VERSION_VALID,
+            "url": URL_VALID,
+            "uid": ENDPOINT_ID_INVALID
         }))
         .unwrap();
 
         let invalid_5: EndpointIn = serde_json::from_value(json!({
-             "version": VERSION_VALID,
-             "url": URL_VALID,
-             "filterTypes": EVENT_TYPES_INVALID
+            "version": VERSION_VALID,
+            "url": URL_VALID,
+            "filterTypes": EVENT_TYPES_INVALID
         }))
         .unwrap();
 
         let invalid_6: Result<EndpointIn, _> = serde_json::from_value(json!({
-             "version": VERSION_VALID,
-             "url": URL_INVALID
+            "version": VERSION_VALID,
+            "url": URL_INVALID
         }));
         assert!(invalid_6.is_err());
 
@@ -1041,22 +1041,22 @@ mod tests {
         }
 
         let valid_1: EndpointIn = serde_json::from_value(json!({
-             "version": VERSION_VALID,
-             "url": URL_VALID,
-             "rateLimit": RATE_LIMIT_VALID,
-             "uid": ENDPOINT_ID_VALID,
-             "filterTypes": EVENT_TYPES_VALID,
-             "channels": EVENT_CHANNELS_VALID
+            "version": VERSION_VALID,
+            "url": URL_VALID,
+            "rateLimit": RATE_LIMIT_VALID,
+            "uid": ENDPOINT_ID_VALID,
+            "filterTypes": EVENT_TYPES_VALID,
+            "channels": EVENT_CHANNELS_VALID
         }))
         .unwrap();
         valid_1.validate().unwrap();
 
         let valid_2: EndpointIn = serde_json::from_value(json!({
-             "url": URL_VALID,
-             "rateLimit": RATE_LIMIT_VALID,
-             "uid": ENDPOINT_ID_VALID,
-             "filterTypes": EVENT_TYPES_VALID,
-             "channels": EVENT_CHANNELS_VALID
+            "url": URL_VALID,
+            "rateLimit": RATE_LIMIT_VALID,
+            "uid": ENDPOINT_ID_VALID,
+            "filterTypes": EVENT_TYPES_VALID,
+            "channels": EVENT_CHANNELS_VALID
         }))
         .unwrap();
         valid_2.validate().unwrap();

--- a/server/svix-server/tests/it/e2e_endpoint.rs
+++ b/server/svix-server/tests/it/e2e_endpoint.rs
@@ -121,7 +121,7 @@ async fn test_create() {
     assert_eq!(out.ep.url, "http://example.com/".to_owned());
     assert_eq!(out.ep.version, 1);
     assert!(!out.ep.disabled);
-    assert_eq!(out.ep.event_types_ids, None);
+    assert_eq!(out.ep.event_types, None);
     assert_eq!(out.ep.channels, None);
 }
 
@@ -165,7 +165,7 @@ async fn test_patch() {
     assert_eq!(out.ep.url, "http://bad.url/".to_owned());
     assert_eq!(out.ep.version, 1);
     assert!(!out.ep.disabled);
-    assert_eq!(out.ep.event_types_ids, None);
+    assert_eq!(out.ep.event_types, None);
     assert_eq!(out.ep.channels, None);
 
     // Test that the rate limit may be set
@@ -186,7 +186,7 @@ async fn test_patch() {
     assert_eq!(out.ep.url, "http://bad.url/".to_owned());
     assert_eq!(out.ep.version, 1);
     assert!(!out.ep.disabled);
-    assert_eq!(out.ep.event_types_ids, None);
+    assert_eq!(out.ep.event_types, None);
     assert_eq!(out.ep.channels, None);
 
     // Test that the rate limit may be unset
@@ -213,7 +213,7 @@ async fn test_patch() {
     assert_eq!(out.ep.url, "http://bad.url/".to_owned());
     assert_eq!(out.ep.version, 1);
     assert!(!out.ep.disabled);
-    assert_eq!(out.ep.event_types_ids, None);
+    assert_eq!(out.ep.event_types, None);
     assert_eq!(out.ep.channels, None);
 
     // Test that the UID may be set
@@ -234,7 +234,7 @@ async fn test_patch() {
     assert_eq!(out.ep.url, "http://bad.url/".to_owned());
     assert_eq!(out.ep.version, 1);
     assert!(!out.ep.disabled);
-    assert_eq!(out.ep.event_types_ids, None);
+    assert_eq!(out.ep.event_types, None);
     assert_eq!(out.ep.channels, None);
 
     // Test the UID may be unset
@@ -255,7 +255,7 @@ async fn test_patch() {
     assert_eq!(out.ep.url, "http://bad.url/".to_owned());
     assert_eq!(out.ep.version, 1);
     assert!(!out.ep.disabled);
-    assert_eq!(out.ep.event_types_ids, None);
+    assert_eq!(out.ep.event_types, None);
     assert_eq!(out.ep.channels, None);
 
     // Test that the URL may be set
@@ -276,7 +276,7 @@ async fn test_patch() {
     assert_eq!(out.ep.uid, None);
     assert_eq!(out.ep.version, 1);
     assert!(!out.ep.disabled);
-    assert_eq!(out.ep.event_types_ids, None);
+    assert_eq!(out.ep.event_types, None);
     assert_eq!(out.ep.channels, None);
 
     // Test that the version may be set
@@ -297,7 +297,7 @@ async fn test_patch() {
     assert_eq!(out.ep.uid, None);
     assert_eq!(out.ep.url, "http://bad.url2/".to_owned());
     assert!(!out.ep.disabled);
-    assert_eq!(out.ep.event_types_ids, None);
+    assert_eq!(out.ep.event_types, None);
     assert_eq!(out.ep.channels, None);
 
     // Test that disabled may be set
@@ -318,7 +318,7 @@ async fn test_patch() {
     assert_eq!(out.ep.uid, None);
     assert_eq!(out.ep.url, "http://bad.url2/".to_owned());
     assert_eq!(out.ep.version, 2);
-    assert_eq!(out.ep.event_types_ids, None);
+    assert_eq!(out.ep.event_types, None);
     assert_eq!(out.ep.channels, None);
 
     // Test that event type IDs may be set
@@ -353,7 +353,7 @@ async fn test_patch() {
         .await
         .unwrap();
     assert_eq!(
-        out.ep.event_types_ids,
+        out.ep.event_types,
         Some(EventTypeNameSet(HashSet::from([EventTypeName(
             "test".to_owned()
         )])))
@@ -378,7 +378,7 @@ async fn test_patch() {
         .get::<EndpointOut>(&url, StatusCode::OK)
         .await
         .unwrap();
-    assert_eq!(out.ep.event_types_ids, None);
+    assert_eq!(out.ep.event_types, None);
     // Assert that no other changes were made
     assert_eq!(out.ep.description, "test".to_owned());
     assert_eq!(out.ep.rate_limit, None);
@@ -418,7 +418,7 @@ async fn test_patch() {
     assert_eq!(out.ep.url, "http://bad.url2/".to_owned());
     assert_eq!(out.ep.version, 2);
     assert!(out.ep.disabled);
-    assert_eq!(out.ep.event_types_ids, None);
+    assert_eq!(out.ep.event_types, None);
 
     // Test that channels may be unset
     let _: EndpointOut = client
@@ -439,7 +439,7 @@ async fn test_patch() {
     assert_eq!(out.ep.url, "http://bad.url2/".to_owned());
     assert_eq!(out.ep.version, 2);
     assert!(out.ep.disabled);
-    assert_eq!(out.ep.event_types_ids, None);
+    assert_eq!(out.ep.event_types, None);
 }
 
 #[allow(deprecated)]
@@ -1796,7 +1796,7 @@ async fn test_endpoint_filter_events() {
         .await
         .unwrap();
 
-    assert_eq!(ep_with_valid_event.ep.event_types_ids.unwrap(), expected_et);
+    assert_eq!(ep_with_valid_event.ep.event_types.unwrap(), expected_et);
 
     let ep_removed_events: EndpointOut = client
         .put(
@@ -1807,13 +1807,13 @@ async fn test_endpoint_filter_events() {
         .await
         .unwrap();
 
-    assert!(ep_removed_events.ep.event_types_ids.is_none());
+    assert!(ep_removed_events.ep.event_types.is_none());
 
     let ep_removed_events = get_endpoint(&client, &app_id, &ep_removed_events.id)
         .await
         .unwrap();
 
-    assert!(ep_removed_events.ep.event_types_ids.is_none());
+    assert!(ep_removed_events.ep.event_types.is_none());
 
     let ep_updated_events: EndpointOut = client
         .put(
@@ -1824,13 +1824,13 @@ async fn test_endpoint_filter_events() {
         .await
         .unwrap();
 
-    assert_eq!(ep_updated_events.ep.event_types_ids.unwrap(), expected_et);
+    assert_eq!(ep_updated_events.ep.event_types.unwrap(), expected_et);
 
     let ep_updated_events: EndpointOut = get_endpoint(&client, &app_id, &ep_with_valid_event.id)
         .await
         .unwrap();
 
-    assert_eq!(ep_updated_events.ep.event_types_ids.unwrap(), expected_et);
+    assert_eq!(ep_updated_events.ep.event_types.unwrap(), expected_et);
 }
 
 #[tokio::test]
@@ -1991,7 +1991,7 @@ async fn test_msg_event_types_filter() {
             &app_id,
             EndpointIn {
                 url: Url::parse(&receiver.endpoint).unwrap(),
-                event_types_ids: event_types,
+                event_types,
                 ..default_test_endpoint()
             },
         )

--- a/server/svix-server/tests/it/utils/common_calls.rs
+++ b/server/svix-server/tests/it/utils/common_calls.rs
@@ -64,7 +64,7 @@ pub fn default_test_endpoint() -> EndpointIn {
         url: Url::parse("http://example.com").unwrap(),
         version: Some(1),
         disabled: Default::default(),
-        event_types_ids: Default::default(),
+        event_types: Default::default(),
         channels: Default::default(),
         key: Default::default(),
         metadata: Default::default(),


### PR DESCRIPTION
Same as we did in the cloud server, except here we already update the OpenAPI spec to only contain the new name (since we have nothing depending on it – for Cloud the same thing is part of the SDK-v2 OpenAPI changes).