### PR TITLE
ci: Stop regenerating libs in cli-lint / rust-lint

### DIFF
--- a/.github/workflows/cli-lint.yml
+++ b/.github/workflows/cli-lint.yml
@@ -49,9 +49,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Regen openapi libs
-        run: ../regen_openapi.py
-
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -44,9 +44,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Regen openapi libs
-        run: ../regen_openapi.py
-
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}


### PR DESCRIPTION
We have a codegen workflow that errors if any files are not up-to-date, we don't need to also have other workflows regenerate the code.
