### PR TITLE
rust: Clean up some allow attributes

### DIFF
--- a/codegen/templates/rust/component_type_summary.rs.jinja
+++ b/codegen/templates/rust/component_type_summary.rs.jinja
@@ -1,5 +1,4 @@
 // this file is @generated
-#![allow(clippy::too_many_arguments)]
 
 {% for _, type in api.types | items -%}
     mod {{ type.name | to_snake_case }};

--- a/codegen/templates/rust/types/struct.rs.jinja
+++ b/codegen/templates/rust/types/struct.rs.jinja
@@ -35,7 +35,7 @@ impl {{ type_name }} {
         {% endfor -%}
     ) -> Self {
         {% if type.fields | selectattr("deprecated") | length > 0 -%}
-            #[allow(deprecated)]
+            #[expect(deprecated)]
         {% endif -%}
         Self {
             {% for field in type.fields -%}

--- a/codegen/templates/svix-cli/api_resource.rs.jinja
+++ b/codegen/templates/svix-cli/api_resource.rs.jinja
@@ -270,7 +270,7 @@ impl {{ resource_type_name }}Commands {
                     {% if has_params %}options,{% endif -%}
                 } => {
                     {% if op.deprecated -%}
-                        #[allow(deprecated)]
+                        #[expect(deprecated)]
                     {% endif -%}
                     {% if op.response_body_schema_name is defined -%}
                         let resp =

--- a/rust/src/models/app_portal_access_in.rs
+++ b/rust/src/models/app_portal_access_in.rs
@@ -67,7 +67,7 @@ pub struct AppPortalAccessIn {
 
 impl AppPortalAccessIn {
     pub fn new() -> Self {
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         Self {
             application: None,
             read_only: None,

--- a/rust/src/models/mod.rs
+++ b/rust/src/models/mod.rs
@@ -1,5 +1,4 @@
 // this file is @generated
-#![allow(clippy::too_many_arguments)]
 
 mod adobe_sign_config;
 mod adobe_sign_config_out;

--- a/svix-cli/src/cmds/api/endpoint.rs
+++ b/svix-cli/src/cmds/api/endpoint.rs
@@ -824,7 +824,7 @@ impl EndpointCommands {
                 id,
                 endpoint_transformation_in,
             } => {
-                #[allow(deprecated)]
+                #[expect(deprecated)]
                 client
                     .endpoint()
                     .transformation_partial_update(


### PR DESCRIPTION
Should keep these to a minimum. `expect` is better because we get a warning if it's no longer applicable (such as the `mod.rs`-level clippy lint I removed entirely).