### PR TITLE
Fix svix-bridge build with --no-default-features

### DIFF
--- a/bridge/svix-bridge/src/allocator.rs
+++ b/bridge/svix-bridge/src/allocator.rs
@@ -59,7 +59,7 @@ mod unsupported {
 
     pub fn get_allocator_stats(
         _bust_cache: bool,
-        _mibs: Arc<AllocatorStatMibs>,
+        _mibs: &Arc<AllocatorStatMibs>,
     ) -> anyhow::Result<Option<(usize, usize)>> {
         Ok(None)
     }


### PR DESCRIPTION
## Motivation

`svix-bridge` fails to compile with `--no-default-features` (fixes #2524 ). I ran into this problem while trying to test my earlier PR #2418 .The two feature-gated definitions of `get_allocator_stats` in `allocator.rs` have divergent signatures: the `supported` (jemalloc) version takes `&AllocatorStatMibs`, while the `unsupported` stub takes `Arc<AllocatorStatMibs>` by value. This breaks the build when jemalloc is disabled, since the call site's `&mibs` no longer matches the stub:

```
error[E0308]: mismatched types
   --> svix-bridge/src/main.rs:291:88
    |
291 |  ...ted, resident))) = get_allocator_stats(true, &mibs) {
    |                        expected `Arc<AllocatorStatMibs>`, found `&Arc<AllocatorStatMibs>`
```

## Solution

Align the `unsupported` stub to take `_mibs: &AllocatorStatMibs`, matching the `supported` signature. The call site passes `&mibs` (an `&Arc<AllocatorStatMibs>`), which changes to `&AllocatorStatMibs` for both variants, so it now compiles regardless of whether jemalloc is enabled.

### Test plan
Since this said command resulted in an error before the fix, to test the solution these three commands should suffice. Project wouldn't compile with these commands and now it does!

- `cargo build -p svix-bridge --no-default-features`  
- `cargo build -p svix-bridge` 
- `cargo clippy -p svix-bridge --no-default-features -- -D warnings` 