### PR TITLE
rust: Make Configuration private

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,9 +6,10 @@ The Svix Server changelog has moved to [server/ChangeLog.md](./server/ChangeLog.
 The Svix Bridge changelog has moved to [bridge/ChangeLog.md](./bridge/ChangeLog.md).
 
 ## Unreleased
+* Libs/Rust: Remove `Configuration` from the public API
+  * The access token can still be accessed using `svix.token()`, if you were using any of the other fields let us know!
 
 ## Version 2.0.0-rc.2
-
 * Libs/JS: Fix a publishing issue
 
 ## Version 2.0.0-rc.1

--- a/codegen/templates/rust/api_summary.rs.jinja
+++ b/codegen/templates/rust/api_summary.rs.jinja
@@ -1,7 +1,7 @@
 // this file is @generated
 #![warn(unreachable_pub)]
 
-mod client;
+pub(crate) mod client;
 
 pub use self::client::{Svix, SvixOptions};
 

--- a/rust/src/api/client.rs
+++ b/rust/src/api/client.rs
@@ -1,8 +1,9 @@
 use std::{sync::Arc, time::Duration};
 
+use hyper::body::Bytes;
 use hyper_util::{client::legacy::Client as HyperClient, rt::TokioExecutor};
 
-use crate::Configuration;
+use crate::connector::{make_connector, Connector};
 
 const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -56,6 +57,16 @@ impl Default for SvixOptions {
     }
 }
 
+pub(crate) struct Configuration {
+    pub base_path: String,
+    pub user_agent: Option<String>,
+    pub bearer_access_token: Option<String>,
+    pub timeout: Option<Duration>,
+    pub num_retries: u32,
+    pub retry_schedule: Option<Vec<Duration>>,
+    pub client: HyperClient<Connector, http_body_util::Full<Bytes>>,
+}
+
 /// Svix API client.
 #[derive(Clone)]
 pub struct Svix {
@@ -85,7 +96,7 @@ impl Svix {
         let cfg = Arc::new(Configuration {
             user_agent: Some(user_agent_fields.join(" ")),
             client: HyperClient::builder(TokioExecutor::new())
-                .build(crate::make_connector(options.proxy_address)),
+                .build(make_connector(options.proxy_address)),
             timeout: options.timeout,
             // These fields will be set by `with_token` below
             base_path: String::new(),
@@ -134,8 +145,13 @@ impl Svix {
         }
     }
 
-    pub fn cfg(&self) -> &Configuration {
+    pub(crate) fn cfg(&self) -> &Configuration {
         &self.cfg
+    }
+
+    /// Get back the access token used to construct this `Svix` client.
+    pub fn token(&self) -> Option<&str> {
+        self.cfg.bearer_access_token.as_deref()
     }
 }
 

--- a/rust/src/api/mod.rs
+++ b/rust/src/api/mod.rs
@@ -1,7 +1,7 @@
 // this file is @generated
 #![warn(unreachable_pub)]
 
-mod client;
+pub(crate) mod client;
 
 pub use self::client::{Svix, SvixOptions};
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -8,11 +8,6 @@
 
 #![forbid(unsafe_code)]
 
-use std::time::Duration;
-
-use hyper::body::Bytes;
-use hyper_util::client::legacy::Client as HyperClient;
-
 pub mod api;
 mod api_internal;
 pub mod autoconfig;
@@ -24,15 +19,4 @@ pub mod models;
 mod request;
 pub mod webhooks;
 
-pub(crate) use connector::{make_connector, Connector};
-
-pub struct Configuration {
-    pub base_path: String,
-    pub user_agent: Option<String>,
-    pub bearer_access_token: Option<String>,
-    pub timeout: Option<Duration>,
-    pub num_retries: u32,
-    pub retry_schedule: Option<Vec<Duration>>,
-
-    client: HyperClient<Connector, http_body_util::Full<Bytes>>,
-}
+pub(crate) use api::client::Configuration;


### PR DESCRIPTION
It's only public for historical reasons.
Our own use of svix.cfg() only uses it to get the access token, which is now covered by svix.token().

This allows us more refactors down the line.
