### PR TITLE
bridge: Release v1.100.0

### DIFF
--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -4608,7 +4608,7 @@ dependencies = [
 
 [[package]]
 name = "svix-bridge"
-version = "1.99.0"
+version = "1.100.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4647,7 +4647,7 @@ dependencies = [
 
 [[package]]
 name = "svix-bridge-plugin-kafka"
-version = "1.99.0"
+version = "1.100.0"
 dependencies = [
  "base64",
  "ctor",
@@ -4665,7 +4665,7 @@ dependencies = [
 
 [[package]]
 name = "svix-bridge-plugin-queue"
-version = "1.99.0"
+version = "1.100.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4690,7 +4690,7 @@ dependencies = [
 
 [[package]]
 name = "svix-bridge-types"
-version = "1.99.0"
+version = "1.100.0"
 dependencies = [
  "async-trait",
  "serde",

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.99.0"
+version = "1.100.0"
 license = "MIT"
 rust-version = "1.95"
 

--- a/bridge/ChangeLog.md
+++ b/bridge/ChangeLog.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+
+## Version 1.100.0
 * Add an opt-in Kafka record envelope for JSON transformations
 * Allow configuring Kafka consumer `auto.offset.reset`
 * Add an optional Kafka idempotency namespace for independent sources


### PR DESCRIPTION
## What's Changed

* Add an opt-in Kafka record envelope for JSON transformations
* Allow configuring Kafka consumer `auto.offset.reset`
* Add an optional Kafka idempotency namespace for independent sources