### PR TITLE
ruby, php: Make the webhook timestamp tolerance configurable

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,9 +13,9 @@ The Svix Bridge changelog has moved to [bridge/ChangeLog.md](./bridge/ChangeLog.
 * Libs/Rust, Libs/JavaScript, Libs/Python, Libs/Go: Strip trailing slashes from a
   user-provided server URL, so `https://api.svix.com/` and `https://api.svix.com`
   behave the same
-* Libs/Ruby, Libs/PHP: Add a webhook verification method that skips the timestamp
-  tolerance check (`verify_ignoring_timestamp` / `verifyIgnoringTimestamp`),
-  matching the Go and Rust SDKs
+* Libs/Ruby, Libs/PHP: The timestamp tolerance used by webhook verification can
+  now be customized through a `tolerance` constructor argument (in seconds;
+  default five minutes)
 
 ## Version 2.0.0-rc.2
 * Libs/JS: Fix a publishing issue

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,9 @@ The Svix Bridge changelog has moved to [bridge/ChangeLog.md](./bridge/ChangeLog.
 * Libs/Rust, Libs/JavaScript, Libs/Python, Libs/Go: Strip trailing slashes from a
   user-provided server URL, so `https://api.svix.com/` and `https://api.svix.com`
   behave the same
+* Libs/Ruby, Libs/PHP: Add a webhook verification method that skips the timestamp
+  tolerance check (`verify_ignoring_timestamp` / `verifyIgnoringTimestamp`),
+  matching the Go and Rust SDKs
 
 ## Version 2.0.0-rc.2
 * Libs/JS: Fix a publishing issue

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,7 +15,7 @@ The Svix Bridge changelog has moved to [bridge/ChangeLog.md](./bridge/ChangeLog.
   behave the same
 * Libs/Ruby, Libs/PHP: The timestamp tolerance used by webhook verification can
   now be customized through a `tolerance` constructor argument (in seconds;
-  default five minutes)
+  defaults to the previously hardcoded value of five minutes)
 
 ## Version 2.0.0-rc.2
 * Libs/JS: Fix a publishing issue

--- a/php/src/Webhook.php
+++ b/php/src/Webhook.php
@@ -5,16 +5,16 @@ namespace Svix;
 class Webhook
 {
     public const SECRET_PREFIX = "whsec_";
-    public const TOLERANCE = 5 * 60;
+    private const DEFAULT_TOLERANCE = 5 * 60;
     private $secret;
-    private $tolerance = self::TOLERANCE;
+    private $tolerance = self::DEFAULT_TOLERANCE;
 
     /**
      * @param string $secret    the endpoint's signing secret
      * @param int    $tolerance maximum difference allowed, in seconds, between the
      *                          webhook's timestamp and the current time; defaults to 5 minutes
      */
-    public function __construct($secret, $tolerance = self::TOLERANCE)
+    public function __construct($secret, $tolerance = self::DEFAULT_TOLERANCE)
     {
         if (substr($secret, 0, strlen(Webhook::SECRET_PREFIX)) === Webhook::SECRET_PREFIX) {
             $secret = substr($secret, strlen(Webhook::SECRET_PREFIX));

--- a/php/src/Webhook.php
+++ b/php/src/Webhook.php
@@ -7,13 +7,24 @@ class Webhook
     public const SECRET_PREFIX = "whsec_";
     public const TOLERANCE = 5 * 60;
     private $secret;
+    private $tolerance = self::TOLERANCE;
 
-    public function __construct($secret)
+    /**
+     * @param string $secret    the endpoint's signing secret
+     * @param int    $tolerance maximum difference allowed, in seconds, between the
+     *                          webhook's timestamp and the current time; defaults to 5 minutes
+     */
+    public function __construct($secret, $tolerance = self::TOLERANCE)
     {
         if (substr($secret, 0, strlen(Webhook::SECRET_PREFIX)) === Webhook::SECRET_PREFIX) {
             $secret = substr($secret, strlen(Webhook::SECRET_PREFIX));
         }
         $this->secret = base64_decode($secret);
+
+        if (!is_int($tolerance) || $tolerance < 0) {
+            throw new \InvalidArgumentException("tolerance must be a non-negative integer");
+        }
+        $this->tolerance = $tolerance;
     }
 
     public static function fromRaw($secret)
@@ -24,37 +35,10 @@ class Webhook
     }
 
     /**
-     * Validates the payload against the svix signature headers using the
-     * webhook's signing secret.
-     *
      * @throws Exception\WebhookVerificationException
      * @throws Exception\WebhookSigningException
      */
     public function verify($payload, $headers)
-    {
-        return $this->verifyInternal($payload, $headers, true);
-    }
-
-    /**
-     * Validates the payload against the svix signature headers using the
-     * webhook's signing secret.
-     *
-     * WARNING: This method does not check the signature's timestamp.
-     * We recommend using the `verify` method instead.
-     *
-     * @throws Exception\WebhookVerificationException
-     * @throws Exception\WebhookSigningException
-     */
-    public function verifyIgnoringTimestamp($payload, $headers)
-    {
-        return $this->verifyInternal($payload, $headers, false);
-    }
-
-    /**
-     * @throws Exception\WebhookVerificationException
-     * @throws Exception\WebhookSigningException
-     */
-    private function verifyInternal($payload, $headers, $enforceTolerance)
     {
         if (
             isset($headers['svix-id'])
@@ -77,14 +61,7 @@ class Webhook
         }
 
 
-        $timestamp = $this->parseTimestampHeader($msgTimestamp);
-        if ($enforceTolerance) {
-            $this->verifyTimestamp($timestamp);
-        } elseif ($timestamp <= 0) {
-            // sign() refuses non-positive timestamps with a WebhookSigningException;
-            // surface malformed header input as a verification error instead.
-            throw new Exception\WebhookVerificationException("Invalid Signature Headers");
-        }
+        $timestamp = $this->verifyTimestamp($msgTimestamp);
 
         $signature = $this->sign($msgId, $timestamp, $payload);
         $expectedSignature = explode(',', $signature, 2)[1];
@@ -125,24 +102,27 @@ class Webhook
         return "v1,{$signature}";
     }
 
-    private function parseTimestampHeader($timestampHeader)
-    {
-        return intval($timestampHeader, 10);
-    }
-
     /**
      * @throws Exception\WebhookVerificationException
      */
-    private function verifyTimestamp($timestamp)
+    private function verifyTimestamp($timestampHeader)
     {
         $now = time();
+        $timestamp = intval($timestampHeader, 10);
 
-        if ($timestamp < ($now - Webhook::TOLERANCE)) {
+        if ($timestamp < ($now - $this->tolerance)) {
             throw new Exception\WebhookVerificationException("Message timestamp too old");
         }
-        if ($timestamp > ($now + Webhook::TOLERANCE)) {
+        if ($timestamp > ($now + $this->tolerance)) {
             throw new Exception\WebhookVerificationException("Message timestamp too new");
         }
+        if ($timestamp <= 0) {
+            // Like the Rust SDK, timestamps before 1970 are not honored even when
+            // the tolerance window would allow them. sign() also refuses them, so
+            // reject the malformed header as a verification failure here.
+            throw new Exception\WebhookVerificationException("Invalid Signature Headers");
+        }
+
         return $timestamp;
     }
 

--- a/php/src/Webhook.php
+++ b/php/src/Webhook.php
@@ -24,10 +24,37 @@ class Webhook
     }
 
     /**
+     * Validates the payload against the svix signature headers using the
+     * webhook's signing secret.
+     *
      * @throws Exception\WebhookVerificationException
      * @throws Exception\WebhookSigningException
      */
     public function verify($payload, $headers)
+    {
+        return $this->verifyInternal($payload, $headers, true);
+    }
+
+    /**
+     * Validates the payload against the svix signature headers using the
+     * webhook's signing secret.
+     *
+     * WARNING: This method does not check the signature's timestamp.
+     * We recommend using the `verify` method instead.
+     *
+     * @throws Exception\WebhookVerificationException
+     * @throws Exception\WebhookSigningException
+     */
+    public function verifyIgnoringTimestamp($payload, $headers)
+    {
+        return $this->verifyInternal($payload, $headers, false);
+    }
+
+    /**
+     * @throws Exception\WebhookVerificationException
+     * @throws Exception\WebhookSigningException
+     */
+    private function verifyInternal($payload, $headers, $enforceTolerance)
     {
         if (
             isset($headers['svix-id'])
@@ -50,7 +77,14 @@ class Webhook
         }
 
 
-        $timestamp = $this->verifyTimestamp($msgTimestamp);
+        $timestamp = $this->parseTimestampHeader($msgTimestamp);
+        if ($enforceTolerance) {
+            $this->verifyTimestamp($timestamp);
+        } elseif ($timestamp <= 0) {
+            // sign() refuses non-positive timestamps with a WebhookSigningException;
+            // surface malformed header input as a verification error instead.
+            throw new Exception\WebhookVerificationException("Invalid Signature Headers");
+        }
 
         $signature = $this->sign($msgId, $timestamp, $payload);
         $expectedSignature = explode(',', $signature, 2)[1];
@@ -91,17 +125,17 @@ class Webhook
         return "v1,{$signature}";
     }
 
+    private function parseTimestampHeader($timestampHeader)
+    {
+        return intval($timestampHeader, 10);
+    }
+
     /**
      * @throws Exception\WebhookVerificationException
      */
-    private function verifyTimestamp($timestampHeader)
+    private function verifyTimestamp($timestamp)
     {
         $now = time();
-        try {
-            $timestamp = intval($timestampHeader, 10);
-        } catch (\Exception $e) {
-            throw new Exception\WebhookVerificationException("Invalid Signature Headers");
-        }
 
         if ($timestamp < ($now - Webhook::TOLERANCE)) {
             throw new Exception\WebhookVerificationException("Message timestamp too old");

--- a/php/tests/WebhookTest.php
+++ b/php/tests/WebhookTest.php
@@ -122,6 +122,111 @@ final class WebhookTest extends \PHPUnit\Framework\TestCase
         $wh->verify($testPayload->payload, $testPayload->header);
     }
 
+    public function testOldTimestampIsValidWhenIgnoringTimestamp()
+    {
+        $testPayload = new TestPayload(time() - self::TOLERANCE - 1);
+
+        $wh = new \Svix\Webhook($testPayload->secret);
+        $json = $wh->verifyIgnoringTimestamp($testPayload->payload, $testPayload->header);
+
+        $this->assertEquals(
+            $json['test'],
+            2432232315,
+            "did not return expected json"
+        );
+    }
+
+    public function testNewTimestampIsValidWhenIgnoringTimestamp()
+    {
+        $testPayload = new TestPayload(time() + self::TOLERANCE + 1);
+
+        $wh = new \Svix\Webhook($testPayload->secret);
+        $json = $wh->verifyIgnoringTimestamp($testPayload->payload, $testPayload->header);
+
+        $this->assertEquals(
+            $json['test'],
+            2432232315,
+            "did not return expected json"
+        );
+    }
+
+    public function testCurrentTimestampIsValidWhenIgnoringTimestamp()
+    {
+        $testPayload = new TestPayload(time());
+
+        $wh = new \Svix\Webhook($testPayload->secret);
+        $json = $wh->verifyIgnoringTimestamp($testPayload->payload, $testPayload->header);
+
+        $this->assertEquals(
+            $json['test'],
+            2432232315,
+            "did not return expected json"
+        );
+    }
+
+    public function testInvalidSignatureThrowsExceptionWhenIgnoringTimestamp()
+    {
+        $this->expectException(\Svix\Exception\WebhookVerificationException::class);
+        $this->expectExceptionMessage("No matching signature found");
+
+        $testPayload = new TestPayload(time());
+        $testPayload->header['svix-signature'] = 'v1,dawfeoifkpqwoekfpqoekf';
+
+        $wh = new \Svix\Webhook($testPayload->secret);
+        $wh->verifyIgnoringTimestamp($testPayload->payload, $testPayload->header);
+    }
+
+    public function testTamperedTimestampThrowsExceptionWhenIgnoringTimestamp()
+    {
+        // The signature covers the timestamp, so changing it after signing must
+        // still fail even though the tolerance isn't enforced.
+        $this->expectException(\Svix\Exception\WebhookVerificationException::class);
+        $this->expectExceptionMessage("No matching signature found");
+
+        $testPayload = new TestPayload(time());
+        $testPayload->header['svix-timestamp'] = strval(intval($testPayload->timestamp) - 1000);
+
+        $wh = new \Svix\Webhook($testPayload->secret);
+        $wh->verifyIgnoringTimestamp($testPayload->payload, $testPayload->header);
+    }
+
+    public function testMissingHeadersThrowExceptionWhenIgnoringTimestamp()
+    {
+        $this->expectException(\Svix\Exception\WebhookVerificationException::class);
+        $this->expectExceptionMessage("Missing required headers");
+
+        $testPayload = new TestPayload(time());
+        unset($testPayload->header['svix-id']);
+
+        $wh = new \Svix\Webhook($testPayload->secret);
+        $wh->verifyIgnoringTimestamp($testPayload->payload, $testPayload->header);
+    }
+
+    public function testNonNumericTimestampThrowsExceptionWhenIgnoringTimestamp()
+    {
+        $this->expectException(\Svix\Exception\WebhookVerificationException::class);
+        $this->expectExceptionMessage("Invalid Signature Headers");
+
+        $testPayload = new TestPayload(time());
+        $testPayload->header['svix-timestamp'] = 'not-a-number';
+
+        $wh = new \Svix\Webhook($testPayload->secret);
+        $wh->verifyIgnoringTimestamp($testPayload->payload, $testPayload->header);
+    }
+
+    public function testNegativeTimestampThrowsExceptionWhenIgnoringTimestamp()
+    {
+        // sign() only accepts positive timestamps, so the ignoring path treats a
+        // non-positive value as malformed input rather than signing with it.
+        $this->expectException(\Svix\Exception\WebhookVerificationException::class);
+        $this->expectExceptionMessage("Invalid Signature Headers");
+
+        $testPayload = new TestPayload(-1234);
+
+        $wh = new \Svix\Webhook($testPayload->secret);
+        $wh->verifyIgnoringTimestamp($testPayload->payload, $testPayload->header);
+    }
+
     public function testMultiSigPayloadIsValid()
     {
         // We're checking that `verify()` doesn't throw an exception.

--- a/php/tests/WebhookTest.php
+++ b/php/tests/WebhookTest.php
@@ -122,12 +122,12 @@ final class WebhookTest extends \PHPUnit\Framework\TestCase
         $wh->verify($testPayload->payload, $testPayload->header);
     }
 
-    public function testOldTimestampIsValidWhenIgnoringTimestamp()
+    public function testCustomToleranceAcceptsOldTimestamp()
     {
-        $testPayload = new TestPayload(time() - self::TOLERANCE - 1);
+        $testPayload = new TestPayload(time() - (2 * self::TOLERANCE));
 
-        $wh = new \Svix\Webhook($testPayload->secret);
-        $json = $wh->verifyIgnoringTimestamp($testPayload->payload, $testPayload->header);
+        $wh = new \Svix\Webhook($testPayload->secret, 3 * self::TOLERANCE);
+        $json = $wh->verify($testPayload->payload, $testPayload->header);
 
         $this->assertEquals(
             $json['test'],
@@ -136,12 +136,23 @@ final class WebhookTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testNewTimestampIsValidWhenIgnoringTimestamp()
+    public function testCustomToleranceRejectsOldTimestampInsideDefault()
     {
-        $testPayload = new TestPayload(time() + self::TOLERANCE + 1);
+        $this->expectException(\Svix\Exception\WebhookVerificationException::class);
+        $this->expectExceptionMessage("Message timestamp too old");
 
-        $wh = new \Svix\Webhook($testPayload->secret);
-        $json = $wh->verifyIgnoringTimestamp($testPayload->payload, $testPayload->header);
+        $testPayload = new TestPayload(time() - 120);
+
+        $wh = new \Svix\Webhook($testPayload->secret, 60);
+        $wh->verify($testPayload->payload, $testPayload->header);
+    }
+
+    public function testCustomToleranceAcceptsNewTimestamp()
+    {
+        $testPayload = new TestPayload(time() + (2 * self::TOLERANCE));
+
+        $wh = new \Svix\Webhook($testPayload->secret, 3 * self::TOLERANCE);
+        $json = $wh->verify($testPayload->payload, $testPayload->header);
 
         $this->assertEquals(
             $json['test'],
@@ -150,21 +161,18 @@ final class WebhookTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testCurrentTimestampIsValidWhenIgnoringTimestamp()
+    public function testCustomToleranceRejectsNewTimestampInsideDefault()
     {
-        $testPayload = new TestPayload(time());
+        $this->expectException(\Svix\Exception\WebhookVerificationException::class);
+        $this->expectExceptionMessage("Message timestamp too new");
 
-        $wh = new \Svix\Webhook($testPayload->secret);
-        $json = $wh->verifyIgnoringTimestamp($testPayload->payload, $testPayload->header);
+        $testPayload = new TestPayload(time() + 120);
 
-        $this->assertEquals(
-            $json['test'],
-            2432232315,
-            "did not return expected json"
-        );
+        $wh = new \Svix\Webhook($testPayload->secret, 60);
+        $wh->verify($testPayload->payload, $testPayload->header);
     }
 
-    public function testInvalidSignatureThrowsExceptionWhenIgnoringTimestamp()
+    public function testInvalidSignatureThrowsWithCustomTolerance()
     {
         $this->expectException(\Svix\Exception\WebhookVerificationException::class);
         $this->expectExceptionMessage("No matching signature found");
@@ -172,59 +180,56 @@ final class WebhookTest extends \PHPUnit\Framework\TestCase
         $testPayload = new TestPayload(time());
         $testPayload->header['svix-signature'] = 'v1,dawfeoifkpqwoekfpqoekf';
 
-        $wh = new \Svix\Webhook($testPayload->secret);
-        $wh->verifyIgnoringTimestamp($testPayload->payload, $testPayload->header);
+        $wh = new \Svix\Webhook($testPayload->secret, 3 * self::TOLERANCE);
+        $wh->verify($testPayload->payload, $testPayload->header);
     }
 
-    public function testTamperedTimestampThrowsExceptionWhenIgnoringTimestamp()
+    public function testTamperedTimestampThrowsWithCustomTolerance()
     {
-        // The signature covers the timestamp, so changing it after signing must
-        // still fail even though the tolerance isn't enforced.
+        // Changing the timestamp value after signing must fail the signature
+        // check even when the altered value is inside the tolerance window.
         $this->expectException(\Svix\Exception\WebhookVerificationException::class);
         $this->expectExceptionMessage("No matching signature found");
 
         $testPayload = new TestPayload(time());
-        $testPayload->header['svix-timestamp'] = strval(intval($testPayload->timestamp) - 1000);
+        $testPayload->header['svix-timestamp'] = strval(intval($testPayload->timestamp) - 600);
 
-        $wh = new \Svix\Webhook($testPayload->secret);
-        $wh->verifyIgnoringTimestamp($testPayload->payload, $testPayload->header);
+        $wh = new \Svix\Webhook($testPayload->secret, 3 * self::TOLERANCE);
+        $wh->verify($testPayload->payload, $testPayload->header);
     }
 
-    public function testMissingHeadersThrowExceptionWhenIgnoringTimestamp()
+    public function testEpochSpanningToleranceRejectsNonPositiveTimestamp()
     {
-        $this->expectException(\Svix\Exception\WebhookVerificationException::class);
-        $this->expectExceptionMessage("Missing required headers");
-
-        $testPayload = new TestPayload(time());
-        unset($testPayload->header['svix-id']);
-
-        $wh = new \Svix\Webhook($testPayload->secret);
-        $wh->verifyIgnoringTimestamp($testPayload->payload, $testPayload->header);
-    }
-
-    public function testNonNumericTimestampThrowsExceptionWhenIgnoringTimestamp()
-    {
-        $this->expectException(\Svix\Exception\WebhookVerificationException::class);
-        $this->expectExceptionMessage("Invalid Signature Headers");
-
-        $testPayload = new TestPayload(time());
-        $testPayload->header['svix-timestamp'] = 'not-a-number';
-
-        $wh = new \Svix\Webhook($testPayload->secret);
-        $wh->verifyIgnoringTimestamp($testPayload->payload, $testPayload->header);
-    }
-
-    public function testNegativeTimestampThrowsExceptionWhenIgnoringTimestamp()
-    {
-        // sign() only accepts positive timestamps, so the ignoring path treats a
-        // non-positive value as malformed input rather than signing with it.
+        // sign() only accepts positive timestamps, so verify() reports a
+        // non-positive value as a verification failure, not a signing one.
         $this->expectException(\Svix\Exception\WebhookVerificationException::class);
         $this->expectExceptionMessage("Invalid Signature Headers");
 
         $testPayload = new TestPayload(-1234);
 
-        $wh = new \Svix\Webhook($testPayload->secret);
-        $wh->verifyIgnoringTimestamp($testPayload->payload, $testPayload->header);
+        $wh = new \Svix\Webhook($testPayload->secret, PHP_INT_MAX);
+        $wh->verify($testPayload->payload, $testPayload->header);
+    }
+
+    public function testNegativeToleranceThrows()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new \Svix\Webhook("whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw", -1);
+    }
+
+    public function testNonIntegerToleranceThrows()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new \Svix\Webhook("whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw", NAN);
+    }
+
+    public function testNullToleranceThrows()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new \Svix\Webhook("whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw", null);
     }
 
     public function testMultiSigPayloadIsValid()

--- a/ruby/lib/svix/webhook.rb
+++ b/ruby/lib/svix/webhook.rb
@@ -19,36 +19,25 @@ module Svix
       end
     end
 
+    # Validates the payload against the svix signature headers using the
+    # webhook's signing secret.
+    #
+    # Raises a WebhookVerificationError if the headers are missing/unreadable
+    # or if the signature doesn't match.
     def verify(payload, headers)
-      msgId = headers["svix-id"]
-      msgSignature = headers["svix-signature"]
-      msgTimestamp = headers["svix-timestamp"]
-      if !msgSignature || !msgId || !msgTimestamp
-        msgId = headers["webhook-id"]
-        msgSignature = headers["webhook-signature"]
-        msgTimestamp = headers["webhook-timestamp"]
-        if !msgSignature || !msgId || !msgTimestamp
-          raise WebhookVerificationError, "Missing required headers"
-        end
-      end
+      verify_internal(payload, headers, true)
+    end
 
-      verify_timestamp(msgTimestamp)
-
-      _, signature = sign(msgId, msgTimestamp, payload).split(",", 2)
-
-      passedSignatures = msgSignature.split(" ")
-      passedSignatures.each do |versionedSignature|
-        version, expectedSignature = versionedSignature.split(",", 2)
-        if version != "v1"
-          next
-        end
-
-        if ::Svix::secure_compare(signature, expectedSignature)
-          return nil
-        end
-      end
-
-      raise WebhookVerificationError, "No matching signature found"
+    # Validates the payload against the svix signature headers using the
+    # webhook's signing secret.
+    #
+    # Raises a WebhookVerificationError if the headers are missing/unreadable
+    # or if the signature doesn't match.
+    #
+    # WARNING: This method does not check the signature's timestamp.
+    # We recommend using the `verify` method instead.
+    def verify_ignoring_timestamp(payload, headers)
+      verify_internal(payload, headers, false)
     end
 
     def sign(msgId, timestamp, payload)
@@ -67,13 +56,49 @@ module Svix
     SECRET_PREFIX = "whsec_"
     TOLERANCE = 5 * 60
 
-    def verify_timestamp(timestampHeader)
+    def verify_internal(payload, headers, enforce_tolerance)
+      msgId = headers["svix-id"]
+      msgSignature = headers["svix-signature"]
+      msgTimestamp = headers["svix-timestamp"]
+      if !msgSignature || !msgId || !msgTimestamp
+        msgId = headers["webhook-id"]
+        msgSignature = headers["webhook-signature"]
+        msgTimestamp = headers["webhook-timestamp"]
+        if !msgSignature || !msgId || !msgTimestamp
+          raise WebhookVerificationError, "Missing required headers"
+        end
+      end
+
+      timestamp = parse_timestamp_header(msgTimestamp)
+      verify_timestamp(timestamp) if enforce_tolerance
+
+      _, signature = sign(msgId, msgTimestamp, payload).split(",", 2)
+
+      passedSignatures = msgSignature.split(" ")
+      passedSignatures.each do |versionedSignature|
+        version, expectedSignature = versionedSignature.split(",", 2)
+        if version != "v1"
+          next
+        end
+
+        if ::Svix::secure_compare(signature, expectedSignature)
+          return nil
+        end
+      end
+
+      raise WebhookVerificationError, "No matching signature found"
+    end
+
+    def parse_timestamp_header(timestampHeader)
       begin
-        now = Integer(Time.now)
-        timestamp = Integer(timestampHeader)
+        Integer(timestampHeader)
       rescue
         raise WebhookVerificationError, "Invalid Signature Headers"
       end
+    end
+
+    def verify_timestamp(timestamp)
+      now = Time.now.to_i
 
       if timestamp < (now - TOLERANCE)
         raise WebhookVerificationError, "Message timestamp too old"

--- a/ruby/lib/svix/webhook.rb
+++ b/ruby/lib/svix/webhook.rb
@@ -3,11 +3,13 @@
 module Svix
   class Webhook
 
-    def self.new_using_raw_bytes(secret)
-      self.new(secret.pack("C*").force_encoding("UTF-8"))
+    def self.new_using_raw_bytes(secret, tolerance: TOLERANCE)
+      self.new(secret.pack("C*").force_encoding("UTF-8"), tolerance: tolerance)
     end
 
-    def initialize(secret)
+    # `tolerance` is the maximum difference allowed, in seconds, between the
+    # webhook's timestamp and the current time. Defaults to 5 minutes.
+    def initialize(secret, tolerance: TOLERANCE)
       if secret.start_with?(SECRET_PREFIX)
         secret = secret[SECRET_PREFIX.length..-1]
       end
@@ -17,46 +19,14 @@ module Svix
       if @secret.empty?
         raise EmptyWebhookSecretError, "Webhook secret must not be blank"
       end
-    end
 
-    # Validates the payload against the svix signature headers using the
-    # webhook's signing secret.
-    #
-    # Raises a WebhookVerificationError if the headers are missing/unreadable
-    # or if the signature doesn't match.
-    def verify(payload, headers)
-      verify_internal(payload, headers, true)
-    end
-
-    # Validates the payload against the svix signature headers using the
-    # webhook's signing secret.
-    #
-    # Raises a WebhookVerificationError if the headers are missing/unreadable
-    # or if the signature doesn't match.
-    #
-    # WARNING: This method does not check the signature's timestamp.
-    # We recommend using the `verify` method instead.
-    def verify_ignoring_timestamp(payload, headers)
-      verify_internal(payload, headers, false)
-    end
-
-    def sign(msgId, timestamp, payload)
-      begin
-        now = Integer(timestamp)
-      rescue
-        raise WebhookSigningError, "Invalid timestamp"
+      if !tolerance.is_a?(Integer) || tolerance < 0
+        raise ArgumentError, "tolerance must be a non-negative integer"
       end
-
-      toSign = "#{msgId}.#{timestamp}.#{payload}"
-      signature = Base64.encode64(OpenSSL::HMAC.digest(OpenSSL::Digest.new("sha256"), @secret, toSign)).strip
-      return "v1,#{signature}"
+      @tolerance = tolerance
     end
 
-    private
-    SECRET_PREFIX = "whsec_"
-    TOLERANCE = 5 * 60
-
-    def verify_internal(payload, headers, enforce_tolerance)
+    def verify(payload, headers)
       msgId = headers["svix-id"]
       msgSignature = headers["svix-signature"]
       msgTimestamp = headers["svix-timestamp"]
@@ -69,8 +39,7 @@ module Svix
         end
       end
 
-      timestamp = parse_timestamp_header(msgTimestamp)
-      verify_timestamp(timestamp) if enforce_tolerance
+      verify_timestamp(msgTimestamp)
 
       _, signature = sign(msgId, msgTimestamp, payload).split(",", 2)
 
@@ -89,23 +58,42 @@ module Svix
       raise WebhookVerificationError, "No matching signature found"
     end
 
-    def parse_timestamp_header(timestampHeader)
+    def sign(msgId, timestamp, payload)
       begin
-        Integer(timestampHeader)
+        now = Integer(timestamp)
+      rescue
+        raise WebhookSigningError, "Invalid timestamp"
+      end
+
+      toSign = "#{msgId}.#{timestamp}.#{payload}"
+      signature = Base64.encode64(OpenSSL::HMAC.digest(OpenSSL::Digest.new("sha256"), @secret, toSign)).strip
+      return "v1,#{signature}"
+    end
+
+    private
+    SECRET_PREFIX = "whsec_"
+    TOLERANCE = 5 * 60
+
+    def verify_timestamp(timestampHeader)
+      begin
+        now = Integer(Time.now)
+        timestamp = Integer(timestampHeader)
       rescue
         raise WebhookVerificationError, "Invalid Signature Headers"
       end
-    end
 
-    def verify_timestamp(timestamp)
-      now = Time.now.to_i
-
-      if timestamp < (now - TOLERANCE)
+      if timestamp < (now - @tolerance)
         raise WebhookVerificationError, "Message timestamp too old"
       end
 
-      if timestamp > (now + TOLERANCE)
+      if timestamp > (now + @tolerance)
         raise WebhookVerificationError, "Message timestamp too new"
+      end
+
+      if timestamp <= 0
+        # Like the Rust SDK, timestamps before 1970 are not honored even when
+        # the tolerance window would allow them.
+        raise WebhookVerificationError, "Invalid Signature Headers"
       end
     end
   end

--- a/ruby/lib/svix/webhook.rb
+++ b/ruby/lib/svix/webhook.rb
@@ -3,13 +3,13 @@
 module Svix
   class Webhook
 
-    def self.new_using_raw_bytes(secret, tolerance: TOLERANCE)
+    def self.new_using_raw_bytes(secret, tolerance: DEFAULT_TOLERANCE)
       self.new(secret.pack("C*").force_encoding("UTF-8"), tolerance: tolerance)
     end
 
     # `tolerance` is the maximum difference allowed, in seconds, between the
     # webhook's timestamp and the current time. Defaults to 5 minutes.
-    def initialize(secret, tolerance: TOLERANCE)
+    def initialize(secret, tolerance: DEFAULT_TOLERANCE)
       if secret.start_with?(SECRET_PREFIX)
         secret = secret[SECRET_PREFIX.length..-1]
       end
@@ -72,7 +72,7 @@ module Svix
 
     private
     SECRET_PREFIX = "whsec_"
-    TOLERANCE = 5 * 60
+    DEFAULT_TOLERANCE = 5 * 60
 
     def verify_timestamp(timestampHeader)
       begin

--- a/ruby/spec/webhook_spec.rb
+++ b/ruby/spec/webhook_spec.rb
@@ -169,80 +169,85 @@ describe Svix::Webhook do
     expect(signature).to(eq(expected))
   end
 
-  it "old timestamp is valid when ignoring the timestamp" do
-    testPayload = TestPayload.new(timestamp: Time.now.to_i - TOLERANCE - 1)
+  it "custom tolerance accepts an old timestamp the default would reject" do
+    testPayload = TestPayload.new(timestamp: Time.now.to_i - (2 * TOLERANCE))
 
-    wh = Svix::Webhook.new(testPayload.secret)
+    wh = Svix::Webhook.new(testPayload.secret, tolerance: 3 * TOLERANCE)
 
-    wh.verify_ignoring_timestamp(testPayload.payload, testPayload.headers)
+    wh.verify(testPayload.payload, testPayload.headers)
   end
 
-  it "new timestamp is valid when ignoring the timestamp" do
-    testPayload = TestPayload.new(timestamp: Time.now.to_i + TOLERANCE + 1)
+  it "custom tolerance rejects an old timestamp the default would accept" do
+    testPayload = TestPayload.new(timestamp: Time.now.to_i - 120)
 
-    wh = Svix::Webhook.new(testPayload.secret)
+    wh = Svix::Webhook.new(testPayload.secret, tolerance: 60)
 
-    wh.verify_ignoring_timestamp(testPayload.payload, testPayload.headers)
+    expect { wh.verify(testPayload.payload, testPayload.headers) }.to(raise_error(Svix::WebhookVerificationError))
   end
 
-  it "current timestamp is valid when ignoring the timestamp" do
-    testPayload = TestPayload.new
+  it "custom tolerance accepts a future timestamp the default would reject" do
+    testPayload = TestPayload.new(timestamp: Time.now.to_i + (2 * TOLERANCE))
 
-    wh = Svix::Webhook.new(testPayload.secret)
+    wh = Svix::Webhook.new(testPayload.secret, tolerance: 3 * TOLERANCE)
 
-    wh.verify_ignoring_timestamp(testPayload.payload, testPayload.headers)
+    wh.verify(testPayload.payload, testPayload.headers)
   end
 
-  it "invalid signature raises error when ignoring the timestamp" do
+  it "custom tolerance rejects a future timestamp the default would accept" do
+    testPayload = TestPayload.new(timestamp: Time.now.to_i + 120)
+
+    wh = Svix::Webhook.new(testPayload.secret, tolerance: 60)
+
+    expect { wh.verify(testPayload.payload, testPayload.headers) }.to(raise_error(Svix::WebhookVerificationError))
+  end
+
+  it "invalid signature still raises with a custom tolerance" do
     testPayload = TestPayload.new
     testPayload.headers["svix-signature"] = "v1,g0hM9SsE+OTPJTGt/tmIKtSyZlE3uFJELVlNIOLawdd"
 
-    wh = Svix::Webhook.new(testPayload.secret)
+    wh = Svix::Webhook.new(testPayload.secret, tolerance: 3 * TOLERANCE)
 
-    expect { wh.verify_ignoring_timestamp(testPayload.payload, testPayload.headers) }
-      .to(raise_error(Svix::WebhookVerificationError))
+    expect { wh.verify(testPayload.payload, testPayload.headers) }.to(raise_error(Svix::WebhookVerificationError))
   end
 
-  it "tampered timestamp raises error when ignoring the timestamp" do
-    # The signature covers the timestamp, so changing it after signing must
-    # still fail even though the tolerance isn't enforced.
+  it "tampered timestamp still raises with a custom tolerance" do
+    # The signature covers the timestamp, so a value changed after signing
+    # must fail even when it is inside the tolerance window.
     testPayload = TestPayload.new
-    testPayload.headers["svix-timestamp"] = testPayload.timestamp - 1000
+    testPayload.headers["svix-timestamp"] = testPayload.timestamp - 600
 
-    wh = Svix::Webhook.new(testPayload.secret)
+    wh = Svix::Webhook.new(testPayload.secret, tolerance: 3 * TOLERANCE)
 
-    expect { wh.verify_ignoring_timestamp(testPayload.payload, testPayload.headers) }
-      .to(raise_error(Svix::WebhookVerificationError))
+    expect { wh.verify(testPayload.payload, testPayload.headers) }
+      .to(raise_error(Svix::WebhookVerificationError, /No matching signature found/))
   end
 
-  it "missing headers raise error when ignoring the timestamp" do
-    testPayload = TestPayload.new
-    testPayload.headers.delete("svix-id")
-
-    wh = Svix::Webhook.new(testPayload.secret)
-
-    expect { wh.verify_ignoring_timestamp(testPayload.payload, testPayload.headers) }
-      .to(raise_error(Svix::WebhookVerificationError))
-  end
-
-  it "non-numeric timestamp raises error when ignoring the timestamp" do
-    testPayload = TestPayload.new
-    testPayload.headers["svix-timestamp"] = "not-a-number"
-
-    wh = Svix::Webhook.new(testPayload.secret)
-
-    expect { wh.verify_ignoring_timestamp(testPayload.payload, testPayload.headers) }
-      .to(raise_error(Svix::WebhookVerificationError))
-  end
-
-  it "negative timestamp is valid when ignoring the timestamp" do
-    # Matches Go and Rust, which accept any integer timestamp once the
-    # tolerance check is skipped.
+  it "a tolerance spanning the epoch still rejects a non-positive timestamp" do
+    # Like the Rust SDK, timestamps before 1970 are not honored even when the
+    # tolerance window would allow them.
     testPayload = TestPayload.new(timestamp: -1234)
 
-    wh = Svix::Webhook.new(testPayload.secret)
+    wh = Svix::Webhook.new(testPayload.secret, tolerance: 10**10)
 
-    wh.verify_ignoring_timestamp(testPayload.payload, testPayload.headers)
+    expect { wh.verify(testPayload.payload, testPayload.headers) }
+      .to(raise_error(Svix::WebhookVerificationError, /Invalid Signature Headers/))
+  end
+
+  it "negative tolerance raises error" do
+    expect { Svix::Webhook.new(DEFAULT_SECRET, tolerance: -1) }.to(raise_error(ArgumentError))
+  end
+
+  it "non-integer tolerance raises error" do
+    expect { Svix::Webhook.new(DEFAULT_SECRET, tolerance: Float::NAN) }.to(raise_error(ArgumentError))
+    expect { Svix::Webhook.new(DEFAULT_SECRET, tolerance: nil) }.to(raise_error(ArgumentError))
+  end
+
+  it "new_using_raw_bytes accepts a custom tolerance" do
+    testPayload = TestPayload.new(timestamp: Time.now.to_i - (2 * TOLERANCE))
+
+    wh = Svix::Webhook.new_using_raw_bytes(testPayload.secret.bytes, tolerance: 3 * TOLERANCE)
+
+    wh.verify(testPayload.payload, testPayload.headers)
   end
 
   it "can validate an empty payload" do

--- a/ruby/spec/webhook_spec.rb
+++ b/ruby/spec/webhook_spec.rb
@@ -169,6 +169,82 @@ describe Svix::Webhook do
     expect(signature).to(eq(expected))
   end
 
+  it "old timestamp is valid when ignoring the timestamp" do
+    testPayload = TestPayload.new(timestamp: Time.now.to_i - TOLERANCE - 1)
+
+    wh = Svix::Webhook.new(testPayload.secret)
+
+    wh.verify_ignoring_timestamp(testPayload.payload, testPayload.headers)
+  end
+
+  it "new timestamp is valid when ignoring the timestamp" do
+    testPayload = TestPayload.new(timestamp: Time.now.to_i + TOLERANCE + 1)
+
+    wh = Svix::Webhook.new(testPayload.secret)
+
+    wh.verify_ignoring_timestamp(testPayload.payload, testPayload.headers)
+  end
+
+  it "current timestamp is valid when ignoring the timestamp" do
+    testPayload = TestPayload.new
+
+    wh = Svix::Webhook.new(testPayload.secret)
+
+    wh.verify_ignoring_timestamp(testPayload.payload, testPayload.headers)
+  end
+
+  it "invalid signature raises error when ignoring the timestamp" do
+    testPayload = TestPayload.new
+    testPayload.headers["svix-signature"] = "v1,g0hM9SsE+OTPJTGt/tmIKtSyZlE3uFJELVlNIOLawdd"
+
+    wh = Svix::Webhook.new(testPayload.secret)
+
+    expect { wh.verify_ignoring_timestamp(testPayload.payload, testPayload.headers) }
+      .to(raise_error(Svix::WebhookVerificationError))
+  end
+
+  it "tampered timestamp raises error when ignoring the timestamp" do
+    # The signature covers the timestamp, so changing it after signing must
+    # still fail even though the tolerance isn't enforced.
+    testPayload = TestPayload.new
+    testPayload.headers["svix-timestamp"] = testPayload.timestamp - 1000
+
+    wh = Svix::Webhook.new(testPayload.secret)
+
+    expect { wh.verify_ignoring_timestamp(testPayload.payload, testPayload.headers) }
+      .to(raise_error(Svix::WebhookVerificationError))
+  end
+
+  it "missing headers raise error when ignoring the timestamp" do
+    testPayload = TestPayload.new
+    testPayload.headers.delete("svix-id")
+
+    wh = Svix::Webhook.new(testPayload.secret)
+
+    expect { wh.verify_ignoring_timestamp(testPayload.payload, testPayload.headers) }
+      .to(raise_error(Svix::WebhookVerificationError))
+  end
+
+  it "non-numeric timestamp raises error when ignoring the timestamp" do
+    testPayload = TestPayload.new
+    testPayload.headers["svix-timestamp"] = "not-a-number"
+
+    wh = Svix::Webhook.new(testPayload.secret)
+
+    expect { wh.verify_ignoring_timestamp(testPayload.payload, testPayload.headers) }
+      .to(raise_error(Svix::WebhookVerificationError))
+  end
+
+  it "negative timestamp is valid when ignoring the timestamp" do
+    # Matches Go and Rust, which accept any integer timestamp once the
+    # tolerance check is skipped.
+    testPayload = TestPayload.new(timestamp: -1234)
+
+    wh = Svix::Webhook.new(testPayload.secret)
+
+    wh.verify_ignoring_timestamp(testPayload.payload, testPayload.headers)
+  end
+
   it "can validate an empty payload" do
     testPayload = TestPayload.new(payload: '')
 


### PR DESCRIPTION
## Motivation

Per the review discussion below: #93 wants the timestamp tolerance to be configurable, the separate-method approach from the earlier version of this PR is out.

## Solution

Both SDKs now take an optional `tolerance` constructor argument (seconds, default 5 minutes). It must be a non-negative integer:
- NaN/null/floats are rejected at construction
- NaN silently disables both window checks and PHP coerces null to a zero-second window

One edge case: a tolerance reaching past the epoch still rejects non-positive timestamps, matching Rust ("we won't honor timestamps before 1970") and keeping PHP's `sign()` from throwing on attacker-controlled input.

Tests cover accept/reject in both directions vs the default, signature failure under a widened window, and the constructor validation. rspec: 56 examples, 0 failures; phpunit: 52 tests, OK.

_PR assisted by Claude_
