### PR TITLE
fix: do not log a warning on every request if otel is disabled

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Server: Fix warning when opentelemetry is disabled
 
 ## Version 1.98.0
 * CLI, Server, Bridge: Set OCI metadata on Docker images

--- a/server/svix-server/src/core/otel_spans.rs
+++ b/server/svix-server/src/core/otel_spans.rs
@@ -19,7 +19,15 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 /// An implementor of [`MakeSpan`] which creates `tracing` spans populated with information about
 /// the request received by an `axum` web server.
 #[derive(Clone, Copy)]
-pub struct AxumOtelSpanCreator;
+pub struct AxumOtelSpanCreator {
+    set_otel_parent: bool,
+}
+
+impl AxumOtelSpanCreator {
+    pub fn new(set_otel_parent: bool) -> Self {
+        Self { set_otel_parent }
+    }
+}
 
 impl<B> MakeSpan<B> for AxumOtelSpanCreator {
     fn make_span(&mut self, request: &http::Request<B>) -> tracing::Span {
@@ -92,8 +100,10 @@ impl<B> MakeSpan<B> for AxumOtelSpanCreator {
             app_id = tracing::field::Empty,
         );
 
-        if let Err(err) = span.set_parent(remote_context) {
-            tracing::warn!(?err, "failed to set span parent from remote context");
+        if self.set_otel_parent {
+            if let Err(err) = span.set_parent(remote_context) {
+                tracing::warn!(?err, "failed to set span parent from remote context");
+            }
         }
 
         span

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -191,7 +191,7 @@ pub async fn run_with_prefix(
         cache: cache.clone(),
         op_webhooks: op_webhook_sender.clone(),
     };
-    let v1_router = v1::router().with_state::<()>(app_state);
+    let v1_router = v1::router(cfg.clone()).with_state::<()>(app_state);
 
     // Initialize all routes which need to be part of OpenAPI first.
     let app = ApiRouter::new()

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -281,7 +281,7 @@ async fn main() -> anyhow::Result<()> {
         Some(Commands::GenerateOpenapi) => {
             let mut openapi = svix_server::openapi::initialize_openapi();
 
-            let router = svix_server::v1::router();
+            let router = svix_server::v1::router(cfg);
             _ = aide::axum::ApiRouter::new()
                 .nest("/api/v1", router)
                 .finish_api_with(&mut openapi, svix_server::openapi::add_security_scheme);

--- a/server/svix-server/src/v1/mod.rs
+++ b/server/svix-server/src/v1/mod.rs
@@ -6,13 +6,14 @@ use tower_http::trace::TraceLayer;
 
 use crate::{
     AppState,
+    cfg::Configuration,
     core::otel_spans::{AxumOtelOnFailure, AxumOtelOnResponse, AxumOtelSpanCreator},
 };
 
 pub mod endpoints;
 pub mod utils;
 
-pub fn router() -> ApiRouter<AppState> {
+pub fn router(cfg: Configuration) -> ApiRouter<AppState> {
     let ret: ApiRouter<AppState> = ApiRouter::new()
         .merge(endpoints::health::router())
         .merge(endpoints::auth::router())
@@ -24,7 +25,9 @@ pub fn router() -> ApiRouter<AppState> {
         .merge(endpoints::admin::router())
         .layer(
             TraceLayer::new_for_http()
-                .make_span_with(AxumOtelSpanCreator)
+                .make_span_with(AxumOtelSpanCreator::new(
+                    cfg.opentelemetry_address.is_some(),
+                ))
                 .on_response(AxumOtelOnResponse)
                 .on_failure(AxumOtelOnFailure),
         );


### PR DESCRIPTION
Since #2423, if opentelemetry is disabled, every request logs 

```
2026-07-21T23:36:19.582233Z  WARN svix_server::core::otel_spans: failed to set span parent from remote context err=LayerNotFound
```

This has presumably been broken for a long time and only became visible because `.set_parent` returns an error now instead of swallowing it silently.

The solution is to just not call `.set_parent` if there isn't an otel layer in place (internally, that function ends up doing a `.downcast_ref()` on the tracing dispatcher to get at the otel layer, which obviously doesn't work if there is no otel layer).

Presumably, I never noticed this because I always have otel enabled while developing.

Fixes #2489 