### PR TITLE
fix(ruby): serialize false patch values

### DIFF
--- a/codegen/templates/ruby/types/macros.rb.jinja
+++ b/codegen/templates/ruby/types/macros.rb.jinja
@@ -31,6 +31,8 @@
     {% endif -%}
     {% if type.name is endingwith "Patch" and field.nullable -%}
     out['{{ field.name }}'] = {{ val_expr }} if @__{{ field.name | to_snake_case }}_is_defined
+    {% elif type.name is endingwith "Patch" and field.type.is_bool() -%}
+    out['{{ field.name }}'] = {{ val_expr }} unless @{{ field.name | to_snake_case }}.nil?
     {% else -%}
     out['{{ field.name }}'] = {{ val_expr }} if @{{ field.name | to_snake_case }}
     {% endif -%}

--- a/ruby/lib/svix/models/endpoint_patch.rb
+++ b/ruby/lib/svix/models/endpoint_patch.rb
@@ -55,7 +55,7 @@ module Svix
       out["throttleRate"] = Svix::serialize_primitive(@throttle_rate) if @__throttle_rate_is_defined
       out["uid"] = Svix::serialize_primitive(@uid) if @__uid_is_defined
       out["url"] = Svix::serialize_primitive(@url) if @url
-      out["disabled"] = Svix::serialize_primitive(@disabled) if @disabled
+      out["disabled"] = Svix::serialize_primitive(@disabled) unless @disabled.nil?
       out["eventTypes"] = Svix::serialize_primitive(@event_types) if @__event_types_is_defined
       out["channels"] = Svix::serialize_primitive(@channels) if @__channels_is_defined
       out["metadata"] = Svix::serialize_primitive(@metadata) if @metadata

--- a/ruby/lib/svix/models/endpoint_transformation_patch.rb
+++ b/ruby/lib/svix/models/endpoint_transformation_patch.rb
@@ -41,7 +41,7 @@ module Svix
     def serialize
       out = Hash.new
       out["code"] = Svix::serialize_primitive(@code) if @__code_is_defined
-      out["enabled"] = Svix::serialize_primitive(@enabled) if @enabled
+      out["enabled"] = Svix::serialize_primitive(@enabled) unless @enabled.nil?
       out["variables"] = Svix::serialize_primitive(@variables) if @__variables_is_defined
       out
     end

--- a/ruby/lib/svix/models/event_type_patch.rb
+++ b/ruby/lib/svix/models/event_type_patch.rb
@@ -45,8 +45,8 @@ module Svix
     def serialize
       out = Hash.new
       out["description"] = Svix::serialize_primitive(@description) if @description
-      out["archived"] = Svix::serialize_primitive(@archived) if @archived
-      out["deprecated"] = Svix::serialize_primitive(@deprecated) if @deprecated
+      out["archived"] = Svix::serialize_primitive(@archived) unless @archived.nil?
+      out["deprecated"] = Svix::serialize_primitive(@deprecated) unless @deprecated.nil?
       out["schemas"] = Svix::serialize_primitive(@schemas) if @__schemas_is_defined
       out["featureFlags"] = Svix::serialize_primitive(@feature_flags) if @__feature_flags_is_defined
       out["groupName"] = Svix::serialize_primitive(@group_name) if @__group_name_is_defined

--- a/ruby/lib/svix/models/ingest_endpoint_transformation_patch.rb
+++ b/ruby/lib/svix/models/ingest_endpoint_transformation_patch.rb
@@ -39,7 +39,7 @@ module Svix
     def serialize
       out = Hash.new
       out["code"] = Svix::serialize_primitive(@code) if @__code_is_defined
-      out["enabled"] = Svix::serialize_primitive(@enabled) if @enabled
+      out["enabled"] = Svix::serialize_primitive(@enabled) unless @enabled.nil?
       out
     end
 

--- a/ruby/lib/svix/models/stream_event_type_patch.rb
+++ b/ruby/lib/svix/models/stream_event_type_patch.rb
@@ -41,8 +41,8 @@ module Svix
       out = Hash.new
       out["description"] = Svix::serialize_primitive(@description) if @__description_is_defined
       out["featureFlags"] = Svix::serialize_primitive(@feature_flags) if @__feature_flags_is_defined
-      out["deprecated"] = Svix::serialize_primitive(@deprecated) if @deprecated
-      out["archived"] = Svix::serialize_primitive(@archived) if @archived
+      out["deprecated"] = Svix::serialize_primitive(@deprecated) unless @deprecated.nil?
+      out["archived"] = Svix::serialize_primitive(@archived) unless @archived.nil?
       out
     end
 

--- a/ruby/spec/webmock_tests_spec.rb
+++ b/ruby/spec/webmock_tests_spec.rb
@@ -277,6 +277,24 @@ describe "API Client" do
       )
         .with(body: "{}")
     )
+    # false is an explicit value for non-nullable booleans
+    svx.endpoint.patch("app_id", "endpoint_id", Svix::EndpointPatch.new(disabled: false))
+    expect(WebMock).to(
+      have_requested(
+        :patch,
+        "#{host}/api/v1/app/app_id/endpoint/endpoint_id"
+      )
+        .with(body: "{\"disabled\":false}")
+    )
+    # Ruby considers an empty string truthy, so it can clear a description.
+    svx.endpoint.patch("app_id", "endpoint_id", Svix::EndpointPatch.new(description: ""))
+    expect(WebMock).to(
+      have_requested(
+        :patch,
+        "#{host}/api/v1/app/app_id/endpoint/endpoint_id"
+      )
+        .with(body: "{\"description\":\"\"}")
+    )
     # nullable field set
     svx.endpoint.patch("app_id", "endpoint_id", Svix::EndpointPatch.new(channels: ["ch1", "ch2"]))
     expect(WebMock).to(
@@ -286,6 +304,17 @@ describe "API Client" do
       )
         .with(body: "{\"channels\":[\"ch1\",\"ch2\"]}")
     )
+  end
+
+  it "serializes false values in patch models" do
+    expect(Svix::EndpointTransformationPatch.new(enabled: false).serialize)
+      .to(eq({"enabled" => false}))
+    expect(Svix::IngestEndpointTransformationPatch.new(enabled: false).serialize)
+      .to(eq({"enabled" => false}))
+    expect(Svix::EventTypePatch.new(archived: false, deprecated: false).serialize)
+      .to(eq({"archived" => false, "deprecated" => false}))
+    expect(Svix::StreamEventTypePatch.new(archived: false, deprecated: false).serialize)
+      .to(eq({"archived" => false, "deprecated" => false}))
   end
 
   it "arbitrary json object body" do


### PR DESCRIPTION
## Motivation

Ruby patch models used truthiness when serializing non-nullable boolean fields, so explicit `false` values were omitted. This prevented re-enabling disabled endpoints and toggling other boolean patch fields back off.

## Solution

- Serialize non-nullable booleans unless their value is `nil`, preserving explicit `false` values.
- Update the Ruby code-generation template and generated models for endpoint, endpoint transformation, ingest endpoint transformation, event type, and stream event type patches.
- Add regression coverage for `false` patch values and confirm an endpoint description can be cleared with an empty string.