### PR TITLE
rust, javascript: Strip trailing slashes from user-provided server URLs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,8 @@ The Svix Bridge changelog has moved to [bridge/ChangeLog.md](./bridge/ChangeLog.
   * The access token can still be accessed using `svix.token()`, if you were using any of the other fields let us know!
 * Libs/Rust **(Breaking)**: Upgrade public dependency `js_option` to 0.2.0
 * Libs/Kotlin: Add missing APIs background-task, connector, environment, and health
+* Libs/Rust, Libs/JavaScript: Strip trailing slashes from a user-provided server URL, so
+  `https://api.svix.com/` and `https://api.svix.com` behave the same
 
 ## Version 2.0.0-rc.2
 * Libs/JS: Fix a publishing issue

--- a/javascript/src/index.test.ts
+++ b/javascript/src/index.test.ts
@@ -2,3 +2,4 @@ import "./autoconfig.test";
 import "./mockttp.test";
 import "./KitchenSink.test";
 import "./webhook.test";
+import "./request.test";

--- a/javascript/src/request.test.ts
+++ b/javascript/src/request.test.ts
@@ -1,0 +1,34 @@
+import { test } from "node:test";
+import { strict as assert } from "node:assert/strict";
+
+import { Svix } from "./index";
+
+/** Exposes the request context the real `Svix` constructor built. */
+class SvixUnderTest extends Svix {
+  public get ctx() {
+    return this.requestCtx;
+  }
+}
+
+function baseUrl(token: string, serverUrl?: string): string {
+  return new SvixUnderTest(token, serverUrl === undefined ? {} : { serverUrl }).ctx
+    .baseUrl;
+}
+
+test("serverUrl trailing slashes are stripped", () => {
+  assert.equal(baseUrl("token", "https://api.example.com/"), "https://api.example.com");
+  assert.equal(baseUrl("token", "https://api.example.com///"), "https://api.example.com");
+  assert.equal(
+    baseUrl("token", "https://api.example.com/prefix/"),
+    "https://api.example.com/prefix"
+  );
+});
+
+test("serverUrl without a trailing slash is unchanged", () => {
+  assert.equal(baseUrl("token", "https://api.example.com"), "https://api.example.com");
+});
+
+test("default and regional server URLs are used as-is", () => {
+  assert.equal(baseUrl("token"), "https://api.svix.com");
+  assert.equal(baseUrl("testsk.eu.abc"), "https://api.eu.svix.com");
+});

--- a/javascript/src/request.ts
+++ b/javascript/src/request.ts
@@ -85,7 +85,8 @@ export function createSvixRequestContext(
   options: SvixRequestContextOptions = {}
 ): SvixRequestContext {
   const regionalUrl = REGIONS.find((x) => x.region === token.split(".")[1])?.url;
-  const baseUrl: string = options.serverUrl ?? regionalUrl ?? "https://api.svix.com";
+  const baseUrl: string =
+    options.serverUrl?.replace(/\/+$/, "") ?? regionalUrl ?? "https://api.svix.com";
 
   if (options.retryScheduleInMs) {
     return {

--- a/rust/src/api/client.rs
+++ b/rust/src/api/client.rs
@@ -202,6 +202,12 @@ mod tests {
 
     #[test]
     fn test_default_server_url() {
+        let svix = Svix::new("token".to_owned(), None);
+        assert_eq!(svix.cfg.base_path, "https://api.svix.com");
+    }
+
+    #[test]
+    fn test_regional_server_url() {
         let svix = Svix::new("token.eu".to_owned(), None);
         assert_eq!(svix.cfg.base_path, "https://api.eu.svix.com");
     }

--- a/rust/src/api/client.rs
+++ b/rust/src/api/client.rs
@@ -10,6 +10,10 @@ const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub struct SvixOptions {
     pub debug: bool,
 
+    /// Base URL of the Svix API server.
+    ///
+    /// Trailing slashes are stripped, so `https://api.svix.com/` and
+    /// `https://api.svix.com` are equivalent.
     pub server_url: Option<String>,
 
     /// Timeout for HTTP requests.
@@ -106,7 +110,9 @@ impl Svix {
         });
         let svix = Self {
             cfg,
-            server_url: options.server_url,
+            server_url: options
+                .server_url
+                .map(|url| url.trim_end_matches('/').to_owned()),
         };
         svix.with_token(token)
     }
@@ -157,7 +163,61 @@ impl Svix {
 
 #[cfg(test)]
 mod tests {
-    use crate::api::Svix;
+    use crate::api::{Svix, SvixOptions};
+
+    fn base_path(server_url: &str) -> String {
+        let svix = Svix::new(
+            "token".to_owned(),
+            Some(SvixOptions {
+                server_url: Some(server_url.to_owned()),
+                ..Default::default()
+            }),
+        );
+        svix.cfg.base_path.clone()
+    }
+
+    #[test]
+    fn test_server_url_trailing_slashes_are_stripped() {
+        assert_eq!(
+            base_path("https://api.example.com/"),
+            "https://api.example.com"
+        );
+        assert_eq!(
+            base_path("https://api.example.com///"),
+            "https://api.example.com"
+        );
+        assert_eq!(
+            base_path("https://api.example.com/prefix/"),
+            "https://api.example.com/prefix"
+        );
+    }
+
+    #[test]
+    fn test_server_url_without_trailing_slash_is_unchanged() {
+        assert_eq!(
+            base_path("https://api.example.com"),
+            "https://api.example.com"
+        );
+    }
+
+    #[test]
+    fn test_default_server_url() {
+        let svix = Svix::new("token.eu".to_owned(), None);
+        assert_eq!(svix.cfg.base_path, "https://api.eu.svix.com");
+    }
+
+    #[test]
+    fn test_with_token_keeps_normalized_server_url() {
+        let svix = Svix::new(
+            "token".to_owned(),
+            Some(SvixOptions {
+                server_url: Some("https://api.example.com/".to_owned()),
+                ..Default::default()
+            }),
+        )
+        .with_token("token2".to_owned());
+        assert_eq!(svix.cfg.base_path, "https://api.example.com");
+    }
 
     #[test]
     fn test_future_send_sync() {


### PR DESCRIPTION
## Motivation

Part of #1154. `https://api.svix.com/` and `https://api.svix.com` should behave the same as a server URL. Today a trailing slash produces a double slash once the request path is appended, since every path already begins with `/`.

#1969 attempted this and was closed by its author after review. This follows the review feedback left there: normalize only URLs that arrive through the options struct, leave the internal request path alone, and unit-test against the real client's internal state rather than reimplementing the logic.

## Solution

Strip trailing slashes from the server URL, but only where it arrives via `SvixOptions` / `SvixRequestContextOptions`. The built-in default and regional URLs are left alone — they don't end in a slash, and normalizing them would paper over that.

**Rust:** `Svix::new` normalizes `SvixOptions::server_url` when it stores it, so `with_token` inherits the normalized value.

**JavaScript:** `createSvixRequestContext` normalizes `options.serverUrl`. `Svix`, `api_internal`, and both `AutoConfig` entry points share that function, so all four paths are covered by the one change. Note that an AutoConfig `surl` is Svix-issued rather than user-typed; normalizing it is a no-op in practice and costs nothing.

The internal request path is untouched — it's always called with a leading slash.

Tests construct a real client and assert on its resulting base URL. In Rust that's the existing `mod tests` in `src/api/client.rs`; in JS it's a new `src/request.test.ts` that subclasses `Svix` to read the request context the real constructor built. Both cover the multi-slash case, a path-prefixed URL, and assert that the default and regional URLs still pass through untouched.

## Scope, and a correction

This fixes **Rust and JavaScript only**, so it's "part of" #1154 rather than closing it.

**Correcting an earlier version of this description:** it said Python was already correct because httpx normalizes `base_url`. That is wrong, and I'd rather flag it than leave it standing. httpx never sees the base URL here — `_make_httpx_client` constructs `httpx.Client(mounts=..., cookies=...)` with no `base_url` argument, and `common.py` builds the URL by concatenation:

```python
url = f"{self._client.base_url}{path}"
```

httpx's `base_url` merging only applies to relative request URLs, and this one is absolute. So Python has the same bug. Go looks the same shape too — `svix_http_client.go` does `client.BaseURL + replacePathKeys(...)`.

## How it was verified

```
rust/     cargo test --lib    21 passed, 0 failed (5 new)
          cargo clippy --all-targets --all-features   clean
          cargo fmt --check   clean on stable and nightly
javascript/  npm test         53 tests, 52 pass, 1 skipped, 0 fail
          npm run typecheck   clean
          npx biome check     clean on the changed files
```

The skipped JS test is the pre-existing e2e suite that needs a live server; the baseline without this patch is 50/49/1.

The tests were also checked by reverting the source change and keeping them: JS goes to 1 failed on the trailing-slash assertion, Rust to 2 failed. They fail for the right reason when the fix is absent.

## Notes

No generated files are touched. `javascript/src/index.ts` carries `@generated` and is in `codegen/generated_files.json`; this PR doesn't modify it. `javascript/src/request.ts` and `rust/src/api/client.rs` are in neither.

That does mean the JS-side public `SvixOptions.serverUrl` is generated from `codegen/templates/javascript/summary.ts.jinja`, so I left the JS type undocumented rather than hand-editing generated output or regenerating here. Say the word if you'd like the doc comment added to the template.

Unrelated, noticed while tracing the entry points: the SDKs disagree on which token segment carries the region. Rust, Python, Ruby, and C# take the last dot-segment; JS takes the second (`token.split(".")[1]`). They agree on two-segment tokens and diverge on three or more. Happy to open a separate issue if that's worth tracking.
