### PR TITLE
bridge/kafka: Add idempotency namespace

### DIFF
--- a/bridge/ChangeLog.md
+++ b/bridge/ChangeLog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 * Add an opt-in Kafka record envelope for JSON transformations
 * Allow configuring Kafka consumer `auto.offset.reset`
+* Add an optional Kafka idempotency namespace for independent sources
 
 ## Version 1.99.0
 * Include the Kafka partition in consumer idempotency keys

--- a/bridge/svix-bridge-plugin-kafka/src/config.rs
+++ b/bridge/svix-bridge-plugin-kafka/src/config.rs
@@ -36,6 +36,10 @@ pub enum KafkaInputOpts {
         #[serde(rename = "kafka_auto_offset_reset", default)]
         auto_offset_reset: KafkaAutoOffsetReset,
 
+        /// A namespace for idempotency keys from independent Kafka sources.
+        #[serde(rename = "kafka_idempotency_namespace")]
+        idempotency_namespace: Option<String>,
+
         /// The value for 'security.protocol' in the kafka config.
         #[serde(flatten)]
         security_protocol: KafkaSecurityProtocol,

--- a/bridge/svix-bridge-plugin-kafka/src/input.rs
+++ b/bridge/svix-bridge-plugin-kafka/src/input.rs
@@ -127,7 +127,10 @@ impl KafkaConsumer {
         let CreateMessageRequest { app_id, message } = payload;
 
         let KafkaInputOpts::Inner {
-            group_id, topic, ..
+            group_id,
+            idempotency_namespace,
+            topic,
+            ..
         } = &self.opts;
 
         let options = MessageCreateOptions {
@@ -137,6 +140,7 @@ impl KafkaConsumer {
             // message doesn't end up creating a duplicate webhook in svix.
             idempotency_key: Some(kafka_idempotency_key(
                 group_id,
+                idempotency_namespace.as_deref(),
                 topic,
                 msg.partition(),
                 msg.offset(),
@@ -239,8 +243,21 @@ impl KafkaConsumer {
     }
 }
 
-fn kafka_idempotency_key(group_id: &str, topic: &str, partition: i32, offset: i64) -> String {
-    format!("svix_bridge_kafka_{group_id}_{topic}_{partition}_{offset}")
+fn kafka_idempotency_key(
+    group_id: &str,
+    idempotency_namespace: Option<&str>,
+    topic: &str,
+    partition: i32,
+    offset: i64,
+) -> String {
+    match idempotency_namespace {
+        Some(idempotency_namespace) => {
+            format!(
+                "svix_bridge_kafka_{group_id}_{idempotency_namespace}_{topic}_{partition}_{offset}"
+            )
+        }
+        None => format!("svix_bridge_kafka_{group_id}_{topic}_{partition}_{offset}"),
+    }
 }
 
 #[async_trait]

--- a/bridge/svix-bridge-plugin-kafka/tests/it/kafka_consumer.rs
+++ b/bridge/svix-bridge-plugin-kafka/tests/it/kafka_consumer.rs
@@ -74,6 +74,7 @@ fn get_test_plugin_with_transformation_input(
         use_transformation,
         transformation_input,
         KafkaAutoOffsetReset::Latest,
+        None,
     )
 }
 
@@ -89,6 +90,23 @@ fn get_test_plugin_with_auto_offset_reset(
         use_transformation,
         KafkaTransformationInput::Payload,
         auto_offset_reset,
+        None,
+    )
+}
+
+fn get_test_plugin_with_idempotency_namespace(
+    svix_url: String,
+    topic: &str,
+    use_transformation: Option<TransformerInputFormat>,
+    idempotency_namespace: &str,
+) -> KafkaConsumer {
+    get_test_plugin_with_kafka_options(
+        svix_url,
+        topic,
+        use_transformation,
+        KafkaTransformationInput::Payload,
+        KafkaAutoOffsetReset::Latest,
+        Some(idempotency_namespace),
     )
 }
 
@@ -98,6 +116,7 @@ fn get_test_plugin_with_kafka_options(
     use_transformation: Option<TransformerInputFormat>,
     transformation_input: KafkaTransformationInput,
     auto_offset_reset: KafkaAutoOffsetReset,
+    idempotency_namespace: Option<&str>,
 ) -> KafkaConsumer {
     KafkaConsumer::new(
         "test".into(),
@@ -108,6 +127,7 @@ fn get_test_plugin_with_kafka_options(
             topic: topic.to_owned(),
             transformation_input,
             auto_offset_reset,
+            idempotency_namespace: idempotency_namespace.map(str::to_owned),
             security_protocol: svix_bridge_plugin_kafka::KafkaSecurityProtocol::Plaintext,
             debug_contexts: None,
         },
@@ -215,6 +235,54 @@ async fn test_consume_ok() {
     // Wait for the consumer to consume.
     tokio::time::sleep(CONSUME_WAIT_TIME).await;
 
+    handle.abort();
+    delete_topic(&admin_client, topic).await;
+}
+
+#[tokio::test]
+async fn test_consume_with_idempotency_namespace_ok() {
+    let topic = unique_topic_name!();
+    let expected_idempotency_key =
+        format!("svix_bridge_kafka_svix_bridge_test_group_id_source-a_{topic}_0_0");
+
+    let admin_client = kafka_admin_client();
+    create_topic(&admin_client, topic).await;
+
+    let producer = kafka_producer();
+
+    let mock_server = MockServer::start().await;
+    let mock = Mock::given(method("POST"))
+        .and(header("idempotency-key", expected_idempotency_key))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+          "eventType": "testing.things",
+          "payload": {
+            "_SVIX_APP_ID": "app_1234",
+            "_SVIX_EVENT_TYPE": "testing.things",
+            "hi": "there",
+          },
+          "id": "msg_xxxx",
+          "timestamp": "2023-04-25T00:00:00Z"
+        })))
+        .named("create_message")
+        .expect(1);
+    mock_server.register(mock).await;
+
+    let plugin =
+        get_test_plugin_with_idempotency_namespace(mock_server.uri(), topic, None, "source-a");
+
+    let handle = tokio::spawn(async move {
+        plugin.run().await;
+    });
+    tokio::time::sleep(CONNECT_WAIT_TIME).await;
+
+    let msg = CreateMessageRequest {
+        app_id: "app_1234".into(),
+        message: MessageIn::new("testing.things".into(), json!({"hi": "there"})),
+    };
+
+    publish(&producer, topic, &serde_json::to_vec(&msg).unwrap()).await;
+
+    tokio::time::sleep(CONSUME_WAIT_TIME).await;
     handle.abort();
     delete_topic(&admin_client, topic).await;
 }

--- a/bridge/svix-bridge.example.senders.yaml
+++ b/bridge/svix-bridge.example.senders.yaml
@@ -147,6 +147,8 @@ senders:
       # kafka_transformation_input: "envelope"
       # Optional - defaults to "latest". Set to "earliest" to consume existing records.
       # kafka_auto_offset_reset: "earliest"
+      # Optional - namespaces idempotency keys for independent Kafka sources.
+      # kafka_idempotency_namespace: "prod-eu-1"
       # Other valid values: "plaintext", "ssl"
       kafka_security_protocol: "sasl_ssl"
       # Only for SASL

--- a/bridge/svix-bridge/src/config/tests.rs
+++ b/bridge/svix-bridge/src/config/tests.rs
@@ -448,6 +448,28 @@ kafka_security_protocol: "plaintext"
     assert!(config.is_err());
 }
 
+#[cfg(feature = "kafka")]
+#[test]
+fn test_kafka_idempotency_namespace_parses_ok() {
+    let config = serde_yaml::from_str::<KafkaInputOpts>(
+        r#"
+type: "kafka"
+kafka_bootstrap_brokers: "localhost:9094"
+kafka_group_id: "kafka_example_consumer_group"
+kafka_topic: "foobar"
+kafka_idempotency_namespace: "source-a"
+kafka_security_protocol: "plaintext"
+"#,
+    )
+    .unwrap();
+
+    let KafkaInputOpts::Inner {
+        idempotency_namespace,
+        ..
+    } = config;
+    assert_eq!(idempotency_namespace.as_deref(), Some("source-a"));
+}
+
 #[test]
 fn test_empty() {
     let conf: Config = serde_yaml::from_str("").unwrap();


### PR DESCRIPTION
## Motivation

The current Kafka sender idempotency key uses `group_id`, `topic`, `partition`, and `offset`.

`group_id` is scoped to a Kafka cluster and is not globally unique across independent Kafka sources. When multiple Kafka clusters deliver to the same Svix instance, distinct records can produce the same idempotency key.

This can cause Svix to deduplicate non-duplicate messages.

When configured, the idempotency namespace changes the key format. Replayed records that cross an upgrade boundary may not deduplicate against keys produced without the namespace. This is limited to replay and reprocessing scenarios.

## Solution

- add an optional `kafka_idempotency_namespace` Kafka input setting
- include the namespace in the sender idempotency key when configured
- preserve the existing idempotency key format when the setting is omitted
- add config and integration coverage for namespaced keys

The namespace represents a stable source identity and can identify an environment, Kafka cluster, region, or backfill source.

## Test plan

- `cargo fmt --check`
- `cargo test -p svix-bridge-plugin-kafka`