### PR TITLE
ci: Update server-release workflow to get version from Cargo

### DIFF
--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -46,9 +46,12 @@ jobs:
           filter: tree:0
       - id: get-version-number
         run: |
-          echo "tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
+          version=$(cargo metadata --format-version 1 \
+            | jq -r '.packages[] | select(.name == "svix-server") | .version')
+          echo "version=v${version}" >> "$GITHUB_OUTPUT"
+        working-directory: server
     outputs:
-      version: ${{ steps.get-version-number.outputs.tag }}
+      version: ${{ steps.get-version-number.outputs.version }}
 
   build:
     needs: [get-version]

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -48,6 +48,10 @@ jobs:
         run: |
           version=$(cargo metadata --format-version 1 \
             | jq -r '.packages[] | select(.name == "svix-server") | .version')
+          if ! [[ "$version" =~ ^[0-9.]+$ ]] ; then
+             echo >&2 "Invalid version $version"
+             exit 1
+          fi
           echo "version=v${version}" >> "$GITHUB_OUTPUT"
         working-directory: server
     outputs:


### PR DESCRIPTION
Now that we no longer use the same version for SDKs and server, bridge. This should also allow us to create the server release tag _after_ successful publish to ghcr, Dockerhub.
