### PR TITLE
devex: explicitly add uv to the dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,17 @@ updates:
     schedule:
       interval: "weekly"
       day: "wednesday"
+  - package-ecosystem: "uv"
+    directory: "/python"
+    open-pull-requests-limit: 2
+    cooldown:
+      default-days: 3
+    groups:
+      development:
+        applies-to: version-updates
+        dependency-type: development
+        patterns:
+          - '*'
+    schedule:
+      interval: "weekly"
+      day: "wednesday"


### PR DESCRIPTION
I noticed that dependabot is complaining about not being able to find `requirements.in` any more; I can't find any reference to any config pointing at that, but maybe if we manually add a dependabot config pointing at the uv stuff in /python it'll cheer up