### PR TITLE
bridge/kafka: Add configurable auto.offset.reset

### DIFF
--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -4647,6 +4647,7 @@ dependencies = [
  "rdkafka",
  "serde",
  "serde_json",
+ "strum",
  "svix-bridge-types",
  "thiserror",
  "tokio",

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -36,6 +36,7 @@ opentelemetry-otlp = { version = "0.32.0", features = ["metrics", "grpc-tonic", 
 opentelemetry_sdk = { version = "0.32.0", features = ["metrics", "rt-tokio", "experimental_metrics_periodicreader_with_async_runtime", "experimental_trace_batch_span_processor_with_async_runtime"] }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
+strum = { version = "0.27.2", features = ["derive"] }
 svix-bridge-types = { path = "svix-bridge-types" }
 thiserror = "2.0.18"
 tokio = { version = "1.38.0", features = ["macros", "time", "rt-multi-thread", "sync"] }

--- a/bridge/ChangeLog.md
+++ b/bridge/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Add an opt-in Kafka record envelope for JSON transformations
+* Allow configuring Kafka consumer `auto.offset.reset`
 
 ## Version 1.99.0
 * Include the Kafka partition in consumer idempotency keys

--- a/bridge/svix-bridge-plugin-kafka/Cargo.toml
+++ b/bridge/svix-bridge-plugin-kafka/Cargo.toml
@@ -11,6 +11,7 @@ base64 = "0.22.1"
 rdkafka = { version = "0.38.0", features = ["cmake-build", "ssl", "tracing"] }
 serde.workspace = true
 serde_json.workspace = true
+strum.workspace = true
 svix-bridge-types.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["time"] }

--- a/bridge/svix-bridge-plugin-kafka/src/config.rs
+++ b/bridge/svix-bridge-plugin-kafka/src/config.rs
@@ -2,6 +2,7 @@ use rdkafka::{
     ClientConfig, consumer::StreamConsumer, error::KafkaResult, producer::FutureProducer,
 };
 use serde::Deserialize;
+use strum::IntoStaticStr;
 use svix_bridge_types::{ReceiverOutput, SenderInput, SenderOutputOpts, TransformationConfig};
 
 use crate::{KafkaProducer, Result, input::KafkaConsumer};
@@ -31,6 +32,10 @@ pub enum KafkaInputOpts {
         #[serde(rename = "kafka_transformation_input", default)]
         transformation_input: KafkaTransformationInput,
 
+        /// The value for 'auto.offset.reset' in the kafka config.
+        #[serde(rename = "kafka_auto_offset_reset", default)]
+        auto_offset_reset: KafkaAutoOffsetReset,
+
         /// The value for 'security.protocol' in the kafka config.
         #[serde(flatten)]
         security_protocol: KafkaSecurityProtocol,
@@ -55,6 +60,7 @@ impl KafkaInputOpts {
         let Self::Inner {
             bootstrap_brokers,
             group_id,
+            auto_offset_reset,
             security_protocol,
             debug_contexts,
             ..
@@ -64,6 +70,7 @@ impl KafkaInputOpts {
         config
             .set("group.id", group_id)
             .set("bootstrap.servers", bootstrap_brokers)
+            .set("auto.offset.reset", <&'static str>::from(auto_offset_reset))
             // messages are committed manually after webhook delivery was successful.
             .set("enable.auto.commit", "false");
 
@@ -76,6 +83,15 @@ impl KafkaInputOpts {
 
         config.create()
     }
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, IntoStaticStr, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum KafkaAutoOffsetReset {
+    #[default]
+    Latest,
+    Earliest,
 }
 
 #[derive(Clone, Deserialize)]

--- a/bridge/svix-bridge-plugin-kafka/src/lib.rs
+++ b/bridge/svix-bridge-plugin-kafka/src/lib.rs
@@ -5,8 +5,8 @@ mod output;
 
 pub use self::{
     config::{
-        KafkaInputOpts, KafkaOutputOpts, KafkaSecurityProtocol, KafkaTransformationInput,
-        into_receiver_output, into_sender_input,
+        KafkaAutoOffsetReset, KafkaInputOpts, KafkaOutputOpts, KafkaSecurityProtocol,
+        KafkaTransformationInput, into_receiver_output, into_sender_input,
     },
     error::{Error, Result},
     input::KafkaConsumer,

--- a/bridge/svix-bridge-plugin-kafka/tests/it/kafka_consumer.rs
+++ b/bridge/svix-bridge-plugin-kafka/tests/it/kafka_consumer.rs
@@ -11,7 +11,9 @@ use rdkafka::{
     util::Timeout,
 };
 use serde_json::json;
-use svix_bridge_plugin_kafka::{KafkaConsumer, KafkaInputOpts, KafkaTransformationInput};
+use svix_bridge_plugin_kafka::{
+    KafkaAutoOffsetReset, KafkaConsumer, KafkaInputOpts, KafkaTransformationInput,
+};
 use svix_bridge_types::{
     CreateMessageRequest, SenderInput, SenderOutputOpts, SvixOptions, SvixSenderOutputOpts,
     TransformationConfig, TransformerInput, TransformerInputFormat, TransformerJob,
@@ -66,6 +68,37 @@ fn get_test_plugin_with_transformation_input(
     use_transformation: Option<TransformerInputFormat>,
     transformation_input: KafkaTransformationInput,
 ) -> KafkaConsumer {
+    get_test_plugin_with_kafka_options(
+        svix_url,
+        topic,
+        use_transformation,
+        transformation_input,
+        KafkaAutoOffsetReset::Latest,
+    )
+}
+
+fn get_test_plugin_with_auto_offset_reset(
+    svix_url: String,
+    topic: &str,
+    use_transformation: Option<TransformerInputFormat>,
+    auto_offset_reset: KafkaAutoOffsetReset,
+) -> KafkaConsumer {
+    get_test_plugin_with_kafka_options(
+        svix_url,
+        topic,
+        use_transformation,
+        KafkaTransformationInput::Payload,
+        auto_offset_reset,
+    )
+}
+
+fn get_test_plugin_with_kafka_options(
+    svix_url: String,
+    topic: &str,
+    use_transformation: Option<TransformerInputFormat>,
+    transformation_input: KafkaTransformationInput,
+    auto_offset_reset: KafkaAutoOffsetReset,
+) -> KafkaConsumer {
     KafkaConsumer::new(
         "test".into(),
         KafkaInputOpts::Inner {
@@ -74,6 +107,7 @@ fn get_test_plugin_with_transformation_input(
             group_id: "svix_bridge_test_group_id".to_owned(),
             topic: topic.to_owned(),
             transformation_input,
+            auto_offset_reset,
             security_protocol: svix_bridge_plugin_kafka::KafkaSecurityProtocol::Plaintext,
             debug_contexts: None,
         },
@@ -180,6 +214,49 @@ async fn test_consume_ok() {
 
     // Wait for the consumer to consume.
     tokio::time::sleep(CONSUME_WAIT_TIME).await;
+
+    handle.abort();
+    delete_topic(&admin_client, topic).await;
+}
+
+#[tokio::test]
+async fn test_consume_with_earliest_auto_offset_reset_ok() {
+    let topic = unique_topic_name!();
+
+    let admin_client = kafka_admin_client();
+    create_topic(&admin_client, topic).await;
+
+    let producer = kafka_producer();
+    let msg = CreateMessageRequest {
+        app_id: "app_1234".into(),
+        message: MessageIn::new("testing.things".into(), json!({"hi": "there"})),
+    };
+    publish(&producer, topic, &serde_json::to_vec(&msg).unwrap()).await;
+
+    let mock_server = MockServer::start().await;
+    let mock = Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+          "eventType": "testing.things",
+          "payload": {
+            "hi": "there",
+          },
+          "id": "msg_xxxx",
+          "timestamp": "2023-04-25T00:00:00Z"
+        })))
+        .named("create_message")
+        .expect(1);
+    mock_server.register(mock).await;
+
+    let plugin = get_test_plugin_with_auto_offset_reset(
+        mock_server.uri(),
+        topic,
+        None,
+        KafkaAutoOffsetReset::Earliest,
+    );
+    let handle = tokio::spawn(async move {
+        plugin.run().await;
+    });
+    tokio::time::sleep(CONNECT_WAIT_TIME + CONSUME_WAIT_TIME).await;
 
     handle.abort();
     delete_topic(&admin_client, topic).await;

--- a/bridge/svix-bridge.example.senders.yaml
+++ b/bridge/svix-bridge.example.senders.yaml
@@ -145,6 +145,8 @@ senders:
       # to JSON transformations. Headers preserve duplicate keys; values are null or base64 strings.
       # The record key is decoded as UTF-8 with invalid bytes replaced.
       # kafka_transformation_input: "envelope"
+      # Optional - defaults to "latest". Set to "earliest" to consume existing records.
+      # kafka_auto_offset_reset: "earliest"
       # Other valid values: "plaintext", "ssl"
       kafka_security_protocol: "sasl_ssl"
       # Only for SASL

--- a/bridge/svix-bridge/src/config/tests.rs
+++ b/bridge/svix-bridge/src/config/tests.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 #[cfg(feature = "kafka")]
-use svix_bridge_plugin_kafka::{KafkaInputOpts, KafkaTransformationInput};
+use svix_bridge_plugin_kafka::{KafkaAutoOffsetReset, KafkaInputOpts, KafkaTransformationInput};
 use svix_bridge_plugin_queue::config::{QueueInputOpts, RabbitMqInputOpts};
 use svix_bridge_types::{SenderOutputOpts, SvixSenderOutputOpts};
 
@@ -379,6 +379,73 @@ senders:
         transformation_input,
         KafkaTransformationInput::Payload
     ));
+}
+
+#[cfg(feature = "kafka")]
+#[test]
+fn test_kafka_auto_offset_reset_parses_ok() {
+    let config: Config = serde_yaml::from_str(
+        r#"
+senders:
+  - name: "kafka-default"
+    input:
+      type: "kafka"
+      kafka_bootstrap_brokers: "localhost:9094"
+      kafka_group_id: "kafka_example_consumer_group"
+      kafka_topic: "foobar"
+      kafka_security_protocol: "plaintext"
+    output:
+      type: "svix"
+      token: "XYZ"
+  - name: "kafka-earliest"
+    input:
+      type: "kafka"
+      kafka_bootstrap_brokers: "localhost:9094"
+      kafka_group_id: "kafka_example_consumer_group"
+      kafka_topic: "foobar"
+      kafka_auto_offset_reset: "earliest"
+      kafka_security_protocol: "plaintext"
+    output:
+      type: "svix"
+      token: "XYZ"
+"#,
+    )
+    .unwrap();
+
+    let SenderInputOpts::Kafka(KafkaInputOpts::Inner {
+        auto_offset_reset: default_auto_offset_reset,
+        ..
+    }) = &config.senders[0].input
+    else {
+        panic!("Expected Kafka input");
+    };
+    let SenderInputOpts::Kafka(KafkaInputOpts::Inner {
+        auto_offset_reset: explicit_auto_offset_reset,
+        ..
+    }) = &config.senders[1].input
+    else {
+        panic!("Expected Kafka input");
+    };
+
+    assert_eq!(default_auto_offset_reset, &KafkaAutoOffsetReset::Latest);
+    assert_eq!(explicit_auto_offset_reset, &KafkaAutoOffsetReset::Earliest);
+}
+
+#[cfg(feature = "kafka")]
+#[test]
+fn test_kafka_auto_offset_reset_rejects_invalid_value() {
+    let config = serde_yaml::from_str::<KafkaInputOpts>(
+        r#"
+type: "kafka"
+kafka_bootstrap_brokers: "localhost:9094"
+kafka_group_id: "kafka_example_consumer_group"
+kafka_topic: "foobar"
+kafka_auto_offset_reset: "invalid"
+kafka_security_protocol: "plaintext"
+"#,
+    );
+
+    assert!(config.is_err());
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

Kafka consumers currently rely on librdkafka's default `auto.offset.reset` behavior. Bridge users cannot configure a consumer to replay records when creating a new consumer group or when stored offsets are no longer valid.

## Solution

Add an optional `kafka_auto_offset_reset` setting for Kafka inputs.

The setting defaults to `latest`, preserving existing behavior. Set it to `earliest` to consume existing records for a new consumer group.

Added configuration tests for the default and an explicit `earliest` value, plus Kafka integration coverage for consuming a record published before the consumer starts.