### PR TITLE
ci: Add some spaces to GHA context substitutions

### DIFF
--- a/.github/workflows/bridge-release.yml
+++ b/.github/workflows/bridge-release.yml
@@ -81,9 +81,9 @@ jobs:
       meta-flavor: |
         latest=true
       meta-tags: |
-        type=semver,pattern={{version}},prefix=v,value=${{needs.get-version.outputs.version}}
-        type=semver,pattern={{major}}.{{minor}},prefix=v,value=${{needs.get-version.outputs.version}}
-        type=semver,pattern={{major}},prefix=v,value=${{needs.get-version.outputs.version}}
+        type=semver,pattern={{version}},prefix=v,value=${{ needs.get-version.outputs.version }}
+        type=semver,pattern={{major}}.{{minor}},prefix=v,value=${{ needs.get-version.outputs.version }}
+        type=semver,pattern={{major}},prefix=v,value=${{ needs.get-version.outputs.version }}
       set-meta-labels: true
       labels: |
         org.opencontainers.image.version=${{ needs.get-version.outputs.version }}
@@ -124,9 +124,9 @@ jobs:
           flavor: |
             latest=true
           tags: |
-            type=semver,pattern={{version}},prefix=v,value=${{needs.get-version.outputs.version}}
-            type=semver,pattern={{major}}.{{minor}},prefix=v,value=${{needs.get-version.outputs.version}}
-            type=semver,pattern={{major}},prefix=v,value=${{needs.get-version.outputs.version}}
+            type=semver,pattern={{version}},prefix=v,value=${{ needs.get-version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},prefix=v,value=${{ needs.get-version.outputs.version }}
+            type=semver,pattern={{major}},prefix=v,value=${{ needs.get-version.outputs.version }}
       - name: "Copy images"
         run: |
           for source in ${{ steps.meta.outputs.tags }}; do

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -76,9 +76,9 @@ jobs:
       meta-flavor: |
         latest=true
       meta-tags: |
-        type=semver,pattern={{version}},prefix=v,value=${{needs.get-version.outputs.version}}
-        type=semver,pattern={{major}}.{{minor}},prefix=v,value=${{needs.get-version.outputs.version}}
-        type=semver,pattern={{major}},prefix=v,value=${{needs.get-version.outputs.version}}
+        type=semver,pattern={{version}},prefix=v,value=${{ needs.get-version.outputs.version }}
+        type=semver,pattern={{major}}.{{minor}},prefix=v,value=${{ needs.get-version.outputs.version }}
+        type=semver,pattern={{major}},prefix=v,value=${{ needs.get-version.outputs.version }}
       set-meta-labels: true
       labels: |
         org.opencontainers.image.version=${{ needs.get-version.outputs.version }}
@@ -119,9 +119,9 @@ jobs:
           flavor: |
             latest=true
           tags: |
-            type=semver,pattern={{version}},prefix=v,value=${{needs.get-version.outputs.version}}
-            type=semver,pattern={{major}}.{{minor}},prefix=v,value=${{needs.get-version.outputs.version}}
-            type=semver,pattern={{major}},prefix=v,value=${{needs.get-version.outputs.version}}
+            type=semver,pattern={{version}},prefix=v,value=${{ needs.get-version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},prefix=v,value=${{ needs.get-version.outputs.version }}
+            type=semver,pattern={{major}},prefix=v,value=${{ needs.get-version.outputs.version }}
       - name: "Copy images"
         run: |
           for source in ${{ steps.meta.outputs.tags }}; do


### PR DESCRIPTION
For consistency, and to make it more visually different from the mustache template substitutions on the same lines.
