### PR TITLE
bridge: Upgrade dependencies

### DIFF
--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -4690,7 +4690,6 @@ dependencies = [
  "enum_dispatch",
  "indexmap",
  "itertools 0.15.0",
- "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",

--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -4689,7 +4689,7 @@ dependencies = [
  "deno_core",
  "enum_dispatch",
  "indexmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",

--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -5026,7 +5026,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -5081,9 +5081,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-ctl"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+checksum = "3a184c43b8ab2f41df2733b55556e3f5f632f4aeaa205b1bb018f574b7f5f142"
 dependencies = [
  "libc",
  "paste",
@@ -5092,9 +5092,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
 dependencies = [
  "cc",
  "libc",
@@ -5102,9 +5102,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -48,9 +48,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amq-protocol"
-version = "8.3.1"
+version = "10.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355603365d2217f7fbc03f0be085ea1440498957890f04276402012cdde445f5"
+checksum = "b63f30a81ad95c7a278080be6d993d5b3e971d93e1b00bd894067220fc756804"
 dependencies = [
  "amq-protocol-tcp",
  "amq-protocol-types",
@@ -62,24 +62,22 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-tcp"
-version = "8.3.1"
+version = "10.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7b97a85e08671697e724a6b7f1459ff81603613695e3151764a9529c6fec15"
+checksum = "2b1bcecdd743111f05c26294d26b887ba6b2e4789c27515aa48f0fe32066e96c"
 dependencies = [
  "amq-protocol-uri",
- "async-trait",
+ "async-rs",
  "cfg-if",
- "executor-trait 2.1.2",
- "reactor-trait 2.8.0",
  "tcp-stream",
  "tracing",
 ]
 
 [[package]]
 name = "amq-protocol-types"
-version = "8.3.1"
+version = "10.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2984a816dba991b5922503921d8f94650792bdeac47c27c83830710d2567f63"
+checksum = "8a268a50e97bd5d52292a8b96636f6436215def6f3d128fb8218318f5feb4c33"
 dependencies = [
  "cookie-factory",
  "nom 8.0.0",
@@ -89,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "amq-protocol-uri"
-version = "8.3.1"
+version = "10.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31db8e69d1456ec8ecf6ee598707179cf1d95f34f7d30037b16ad43f0cddcff"
+checksum = "8a34581b010818ef3da6b5a853e94f6438b3903914baba77a15f7fb2c7ad8958"
 dependencies = [
  "amq-protocol-types",
  "percent-encoding",
@@ -182,6 +180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arcstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+
+[[package]]
 name = "asn1-rs"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +258,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compat"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ba85bc55464dcbf728b56d97e119d673f4cf9062be330a9a26f3acf504a590"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "once_cell",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,52 +292,10 @@ checksum = "13f937e26114b93193065fd44f507aa2e9169ad0cdabbb996920b1fe1ddea7ba"
 dependencies = [
  "async-channel",
  "async-executor",
- "async-io",
  "async-lock",
  "blocking",
  "futures-lite",
-]
-
-[[package]]
-name = "async-global-executor-trait"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af57045d58eeb1f7060e7025a1631cbc6399e0a1d10ad6735b3d0ea7f8346ce"
-dependencies = [
- "async-global-executor",
- "async-trait",
- "executor-trait 2.1.2",
-]
-
-[[package]]
-name = "async-global-executor-trait"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3727b7da74b92d2d03403cf1142706b53423e5c050791af438f8f50edea057a"
-dependencies = [
- "async-global-executor",
- "async-global-executor-trait 2.2.0",
- "async-trait",
- "executor-trait 2.1.2",
- "executor-trait 3.1.0",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix 1.1.4",
- "slab",
- "windows-sys 0.61.2",
+ "tokio",
 ]
 
 [[package]]
@@ -335,15 +310,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-reactor-trait"
-version = "3.1.1"
+name = "async-rs"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab52004af1f14a170088bd9e10a2d3b2f2307ce04320e58a6ce36ee531be625"
+checksum = "3cd5147201b63ba6883ffabca3a153822f71541748d7108e3e799beaeb283131"
 dependencies = [
- "async-io",
+ "async-compat",
+ "async-global-executor",
  "async-trait",
  "futures-core",
- "reactor-trait 3.1.1",
+ "futures-io",
+ "hickory-resolver",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -944,16 +923,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bb8-redis"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5143936af5e1eea1a881e3e3d21b6777da6315e5e307bc3d0c2301c44fa37da9"
-dependencies = [
- "bb8",
- "redis",
-]
-
-[[package]]
 name = "better_scoped_tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,6 +1359,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1681,7 +1674,7 @@ dependencies = [
  "asn1-rs",
  "displaydoc",
  "nom 7.1.3",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "rusticata-macros",
 ]
@@ -1752,7 +1745,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33175ddb7a6d418589cab2966bd14a710b3b1139459d3d5ca9edf783c4833f4c"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "rustc-hash",
  "swc_atoms",
  "swc_common",
@@ -1847,24 +1840,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "executor-trait"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c39dff9342e4e0e16ce96be751eb21a94e94a87bb2f6e63ad1961c2ce109bf"
-dependencies = [
- "async-trait",
-]
-
-[[package]]
-name = "executor-trait"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d6a1fc6700fa12782770cb344a29172ae940ea41d5fd5049fdf236dd6eaa92"
-dependencies = [
- "async-trait",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1894,9 +1869,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2274,6 +2249,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto",
+ "idna",
+ "ipnet",
+ "jni",
+ "rand 0.10.2",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.2",
+ "ring",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto",
+ "ipconfig",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.2",
+ "resolv-conf",
+ "smallvec",
+ "system-configuration",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2630,10 +2675,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "is-macro"
@@ -2785,20 +2846,19 @@ dependencies = [
 
 [[package]]
 name = "lapin"
-version = "3.7.2"
+version = "4.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "913a84142a99160ecef997a5c17c53639bcbac4424a0315a5ffe6c8be8e8db86"
+checksum = "0fd20e01fd92597ca352ca7ceed3c589851ebad279dfcada48aa4d24fd3a7caa"
 dependencies = [
  "amq-protocol",
- "async-global-executor-trait 3.1.0",
- "async-reactor-trait",
+ "async-rs",
  "async-trait",
  "backon",
- "executor-trait 2.1.2",
+ "cfg-if",
+ "event-listener",
  "flume",
  "futures-core",
  "futures-io",
- "reactor-trait 2.8.0",
  "tracing",
 ]
 
@@ -2930,6 +2990,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2945,6 +3022,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -3002,6 +3085,16 @@ dependencies = [
  "num-traits",
  "rand 0.8.7",
  "serde",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -3081,12 +3174,11 @@ dependencies = [
 [[package]]
 name = "omniqueue"
 version = "0.3.0"
-source = "git+https://github.com/svix/omniqueue-rs?rev=cd5d3995d104da36f952c2770b50535450514f92#cd5d3995d104da36f952c2770b50535450514f92"
+source = "git+https://github.com/svix/omniqueue-rs?rev=8b760df52eb9210c86e6d898ffe8d44f552bd782#8b760df52eb9210c86e6d898ffe8d44f552bd782"
 dependencies = [
  "aws-config",
  "aws-sdk-sqs",
  "bb8",
- "bb8-redis",
  "bytesize",
  "futures-util",
  "gcloud-googleapis",
@@ -3095,10 +3187,9 @@ dependencies = [
  "redis",
  "serde",
  "serde_json",
- "svix-ksuid 0.8.0",
+ "svix-ksuid",
  "sync_wrapper",
  "thiserror",
- "time",
  "tokio",
  "tracing",
 ]
@@ -3108,6 +3199,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -3456,20 +3551,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "portable-atomic"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3497,6 +3578,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
 ]
 
 [[package]]
@@ -3792,42 +3884,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "reactor-trait"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffbbf16bc3e4db5fdcf4b77cebf1313610b54b339712aa90088d2d9b1acb1f1"
-dependencies = [
- "async-trait",
- "reactor-trait 3.1.1",
-]
-
-[[package]]
-name = "reactor-trait"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1c85237926dd82e8bc3634240ecf2236ea81e904b3d83cdb1df974af9af293"
-dependencies = [
- "async-io",
- "async-trait",
- "executor-trait 2.1.2",
- "flume",
- "futures-core",
- "futures-io",
-]
-
-[[package]]
 name = "redis"
-version = "0.32.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "014cc767fefab6a3e798ca45112bccad9c6e0e218fbd49720042716c73cfef44"
+checksum = "e37a4ca5c6ca42aa3e6df2fd32b987a65d32a4c2159a6f3fe0fd1df306a2658f"
 dependencies = [
+ "arcstr",
+ "async-lock",
  "bytes",
  "cfg-if",
  "combine",
  "futures-util",
  "itoa",
  "native-tls",
- "num-bigint",
+ "num-bigint 0.5.1",
  "percent-encoding",
  "pin-project-lite",
  "ryu",
@@ -3837,6 +3907,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-util",
  "url",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -3925,6 +3996,12 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "ring"
@@ -4016,16 +4093,16 @@ dependencies = [
 
 [[package]]
 name = "rustls-connector"
-version = "0.21.11"
+version = "0.23.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10eb7ce243317e6b6a342ef6bff8c2e0d46d78120a9aeb2ee39693a569615c96"
+checksum = "1babecfcc65b139b812e74bcc7f9ec7b4e00db659fd42d99567b7e77f0c714c6"
 dependencies = [
  "futures-io",
  "futures-rustls",
  "log",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "rustls-webpki",
 ]
 
@@ -4039,15 +4116,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -4281,7 +4349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3495190857461e87a2716141043218aad5281f219f54a03b7ebbe605b3b931df"
 dependencies = [
  "deno_error 0.6.1",
- "num-bigint",
+ "num-bigint 0.4.8",
  "serde",
  "smallvec",
  "thiserror",
@@ -4414,7 +4482,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "thiserror",
  "time",
@@ -4635,7 +4703,7 @@ dependencies = [
  "svix-bridge-plugin-kafka",
  "svix-bridge-plugin-queue",
  "svix-bridge-types",
- "svix-ksuid 0.10.0",
+ "svix-ksuid",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "tokio",
@@ -4668,6 +4736,7 @@ dependencies = [
 name = "svix-bridge-plugin-queue"
 version = "1.100.0"
 dependencies = [
+ "async-rs",
  "aws-config",
  "aws-credential-types",
  "aws-sdk-sqs",
@@ -4682,8 +4751,6 @@ dependencies = [
  "svix-bridge-types",
  "thiserror",
  "tokio",
- "tokio-executor-trait 3.1.0",
- "tokio-reactor-trait",
  "tracing",
  "tracing-subscriber",
  "wiremock",
@@ -4698,18 +4765,6 @@ dependencies = [
  "serde_json",
  "svix",
  "tokio",
-]
-
-[[package]]
-name = "svix-ksuid"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66f014385b7fc154f59e9480770c2187b6e61037c2439895788a9a4d421d7859"
-dependencies = [
- "base-encode",
- "byteorder",
- "getrandom 0.2.17",
- "time",
 ]
 
 [[package]]
@@ -4748,7 +4803,7 @@ dependencies = [
  "either",
  "from_variant",
  "new_debug_unreachable",
- "num-bigint",
+ "num-bigint 0.4.8",
  "once_cell",
  "rustc-hash",
  "serde",
@@ -4769,7 +4824,7 @@ checksum = "a573a0c72850dec8d4d8085f152d5778af35a2520c3093b242d2d1d50776da7c"
 dependencies = [
  "bitflags",
  "is-macro",
- "num-bigint",
+ "num-bigint 0.4.8",
  "once_cell",
  "phf",
  "rustc-hash",
@@ -4789,7 +4844,7 @@ checksum = "5e82f7747e052c6ff6e111fa4adeb14e33b46ee6e94fe5ef717601f651db48fc"
 dependencies = [
  "bitflags",
  "either",
- "num-bigint",
+ "num-bigint 0.4.8",
  "rustc-hash",
  "seq-macro",
  "serde",
@@ -4811,7 +4866,7 @@ checksum = "7f1a51af1a92cd4904c073b293e491bbc0918400a45d58227b34c961dd6f52d7"
 dependencies = [
  "bitflags",
  "either",
- "num-bigint",
+ "num-bigint 0.4.8",
  "phf",
  "rustc-hash",
  "seq-macro",
@@ -4940,6 +4995,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4947,16 +5008,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tcp-stream"
-version = "0.30.9"
+version = "0.34.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282ebecea8280bce8b7a0695b5dc93a19839dd445cbba70d3e07c9f6e12c4653"
+checksum = "300d0735de48a565461c2ea14cc75b80ee5b6be3b4f5aeabe3553e4c2df8d23d"
 dependencies = [
+ "async-rs",
  "cfg-if",
  "futures-io",
  "p12-keystore",
- "reactor-trait 2.8.0",
  "rustls-connector",
- "rustls-pemfile",
 ]
 
 [[package]]
@@ -5132,30 +5192,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-executor-trait"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6278565f9fd60c2d205dfbc827e8bb1236c2b1a57148708e95861eff7a6b3bad"
-dependencies = [
- "async-trait",
- "executor-trait 2.1.2",
- "tokio",
-]
-
-[[package]]
-name = "tokio-executor-trait"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7fe39b60ffe238db070f2e66fab42c3c2967482e2fbf754afd7e65525cf0da"
-dependencies = [
- "async-trait",
- "executor-trait 2.1.2",
- "executor-trait 3.1.0",
- "tokio",
- "tokio-executor-trait 2.4.0",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5174,21 +5210,6 @@ checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
-]
-
-[[package]]
-name = "tokio-reactor-trait"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5410ef3f06b4ca0b3868bebeb24e19fef3a05e2ad086f2b8230f2bdf4052cdf"
-dependencies = [
- "async-trait",
- "futures-core",
- "futures-io",
- "reactor-trait 3.1.1",
- "tokio",
- "tokio-stream",
- "tokio-util",
 ]
 
 [[package]]
@@ -5230,7 +5251,6 @@ checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
- "futures-io",
  "futures-sink",
  "libc",
  "pin-project-lite",
@@ -5748,6 +5768,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6031,6 +6057,12 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "yoke"

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -33,6 +33,7 @@ uninlined_format_args = "warn"
 
 [workspace.dependencies]
 axum = { version = "0.8.9", features = ["macros"] }
+omniqueue = { git = "https://github.com/svix/omniqueue-rs", rev = "8b760df52eb9210c86e6d898ffe8d44f552bd782", default-features = false, features = ["gcp_pubsub", "rabbitmq", "redis", "sqs"] }
 opentelemetry = "0.32.0"
 opentelemetry-otlp = { version = "0.32.0", features = ["metrics", "grpc-tonic", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.32.0", features = ["metrics", "rt-tokio", "experimental_metrics_periodicreader_with_async_runtime", "experimental_trace_batch_span_processor_with_async_runtime"] }

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -33,6 +33,7 @@ uninlined_format_args = "warn"
 
 [workspace.dependencies]
 axum = { version = "0.8.9", features = ["macros"] }
+itertools = "0.15.0"
 omniqueue = { git = "https://github.com/svix/omniqueue-rs", rev = "8b760df52eb9210c86e6d898ffe8d44f552bd782", default-features = false, features = ["gcp_pubsub", "rabbitmq", "redis", "sqs"] }
 opentelemetry = "0.32.0"
 opentelemetry-otlp = { version = "0.32.0", features = ["metrics", "grpc-tonic", "reqwest-client"] }

--- a/bridge/svix-bridge-plugin-queue/Cargo.toml
+++ b/bridge/svix-bridge-plugin-queue/Cargo.toml
@@ -7,30 +7,24 @@ publish = false
 license.workspace = true
 
 [dependencies]
+omniqueue.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 svix-bridge-types.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
-tokio-executor-trait = "3.1"
-tokio-reactor-trait = "4.1"
 tracing.workspace = true
 
-[dependencies.omniqueue]
-git = "https://github.com/svix/omniqueue-rs"
-rev = "cd5d3995d104da36f952c2770b50535450514f92"
-default-features = false
-features = ["gcp_pubsub", "rabbitmq", "redis", "sqs"]
-
 [dev-dependencies]
+async-rs = "0.8.11"
 aws-config = "1.8.12"
 aws-credential-types = "1.2"
 aws-sdk-sqs = { version = "1.97.0", default-features = false, features = ["default-https-client", "rt-tokio"] }
 fastrand = "2.0.1"
 gcloud-googleapis = "1.2.0"
 gcloud-pubsub = "1.3.0"
-lapin = "3.7.2"
-redis = { version = "0.32.4", features = ["tokio-comp", "streams"] }
+lapin = "4.10.0"
+redis = { version = "1.6.0", features = ["tokio-comp", "streams"] }
 tracing-subscriber.workspace = true
 wiremock.workspace = true
 

--- a/bridge/svix-bridge-plugin-queue/tests/it/rabbitmq_consumer.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/it/rabbitmq_consumer.rs
@@ -56,7 +56,7 @@ fn get_test_plugin(
 async fn declare_queue(name: &str, channel: &Channel) -> Queue {
     channel
         .queue_declare(
-            name,
+            name.into(),
             QueueDeclareOptions {
                 auto_delete: true,
                 ..Default::default()
@@ -68,18 +68,17 @@ async fn declare_queue(name: &str, channel: &Channel) -> Queue {
 }
 
 async fn mq_connection(uri: &str) -> Connection {
-    let options = ConnectionProperties::default()
-        .with_connection_name("test".into())
-        .with_executor(tokio_executor_trait::Tokio::current())
-        .with_reactor(tokio_reactor_trait::Tokio::current());
-    Connection::connect(uri, options).await.unwrap()
+    let options = ConnectionProperties::default().with_connection_name("test".into());
+    Connection::connect_with_runtime(uri, options, async_rs::Runtime::tokio_current())
+        .await
+        .unwrap()
 }
 
 async fn publish(channel: &Channel, queue_name: &str, payload: &[u8]) {
     let confirm = channel
         .basic_publish(
-            "",
-            queue_name,
+            "".into(),
+            queue_name.into(),
             Default::default(),
             payload,
             Default::default(),
@@ -144,7 +143,7 @@ async fn test_consume_ok() {
 
     handle.abort();
     channel
-        .queue_delete(queue_name, Default::default())
+        .queue_delete(queue_name.into(), Default::default())
         .await
         .ok();
 }
@@ -222,7 +221,7 @@ async fn test_consume_transformed_json_ok() {
 
     handle.abort();
     channel
-        .queue_delete(queue_name, Default::default())
+        .queue_delete(queue_name.into(), Default::default())
         .await
         .ok();
 }
@@ -305,7 +304,7 @@ async fn test_consume_transformed_string_ok() {
 
     handle.abort();
     channel
-        .queue_delete(queue_name, Default::default())
+        .queue_delete(queue_name.into(), Default::default())
         .await
         .ok();
 }
@@ -358,7 +357,7 @@ async fn test_missing_app_id_nack() {
     tokio::time::sleep(Duration::from_millis(WAIT_MS)).await;
     handle.abort();
     channel
-        .queue_delete(queue_name, Default::default())
+        .queue_delete(queue_name.into(), Default::default())
         .await
         .ok();
 }
@@ -410,7 +409,7 @@ async fn test_missing_event_type_nack() {
     tokio::time::sleep(Duration::from_millis(WAIT_MS)).await;
     handle.abort();
     channel
-        .queue_delete(queue_name, Default::default())
+        .queue_delete(queue_name.into(), Default::default())
         .await
         .ok();
 }
@@ -461,7 +460,7 @@ async fn test_consume_svix_503() {
     assert!(!handle.is_finished());
     handle.abort();
     channel
-        .queue_delete(queue_name, Default::default())
+        .queue_delete(queue_name.into(), Default::default())
         .await
         .ok();
 }
@@ -506,7 +505,7 @@ async fn test_consume_svix_offline() {
     assert!(!handle.is_finished());
     handle.abort();
     channel
-        .queue_delete(queue_name, Default::default())
+        .queue_delete(queue_name.into(), Default::default())
         .await
         .ok();
 }

--- a/bridge/svix-bridge-plugin-queue/tests/it/rabbitmq_receiver.rs
+++ b/bridge/svix-bridge-plugin-queue/tests/it/rabbitmq_receiver.rs
@@ -20,7 +20,7 @@ use tokio::{
 async fn declare_queue(name: &str, channel: &Channel) -> Queue {
     channel
         .queue_declare(
-            name,
+            name.into(),
             QueueDeclareOptions {
                 auto_delete: true,
                 ..Default::default()
@@ -32,11 +32,10 @@ async fn declare_queue(name: &str, channel: &Channel) -> Queue {
 }
 
 async fn mq_connection(uri: &str) -> Connection {
-    let options = ConnectionProperties::default()
-        .with_connection_name("test".into())
-        .with_executor(tokio_executor_trait::Tokio::current())
-        .with_reactor(tokio_reactor_trait::Tokio::current());
-    Connection::connect(uri, options).await.unwrap()
+    let options = ConnectionProperties::default().with_connection_name("test".into());
+    Connection::connect_with_runtime(uri, options, async_rs::Runtime::tokio_current())
+        .await
+        .unwrap()
 }
 
 const WAIT_MS: u64 = 200;

--- a/bridge/svix-bridge/Cargo.toml
+++ b/bridge/svix-bridge/Cargo.toml
@@ -12,8 +12,8 @@ kafka = ["dep:svix-bridge-plugin-kafka"]
 jemalloc = ["tikv-jemallocator", "tikv-jemalloc-ctl"]
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemalloc-ctl = { version = "0.6.0", optional = true, features = ["use_std", "stats"] }
-tikv-jemallocator = { version = "0.6.0", optional = true }
+tikv-jemalloc-ctl = { version = "0.7.0", optional = true, features = ["use_std", "stats"] }
+tikv-jemallocator = { version = "0.7.0", optional = true }
 
 [dependencies]
 anyhow = "1"

--- a/bridge/svix-bridge/Cargo.toml
+++ b/bridge/svix-bridge/Cargo.toml
@@ -26,7 +26,6 @@ deno_core = "0.352.1"
 enum_dispatch = "0.3"
 indexmap = { version = "2.10.0", features = ["serde"] }
 itertools.workspace = true
-once_cell = "1.18.0"
 opentelemetry.workspace = true
 opentelemetry-otlp.workspace = true
 opentelemetry_sdk.workspace = true

--- a/bridge/svix-bridge/Cargo.toml
+++ b/bridge/svix-bridge/Cargo.toml
@@ -25,7 +25,7 @@ deno_ast = "0.53.0"
 deno_core = "0.352.1"
 enum_dispatch = "0.3"
 indexmap = { version = "2.10.0", features = ["serde"] }
-itertools = "0.14.0"
+itertools.workspace = true
 once_cell = "1.18.0"
 opentelemetry.workspace = true
 opentelemetry-otlp.workspace = true

--- a/bridge/svix-bridge/src/main.rs
+++ b/bridge/svix-bridge/src/main.rs
@@ -1,12 +1,12 @@
 use std::{
     io::{Error, Result},
     path::PathBuf,
+    sync::LazyLock,
     time::Duration,
 };
 
 use clap::Parser;
 use itertools::{Either, Itertools};
-use once_cell::sync::Lazy;
 use opentelemetry::{InstrumentationScope, trace::TracerProvider as _};
 use opentelemetry_otlp::WithExportConfig as _;
 use opentelemetry_sdk::{
@@ -44,7 +44,7 @@ compile_error!("jemalloc cannot be enabled on msvc");
 // Seems like it would be useful to be able to configure this.
 // In some docker setups, hostname is sometimes the container id, and advertising this can be
 // helpful.
-static INSTANCE_ID: Lazy<String> = Lazy::new(|| KsuidMs::now(None).to_string());
+static INSTANCE_ID: LazyLock<String> = LazyLock::new(|| KsuidMs::now(None).to_string());
 
 fn get_svc_identifiers(cfg: &Config) -> opentelemetry_sdk::Resource {
     opentelemetry_sdk::Resource::builder()

--- a/bridge/svix-bridge/src/webhook_receiver/mod.rs
+++ b/bridge/svix-bridge/src/webhook_receiver/mod.rs
@@ -1,4 +1,9 @@
-use std::{convert::Infallible, net::SocketAddr, sync::Arc, time::Duration};
+use std::{
+    convert::Infallible,
+    net::SocketAddr,
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
 
 use axum::{
     Router,
@@ -39,8 +44,7 @@ fn router() -> Router<InternalState> {
         )
         .route("/health", get(health_handler))
 }
-static START_TIME: once_cell::sync::Lazy<std::time::Instant> =
-    once_cell::sync::Lazy::new(std::time::Instant::now);
+static START_TIME: LazyLock<std::time::Instant> = LazyLock::new(std::time::Instant::now);
 
 fn get_uptime_seconds() -> u64 {
     START_TIME.elapsed().as_secs()
@@ -64,7 +68,7 @@ pub async fn run(
     routes: Vec<WebhookReceiverConfig>,
     transformer_tx: TransformerTx,
 ) -> std::io::Result<()> {
-    once_cell::sync::Lazy::force(&START_TIME);
+    LazyLock::force(&START_TIME);
     let state = InternalState::from_receiver_configs(routes, transformer_tx)
         .await
         .map_err(std::io::Error::other)?;

--- a/deny.toml
+++ b/deny.toml
@@ -18,10 +18,6 @@ ignore = [
     "RUSTSEC-2026-0173",
     # TODO: Wait for dependencies to upgrade off of paste
     "RUSTSEC-2024-0436",
-    # rustls-pemfile is unmaintained, but we only use it for parsing system
-    # certificates. This is not a serious attack vector for our use case.
-    # TODO: Upgrade rustls-native-certs to 0.8.x to get rid of this.
-    "RUSTSEC-2025-0134",
     # bincode (depended on by deno) is unmaintained
     "RUSTSEC-2025-0141",
     # smartstring (dependency of deno) is unmaintained

--- a/deny.toml
+++ b/deny.toml
@@ -30,6 +30,7 @@ allow = [
     "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "BSL-1.0",
     "CDLA-Permissive-2.0",
     "ISC",
     "MIT",


### PR DESCRIPTION
… and drop `once_cell` because we can use std's `LazyLock` instead.