### PR TITLE
Fix regex for client-integration-tests/docker-compose.yml

### DIFF
--- a/tools/bump_version.py
+++ b/tools/bump_version.py
@@ -181,7 +181,7 @@ VERSION_FILES = [
 OLD_VERSION_FILES = [
     VersionFile(
         "client-integration-tests/docker-compose.yml",
-        [r"(image: docker.io/svix/svix-server:)(v.+)"],
+        [r"(image: docker.io/svix/svix-server:v)(.+)"],
     ),
 ]
 


### PR DESCRIPTION
… in `bump-version.py`.

It was removing the `v` from the tag.