### PR TITLE
rust: Add Svix::server_url

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ The Svix Server changelog has moved to [server/ChangeLog.md](./server/ChangeLog.
 The Svix Bridge changelog has moved to [bridge/ChangeLog.md](./bridge/ChangeLog.md).
 
 ## Unreleased
+* Libs/Rust: Add `Svix::server_url` accessor method
 
 ## Version 2.0.0
 * Libs/All **(Breaking)**: The `PatchConfig`-suffixed types are now `ConfigPatch`-suffixed

--- a/rust/src/api/client.rs
+++ b/rust/src/api/client.rs
@@ -133,7 +133,7 @@ impl Svix {
                 Some("au") => "https://api.au.svix.com",
                 _ => "https://api.svix.com",
             }
-            .to_string()
+            .to_owned()
         });
         let cfg = Arc::new(Configuration {
             base_path,
@@ -158,6 +158,14 @@ impl Svix {
     /// Get back the access token used to construct this `Svix` client.
     pub fn token(&self) -> Option<&str> {
         self.cfg.bearer_access_token.as_deref()
+    }
+
+    /// Get the server base URL used for API requests.
+    ///
+    /// Never includes a trailing slash, even if one was part of the server URL
+    /// passed via [`SvixOptions`].
+    pub fn server_url(&self) -> &str {
+        &self.cfg.base_path
     }
 }
 


### PR DESCRIPTION
We are using this internally, currently via the cfg method that's public in v1 of the SDK.
