### PR TITLE
ruby, php: Accept webhook headers of any casing as a fallback

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@ The Svix Bridge changelog has moved to [bridge/ChangeLog.md](./bridge/ChangeLog.
 
 ## Unreleased
 * Libs/Rust: Add `Svix::server_url` accessor method
+* Libs/Ruby, Libs/PHP: Webhook verification now falls back to a case-insensitive
+  header lookup when the exact lowercase names are absent, so header sets like
+  `Svix-Id` (as returned by PHP's `getallheaders()` and by Rack) verify instead of
+  failing with "Missing required headers"
 
 ## Version 2.0.0
 * Libs/All **(Breaking)**: The `PatchConfig`-suffixed types are now `ConfigPatch`-suffixed

--- a/php/src/Webhook.php
+++ b/php/src/Webhook.php
@@ -40,26 +40,19 @@ class Webhook
      */
     public function verify($payload, $headers)
     {
-        if (
-            isset($headers['svix-id'])
-            && isset($headers['svix-timestamp'])
-            && isset($headers['svix-signature'])
-        ) {
-            $msgId = $headers['svix-id'];
-            $msgTimestamp = $headers['svix-timestamp'];
-            $msgSignature = $headers['svix-signature'];
-        } elseif (
-            isset($headers['webhook-id'])
-            && isset($headers['webhook-timestamp'])
-            && isset($headers['webhook-signature'])
-        ) {
-            $msgId = $headers['webhook-id'];
-            $msgTimestamp = $headers['webhook-timestamp'];
-            $msgSignature = $headers['webhook-signature'];
-        } else {
+        $signedHeaders = self::findSignedHeaders($headers);
+        if ($signedHeaders === null && is_array($headers)) {
+            // Svix sends the headers in lowercase, so the lookup above is the
+            // common case. Some servers hand them back with a different casing
+            // (`getallheaders()` typically returns `Svix-Id`), so retry once
+            // against lowercased keys rather than paying for that every time.
+            $signedHeaders = self::findSignedHeaders(array_change_key_case($headers, CASE_LOWER));
+        }
+        if ($signedHeaders === null) {
             throw new Exception\WebhookVerificationException("Missing required headers");
         }
 
+        list($msgId, $msgTimestamp, $msgSignature) = $signedHeaders;
 
         $timestamp = $this->verifyTimestamp($msgTimestamp);
 
@@ -129,5 +122,28 @@ class Webhook
     private function isPositiveInteger($v)
     {
         return is_numeric($v) && !is_float($v + 0) && (int) $v == $v && (int) $v > 0;
+    }
+
+    /**
+     * Returns the id, timestamp and signature values as a list, or null when
+     * neither the branded nor the unbranded set of headers is present.
+     */
+    private static function findSignedHeaders($headers)
+    {
+        foreach (["svix", "webhook"] as $prefix) {
+            if (
+                isset($headers["{$prefix}-id"])
+                && isset($headers["{$prefix}-timestamp"])
+                && isset($headers["{$prefix}-signature"])
+            ) {
+                return [
+                    $headers["{$prefix}-id"],
+                    $headers["{$prefix}-timestamp"],
+                    $headers["{$prefix}-signature"],
+                ];
+            }
+        }
+
+        return null;
     }
 }

--- a/php/tests/WebhookTest.php
+++ b/php/tests/WebhookTest.php
@@ -40,6 +40,78 @@ final class WebhookTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testTitleCasedSignatureIsValidAndReturnsJson()
+    {
+        $testPayload = new TestPayload(time());
+        $testPayload->header = array(
+            "Svix-Id" => $testPayload->header['svix-id'],
+            "Svix-Signature" => $testPayload->header['svix-signature'],
+            "Svix-Timestamp" => $testPayload->header['svix-timestamp'],
+        );
+
+        $wh = new \Svix\Webhook($testPayload->secret);
+        $json = $wh->verify($testPayload->payload, $testPayload->header);
+
+        $this->assertEquals(
+            $json['test'],
+            2432232315,
+            "did not return expected json"
+        );
+    }
+
+    public function testMixedCaseSignatureIsValidAndReturnsJson()
+    {
+        $testPayload = new TestPayload(time());
+        $testPayload->header = array(
+            "SVIX-ID" => $testPayload->header['svix-id'],
+            "sViX-SiGnAtUrE" => $testPayload->header['svix-signature'],
+            "Svix-TimeStamp" => $testPayload->header['svix-timestamp'],
+        );
+
+        $wh = new \Svix\Webhook($testPayload->secret);
+        $json = $wh->verify($testPayload->payload, $testPayload->header);
+
+        $this->assertEquals(
+            $json['test'],
+            2432232315,
+            "did not return expected json"
+        );
+    }
+
+    public function testTitleCasedBrandlessSignatureIsValidAndReturnsJson()
+    {
+        $testPayload = new TestPayload(time());
+        $testPayload->header = array(
+            "Webhook-Id" => $testPayload->header['svix-id'],
+            "Webhook-Signature" => $testPayload->header['svix-signature'],
+            "Webhook-Timestamp" => $testPayload->header['svix-timestamp'],
+        );
+
+        $wh = new \Svix\Webhook($testPayload->secret);
+        $json = $wh->verify($testPayload->payload, $testPayload->header);
+
+        $this->assertEquals(
+            $json['test'],
+            2432232315,
+            "did not return expected json"
+        );
+    }
+
+    public function testMissingTitleCasedIdThrowsException()
+    {
+        $this->expectException(\Svix\Exception\WebhookVerificationException::class);
+        $this->expectExceptionMessage("Missing required headers");
+
+        $testPayload = new TestPayload(time());
+        $testPayload->header = array(
+            "Svix-Signature" => $testPayload->header['svix-signature'],
+            "Svix-Timestamp" => $testPayload->header['svix-timestamp'],
+        );
+
+        $wh = new \Svix\Webhook($testPayload->secret);
+        $wh->verify($testPayload->payload, $testPayload->header);
+    }
+
     public function testInvalidSignatureThrowsException()
     {
         $this->expectException(\Svix\Exception\WebhookVerificationException::class);

--- a/ruby/lib/svix/webhook.rb
+++ b/ruby/lib/svix/webhook.rb
@@ -27,16 +27,9 @@ module Svix
     end
 
     def verify(payload, headers)
-      msgId = headers["svix-id"]
-      msgSignature = headers["svix-signature"]
-      msgTimestamp = headers["svix-timestamp"]
+      msgId, msgTimestamp, msgSignature = find_signed_headers(headers)
       if !msgSignature || !msgId || !msgTimestamp
-        msgId = headers["webhook-id"]
-        msgSignature = headers["webhook-signature"]
-        msgTimestamp = headers["webhook-timestamp"]
-        if !msgSignature || !msgId || !msgTimestamp
-          raise WebhookVerificationError, "Missing required headers"
-        end
+        raise WebhookVerificationError, "Missing required headers"
       end
 
       verify_timestamp(msgTimestamp)
@@ -73,6 +66,41 @@ module Svix
     private
     SECRET_PREFIX = "whsec_"
     DEFAULT_TOLERANCE = 5 * 60
+
+    # Returns the id, timestamp and signature values, or nil when neither the
+    # branded nor the unbranded set of headers is present.
+    def find_signed_headers(headers)
+      found = lookup_signed_headers(headers)
+      return found if found
+
+      # Svix sends the headers in lowercase, so the lookup above is the common
+      # case. Some servers hand them back with a different casing (Rack
+      # typically yields "Svix-Id"), so retry once against downcased keys
+      # rather than paying for that every time.
+      return nil unless headers.respond_to?(:each_pair)
+
+      lookup_signed_headers(downcase_keys(headers))
+    end
+
+    def lookup_signed_headers(headers)
+      ["svix", "webhook"].each do |prefix|
+        msgId = headers["#{prefix}-id"]
+        msgTimestamp = headers["#{prefix}-timestamp"]
+        msgSignature = headers["#{prefix}-signature"]
+
+        if msgId && msgTimestamp && msgSignature
+          return [msgId, msgTimestamp, msgSignature]
+        end
+      end
+
+      nil
+    end
+
+    def downcase_keys(headers)
+      headers.each_pair.with_object({}) do |(name, value), downcased|
+        downcased[name.to_s.downcase] = value
+      end
+    end
 
     def verify_timestamp(timestampHeader)
       begin

--- a/ruby/spec/webhook_spec.rb
+++ b/ruby/spec/webhook_spec.rb
@@ -107,6 +107,58 @@ describe Svix::Webhook do
     wh.verify(testPayload.payload, testPayload.headers)
   end
 
+  it "title cased signature is valid" do
+    testPayload = TestPayload.new
+    testPayload.headers = {
+      "Svix-Id" => testPayload.headers["svix-id"],
+      "Svix-Signature" => testPayload.headers["svix-signature"],
+      "Svix-Timestamp" => testPayload.headers["svix-timestamp"]
+    }
+
+    wh = Svix::Webhook.new(testPayload.secret)
+
+    wh.verify(testPayload.payload, testPayload.headers)
+  end
+
+  it "mixed case signature is valid" do
+    testPayload = TestPayload.new
+    testPayload.headers = {
+      "SVIX-ID" => testPayload.headers["svix-id"],
+      "sViX-SiGnAtUrE" => testPayload.headers["svix-signature"],
+      "Svix-TimeStamp" => testPayload.headers["svix-timestamp"]
+    }
+
+    wh = Svix::Webhook.new(testPayload.secret)
+
+    wh.verify(testPayload.payload, testPayload.headers)
+  end
+
+  it "title cased unbranded signature is valid" do
+    testPayload = TestPayload.new
+    testPayload.headers = {
+      "Webhook-Id" => testPayload.headers["svix-id"],
+      "Webhook-Signature" => testPayload.headers["svix-signature"],
+      "Webhook-Timestamp" => testPayload.headers["svix-timestamp"]
+    }
+
+    wh = Svix::Webhook.new(testPayload.secret)
+
+    wh.verify(testPayload.payload, testPayload.headers)
+  end
+
+  it "missing title cased id raises error" do
+    testPayload = TestPayload.new
+    testPayload.headers = {
+      "Svix-Signature" => testPayload.headers["svix-signature"],
+      "Svix-Timestamp" => testPayload.headers["svix-timestamp"]
+    }
+
+    wh = Svix::Webhook.new(testPayload.secret)
+
+    expect { wh.verify(testPayload.payload, testPayload.headers) }
+      .to(raise_error(Svix::WebhookVerificationError, /Missing required headers/))
+  end
+
   it "old timestamp raises error" do
     testPayload = TestPayload.new(timestamp: Time.now.to_i - TOLERANCE - 1)
 


### PR DESCRIPTION
## Motivation

The PHP and Ruby verifiers look the signature headers up by their exact lowercase names, so a request whose headers arrive as `Svix-Id` rather than `svix-id` is rejected with "Missing required headers" even though the signature itself is perfectly good. HTTP header names are case-insensitive, so nothing on the sending side is wrong here. It is the receiving side that decides the casing, and the casing it picks is often not lowercase. PHP's `getallheaders()` commonly hands back `Svix-Id`, and Rack presents the same shape to Ruby apps, so an otherwise correct integration fails purely on how the server chose to spell the header names.

The other libraries already handle this. `python/svix/webhooks.py` lowercases every incoming key before it looks anything up, and `javascript/src/webhook.ts` does the same at the top of `Webhook.verify`. Go never had the problem, since `http.Header.Get` is case-insensitive by spec. PHP and Ruby are the two that were left behind.

## Solution

Both verifiers now try the exact lowercase names first, exactly as they did before, and build a lowercased view of the headers only when that first lookup comes up empty. The path for headers spelled the way Svix actually sends them is unchanged and does no extra work, which is what the issue asks for. The lowercased retry preserves the existing preference for the branded `svix-` names over the unbranded `webhook-` ones. When both sets are present at once, an exact lowercase match still wins over a differently cased one, which is the cost of keeping the common path free of any allocation.

Tests were added in `php/tests/WebhookTest.php` and `ruby/spec/webhook_spec.rb`. Each language covers a title-cased header set and a deliberately mixed-case one using `SVIX-ID` alongside `sViX-SiGnAtUrE`. The unbranded `Webhook-` names are covered in title case as well. Each language also has a case where one of the title-cased headers is genuinely absent and verification still raises "Missing required headers", so the fallback cannot quietly paper over an incomplete request. The exact lowercase path was already covered by the existing tests and still passes.

I ran `vendor/bin/phpunit --configuration phpunit.xml` and `bundle exec rspec spec/webhook_spec.rb` locally, on PHP 8.5.9 and Ruby 3.3.0. Reverting the two source files while keeping the new tests makes the casing tests fail, so they do exercise the change. There is a ChangeLog entry under Unreleased.

Fixes #1013