### PR TITLE
ci: Stop producing standalone binaries in bridge / server release

### DIFF
--- a/.github/workflows/bridge-release.yml
+++ b/.github/workflows/bridge-release.yml
@@ -13,39 +13,6 @@ permissions:
   packages: write
 
 jobs:
-  release:
-    name: release x86_64-unknown-linux-gnu
-    runs-on: ubuntu-24.04
-    environment: release
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-24.04
-            extension: ""
-
-          - target: aarch64-apple-darwin
-            os: macos-latest
-            extension: ""
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Compile bridge
-        run: cargo build --release --manifest-path bridge/svix-bridge/Cargo.toml
-
-      - name: Release
-        uses: actions/upload-artifact@v7
-        with:
-          name: svix-bridge-${{ matrix.target }}
-          path: bridge/target/release/svix-bridge
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   get-version:
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -13,28 +13,6 @@ permissions:
   packages: write
 
 jobs:
-  release:
-    name: release x86_64-unknown-linux-gnu
-    runs-on: ubuntu-24.04
-    environment: release
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Compile server
-        run: cargo build --release --manifest-path server/svix-server/Cargo.toml
-
-      - name: Release
-        uses: actions/upload-artifact@v7
-        with:
-          name: svix-server-x86_64-unknown-linux-gnu
-          path: server/target/release/svix-server
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   get-version:
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
We only ever uploaded them as CI artifacts, not as release artifacts. That means they were very hard to find, and expired after a while. It seems very unlikely anybody ever used them.