### PR TITLE
Release SDKs + CLI v2.1.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,9 @@ The Svix Server changelog has moved to [server/ChangeLog.md](./server/ChangeLog.
 The Svix Bridge changelog has moved to [bridge/ChangeLog.md](./bridge/ChangeLog.md).
 
 ## Unreleased
+* Libs/All: Add support for new bulk-expunge endpoint (`svix.message.bulkExpungeContent`)
+  * At the time of writing, it is a cloud-only endpoint, but it is in the process of being added
+    to Svix Server OSS as well (likely to be released in Server v1.101.0)
 * Libs/Rust: Add `Svix::server_url` accessor method
 
 ## Version 2.0.0


### PR DESCRIPTION
## What's Changed

* Libs/All: Add support for new bulk-expunge endpoint (`svix.message.bulkExpungeContent`)
  * At the time of writing, it is a cloud-only endpoint, but it is in the process of being added
    to Svix Server OSS as well (likely to be released in Server v1.101.0)
* Libs/Rust: Add `Svix::server_url` accessor method