### PR TITLE
ci: Update bridge-release workflow to get version from Cargo

### DIFF
--- a/.github/workflows/bridge-release.yml
+++ b/.github/workflows/bridge-release.yml
@@ -24,9 +24,16 @@ jobs:
           filter: tree:0
       - id: get-version-number
         run: |
-          echo "tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
+          version=$(cargo metadata --format-version 1 \
+            | jq -r '.packages[] | select(.name == "svix-bridge") | .version')
+          if ! [[ "$version" =~ ^[0-9.]+$ ]] ; then
+             echo >&2 "Invalid version $version"
+             exit 1
+          fi
+          echo "version=v${version}" >> "$GITHUB_OUTPUT"
+        working-directory: bridge
     outputs:
-      version: ${{ steps.get-version-number.outputs.tag }}
+      version: ${{ steps.get-version-number.outputs.version }}
 
   build:
     needs: [get-version]


### PR DESCRIPTION
It worked for server, let's do the same for bridge.