### PR TITLE
gha: pin all workflow dependencies by SHA; set up dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "server"
+    # don't actually post regular version upgrade PRs, only security updates
+    open-pull-requests-limit: 0
+    # shouldn't actually matter because security update PRs happen immediately
+    # as advisories are reported, but is a required key
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker-compose"
+    directory: "server"
+    # don't actually post regular version upgrade PRs, only security updates
+    open-pull-requests-limit: 0
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # allow doing version updates for github-actions dependabot bumps
+    open-pull-requests-limit: 2
+    cooldown:
+      default-days: 3
+    groups:
+      workflows:
+        applies-to: version-updates
+        patterns:
+          - '*'
+    schedule:
+      interval: "weekly"
+      day: "wednesday"

--- a/.github/workflows/bridge-ci.yml
+++ b/.github/workflows/bridge-ci.yml
@@ -16,10 +16,12 @@ jobs:
     name: Check formatting
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@nightly
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
+          toolchain: nightly
           components: rustfmt
 
       - name: rustfmt
@@ -44,9 +46,11 @@ jobs:
     name: Check for unused dependencies
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: taiki-e/install-action@cargo-machete
+      - uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+        with:
+          tool: cargo-machete
 
       - run: cargo machete
 
@@ -57,14 +61,15 @@ jobs:
       matrix:
         rust: ["1.95", stable, beta]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@master
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: ${{ matrix.rust }}
           components: clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: "bridge -> target"
           # only save the cache on the main branch
@@ -73,7 +78,9 @@ jobs:
           # include relevant information in the cache name
           prefix-key: "bridge-${{ matrix.rust }}"
 
-      - uses: taiki-e/install-action@nextest
+      - uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+        with:
+          tool: nextest
 
       - name: Clippy
         run: cargo clippy --locked --all-targets --all-features -- -D warnings

--- a/.github/workflows/bridge-release.yml
+++ b/.github/workflows/bridge-release.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           filter: tree:0
@@ -30,7 +30,7 @@ jobs:
 
   build:
     needs: [get-version]
-    uses: docker/github-builder/.github/workflows/build.yml@v1
+    uses: docker/github-builder/.github/workflows/build.yml@27ade872c1e2296e62ef15ab3b10d37665e57cf7 # v1.15.0
     permissions:
       contents: read # to fetch the repository content
       id-token: write # for signing attestation(s) with GitHub OIDC Token
@@ -67,24 +67,24 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install regctl
-        uses: iarekylew00t/regctl-installer@v4
+        uses: iarekylew00t/regctl-installer@70686e10f8f949b24d6158e898a89cf21c3ac59c # v4.0.14
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Recompute meta tags
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ghcr.io/svix/svix-bridge-staging
           sep-tags: " "

--- a/.github/workflows/bridge-security.yml
+++ b/.github/workflows/bridge-security.yml
@@ -23,7 +23,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: actions/checkout@v7
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           manifest-path: bridge/Cargo.toml

--- a/.github/workflows/ci-required-checks.yml
+++ b/.github/workflows/ci-required-checks.yml
@@ -49,8 +49,8 @@ jobs:
       ruby-lint: ${{ steps.filter.outputs.ruby-lint }}
       openapi-compatibility-check: ${{ steps.filter.outputs.openapi-compatibility-check }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: filter
         with:
           filters: |

--- a/.github/workflows/cli-docker-release.yml
+++ b/.github/workflows/cli-docker-release.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           filter: tree:0
@@ -29,7 +29,7 @@ jobs:
       version: ${{ steps.get-version-number.outputs.tag }}
   build:
     needs: [get-version]
-    uses: docker/github-builder/.github/workflows/build.yml@v1
+    uses: docker/github-builder/.github/workflows/build.yml@27ade872c1e2296e62ef15ab3b10d37665e57cf7 # v1.15.0
     permissions:
       contents: read # to fetch the repository content
       id-token: write # for signing attestation(s) with GitHub OIDC Token
@@ -65,24 +65,24 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install regctl
-        uses: iarekylew00t/regctl-installer@v4
+        uses: iarekylew00t/regctl-installer@70686e10f8f949b24d6158e898a89cf21c3ac59c # v4.0.14
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Recompute meta tags
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ghcr.io/svix/svix-cli-staging
           sep-tags: " "

--- a/.github/workflows/cli-lint.yml
+++ b/.github/workflows/cli-lint.yml
@@ -15,10 +15,11 @@ jobs:
     name: Check formatting
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
+          toolchain: nightly
           components: rustfmt
 
       - name: rustfmt
@@ -47,14 +48,14 @@ jobs:
         # keep this in sync with svix-cli/Cargo.toml MSRV
         rust: ["1.88.0", stable, beta]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: ${{ matrix.rust }}
           components: clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: "svix-cli -> target"
           # only save the cache on the main branch
@@ -63,7 +64,9 @@ jobs:
           # include relevant information in the cache name
           prefix-key: "cli-${{ matrix.rust }}"
 
-      - uses: taiki-e/install-action@nextest
+      - uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+        with:
+          tool: nextest
 
       - name: Clippy
         run: cargo clippy --locked --all-targets --all-features -- -D warnings

--- a/.github/workflows/cli-security.yml
+++ b/.github/workflows/cli-security.yml
@@ -22,7 +22,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: actions/checkout@v7
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           manifest-path: svix-cli/Cargo.toml

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -11,7 +11,7 @@ jobs:
     name: Check for uncommitted changes
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Regen openapi libs
         run: ./regen_openapi.py

--- a/.github/workflows/csharp-lint.yml
+++ b/.github/workflows/csharp-lint.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/csharp-release.yml
+++ b/.github/workflows/csharp-release.yml
@@ -13,7 +13,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v4
@@ -31,7 +31,7 @@ jobs:
           dotnet build --configuration Release Svix --no-restore
 
       - name: NuGet login
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
         id: login
         with:
           user: ${{ secrets.NUGET_USER }}

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         version: ["1.23.x", "1.21.x"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Setup Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -6,9 +6,9 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: latest
           working-directory: go

--- a/.github/workflows/java-lint.yml
+++ b/.github/workflows/java-lint.yml
@@ -14,7 +14,7 @@ jobs:
             args: "-x :compileJava11Java -x :processJava11Resources -x :java11Classes"
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/java-release.yml
+++ b/.github/workflows/java-release.yml
@@ -11,7 +11,7 @@ jobs:
     environment: release
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/javascript-lint.yml
+++ b/.github/workflows/javascript-lint.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/javascript-release.yml
+++ b/.github/workflows/javascript-release.yml
@@ -17,7 +17,7 @@ jobs:
         working-directory: javascript
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/kotlin-lint.yml
+++ b/.github/workflows/kotlin-lint.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/kotlin-release.yml
+++ b/.github/workflows/kotlin-release.yml
@@ -11,7 +11,7 @@ jobs:
     environment: release
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Java
         uses: actions/setup-java@v4

--- a/.github/workflows/openapi-compatibility-check.yml
+++ b/.github/workflows/openapi-compatibility-check.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.14"
       - run: python tools/validate_openapi_compatibility.py server/openapi.json codegen/lib-openapi.json

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -11,7 +11,7 @@ jobs:
         dependencies: ['highest', 'lowest']
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install php
         uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # 2.35.4

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
@@ -25,7 +25,7 @@ jobs:
   python-test-release:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: 3.14

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -18,7 +18,7 @@ jobs:
     environment: release
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:

--- a/.github/workflows/ruby-lint.yml
+++ b/.github/workflows/ruby-lint.yml
@@ -13,10 +13,10 @@ jobs:
         ruby-version: [3.2.10, 3.3.10, 3.4.9, 4.0.2]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
 

--- a/.github/workflows/ruby-release.yml
+++ b/.github/workflows/ruby-release.yml
@@ -15,10 +15,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: 3.4.2
 
@@ -33,7 +33,7 @@ jobs:
           bundler exec rake build
 
       - name: Configure RubyGems credentials (trusted publishing)
-        uses: rubygems/configure-rubygems-credentials@main
+        uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2.1.0
 
       - name: Publish
         run: |

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -15,10 +15,11 @@ jobs:
     name: Check formatting
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
+          toolchain: nightly
           components: rustfmt
 
       - name: rustfmt
@@ -28,9 +29,11 @@ jobs:
     name: Check for unused dependencies
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: taiki-e/install-action@cargo-machete
+      - uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+        with:
+          tool: cargo-machete
 
       - run: cargo machete
 
@@ -42,14 +45,14 @@ jobs:
         # bump this when bumping the MSRV
         rust: ["1.88.0", stable, beta]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: ${{ matrix.rust }}
           components: clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: "rust -> target"
           # only save the cache on the main branch
@@ -58,7 +61,9 @@ jobs:
           # include relevant information in the cache name
           prefix-key: "rust-client-${{ matrix.rust }}"
 
-      - uses: taiki-e/install-action@nextest
+      - uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+        with:
+          tool: nextest
 
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -16,13 +16,14 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
+          toolchain: stable
           components: clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: "rust -> target"
           # only restore cache for faster publishing, don't save back results
@@ -30,7 +31,7 @@ jobs:
           # use the cache from rust-lint/stable
           prefix-key: "rust-client-stable"
 
-      - uses: rust-lang/crates-io-auth-action@v1
+      - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: auth
 
       - name: Publish

--- a/.github/workflows/rust-security.yml
+++ b/.github/workflows/rust-security.yml
@@ -18,7 +18,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: actions/checkout@v7
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           manifest-path: rust/Cargo.toml

--- a/.github/workflows/sdks-release.yml
+++ b/.github/workflows/sdks-release.yml
@@ -60,7 +60,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: recursive
@@ -132,7 +132,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: recursive
@@ -191,7 +191,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: recursive
@@ -241,7 +241,7 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: recursive
@@ -306,7 +306,7 @@ jobs:
       GITHUB_EMAIL: "admin+bot@axo.dev"
     if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: true
           repository: "svix/homebrew-svix"
@@ -389,7 +389,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -16,10 +16,11 @@ jobs:
     name: Check formatting
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
+          toolchain: nightly
           components: rustfmt
 
       - name: rustfmt
@@ -29,7 +30,7 @@ jobs:
     name: Check for unused dependencies
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
         with:
@@ -41,7 +42,7 @@ jobs:
     name: 'Run cargo-sort'
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         name: Checkout
 
       - name: Install cargo sort
@@ -60,14 +61,14 @@ jobs:
         # bump this when bumping the MSRV
         rust: ["1.88.0", stable, beta]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: ${{ matrix.rust }}
           components: clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: "server -> target"
           # only save the cache on the main branch
@@ -76,7 +77,10 @@ jobs:
           # include relevant information in the cache name
           prefix-key: "server-${{ matrix.rust }}"
 
-      - uses: taiki-e/install-action@nextest
+      - name: Install nextest
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+        with:
+          tool: nextest
 
       - name: Build
         run: cargo test --all-features --no-run --locked

--- a/.github/workflows/server-docker-image.yml
+++ b/.github/workflows/server-docker-image.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Build server image
         run: docker compose build

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           filter: tree:0
@@ -37,7 +37,7 @@ jobs:
 
   build:
     needs: [get-version]
-    uses: docker/github-builder/.github/workflows/build.yml@v1
+    uses: docker/github-builder/.github/workflows/build.yml@27ade872c1e2296e62ef15ab3b10d37665e57cf7 # v1.15.0
     permissions:
       contents: read # to fetch the repository content
       id-token: write # for signing attestation(s) with GitHub OIDC Token
@@ -73,24 +73,24 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install regctl
-        uses: iarekylew00t/regctl-installer@v4
+        uses: iarekylew00t/regctl-installer@70686e10f8f949b24d6158e898a89cf21c3ac59c # v4.0.14
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Recompute meta tags
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ghcr.io/svix/svix-server-staging
           sep-tags: " "

--- a/.github/workflows/server-security.yml
+++ b/.github/workflows/server-security.yml
@@ -23,7 +23,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: actions/checkout@v7
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           manifest-path: server/Cargo.toml

--- a/.github/workflows/update-postman.yml
+++ b/.github/workflows/update-postman.yml
@@ -11,7 +11,7 @@ jobs:
     environment: release
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Update Postman Collection
         run: npm install openapi-to-postmanv2 && node tools/update_postman.js

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,22 +14,37 @@ repos:
       - id: check-yaml
       - id: check-json
         exclude: "(kotlin/lib/src/test/resources/__files/ExpectedMsgCreateBodyWithHeaders.json)|(tsconfig.json)"
+
   - repo: https://github.com/google/yamlfmt
     rev: v0.17.2
     hooks:
       - id: yamlfmt
+
   - repo: https://github.com/crate-ci/typos
     rev: v1.48.0
     hooks:
       - id: typos
+
   - repo: https://github.com/scop/pre-commit-shfmt
     rev: v3.13.1-1
     hooks:
       - id: shfmt
         exclude: gradlew
         args: ["--write", "-i", "4", "-ci"]
+
   - repo: https://github.com/koalaman/shellcheck-precommit
     rev: v0.11.0
     hooks:
       - id: shellcheck
         exclude: gradlew
+
+  - repo: https://github.com/hyland/github-actions-ensure-sha-pinned-actions
+    rev: 22ca7a8cf33e873ba1d6fbcd2b71fa0ec5006b17 # v1.1.0
+    hooks:
+      - id: gha-sha-convert
+        args: ["--allowlist", "actions/*"]
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: f805888065fdb6162e1f800e50bb9460cbd223d6 # v0.37.2
+    hooks:
+      - id: check-dependabot


### PR DESCRIPTION
This pins all github actions workflow dependencies by SHA (instead of using potentially-mutable tags and branches) and sets up dependabot to periodically update them.