### PR TITLE
Silence new clippy lint on nightly

### DIFF
--- a/server/svix-server/src/core/cache/mod.rs
+++ b/server/svix-server/src/core/cache/mod.rs
@@ -136,6 +136,7 @@ const RETRY_SCHEDULE: &[Duration] = &[
     Duration::from_millis(40),
 ];
 
+#[allow(clippy::double_must_use)] // macro nonsense
 #[async_trait]
 #[enum_dispatch(Cache)]
 pub trait CacheBehavior: Sync + Send {


### PR DESCRIPTION
Clippy complains about a `#[must_use]` annotation on a fn that returns `std::future::Future`. We don't have such an attribute there, it's part of the `enum_dispatch` macro output.