### PR TITLE
csharp: Fix expanded_status default value

### DIFF
--- a/codegen/templates/csharp/api_resource.cs.jinja
+++ b/codegen/templates/csharp/api_resource.cs.jinja
@@ -30,7 +30,9 @@ namespace {{ context.namespace }}
     public new Dictionary<string, string> QueryParams() {
             return SerializeParams(new Dictionary<string, object?> {
             {%- for p in op.query_params %}
-                { "{{ p.name }}", {{ p.name | to_upper_camel_case }} },
+                { "{{ p.name }}", {{ p.name | to_upper_camel_case }}
+                {%- if p.name == "expanded_statuses" %} ?? true {% endif -%}
+                },
             {% endfor %}
             });
        }
@@ -65,6 +67,7 @@ namespace {{ context.namespace }}
     {%- include api_resource_extra ignore missing %}
 {%- for op in resource.operations %}
     {%- set req_body_varname = op.request_body_schema_name | to_lower_camel_case %}
+    {%- set options_type = r_name_pascal_case ~ op.name | to_upper_camel_case ~ "Options" %}
     {% for async in [true, false] %}
         {%- if op.description is defined %}
         /// <summary>
@@ -98,7 +101,7 @@ namespace {{ context.namespace }}
 
         {# query params/headers class #}
         {%- if op | has_query_or_header_params %}
-            {{ r_name_pascal_case }}{{ op.name | to_upper_camel_case }}Options? options = null,
+            {{ options_type }}? options = null,
         {%- endif %}
 
         {# async cancellation token, needed for some reason #}
@@ -108,6 +111,12 @@ namespace {{ context.namespace }}
         {%- endset %}
         {{ args_str | strip_trailing_comma }} )
         {
+        {%- if op | has_query_or_header_params %}
+            if (options== null)
+            {
+                options = new {{ options_type }}();
+            }
+        {%- endif %}
 
         {%- if op.request_body_schema_name is defined %}
             {{ req_body_varname }} = {{ req_body_varname }} ?? throw new ArgumentNullException(nameof({{ req_body_varname }}));
@@ -130,9 +139,9 @@ namespace {{ context.namespace }}
                             { "with_content", "false" },
                         }
                     {%- else -%}
-                        options?.QueryParams()
+                        options.QueryParams()
                     {%- endif %}
-                    , headerParams: options?.HeaderParams()
+                    , headerParams: options.HeaderParams()
         {%- endif %}
         {%- if op.request_body_schema_name is defined %}
                     , content: {{ req_body_varname }}
@@ -142,7 +151,7 @@ namespace {{ context.namespace }}
         {%- endif %}
                 );
                 {% if op.id == "v1.message.create" -%}
-                    if (options?.WithContent ?? true) {
+                    if (options.WithContent ?? true) {
                         response.Data.Payload = messageIn.Payload;
                     }
                 {% endif -%}

--- a/csharp/Svix/ApiInternal/MessagePollerv2.cs
+++ b/csharp/Svix/ApiInternal/MessagePollerv2.cs
@@ -51,6 +51,10 @@ namespace Svix.ApiInternal
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new MessagePollerv2ConsumerPollOptions();
+            }
             try
             {
                 var response = await _client.SvixHttpClient.SendRequestAsync<PollerV2PollOut>(
@@ -62,8 +66,8 @@ namespace Svix.ApiInternal
                         { "sink_id", sinkId },
                         { "consumer_id", consumerId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     cancellationToken: cancellationToken
                 );
                 return response.Data;
@@ -86,6 +90,10 @@ namespace Svix.ApiInternal
             MessagePollerv2ConsumerPollOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new MessagePollerv2ConsumerPollOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<PollerV2PollOut>(
@@ -97,8 +105,8 @@ namespace Svix.ApiInternal
                         { "sink_id", sinkId },
                         { "consumer_id", consumerId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }
@@ -122,6 +130,10 @@ namespace Svix.ApiInternal
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new MessagePollerv2ConsumerCommitOptions();
+            }
             pollerV2CommitIn =
                 pollerV2CommitIn ?? throw new ArgumentNullException(nameof(pollerV2CommitIn));
             try
@@ -135,8 +147,8 @@ namespace Svix.ApiInternal
                         { "sink_id", sinkId },
                         { "consumer_id", consumerId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: pollerV2CommitIn,
                     cancellationToken: cancellationToken
                 );
@@ -161,6 +173,10 @@ namespace Svix.ApiInternal
             MessagePollerv2ConsumerCommitOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new MessagePollerv2ConsumerCommitOptions();
+            }
             pollerV2CommitIn =
                 pollerV2CommitIn ?? throw new ArgumentNullException(nameof(pollerV2CommitIn));
             try
@@ -174,8 +190,8 @@ namespace Svix.ApiInternal
                         { "sink_id", sinkId },
                         { "consumer_id", consumerId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: pollerV2CommitIn
                 );
                 return response.Data;

--- a/csharp/Svix/Application.cs
+++ b/csharp/Svix/Application.cs
@@ -54,14 +54,18 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new ApplicationListOptions();
+            }
             try
             {
                 var response =
                     await _client.SvixHttpClient.SendRequestAsync<ListResponseApplicationOut>(
                         method: HttpMethod.Get,
                         path: "/api/v1/app",
-                        queryParams: options?.QueryParams(),
-                        headerParams: options?.HeaderParams(),
+                        queryParams: options.QueryParams(),
+                        headerParams: options.HeaderParams(),
                         cancellationToken: cancellationToken
                     );
                 return response.Data;
@@ -79,13 +83,17 @@ namespace Svix
         /// </summary>
         public ListResponseApplicationOut List(ApplicationListOptions? options = null)
         {
+            if (options == null)
+            {
+                options = new ApplicationListOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<ListResponseApplicationOut>(
                     method: HttpMethod.Get,
                     path: "/api/v1/app",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }
@@ -106,14 +114,18 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new ApplicationCreateOptions();
+            }
             applicationIn = applicationIn ?? throw new ArgumentNullException(nameof(applicationIn));
             try
             {
                 var response = await _client.SvixHttpClient.SendRequestAsync<ApplicationOut>(
                     method: HttpMethod.Post,
                     path: "/api/v1/app",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: applicationIn,
                     cancellationToken: cancellationToken
                 );
@@ -135,14 +147,18 @@ namespace Svix
             ApplicationCreateOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new ApplicationCreateOptions();
+            }
             applicationIn = applicationIn ?? throw new ArgumentNullException(nameof(applicationIn));
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<ApplicationOut>(
                     method: HttpMethod.Post,
                     path: "/api/v1/app",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: applicationIn
                 );
                 return response.Data;

--- a/csharp/Svix/Authentication.cs
+++ b/csharp/Svix/Authentication.cs
@@ -103,6 +103,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new AuthenticationAppPortalAccessOptions();
+            }
             appPortalAccessIn =
                 appPortalAccessIn ?? throw new ArgumentNullException(nameof(appPortalAccessIn));
             try
@@ -111,8 +115,8 @@ namespace Svix
                     method: HttpMethod.Post,
                     path: "/api/v1/auth/app-portal-access/{app_id}",
                     pathParams: new Dictionary<string, string> { { "app_id", appId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: appPortalAccessIn,
                     cancellationToken: cancellationToken
                 );
@@ -135,6 +139,10 @@ namespace Svix
             AuthenticationAppPortalAccessOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new AuthenticationAppPortalAccessOptions();
+            }
             appPortalAccessIn =
                 appPortalAccessIn ?? throw new ArgumentNullException(nameof(appPortalAccessIn));
             try
@@ -143,8 +151,8 @@ namespace Svix
                     method: HttpMethod.Post,
                     path: "/api/v1/auth/app-portal-access/{app_id}",
                     pathParams: new Dictionary<string, string> { { "app_id", appId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: appPortalAccessIn
                 );
                 return response.Data;
@@ -167,13 +175,17 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new AuthenticationLogoutOptions();
+            }
             try
             {
                 var response = await _client.SvixHttpClient.SendRequestAsync<bool>(
                     method: HttpMethod.Post,
                     path: "/api/v1/auth/logout",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     cancellationToken: cancellationToken
                 );
                 return response.Data;
@@ -193,13 +205,17 @@ namespace Svix
         /// </summary>
         public bool Logout(AuthenticationLogoutOptions? options = null)
         {
+            if (options == null)
+            {
+                options = new AuthenticationLogoutOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<bool>(
                     method: HttpMethod.Post,
                     path: "/api/v1/auth/logout",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }
@@ -221,6 +237,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new AuthenticationExpireAllOptions();
+            }
             applicationTokenExpireIn =
                 applicationTokenExpireIn
                 ?? throw new ArgumentNullException(nameof(applicationTokenExpireIn));
@@ -230,8 +250,8 @@ namespace Svix
                     method: HttpMethod.Post,
                     path: "/api/v1/auth/app/{app_id}/expire-all",
                     pathParams: new Dictionary<string, string> { { "app_id", appId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: applicationTokenExpireIn,
                     cancellationToken: cancellationToken
                 );
@@ -254,6 +274,10 @@ namespace Svix
             AuthenticationExpireAllOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new AuthenticationExpireAllOptions();
+            }
             applicationTokenExpireIn =
                 applicationTokenExpireIn
                 ?? throw new ArgumentNullException(nameof(applicationTokenExpireIn));
@@ -263,8 +287,8 @@ namespace Svix
                     method: HttpMethod.Post,
                     path: "/api/v1/auth/app/{app_id}/expire-all",
                     pathParams: new Dictionary<string, string> { { "app_id", appId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: applicationTokenExpireIn
                 );
                 return response.Data;
@@ -339,6 +363,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new AuthenticationStreamPortalAccessOptions();
+            }
             streamPortalAccessIn =
                 streamPortalAccessIn
                 ?? throw new ArgumentNullException(nameof(streamPortalAccessIn));
@@ -348,8 +376,8 @@ namespace Svix
                     method: HttpMethod.Post,
                     path: "/api/v1/auth/stream-portal-access/{stream_id}",
                     pathParams: new Dictionary<string, string> { { "stream_id", streamId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: streamPortalAccessIn,
                     cancellationToken: cancellationToken
                 );
@@ -372,6 +400,10 @@ namespace Svix
             AuthenticationStreamPortalAccessOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new AuthenticationStreamPortalAccessOptions();
+            }
             streamPortalAccessIn =
                 streamPortalAccessIn
                 ?? throw new ArgumentNullException(nameof(streamPortalAccessIn));
@@ -381,8 +413,8 @@ namespace Svix
                     method: HttpMethod.Post,
                     path: "/api/v1/auth/stream-portal-access/{stream_id}",
                     pathParams: new Dictionary<string, string> { { "stream_id", streamId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: streamPortalAccessIn
                 );
                 return response.Data;
@@ -405,13 +437,17 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new AuthenticationStreamLogoutOptions();
+            }
             try
             {
                 var response = await _client.SvixHttpClient.SendRequestAsync<bool>(
                     method: HttpMethod.Post,
                     path: "/api/v1/auth/stream-logout",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     cancellationToken: cancellationToken
                 );
                 return response.Data;
@@ -431,13 +467,17 @@ namespace Svix
         /// </summary>
         public bool StreamLogout(AuthenticationStreamLogoutOptions? options = null)
         {
+            if (options == null)
+            {
+                options = new AuthenticationStreamLogoutOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<bool>(
                     method: HttpMethod.Post,
                     path: "/api/v1/auth/stream-logout",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }
@@ -459,6 +499,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new AuthenticationStreamExpireAllOptions();
+            }
             streamTokenExpireIn =
                 streamTokenExpireIn ?? throw new ArgumentNullException(nameof(streamTokenExpireIn));
             try
@@ -467,8 +511,8 @@ namespace Svix
                     method: HttpMethod.Post,
                     path: "/api/v1/auth/stream/{stream_id}/expire-all",
                     pathParams: new Dictionary<string, string> { { "stream_id", streamId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: streamTokenExpireIn,
                     cancellationToken: cancellationToken
                 );
@@ -491,6 +535,10 @@ namespace Svix
             AuthenticationStreamExpireAllOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new AuthenticationStreamExpireAllOptions();
+            }
             streamTokenExpireIn =
                 streamTokenExpireIn ?? throw new ArgumentNullException(nameof(streamTokenExpireIn));
             try
@@ -499,8 +547,8 @@ namespace Svix
                     method: HttpMethod.Post,
                     path: "/api/v1/auth/stream/{stream_id}/expire-all",
                     pathParams: new Dictionary<string, string> { { "stream_id", streamId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: streamTokenExpireIn
                 );
                 return response.Data;
@@ -524,6 +572,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new AuthenticationRotateStreamPollerTokenOptions();
+            }
             rotatePollerTokenIn =
                 rotatePollerTokenIn ?? throw new ArgumentNullException(nameof(rotatePollerTokenIn));
             try
@@ -536,8 +588,8 @@ namespace Svix
                         { "stream_id", streamId },
                         { "sink_id", sinkId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: rotatePollerTokenIn,
                     cancellationToken: cancellationToken
                 );
@@ -561,6 +613,10 @@ namespace Svix
             AuthenticationRotateStreamPollerTokenOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new AuthenticationRotateStreamPollerTokenOptions();
+            }
             rotatePollerTokenIn =
                 rotatePollerTokenIn ?? throw new ArgumentNullException(nameof(rotatePollerTokenIn));
             try
@@ -573,8 +629,8 @@ namespace Svix
                         { "stream_id", streamId },
                         { "sink_id", sinkId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: rotatePollerTokenIn
                 );
                 return response.Data;

--- a/csharp/Svix/BackgroundTask.cs
+++ b/csharp/Svix/BackgroundTask.cs
@@ -40,14 +40,18 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new BackgroundTaskListOptions();
+            }
             try
             {
                 var response =
                     await _client.SvixHttpClient.SendRequestAsync<ListResponseBackgroundTaskOut>(
                         method: HttpMethod.Get,
                         path: "/api/v1/background-task",
-                        queryParams: options?.QueryParams(),
-                        headerParams: options?.HeaderParams(),
+                        queryParams: options.QueryParams(),
+                        headerParams: options.HeaderParams(),
                         cancellationToken: cancellationToken
                     );
                 return response.Data;
@@ -65,13 +69,17 @@ namespace Svix
         /// </summary>
         public ListResponseBackgroundTaskOut List(BackgroundTaskListOptions? options = null)
         {
+            if (options == null)
+            {
+                options = new BackgroundTaskListOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<ListResponseBackgroundTaskOut>(
                     method: HttpMethod.Get,
                     path: "/api/v1/background-task",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }

--- a/csharp/Svix/Connector.cs
+++ b/csharp/Svix/Connector.cs
@@ -50,14 +50,18 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new ConnectorListOptions();
+            }
             try
             {
                 var response =
                     await _client.SvixHttpClient.SendRequestAsync<ListResponseConnectorOut>(
                         method: HttpMethod.Get,
                         path: "/api/v1/connector",
-                        queryParams: options?.QueryParams(),
-                        headerParams: options?.HeaderParams(),
+                        queryParams: options.QueryParams(),
+                        headerParams: options.HeaderParams(),
                         cancellationToken: cancellationToken
                     );
                 return response.Data;
@@ -75,13 +79,17 @@ namespace Svix
         /// </summary>
         public ListResponseConnectorOut List(ConnectorListOptions? options = null)
         {
+            if (options == null)
+            {
+                options = new ConnectorListOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<ListResponseConnectorOut>(
                     method: HttpMethod.Get,
                     path: "/api/v1/connector",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }
@@ -102,14 +110,18 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new ConnectorCreateOptions();
+            }
             connectorIn = connectorIn ?? throw new ArgumentNullException(nameof(connectorIn));
             try
             {
                 var response = await _client.SvixHttpClient.SendRequestAsync<ConnectorOut>(
                     method: HttpMethod.Post,
                     path: "/api/v1/connector",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: connectorIn,
                     cancellationToken: cancellationToken
                 );
@@ -128,14 +140,18 @@ namespace Svix
         /// </summary>
         public ConnectorOut Create(ConnectorIn connectorIn, ConnectorCreateOptions? options = null)
         {
+            if (options == null)
+            {
+                options = new ConnectorCreateOptions();
+            }
             connectorIn = connectorIn ?? throw new ArgumentNullException(nameof(connectorIn));
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<ConnectorOut>(
                     method: HttpMethod.Post,
                     path: "/api/v1/connector",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: connectorIn
                 );
                 return response.Data;

--- a/csharp/Svix/Endpoint.cs
+++ b/csharp/Svix/Endpoint.cs
@@ -122,6 +122,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new EndpointListOptions();
+            }
             try
             {
                 var response =
@@ -129,8 +133,8 @@ namespace Svix
                         method: HttpMethod.Get,
                         path: "/api/v1/app/{app_id}/endpoint",
                         pathParams: new Dictionary<string, string> { { "app_id", appId } },
-                        queryParams: options?.QueryParams(),
-                        headerParams: options?.HeaderParams(),
+                        queryParams: options.QueryParams(),
+                        headerParams: options.HeaderParams(),
                         cancellationToken: cancellationToken
                     );
                 return response.Data;
@@ -148,14 +152,18 @@ namespace Svix
         /// </summary>
         public ListResponseEndpointOut List(string appId, EndpointListOptions? options = null)
         {
+            if (options == null)
+            {
+                options = new EndpointListOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<ListResponseEndpointOut>(
                     method: HttpMethod.Get,
                     path: "/api/v1/app/{app_id}/endpoint",
                     pathParams: new Dictionary<string, string> { { "app_id", appId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }
@@ -179,6 +187,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new EndpointCreateOptions();
+            }
             endpointIn = endpointIn ?? throw new ArgumentNullException(nameof(endpointIn));
             try
             {
@@ -186,8 +198,8 @@ namespace Svix
                     method: HttpMethod.Post,
                     path: "/api/v1/app/{app_id}/endpoint",
                     pathParams: new Dictionary<string, string> { { "app_id", appId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: endpointIn,
                     cancellationToken: cancellationToken
                 );
@@ -212,6 +224,10 @@ namespace Svix
             EndpointCreateOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new EndpointCreateOptions();
+            }
             endpointIn = endpointIn ?? throw new ArgumentNullException(nameof(endpointIn));
             try
             {
@@ -219,8 +235,8 @@ namespace Svix
                     method: HttpMethod.Post,
                     path: "/api/v1/app/{app_id}/endpoint",
                     pathParams: new Dictionary<string, string> { { "app_id", appId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: endpointIn
                 );
                 return response.Data;
@@ -549,6 +565,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new EndpointRotateSecretOptions();
+            }
             endpointSecretRotateIn =
                 endpointSecretRotateIn
                 ?? throw new ArgumentNullException(nameof(endpointSecretRotateIn));
@@ -562,8 +582,8 @@ namespace Svix
                         { "app_id", appId },
                         { "endpoint_id", endpointId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: endpointSecretRotateIn,
                     cancellationToken: cancellationToken
                 );
@@ -589,6 +609,10 @@ namespace Svix
             EndpointRotateSecretOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new EndpointRotateSecretOptions();
+            }
             endpointSecretRotateIn =
                 endpointSecretRotateIn
                 ?? throw new ArgumentNullException(nameof(endpointSecretRotateIn));
@@ -602,8 +626,8 @@ namespace Svix
                         { "app_id", appId },
                         { "endpoint_id", endpointId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: endpointSecretRotateIn
                 );
                 return response.Data;
@@ -965,6 +989,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new EndpointReplayMissingOptions();
+            }
             replayIn = replayIn ?? throw new ArgumentNullException(nameof(replayIn));
             try
             {
@@ -976,8 +1004,8 @@ namespace Svix
                         { "app_id", appId },
                         { "endpoint_id", endpointId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: replayIn,
                     cancellationToken: cancellationToken
                 );
@@ -1016,6 +1044,10 @@ namespace Svix
             EndpointReplayMissingOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new EndpointReplayMissingOptions();
+            }
             replayIn = replayIn ?? throw new ArgumentNullException(nameof(replayIn));
             try
             {
@@ -1027,8 +1059,8 @@ namespace Svix
                         { "app_id", appId },
                         { "endpoint_id", endpointId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: replayIn
                 );
                 return response.Data;
@@ -1067,6 +1099,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new EndpointBulkReplayOptions();
+            }
             bulkReplayIn = bulkReplayIn ?? throw new ArgumentNullException(nameof(bulkReplayIn));
             try
             {
@@ -1078,8 +1114,8 @@ namespace Svix
                         { "app_id", appId },
                         { "endpoint_id", endpointId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: bulkReplayIn,
                     cancellationToken: cancellationToken
                 );
@@ -1118,6 +1154,10 @@ namespace Svix
             EndpointBulkReplayOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new EndpointBulkReplayOptions();
+            }
             bulkReplayIn = bulkReplayIn ?? throw new ArgumentNullException(nameof(bulkReplayIn));
             try
             {
@@ -1129,8 +1169,8 @@ namespace Svix
                         { "app_id", appId },
                         { "endpoint_id", endpointId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: bulkReplayIn
                 );
                 return response.Data;
@@ -1153,6 +1193,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new EndpointGetStatsOptions();
+            }
             try
             {
                 var response = await _client.SvixHttpClient.SendRequestAsync<EndpointStats>(
@@ -1163,8 +1207,8 @@ namespace Svix
                         { "app_id", appId },
                         { "endpoint_id", endpointId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     cancellationToken: cancellationToken
                 );
                 return response.Data;
@@ -1186,6 +1230,10 @@ namespace Svix
             EndpointGetStatsOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new EndpointGetStatsOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<EndpointStats>(
@@ -1196,8 +1244,8 @@ namespace Svix
                         { "app_id", appId },
                         { "endpoint_id", endpointId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }
@@ -1234,6 +1282,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new EndpointRecoverOptions();
+            }
             recoverIn = recoverIn ?? throw new ArgumentNullException(nameof(recoverIn));
             try
             {
@@ -1245,8 +1297,8 @@ namespace Svix
                         { "app_id", appId },
                         { "endpoint_id", endpointId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: recoverIn,
                     cancellationToken: cancellationToken
                 );
@@ -1284,6 +1336,10 @@ namespace Svix
             EndpointRecoverOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new EndpointRecoverOptions();
+            }
             recoverIn = recoverIn ?? throw new ArgumentNullException(nameof(recoverIn));
             try
             {
@@ -1295,8 +1351,8 @@ namespace Svix
                         { "app_id", appId },
                         { "endpoint_id", endpointId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: recoverIn
                 );
                 return response.Data;
@@ -1320,6 +1376,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new EndpointSendExampleOptions();
+            }
             eventExampleIn =
                 eventExampleIn ?? throw new ArgumentNullException(nameof(eventExampleIn));
             try
@@ -1332,8 +1392,8 @@ namespace Svix
                         { "app_id", appId },
                         { "endpoint_id", endpointId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: eventExampleIn,
                     cancellationToken: cancellationToken
                 );
@@ -1357,6 +1417,10 @@ namespace Svix
             EndpointSendExampleOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new EndpointSendExampleOptions();
+            }
             eventExampleIn =
                 eventExampleIn ?? throw new ArgumentNullException(nameof(eventExampleIn));
             try
@@ -1369,8 +1433,8 @@ namespace Svix
                         { "app_id", appId },
                         { "endpoint_id", endpointId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: eventExampleIn
                 );
                 return response.Data;

--- a/csharp/Svix/Environment.cs
+++ b/csharp/Svix/Environment.cs
@@ -44,13 +44,17 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new EnvironmentExportOptions();
+            }
             try
             {
                 var response = await _client.SvixHttpClient.SendRequestAsync<EnvironmentOut>(
                     method: HttpMethod.Post,
                     path: "/api/v1/environment/export",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     cancellationToken: cancellationToken
                 );
                 return response.Data;
@@ -71,13 +75,17 @@ namespace Svix
         /// </summary>
         public EnvironmentOut Export(EnvironmentExportOptions? options = null)
         {
+            if (options == null)
+            {
+                options = new EnvironmentExportOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<EnvironmentOut>(
                     method: HttpMethod.Post,
                     path: "/api/v1/environment/export",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }
@@ -103,14 +111,18 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new EnvironmentImportOptions();
+            }
             environmentIn = environmentIn ?? throw new ArgumentNullException(nameof(environmentIn));
             try
             {
                 var response = await _client.SvixHttpClient.SendRequestAsync<bool>(
                     method: HttpMethod.Post,
                     path: "/api/v1/environment/import",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: environmentIn,
                     cancellationToken: cancellationToken
                 );
@@ -134,14 +146,18 @@ namespace Svix
         /// </summary>
         public bool Import(EnvironmentIn environmentIn, EnvironmentImportOptions? options = null)
         {
+            if (options == null)
+            {
+                options = new EnvironmentImportOptions();
+            }
             environmentIn = environmentIn ?? throw new ArgumentNullException(nameof(environmentIn));
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<bool>(
                     method: HttpMethod.Post,
                     path: "/api/v1/environment/import",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: environmentIn
                 );
                 return response.Data;

--- a/csharp/Svix/EventType.cs
+++ b/csharp/Svix/EventType.cs
@@ -74,14 +74,18 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new EventTypeListOptions();
+            }
             try
             {
                 var response =
                     await _client.SvixHttpClient.SendRequestAsync<ListResponseEventTypeOut>(
                         method: HttpMethod.Get,
                         path: "/api/v1/event-type",
-                        queryParams: options?.QueryParams(),
-                        headerParams: options?.HeaderParams(),
+                        queryParams: options.QueryParams(),
+                        headerParams: options.HeaderParams(),
                         cancellationToken: cancellationToken
                     );
                 return response.Data;
@@ -99,13 +103,17 @@ namespace Svix
         /// </summary>
         public ListResponseEventTypeOut List(EventTypeListOptions? options = null)
         {
+            if (options == null)
+            {
+                options = new EventTypeListOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<ListResponseEventTypeOut>(
                     method: HttpMethod.Get,
                     path: "/api/v1/event-type",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }
@@ -130,14 +138,18 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new EventTypeCreateOptions();
+            }
             eventTypeIn = eventTypeIn ?? throw new ArgumentNullException(nameof(eventTypeIn));
             try
             {
                 var response = await _client.SvixHttpClient.SendRequestAsync<EventTypeOut>(
                     method: HttpMethod.Post,
                     path: "/api/v1/event-type",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: eventTypeIn,
                     cancellationToken: cancellationToken
                 );
@@ -160,14 +172,18 @@ namespace Svix
         /// </summary>
         public EventTypeOut Create(EventTypeIn eventTypeIn, EventTypeCreateOptions? options = null)
         {
+            if (options == null)
+            {
+                options = new EventTypeCreateOptions();
+            }
             eventTypeIn = eventTypeIn ?? throw new ArgumentNullException(nameof(eventTypeIn));
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<EventTypeOut>(
                     method: HttpMethod.Post,
                     path: "/api/v1/event-type",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: eventTypeIn
                 );
                 return response.Data;
@@ -193,6 +209,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new EventTypeImportOpenapiOptions();
+            }
             eventTypeImportOpenApiIn =
                 eventTypeImportOpenApiIn
                 ?? throw new ArgumentNullException(nameof(eventTypeImportOpenApiIn));
@@ -202,8 +222,8 @@ namespace Svix
                     await _client.SvixHttpClient.SendRequestAsync<EventTypeImportOpenApiOut>(
                         method: HttpMethod.Post,
                         path: "/api/v1/event-type/import/openapi",
-                        queryParams: options?.QueryParams(),
-                        headerParams: options?.HeaderParams(),
+                        queryParams: options.QueryParams(),
+                        headerParams: options.HeaderParams(),
                         content: eventTypeImportOpenApiIn,
                         cancellationToken: cancellationToken
                     );
@@ -229,6 +249,10 @@ namespace Svix
             EventTypeImportOpenapiOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new EventTypeImportOpenapiOptions();
+            }
             eventTypeImportOpenApiIn =
                 eventTypeImportOpenApiIn
                 ?? throw new ArgumentNullException(nameof(eventTypeImportOpenApiIn));
@@ -237,8 +261,8 @@ namespace Svix
                 var response = _client.SvixHttpClient.SendRequest<EventTypeImportOpenApiOut>(
                     method: HttpMethod.Post,
                     path: "/api/v1/event-type/import/openapi",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: eventTypeImportOpenApiIn
                 );
                 return response.Data;
@@ -380,6 +404,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new EventTypeDeleteOptions();
+            }
             try
             {
                 var response = await _client.SvixHttpClient.SendRequestAsync<bool>(
@@ -389,8 +417,8 @@ namespace Svix
                     {
                         { "event_type_name", eventTypeName },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     cancellationToken: cancellationToken
                 );
                 return response.Data;
@@ -413,6 +441,10 @@ namespace Svix
         /// </summary>
         public bool Delete(string eventTypeName, EventTypeDeleteOptions? options = null)
         {
+            if (options == null)
+            {
+                options = new EventTypeDeleteOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<bool>(
@@ -422,8 +454,8 @@ namespace Svix
                     {
                         { "event_type_name", eventTypeName },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }

--- a/csharp/Svix/Ingest.cs
+++ b/csharp/Svix/Ingest.cs
@@ -41,6 +41,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new IngestDashboardOptions();
+            }
             ingestSourceConsumerPortalAccessIn =
                 ingestSourceConsumerPortalAccessIn
                 ?? throw new ArgumentNullException(nameof(ingestSourceConsumerPortalAccessIn));
@@ -50,8 +54,8 @@ namespace Svix
                     method: HttpMethod.Post,
                     path: "/ingest/api/v1/source/{source_id}/dashboard",
                     pathParams: new Dictionary<string, string> { { "source_id", sourceId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: ingestSourceConsumerPortalAccessIn,
                     cancellationToken: cancellationToken
                 );
@@ -74,6 +78,10 @@ namespace Svix
             IngestDashboardOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new IngestDashboardOptions();
+            }
             ingestSourceConsumerPortalAccessIn =
                 ingestSourceConsumerPortalAccessIn
                 ?? throw new ArgumentNullException(nameof(ingestSourceConsumerPortalAccessIn));
@@ -83,8 +91,8 @@ namespace Svix
                     method: HttpMethod.Post,
                     path: "/ingest/api/v1/source/{source_id}/dashboard",
                     pathParams: new Dictionary<string, string> { { "source_id", sourceId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: ingestSourceConsumerPortalAccessIn
                 );
                 return response.Data;

--- a/csharp/Svix/IngestEndpoint.cs
+++ b/csharp/Svix/IngestEndpoint.cs
@@ -61,6 +61,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new IngestEndpointListOptions();
+            }
             try
             {
                 var response =
@@ -68,8 +72,8 @@ namespace Svix
                         method: HttpMethod.Get,
                         path: "/ingest/api/v1/source/{source_id}/endpoint",
                         pathParams: new Dictionary<string, string> { { "source_id", sourceId } },
-                        queryParams: options?.QueryParams(),
-                        headerParams: options?.HeaderParams(),
+                        queryParams: options.QueryParams(),
+                        headerParams: options.HeaderParams(),
                         cancellationToken: cancellationToken
                     );
                 return response.Data;
@@ -90,14 +94,18 @@ namespace Svix
             IngestEndpointListOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new IngestEndpointListOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<ListResponseIngestEndpointOut>(
                     method: HttpMethod.Get,
                     path: "/ingest/api/v1/source/{source_id}/endpoint",
                     pathParams: new Dictionary<string, string> { { "source_id", sourceId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }
@@ -119,6 +127,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new IngestEndpointCreateOptions();
+            }
             ingestEndpointIn =
                 ingestEndpointIn ?? throw new ArgumentNullException(nameof(ingestEndpointIn));
             try
@@ -127,8 +139,8 @@ namespace Svix
                     method: HttpMethod.Post,
                     path: "/ingest/api/v1/source/{source_id}/endpoint",
                     pathParams: new Dictionary<string, string> { { "source_id", sourceId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: ingestEndpointIn,
                     cancellationToken: cancellationToken
                 );
@@ -151,6 +163,10 @@ namespace Svix
             IngestEndpointCreateOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new IngestEndpointCreateOptions();
+            }
             ingestEndpointIn =
                 ingestEndpointIn ?? throw new ArgumentNullException(nameof(ingestEndpointIn));
             try
@@ -159,8 +175,8 @@ namespace Svix
                     method: HttpMethod.Post,
                     path: "/ingest/api/v1/source/{source_id}/endpoint",
                     pathParams: new Dictionary<string, string> { { "source_id", sourceId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: ingestEndpointIn
                 );
                 return response.Data;
@@ -434,6 +450,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new IngestEndpointRotateSecretOptions();
+            }
             ingestEndpointSecretIn =
                 ingestEndpointSecretIn
                 ?? throw new ArgumentNullException(nameof(ingestEndpointSecretIn));
@@ -447,8 +467,8 @@ namespace Svix
                         { "source_id", sourceId },
                         { "endpoint_id", endpointId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: ingestEndpointSecretIn,
                     cancellationToken: cancellationToken
                 );
@@ -474,6 +494,10 @@ namespace Svix
             IngestEndpointRotateSecretOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new IngestEndpointRotateSecretOptions();
+            }
             ingestEndpointSecretIn =
                 ingestEndpointSecretIn
                 ?? throw new ArgumentNullException(nameof(ingestEndpointSecretIn));
@@ -487,8 +511,8 @@ namespace Svix
                         { "source_id", sourceId },
                         { "endpoint_id", endpointId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: ingestEndpointSecretIn
                 );
                 return response.Data;

--- a/csharp/Svix/IngestSource.cs
+++ b/csharp/Svix/IngestSource.cs
@@ -60,14 +60,18 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new IngestSourceListOptions();
+            }
             try
             {
                 var response =
                     await _client.SvixHttpClient.SendRequestAsync<ListResponseIngestSourceOut>(
                         method: HttpMethod.Get,
                         path: "/ingest/api/v1/source",
-                        queryParams: options?.QueryParams(),
-                        headerParams: options?.HeaderParams(),
+                        queryParams: options.QueryParams(),
+                        headerParams: options.HeaderParams(),
                         cancellationToken: cancellationToken
                     );
                 return response.Data;
@@ -85,13 +89,17 @@ namespace Svix
         /// </summary>
         public ListResponseIngestSourceOut List(IngestSourceListOptions? options = null)
         {
+            if (options == null)
+            {
+                options = new IngestSourceListOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<ListResponseIngestSourceOut>(
                     method: HttpMethod.Get,
                     path: "/ingest/api/v1/source",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }
@@ -112,6 +120,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new IngestSourceCreateOptions();
+            }
             ingestSourceIn =
                 ingestSourceIn ?? throw new ArgumentNullException(nameof(ingestSourceIn));
             try
@@ -119,8 +131,8 @@ namespace Svix
                 var response = await _client.SvixHttpClient.SendRequestAsync<IngestSourceOut>(
                     method: HttpMethod.Post,
                     path: "/ingest/api/v1/source",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: ingestSourceIn,
                     cancellationToken: cancellationToken
                 );
@@ -142,6 +154,10 @@ namespace Svix
             IngestSourceCreateOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new IngestSourceCreateOptions();
+            }
             ingestSourceIn =
                 ingestSourceIn ?? throw new ArgumentNullException(nameof(ingestSourceIn));
             try
@@ -149,8 +165,8 @@ namespace Svix
                 var response = _client.SvixHttpClient.SendRequest<IngestSourceOut>(
                     method: HttpMethod.Post,
                     path: "/ingest/api/v1/source",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: ingestSourceIn
                 );
                 return response.Data;
@@ -328,14 +344,18 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new IngestSourceRotateTokenOptions();
+            }
             try
             {
                 var response = await _client.SvixHttpClient.SendRequestAsync<RotateTokenOut>(
                     method: HttpMethod.Post,
                     path: "/ingest/api/v1/source/{source_id}/token/rotate",
                     pathParams: new Dictionary<string, string> { { "source_id", sourceId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     cancellationToken: cancellationToken
                 );
                 return response.Data;
@@ -361,14 +381,18 @@ namespace Svix
             IngestSourceRotateTokenOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new IngestSourceRotateTokenOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<RotateTokenOut>(
                     method: HttpMethod.Post,
                     path: "/ingest/api/v1/source/{source_id}/token/rotate",
                     pathParams: new Dictionary<string, string> { { "source_id", sourceId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }

--- a/csharp/Svix/Integration.cs
+++ b/csharp/Svix/Integration.cs
@@ -61,6 +61,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new IntegrationListOptions();
+            }
             try
             {
                 var response =
@@ -68,8 +72,8 @@ namespace Svix
                         method: HttpMethod.Get,
                         path: "/api/v1/app/{app_id}/integration",
                         pathParams: new Dictionary<string, string> { { "app_id", appId } },
-                        queryParams: options?.QueryParams(),
-                        headerParams: options?.HeaderParams(),
+                        queryParams: options.QueryParams(),
+                        headerParams: options.HeaderParams(),
                         cancellationToken: cancellationToken
                     );
                 return response.Data;
@@ -87,14 +91,18 @@ namespace Svix
         /// </summary>
         public ListResponseIntegrationOut List(string appId, IntegrationListOptions? options = null)
         {
+            if (options == null)
+            {
+                options = new IntegrationListOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<ListResponseIntegrationOut>(
                     method: HttpMethod.Get,
                     path: "/api/v1/app/{app_id}/integration",
                     pathParams: new Dictionary<string, string> { { "app_id", appId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }
@@ -116,6 +124,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new IntegrationCreateOptions();
+            }
             integrationIn = integrationIn ?? throw new ArgumentNullException(nameof(integrationIn));
             try
             {
@@ -123,8 +135,8 @@ namespace Svix
                     method: HttpMethod.Post,
                     path: "/api/v1/app/{app_id}/integration",
                     pathParams: new Dictionary<string, string> { { "app_id", appId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: integrationIn,
                     cancellationToken: cancellationToken
                 );
@@ -147,6 +159,10 @@ namespace Svix
             IntegrationCreateOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new IntegrationCreateOptions();
+            }
             integrationIn = integrationIn ?? throw new ArgumentNullException(nameof(integrationIn));
             try
             {
@@ -154,8 +170,8 @@ namespace Svix
                     method: HttpMethod.Post,
                     path: "/api/v1/app/{app_id}/integration",
                     pathParams: new Dictionary<string, string> { { "app_id", appId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: integrationIn
                 );
                 return response.Data;
@@ -360,6 +376,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new IntegrationRotateKeyOptions();
+            }
             try
             {
                 var response = await _client.SvixHttpClient.SendRequestAsync<IntegrationKeyOut>(
@@ -370,8 +390,8 @@ namespace Svix
                         { "app_id", appId },
                         { "integ_id", integId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     cancellationToken: cancellationToken
                 );
                 return response.Data;
@@ -393,6 +413,10 @@ namespace Svix
             IntegrationRotateKeyOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new IntegrationRotateKeyOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<IntegrationKeyOut>(
@@ -403,8 +427,8 @@ namespace Svix
                         { "app_id", appId },
                         { "integ_id", integId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }

--- a/csharp/Svix/Message.cs
+++ b/csharp/Svix/Message.cs
@@ -169,6 +169,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new MessageListOptions();
+            }
             try
             {
                 var response =
@@ -176,8 +180,8 @@ namespace Svix
                         method: HttpMethod.Get,
                         path: "/api/v1/app/{app_id}/msg",
                         pathParams: new Dictionary<string, string> { { "app_id", appId } },
-                        queryParams: options?.QueryParams(),
-                        headerParams: options?.HeaderParams(),
+                        queryParams: options.QueryParams(),
+                        headerParams: options.HeaderParams(),
                         cancellationToken: cancellationToken
                     );
                 return response.Data;
@@ -203,14 +207,18 @@ namespace Svix
         /// </summary>
         public ListResponseMessageOut List(string appId, MessageListOptions? options = null)
         {
+            if (options == null)
+            {
+                options = new MessageListOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<ListResponseMessageOut>(
                     method: HttpMethod.Get,
                     path: "/api/v1/app/{app_id}/msg",
                     pathParams: new Dictionary<string, string> { { "app_id", appId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }
@@ -240,6 +248,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new MessageCreateOptions();
+            }
             messageIn = messageIn ?? throw new ArgumentNullException(nameof(messageIn));
             try
             {
@@ -248,11 +260,11 @@ namespace Svix
                     path: "/api/v1/app/{app_id}/msg",
                     pathParams: new Dictionary<string, string> { { "app_id", appId } },
                     queryParams: new Dictionary<string, string> { { "with_content", "false" } },
-                    headerParams: options?.HeaderParams(),
+                    headerParams: options.HeaderParams(),
                     content: messageIn,
                     cancellationToken: cancellationToken
                 );
-                if (options?.WithContent ?? true)
+                if (options.WithContent ?? true)
                 {
                     response.Data.Payload = messageIn.Payload;
                 }
@@ -283,6 +295,10 @@ namespace Svix
             MessageCreateOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new MessageCreateOptions();
+            }
             messageIn = messageIn ?? throw new ArgumentNullException(nameof(messageIn));
             try
             {
@@ -291,10 +307,10 @@ namespace Svix
                     path: "/api/v1/app/{app_id}/msg",
                     pathParams: new Dictionary<string, string> { { "app_id", appId } },
                     queryParams: new Dictionary<string, string> { { "with_content", "false" } },
-                    headerParams: options?.HeaderParams(),
+                    headerParams: options.HeaderParams(),
                     content: messageIn
                 );
-                if (options?.WithContent ?? true)
+                if (options.WithContent ?? true)
                 {
                     response.Data.Payload = messageIn.Payload;
                 }
@@ -323,6 +339,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new MessagePrecheckOptions();
+            }
             messagePrecheckIn =
                 messagePrecheckIn ?? throw new ArgumentNullException(nameof(messagePrecheckIn));
             try
@@ -331,8 +351,8 @@ namespace Svix
                     method: HttpMethod.Post,
                     path: "/api/v1/app/{app_id}/msg/precheck/active",
                     pathParams: new Dictionary<string, string> { { "app_id", appId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: messagePrecheckIn,
                     cancellationToken: cancellationToken
                 );
@@ -360,6 +380,10 @@ namespace Svix
             MessagePrecheckOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new MessagePrecheckOptions();
+            }
             messagePrecheckIn =
                 messagePrecheckIn ?? throw new ArgumentNullException(nameof(messagePrecheckIn));
             try
@@ -368,8 +392,8 @@ namespace Svix
                     method: HttpMethod.Post,
                     path: "/api/v1/app/{app_id}/msg/precheck/active",
                     pathParams: new Dictionary<string, string> { { "app_id", appId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: messagePrecheckIn
                 );
                 return response.Data;
@@ -392,6 +416,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new MessageGetOptions();
+            }
             try
             {
                 var response = await _client.SvixHttpClient.SendRequestAsync<MessageOut>(
@@ -402,8 +430,8 @@ namespace Svix
                         { "app_id", appId },
                         { "msg_id", msgId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     cancellationToken: cancellationToken
                 );
                 return response.Data;
@@ -421,6 +449,10 @@ namespace Svix
         /// </summary>
         public MessageOut Get(string appId, string msgId, MessageGetOptions? options = null)
         {
+            if (options == null)
+            {
+                options = new MessageGetOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<MessageOut>(
@@ -431,8 +463,8 @@ namespace Svix
                         { "app_id", appId },
                         { "msg_id", msgId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }
@@ -530,14 +562,18 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new MessageExpungeAllContentsOptions();
+            }
             try
             {
                 var response = await _client.SvixHttpClient.SendRequestAsync<ExpungeAllContentsOut>(
                     method: HttpMethod.Post,
                     path: "/api/v1/app/{app_id}/msg/expunge-all-contents",
                     pathParams: new Dictionary<string, string> { { "app_id", appId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     cancellationToken: cancellationToken
                 );
                 return response.Data;
@@ -572,14 +608,18 @@ namespace Svix
             MessageExpungeAllContentsOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new MessageExpungeAllContentsOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<ExpungeAllContentsOut>(
                     method: HttpMethod.Post,
                     path: "/api/v1/app/{app_id}/msg/expunge-all-contents",
                     pathParams: new Dictionary<string, string> { { "app_id", appId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }

--- a/csharp/Svix/MessageAttempt.cs
+++ b/csharp/Svix/MessageAttempt.cs
@@ -35,7 +35,7 @@ namespace Svix
                     { "after", After },
                     { "with_content", WithContent },
                     { "with_msg", WithMsg },
-                    { "expanded_statuses", ExpandedStatuses },
+                    { "expanded_statuses", ExpandedStatuses ?? true },
                     { "event_types", EventTypes },
                 }
             );
@@ -72,7 +72,7 @@ namespace Svix
                     { "before", Before },
                     { "after", After },
                     { "with_content", WithContent },
-                    { "expanded_statuses", ExpandedStatuses },
+                    { "expanded_statuses", ExpandedStatuses ?? true },
                     { "event_types", EventTypes },
                 }
             );
@@ -105,7 +105,7 @@ namespace Svix
                     { "before", Before },
                     { "after", After },
                     { "with_content", WithContent },
-                    { "expanded_statuses", ExpandedStatuses },
+                    { "expanded_statuses", ExpandedStatuses ?? true },
                     { "event_types", EventTypes },
                 }
             );
@@ -132,7 +132,10 @@ namespace Svix
         public new Dictionary<string, string> QueryParams()
         {
             return SerializeParams(
-                new Dictionary<string, object?> { { "expanded_statuses", ExpandedStatuses } }
+                new Dictionary<string, object?>
+                {
+                    { "expanded_statuses", ExpandedStatuses ?? true },
+                }
             );
         }
     }
@@ -168,6 +171,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new MessageAttemptListByEndpointOptions();
+            }
             try
             {
                 var response =
@@ -179,8 +186,8 @@ namespace Svix
                             { "app_id", appId },
                             { "endpoint_id", endpointId },
                         },
-                        queryParams: options?.QueryParams(),
-                        headerParams: options?.HeaderParams(),
+                        queryParams: options.QueryParams(),
+                        headerParams: options.HeaderParams(),
                         cancellationToken: cancellationToken
                     );
                 return response.Data;
@@ -207,6 +214,10 @@ namespace Svix
             MessageAttemptListByEndpointOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new MessageAttemptListByEndpointOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<ListResponseMessageAttemptOut>(
@@ -217,8 +228,8 @@ namespace Svix
                         { "app_id", appId },
                         { "endpoint_id", endpointId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }
@@ -245,6 +256,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new MessageAttemptListByMsgOptions();
+            }
             try
             {
                 var response =
@@ -256,8 +271,8 @@ namespace Svix
                             { "app_id", appId },
                             { "msg_id", msgId },
                         },
-                        queryParams: options?.QueryParams(),
-                        headerParams: options?.HeaderParams(),
+                        queryParams: options.QueryParams(),
+                        headerParams: options.HeaderParams(),
                         cancellationToken: cancellationToken
                     );
                 return response.Data;
@@ -284,6 +299,10 @@ namespace Svix
             MessageAttemptListByMsgOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new MessageAttemptListByMsgOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<ListResponseMessageAttemptOut>(
@@ -294,8 +313,8 @@ namespace Svix
                         { "app_id", appId },
                         { "msg_id", msgId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }
@@ -325,6 +344,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new MessageAttemptListAttemptedMessagesOptions();
+            }
             try
             {
                 var response =
@@ -336,8 +359,8 @@ namespace Svix
                             { "app_id", appId },
                             { "endpoint_id", endpointId },
                         },
-                        queryParams: options?.QueryParams(),
-                        headerParams: options?.HeaderParams(),
+                        queryParams: options.QueryParams(),
+                        headerParams: options.HeaderParams(),
                         cancellationToken: cancellationToken
                     );
                 return response.Data;
@@ -367,6 +390,10 @@ namespace Svix
             MessageAttemptListAttemptedMessagesOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new MessageAttemptListAttemptedMessagesOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<ListResponseEndpointMessageOut>(
@@ -377,8 +404,8 @@ namespace Svix
                         { "app_id", appId },
                         { "endpoint_id", endpointId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }
@@ -403,6 +430,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new MessageAttemptListAttemptedDestinationsOptions();
+            }
             try
             {
                 var response =
@@ -414,8 +445,8 @@ namespace Svix
                             { "app_id", appId },
                             { "msg_id", msgId },
                         },
-                        queryParams: options?.QueryParams(),
-                        headerParams: options?.HeaderParams(),
+                        queryParams: options.QueryParams(),
+                        headerParams: options.HeaderParams(),
                         cancellationToken: cancellationToken
                     );
                 return response.Data;
@@ -440,6 +471,10 @@ namespace Svix
             MessageAttemptListAttemptedDestinationsOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new MessageAttemptListAttemptedDestinationsOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<ListResponseMessageEndpointOut>(
@@ -450,8 +485,8 @@ namespace Svix
                         { "app_id", appId },
                         { "msg_id", msgId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }
@@ -474,6 +509,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new MessageAttemptGetOptions();
+            }
             try
             {
                 var response = await _client.SvixHttpClient.SendRequestAsync<MessageAttemptOut>(
@@ -485,8 +524,8 @@ namespace Svix
                         { "msg_id", msgId },
                         { "attempt_id", attemptId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     cancellationToken: cancellationToken
                 );
                 return response.Data;
@@ -509,6 +548,10 @@ namespace Svix
             MessageAttemptGetOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new MessageAttemptGetOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<MessageAttemptOut>(
@@ -520,8 +563,8 @@ namespace Svix
                         { "msg_id", msgId },
                         { "attempt_id", attemptId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }
@@ -610,6 +653,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new MessageAttemptResendOptions();
+            }
             try
             {
                 var response = await _client.SvixHttpClient.SendRequestAsync<EmptyResponse>(
@@ -621,8 +668,8 @@ namespace Svix
                         { "msg_id", msgId },
                         { "endpoint_id", endpointId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     cancellationToken: cancellationToken
                 );
                 return response.Data;
@@ -645,6 +692,10 @@ namespace Svix
             MessageAttemptResendOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new MessageAttemptResendOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<EmptyResponse>(
@@ -656,8 +707,8 @@ namespace Svix
                         { "msg_id", msgId },
                         { "endpoint_id", endpointId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }

--- a/csharp/Svix/MessagePoller.cs
+++ b/csharp/Svix/MessagePoller.cs
@@ -67,6 +67,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new MessagePollerPollOptions();
+            }
             try
             {
                 var response = await _client.SvixHttpClient.SendRequestAsync<PollingEndpointOut>(
@@ -77,8 +81,8 @@ namespace Svix
                         { "app_id", appId },
                         { "sink_id", sinkId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     cancellationToken: cancellationToken
                 );
                 return response.Data;
@@ -100,6 +104,10 @@ namespace Svix
             MessagePollerPollOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new MessagePollerPollOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<PollingEndpointOut>(
@@ -110,8 +118,8 @@ namespace Svix
                         { "app_id", appId },
                         { "sink_id", sinkId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }
@@ -135,6 +143,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new MessagePollerConsumerSeekOptions();
+            }
             pollingEndpointConsumerSeekIn =
                 pollingEndpointConsumerSeekIn
                 ?? throw new ArgumentNullException(nameof(pollingEndpointConsumerSeekIn));
@@ -150,8 +162,8 @@ namespace Svix
                             { "sink_id", sinkId },
                             { "consumer_id", consumerId },
                         },
-                        queryParams: options?.QueryParams(),
-                        headerParams: options?.HeaderParams(),
+                        queryParams: options.QueryParams(),
+                        headerParams: options.HeaderParams(),
                         content: pollingEndpointConsumerSeekIn,
                         cancellationToken: cancellationToken
                     );
@@ -176,6 +188,10 @@ namespace Svix
             MessagePollerConsumerSeekOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new MessagePollerConsumerSeekOptions();
+            }
             pollingEndpointConsumerSeekIn =
                 pollingEndpointConsumerSeekIn
                 ?? throw new ArgumentNullException(nameof(pollingEndpointConsumerSeekIn));
@@ -190,8 +206,8 @@ namespace Svix
                         { "sink_id", sinkId },
                         { "consumer_id", consumerId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: pollingEndpointConsumerSeekIn
                 );
                 return response.Data;
@@ -216,6 +232,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new MessagePollerConsumerPollOptions();
+            }
             try
             {
                 var response = await _client.SvixHttpClient.SendRequestAsync<PollingEndpointOut>(
@@ -227,8 +247,8 @@ namespace Svix
                         { "sink_id", sinkId },
                         { "consumer_id", consumerId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     cancellationToken: cancellationToken
                 );
                 return response.Data;
@@ -252,6 +272,10 @@ namespace Svix
             MessagePollerConsumerPollOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new MessagePollerConsumerPollOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<PollingEndpointOut>(
@@ -263,8 +287,8 @@ namespace Svix
                         { "sink_id", sinkId },
                         { "consumer_id", consumerId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }

--- a/csharp/Svix/OperationalWebhookEndpoint.cs
+++ b/csharp/Svix/OperationalWebhookEndpoint.cs
@@ -60,14 +60,18 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new OperationalWebhookEndpointListOptions();
+            }
             try
             {
                 var response =
                     await _client.SvixHttpClient.SendRequestAsync<ListResponseOperationalWebhookEndpointOut>(
                         method: HttpMethod.Get,
                         path: "/api/v1/operational-webhook/endpoint",
-                        queryParams: options?.QueryParams(),
-                        headerParams: options?.HeaderParams(),
+                        queryParams: options.QueryParams(),
+                        headerParams: options.HeaderParams(),
                         cancellationToken: cancellationToken
                     );
                 return response.Data;
@@ -87,14 +91,18 @@ namespace Svix
             OperationalWebhookEndpointListOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new OperationalWebhookEndpointListOptions();
+            }
             try
             {
                 var response =
                     _client.SvixHttpClient.SendRequest<ListResponseOperationalWebhookEndpointOut>(
                         method: HttpMethod.Get,
                         path: "/api/v1/operational-webhook/endpoint",
-                        queryParams: options?.QueryParams(),
-                        headerParams: options?.HeaderParams()
+                        queryParams: options.QueryParams(),
+                        headerParams: options.HeaderParams()
                     );
                 return response.Data;
             }
@@ -115,6 +123,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new OperationalWebhookEndpointCreateOptions();
+            }
             operationalWebhookEndpointIn =
                 operationalWebhookEndpointIn
                 ?? throw new ArgumentNullException(nameof(operationalWebhookEndpointIn));
@@ -124,8 +136,8 @@ namespace Svix
                     await _client.SvixHttpClient.SendRequestAsync<OperationalWebhookEndpointOut>(
                         method: HttpMethod.Post,
                         path: "/api/v1/operational-webhook/endpoint",
-                        queryParams: options?.QueryParams(),
-                        headerParams: options?.HeaderParams(),
+                        queryParams: options.QueryParams(),
+                        headerParams: options.HeaderParams(),
                         content: operationalWebhookEndpointIn,
                         cancellationToken: cancellationToken
                     );
@@ -147,6 +159,10 @@ namespace Svix
             OperationalWebhookEndpointCreateOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new OperationalWebhookEndpointCreateOptions();
+            }
             operationalWebhookEndpointIn =
                 operationalWebhookEndpointIn
                 ?? throw new ArgumentNullException(nameof(operationalWebhookEndpointIn));
@@ -155,8 +171,8 @@ namespace Svix
                 var response = _client.SvixHttpClient.SendRequest<OperationalWebhookEndpointOut>(
                     method: HttpMethod.Post,
                     path: "/api/v1/operational-webhook/endpoint",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: operationalWebhookEndpointIn
                 );
                 return response.Data;
@@ -404,6 +420,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new OperationalWebhookEndpointRotateSecretOptions();
+            }
             operationalWebhookEndpointSecretIn =
                 operationalWebhookEndpointSecretIn
                 ?? throw new ArgumentNullException(nameof(operationalWebhookEndpointSecretIn));
@@ -413,8 +433,8 @@ namespace Svix
                     method: HttpMethod.Post,
                     path: "/api/v1/operational-webhook/endpoint/{endpoint_id}/secret/rotate",
                     pathParams: new Dictionary<string, string> { { "endpoint_id", endpointId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: operationalWebhookEndpointSecretIn,
                     cancellationToken: cancellationToken
                 );
@@ -439,6 +459,10 @@ namespace Svix
             OperationalWebhookEndpointRotateSecretOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new OperationalWebhookEndpointRotateSecretOptions();
+            }
             operationalWebhookEndpointSecretIn =
                 operationalWebhookEndpointSecretIn
                 ?? throw new ArgumentNullException(nameof(operationalWebhookEndpointSecretIn));
@@ -448,8 +472,8 @@ namespace Svix
                     method: HttpMethod.Post,
                     path: "/api/v1/operational-webhook/endpoint/{endpoint_id}/secret/rotate",
                     pathParams: new Dictionary<string, string> { { "endpoint_id", endpointId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: operationalWebhookEndpointSecretIn
                 );
                 return response.Data;

--- a/csharp/Svix/Statistics.cs
+++ b/csharp/Svix/Statistics.cs
@@ -139,6 +139,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new StatisticsAggregateAppStatsOptions();
+            }
             appUsageStatsIn =
                 appUsageStatsIn ?? throw new ArgumentNullException(nameof(appUsageStatsIn));
             try
@@ -146,8 +150,8 @@ namespace Svix
                 var response = await _client.SvixHttpClient.SendRequestAsync<AppUsageStatsOut>(
                     method: HttpMethod.Post,
                     path: "/api/v1/stats/usage/app",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: appUsageStatsIn,
                     cancellationToken: cancellationToken
                 );
@@ -190,6 +194,10 @@ namespace Svix
             StatisticsAggregateAppStatsOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new StatisticsAggregateAppStatsOptions();
+            }
             appUsageStatsIn =
                 appUsageStatsIn ?? throw new ArgumentNullException(nameof(appUsageStatsIn));
             try
@@ -197,8 +205,8 @@ namespace Svix
                 var response = _client.SvixHttpClient.SendRequest<AppUsageStatsOut>(
                     method: HttpMethod.Post,
                     path: "/api/v1/stats/usage/app",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: appUsageStatsIn
                 );
                 return response.Data;

--- a/csharp/Svix/StreamingEventType.cs
+++ b/csharp/Svix/StreamingEventType.cs
@@ -60,14 +60,18 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new StreamingEventTypeListOptions();
+            }
             try
             {
                 var response =
                     await _client.SvixHttpClient.SendRequestAsync<ListResponseStreamEventTypeOut>(
                         method: HttpMethod.Get,
                         path: "/api/v1/stream/event-type",
-                        queryParams: options?.QueryParams(),
-                        headerParams: options?.HeaderParams(),
+                        queryParams: options.QueryParams(),
+                        headerParams: options.HeaderParams(),
                         cancellationToken: cancellationToken
                     );
                 return response.Data;
@@ -85,13 +89,17 @@ namespace Svix
         /// </summary>
         public ListResponseStreamEventTypeOut List(StreamingEventTypeListOptions? options = null)
         {
+            if (options == null)
+            {
+                options = new StreamingEventTypeListOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<ListResponseStreamEventTypeOut>(
                     method: HttpMethod.Get,
                     path: "/api/v1/stream/event-type",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }
@@ -112,6 +120,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new StreamingEventTypeCreateOptions();
+            }
             streamEventTypeIn =
                 streamEventTypeIn ?? throw new ArgumentNullException(nameof(streamEventTypeIn));
             try
@@ -119,8 +131,8 @@ namespace Svix
                 var response = await _client.SvixHttpClient.SendRequestAsync<StreamEventTypeOut>(
                     method: HttpMethod.Post,
                     path: "/api/v1/stream/event-type",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: streamEventTypeIn,
                     cancellationToken: cancellationToken
                 );
@@ -142,6 +154,10 @@ namespace Svix
             StreamingEventTypeCreateOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new StreamingEventTypeCreateOptions();
+            }
             streamEventTypeIn =
                 streamEventTypeIn ?? throw new ArgumentNullException(nameof(streamEventTypeIn));
             try
@@ -149,8 +165,8 @@ namespace Svix
                 var response = _client.SvixHttpClient.SendRequest<StreamEventTypeOut>(
                     method: HttpMethod.Post,
                     path: "/api/v1/stream/event-type",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: streamEventTypeIn
                 );
                 return response.Data;
@@ -275,14 +291,18 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new StreamingEventTypeDeleteOptions();
+            }
             try
             {
                 var response = await _client.SvixHttpClient.SendRequestAsync<bool>(
                     method: HttpMethod.Delete,
                     path: "/api/v1/stream/event-type/{name}",
                     pathParams: new Dictionary<string, string> { { "name", name } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     cancellationToken: cancellationToken
                 );
                 return response.Data;
@@ -300,14 +320,18 @@ namespace Svix
         /// </summary>
         public bool Delete(string name, StreamingEventTypeDeleteOptions? options = null)
         {
+            if (options == null)
+            {
+                options = new StreamingEventTypeDeleteOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<bool>(
                     method: HttpMethod.Delete,
                     path: "/api/v1/stream/event-type/{name}",
                     pathParams: new Dictionary<string, string> { { "name", name } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }

--- a/csharp/Svix/StreamingEvents.cs
+++ b/csharp/Svix/StreamingEvents.cs
@@ -52,6 +52,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new StreamingEventsGetOptions();
+            }
             try
             {
                 var response = await _client.SvixHttpClient.SendRequestAsync<EventStreamOut>(
@@ -62,8 +66,8 @@ namespace Svix
                         { "stream_id", streamId },
                         { "sink_id", sinkId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     cancellationToken: cancellationToken
                 );
                 return response.Data;
@@ -87,6 +91,10 @@ namespace Svix
             StreamingEventsGetOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new StreamingEventsGetOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<EventStreamOut>(
@@ -97,8 +105,8 @@ namespace Svix
                         { "stream_id", streamId },
                         { "sink_id", sinkId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }
@@ -120,6 +128,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new StreamingEventsCreateOptions();
+            }
             createStreamEventsIn =
                 createStreamEventsIn
                 ?? throw new ArgumentNullException(nameof(createStreamEventsIn));
@@ -129,8 +141,8 @@ namespace Svix
                     method: HttpMethod.Post,
                     path: "/api/v1/stream/{stream_id}/events",
                     pathParams: new Dictionary<string, string> { { "stream_id", streamId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: createStreamEventsIn,
                     cancellationToken: cancellationToken
                 );
@@ -153,6 +165,10 @@ namespace Svix
             StreamingEventsCreateOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new StreamingEventsCreateOptions();
+            }
             createStreamEventsIn =
                 createStreamEventsIn
                 ?? throw new ArgumentNullException(nameof(createStreamEventsIn));
@@ -162,8 +178,8 @@ namespace Svix
                     method: HttpMethod.Post,
                     path: "/api/v1/stream/{stream_id}/events",
                     pathParams: new Dictionary<string, string> { { "stream_id", streamId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: createStreamEventsIn
                 );
                 return response.Data;

--- a/csharp/Svix/StreamingSink.cs
+++ b/csharp/Svix/StreamingSink.cs
@@ -61,6 +61,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new StreamingSinkListOptions();
+            }
             try
             {
                 var response =
@@ -68,8 +72,8 @@ namespace Svix
                         method: HttpMethod.Get,
                         path: "/api/v1/stream/{stream_id}/sink",
                         pathParams: new Dictionary<string, string> { { "stream_id", streamId } },
-                        queryParams: options?.QueryParams(),
-                        headerParams: options?.HeaderParams(),
+                        queryParams: options.QueryParams(),
+                        headerParams: options.HeaderParams(),
                         cancellationToken: cancellationToken
                     );
                 return response.Data;
@@ -90,14 +94,18 @@ namespace Svix
             StreamingSinkListOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new StreamingSinkListOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<ListResponseStreamSinkOut>(
                     method: HttpMethod.Get,
                     path: "/api/v1/stream/{stream_id}/sink",
                     pathParams: new Dictionary<string, string> { { "stream_id", streamId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }
@@ -119,6 +127,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new StreamingSinkCreateOptions();
+            }
             streamSinkIn = streamSinkIn ?? throw new ArgumentNullException(nameof(streamSinkIn));
             try
             {
@@ -126,8 +138,8 @@ namespace Svix
                     method: HttpMethod.Post,
                     path: "/api/v1/stream/{stream_id}/sink",
                     pathParams: new Dictionary<string, string> { { "stream_id", streamId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: streamSinkIn,
                     cancellationToken: cancellationToken
                 );
@@ -150,6 +162,10 @@ namespace Svix
             StreamingSinkCreateOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new StreamingSinkCreateOptions();
+            }
             streamSinkIn = streamSinkIn ?? throw new ArgumentNullException(nameof(streamSinkIn));
             try
             {
@@ -157,8 +173,8 @@ namespace Svix
                     method: HttpMethod.Post,
                     path: "/api/v1/stream/{stream_id}/sink",
                     pathParams: new Dictionary<string, string> { { "stream_id", streamId } },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: streamSinkIn
                 );
                 return response.Data;
@@ -555,6 +571,10 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new StreamingSinkRotateSecretOptions();
+            }
             endpointSecretRotateIn =
                 endpointSecretRotateIn
                 ?? throw new ArgumentNullException(nameof(endpointSecretRotateIn));
@@ -568,8 +588,8 @@ namespace Svix
                         { "stream_id", streamId },
                         { "sink_id", sinkId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: endpointSecretRotateIn,
                     cancellationToken: cancellationToken
                 );
@@ -593,6 +613,10 @@ namespace Svix
             StreamingSinkRotateSecretOptions? options = null
         )
         {
+            if (options == null)
+            {
+                options = new StreamingSinkRotateSecretOptions();
+            }
             endpointSecretRotateIn =
                 endpointSecretRotateIn
                 ?? throw new ArgumentNullException(nameof(endpointSecretRotateIn));
@@ -606,8 +630,8 @@ namespace Svix
                         { "stream_id", streamId },
                         { "sink_id", sinkId },
                     },
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: endpointSecretRotateIn
                 );
                 return response.Data;

--- a/csharp/Svix/StreamingStream.cs
+++ b/csharp/Svix/StreamingStream.cs
@@ -48,13 +48,17 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new StreamingStreamListOptions();
+            }
             try
             {
                 var response = await _client.SvixHttpClient.SendRequestAsync<ListResponseStreamOut>(
                     method: HttpMethod.Get,
                     path: "/api/v1/stream",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     cancellationToken: cancellationToken
                 );
                 return response.Data;
@@ -72,13 +76,17 @@ namespace Svix
         /// </summary>
         public ListResponseStreamOut List(StreamingStreamListOptions? options = null)
         {
+            if (options == null)
+            {
+                options = new StreamingStreamListOptions();
+            }
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<ListResponseStreamOut>(
                     method: HttpMethod.Get,
                     path: "/api/v1/stream",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams()
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams()
                 );
                 return response.Data;
             }
@@ -99,14 +107,18 @@ namespace Svix
             CancellationToken cancellationToken = default
         )
         {
+            if (options == null)
+            {
+                options = new StreamingStreamCreateOptions();
+            }
             streamIn = streamIn ?? throw new ArgumentNullException(nameof(streamIn));
             try
             {
                 var response = await _client.SvixHttpClient.SendRequestAsync<StreamOut>(
                     method: HttpMethod.Post,
                     path: "/api/v1/stream",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: streamIn,
                     cancellationToken: cancellationToken
                 );
@@ -125,14 +137,18 @@ namespace Svix
         /// </summary>
         public StreamOut Create(StreamIn streamIn, StreamingStreamCreateOptions? options = null)
         {
+            if (options == null)
+            {
+                options = new StreamingStreamCreateOptions();
+            }
             streamIn = streamIn ?? throw new ArgumentNullException(nameof(streamIn));
             try
             {
                 var response = _client.SvixHttpClient.SendRequest<StreamOut>(
                     method: HttpMethod.Post,
                     path: "/api/v1/stream",
-                    queryParams: options?.QueryParams(),
-                    headerParams: options?.HeaderParams(),
+                    queryParams: options.QueryParams(),
+                    headerParams: options.HeaderParams(),
                     content: streamIn
                 );
                 return response.Data;

--- a/csharp/Svix/SvixOptionsBase.cs
+++ b/csharp/Svix/SvixOptionsBase.cs
@@ -13,15 +13,7 @@ namespace Svix
             var dict = new Dictionary<string, string>();
             foreach (KeyValuePair<string, object?> entry in rawParams)
             {
-                if (entry.Value == null)
-                {
-                    // HACK: default expanded_statuses to true, it only defaults to false
-                    //       server-side because of backwards-compatibility for old SDKs
-                    if (entry.Key == "expanded_statuses")
-                    {
-                        dict[entry.Key] = "true";
-                    }
-                }
+                if (entry.Value == null) { }
                 else if (IsGenericList(entry.Value))
                 {
                     var list = (System.Collections.IEnumerable)entry.Value;


### PR DESCRIPTION
It was only being honored when the options were not null. Found this bug in #2439 (through the cmg test that asserts that `with_content=false` is used, which was no longer true after removing the hack that would always set it).