### PR TITLE
bridge/kafka: Add transformation envelope

### DIFF
--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -4641,6 +4641,7 @@ dependencies = [
 name = "svix-bridge-plugin-kafka"
 version = "1.99.0"
 dependencies = [
+ "base64",
  "ctor",
  "rdkafka",
  "serde",

--- a/bridge/ChangeLog.md
+++ b/bridge/ChangeLog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Add an opt-in Kafka record envelope for JSON transformations
 
 ## Version 1.99.0
 * Include the Kafka partition in consumer idempotency keys

--- a/bridge/svix-bridge-plugin-kafka/Cargo.toml
+++ b/bridge/svix-bridge-plugin-kafka/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 license.workspace = true
 
 [dependencies]
+base64 = "0.22.1"
 rdkafka = { version = "0.38.0", features = ["cmake-build", "ssl", "tracing"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/bridge/svix-bridge-plugin-kafka/src/config.rs
+++ b/bridge/svix-bridge-plugin-kafka/src/config.rs
@@ -27,6 +27,10 @@ pub enum KafkaInputOpts {
         #[serde(rename = "kafka_topic")]
         topic: String,
 
+        /// The input passed to JSON transformations.
+        #[serde(rename = "kafka_transformation_input", default)]
+        transformation_input: KafkaTransformationInput,
+
         /// The value for 'security.protocol' in the kafka config.
         #[serde(flatten)]
         security_protocol: KafkaSecurityProtocol,
@@ -36,6 +40,14 @@ pub enum KafkaInputOpts {
         #[serde(rename = "kafka_debug_contexts")]
         debug_contexts: Option<String>,
     },
+}
+
+#[derive(Clone, Copy, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum KafkaTransformationInput {
+    #[default]
+    Payload,
+    Envelope,
 }
 
 impl KafkaInputOpts {

--- a/bridge/svix-bridge-plugin-kafka/src/input.rs
+++ b/bridge/svix-bridge-plugin-kafka/src/input.rs
@@ -3,10 +3,12 @@ use std::{
     time::{Duration, Instant},
 };
 
+use base64::{Engine as _, engine::general_purpose::STANDARD};
 use rdkafka::{
     Message as _,
     consumer::{CommitMode, Consumer as _},
     error::KafkaError,
+    message::Headers as _,
 };
 use svix_bridge_types::{
     CreateMessageRequest, JsObject, SenderInput, SenderOutputOpts, TransformationConfig,
@@ -16,7 +18,10 @@ use svix_bridge_types::{
 };
 use tokio::task::spawn_blocking;
 
-use crate::{Error, Result, config::KafkaInputOpts};
+use crate::{
+    Error, Result,
+    config::{KafkaInputOpts, KafkaTransformationInput},
+};
 
 pub struct KafkaConsumer {
     name: String,
@@ -46,6 +51,44 @@ impl KafkaConsumer {
         })
     }
 
+    fn kafka_header_value_as_json(value: Option<&[u8]>) -> serde_json::Value {
+        value.map_or(serde_json::Value::Null, |value| {
+            serde_json::Value::String(STANDARD.encode(value))
+        })
+    }
+
+    fn kafka_key_as_json(key: Option<&[u8]>) -> serde_json::Value {
+        key.map_or(serde_json::Value::Null, |key| {
+            serde_json::Value::String(String::from_utf8_lossy(key).into_owned())
+        })
+    }
+
+    fn kafka_envelope(
+        msg: &rdkafka::message::BorrowedMessage<'_>,
+        payload: serde_json::Value,
+    ) -> serde_json::Value {
+        let headers: Vec<_> = msg
+            .headers()
+            .into_iter()
+            .flat_map(|headers| headers.iter())
+            .map(|header| {
+                serde_json::json!({
+                    "key": header.key,
+                    "value": Self::kafka_header_value_as_json(header.value),
+                })
+            })
+            .collect();
+
+        serde_json::json!({
+            "headers": headers,
+            "key": Self::kafka_key_as_json(msg.key()),
+            "topic": msg.topic(),
+            "partition": msg.partition(),
+            "offset": msg.offset(),
+            "payload": payload,
+        })
+    }
+
     #[tracing::instrument(skip_all)]
     async fn process(&self, msg: &rdkafka::message::BorrowedMessage<'_>) -> Result<()> {
         let payload = msg.payload().ok_or_else(|| Error::MissingPayload)?;
@@ -54,7 +97,18 @@ impl KafkaConsumer {
                 TransformerInputFormat::Json => {
                     let json_payload =
                         serde_json::from_slice(payload).map_err(Error::Deserialization)?;
-                    TransformerInput::Json(json_payload)
+                    let KafkaInputOpts::Inner {
+                        transformation_input,
+                        ..
+                    } = &self.opts;
+                    let input = match transformation_input {
+                        KafkaTransformationInput::Payload => json_payload,
+                        KafkaTransformationInput::Envelope => {
+                            Self::kafka_envelope(msg, json_payload)
+                        }
+                    };
+
+                    TransformerInput::Json(input)
                 }
                 TransformerInputFormat::String => {
                     let raw_payload = str::from_utf8(payload).map_err(Error::NonUtf8Payload)?;

--- a/bridge/svix-bridge-plugin-kafka/src/lib.rs
+++ b/bridge/svix-bridge-plugin-kafka/src/lib.rs
@@ -5,8 +5,8 @@ mod output;
 
 pub use self::{
     config::{
-        KafkaInputOpts, KafkaOutputOpts, KafkaSecurityProtocol, into_receiver_output,
-        into_sender_input,
+        KafkaInputOpts, KafkaOutputOpts, KafkaSecurityProtocol, KafkaTransformationInput,
+        into_receiver_output, into_sender_input,
     },
     error::{Error, Result},
     input::KafkaConsumer,

--- a/bridge/svix-bridge-plugin-kafka/tests/it/kafka_consumer.rs
+++ b/bridge/svix-bridge-plugin-kafka/tests/it/kafka_consumer.rs
@@ -6,11 +6,12 @@ use std::time::Duration;
 
 use rdkafka::{
     ClientConfig,
+    message::{Header, OwnedHeaders},
     producer::{FutureProducer, FutureRecord},
     util::Timeout,
 };
 use serde_json::json;
-use svix_bridge_plugin_kafka::{KafkaConsumer, KafkaInputOpts};
+use svix_bridge_plugin_kafka::{KafkaConsumer, KafkaInputOpts, KafkaTransformationInput};
 use svix_bridge_types::{
     CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions, SvixSenderOutputOpts,
     TransformationConfig, TransformerInput, TransformerInputFormat, TransformerJob,
@@ -51,6 +52,20 @@ fn get_test_plugin(
     topic: &str,
     use_transformation: Option<TransformerInputFormat>,
 ) -> KafkaConsumer {
+    get_test_plugin_with_transformation_input(
+        svix_url,
+        topic,
+        use_transformation,
+        KafkaTransformationInput::Payload,
+    )
+}
+
+fn get_test_plugin_with_transformation_input(
+    svix_url: String,
+    topic: &str,
+    use_transformation: Option<TransformerInputFormat>,
+    transformation_input: KafkaTransformationInput,
+) -> KafkaConsumer {
     KafkaConsumer::new(
         "test".into(),
         KafkaInputOpts::Inner {
@@ -58,6 +73,7 @@ fn get_test_plugin(
             // All tests use different topics, so it's fine to have only one consumer group ID
             group_id: "svix_bridge_test_group_id".to_owned(),
             topic: topic.to_owned(),
+            transformation_input,
             security_protocol: svix_bridge_plugin_kafka::KafkaSecurityProtocol::Plaintext,
             debug_contexts: None,
         },
@@ -89,6 +105,25 @@ async fn publish(producer: &FutureProducer, topic: &str, payload: &[u8]) {
     producer
         .send(
             FutureRecord::<(), _>::to(topic).payload(payload),
+            Timeout::After(Duration::from_secs(3)),
+        )
+        .await
+        .unwrap();
+}
+
+async fn publish_with_metadata(
+    producer: &FutureProducer,
+    topic: &str,
+    key: &[u8],
+    headers: OwnedHeaders,
+    payload: &[u8],
+) {
+    producer
+        .send(
+            FutureRecord::<[u8], _>::to(topic)
+                .key(key)
+                .headers(headers)
+                .payload(payload),
             Timeout::After(Duration::from_secs(3)),
         )
         .await
@@ -217,6 +252,117 @@ async fn test_consume_transformed_json_ok() {
     // Wait for the consumer to consume.
     tokio::time::sleep(CONSUME_WAIT_TIME).await;
 
+    handle.abort();
+    delete_topic(&admin_client, topic).await;
+}
+
+#[tokio::test]
+async fn test_consume_transformed_json_envelope_ok() {
+    let topic = unique_topic_name!();
+
+    let admin_client = kafka_admin_client();
+    create_topic(&admin_client, topic).await;
+
+    let producer = kafka_producer();
+
+    let mock_server = MockServer::start().await;
+    let mock = Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+          "eventType": "testing.things",
+          "payload": {
+            "hi": "there",
+          },
+          "id": "msg_xxxx",
+          "timestamp": "2023-04-25T00:00:00Z"
+        })))
+        .named("create_message")
+        .expect(1);
+    mock_server.register(mock).await;
+
+    let mut plugin = get_test_plugin_with_transformation_input(
+        mock_server.uri(),
+        topic,
+        Some(TransformerInputFormat::Json),
+        KafkaTransformationInput::Envelope,
+    );
+    let (transformer_tx, mut transformer_rx) =
+        tokio::sync::mpsc::unbounded_channel::<TransformerJob>();
+    let (input_tx, input_rx) = tokio::sync::oneshot::channel();
+    let transformer_handle = tokio::spawn(async move {
+        let job = transformer_rx.recv().await.unwrap();
+        let input = match job.input {
+            TransformerInput::Json(input) => input,
+            _ => unreachable!(),
+        };
+        let output = input["payload"].as_object().unwrap().clone();
+        input_tx.send(input).unwrap();
+        job.callback_tx
+            .send(Ok(TransformerOutput::Object(output)))
+            .unwrap();
+    });
+    plugin.set_transformer(Some(transformer_tx));
+
+    let handle = tokio::spawn(async move {
+        plugin.run().await;
+    });
+    tokio::time::sleep(CONNECT_WAIT_TIME).await;
+
+    let msg = CreateMessageRequest {
+        app_id: "app_1234".into(),
+        message: MessageIn::new("testing.things".into(), json!({"hi": "there"})),
+    };
+    let headers = OwnedHeaders::new()
+        .insert(Header {
+            key: "test-header",
+            value: Some(b"test-value"),
+        })
+        .insert(Header {
+            key: "duplicate",
+            value: Some(b"first"),
+        })
+        .insert(Header {
+            key: "duplicate",
+            value: Some(b"second"),
+        })
+        .insert(Header {
+            key: "binary",
+            value: Some(&[0xff]),
+        })
+        .insert(Header {
+            key: "empty",
+            value: None::<&[u8]>,
+        });
+    publish_with_metadata(
+        &producer,
+        topic,
+        &[b'm', 0xff, b'k'],
+        headers,
+        &serde_json::to_vec(&msg).unwrap(),
+    )
+    .await;
+
+    let input = tokio::time::timeout(CONSUME_WAIT_TIME, input_rx)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(input["key"], "m\u{fffd}k");
+    assert_eq!(input["topic"], topic.as_str());
+    assert_eq!(input["partition"], 0);
+    assert_eq!(input["offset"], 0);
+    assert_eq!(
+        input["headers"],
+        json!([
+            { "key": "test-header", "value": "dGVzdC12YWx1ZQ==" },
+            { "key": "duplicate", "value": "Zmlyc3Q=" },
+            { "key": "duplicate", "value": "c2Vjb25k" },
+            { "key": "binary", "value": "/w==" },
+            { "key": "empty", "value": null },
+        ])
+    );
+    assert_eq!(input["payload"], serde_json::to_value(&msg).unwrap());
+
+    transformer_handle.await.unwrap();
+    tokio::time::sleep(CONSUME_WAIT_TIME).await;
     handle.abort();
     delete_topic(&admin_client, topic).await;
 }

--- a/bridge/svix-bridge.example.senders.yaml
+++ b/bridge/svix-bridge.example.senders.yaml
@@ -141,6 +141,10 @@ senders:
       kafka_bootstrap_brokers: "localhost:9094"
       kafka_group_id: "kafka_example_consumer_group"
       kafka_topic: "foobar"
+      # Optional - defaults to "payload". "envelope" passes Kafka record metadata and payload
+      # to JSON transformations. Headers preserve duplicate keys; values are null or base64 strings.
+      # The record key is decoded as UTF-8 with invalid bytes replaced.
+      # kafka_transformation_input: "envelope"
       # Other valid values: "plaintext", "ssl"
       kafka_security_protocol: "sasl_ssl"
       # Only for SASL

--- a/bridge/svix-bridge/src/config/tests.rs
+++ b/bridge/svix-bridge/src/config/tests.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+#[cfg(feature = "kafka")]
+use svix_bridge_plugin_kafka::{KafkaInputOpts, KafkaTransformationInput};
 use svix_bridge_plugin_queue::config::{QueueInputOpts, RabbitMqInputOpts};
 use svix_bridge_types::{SenderOutputOpts, SvixSenderOutputOpts};
 
@@ -343,6 +345,40 @@ fn test_senders_parses_ok() {
 fn test_omnibus_parses_ok() {
     let conf: Result<Config, _> = serde_yaml::from_str(OMNIBUS);
     conf.unwrap();
+}
+
+#[cfg(feature = "kafka")]
+#[test]
+fn test_kafka_transformation_input_defaults_to_payload() {
+    let config: Config = serde_yaml::from_str(
+        r#"
+senders:
+  - name: "kafka-example"
+    input:
+      type: "kafka"
+      kafka_bootstrap_brokers: "localhost:9094"
+      kafka_group_id: "kafka_example_consumer_group"
+      kafka_topic: "foobar"
+      kafka_security_protocol: "plaintext"
+    output:
+      type: "svix"
+      token: "XYZ"
+"#,
+    )
+    .unwrap();
+
+    let SenderInputOpts::Kafka(KafkaInputOpts::Inner {
+        transformation_input,
+        ..
+    }) = &config.senders[0].input
+    else {
+        panic!("Expected Kafka input");
+    };
+
+    assert!(matches!(
+        transformation_input,
+        KafkaTransformationInput::Payload
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

Kafka JSON transformations currently receive only the record payload. This prevents transformations from routing or enriching messages using Kafka headers, keys, or record metadata.

## Solution

Add an opt-in `kafka_transformation_input: envelope` mode for Kafka JSON transformations.

When enabled, transformations receive the record headers, key, topic, partition, offset, and parsed payload. The default remains `payload`, preserving the existing transformation input contract.

Headers are represented as an ordered array to preserve duplicate keys. UTF-8 values are passed as strings; binary values are represented as base64.

Added integration coverage for envelope metadata and a configuration test that verifies the default remains `Payload`.