### PR TITLE
Remove tag-namespace from dist config again

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -9,8 +9,6 @@ cargo-dist-version = "0.32.0"
 ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell", "homebrew", "msi"]
-# A prefix git tags must include for dist to care about them
-tag-namespace = "sdks"
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Whether dist should create a Github Release or use an existing draft


### PR DESCRIPTION
Hoping that this will unbreak the v2.1.0 release. The option never worked anyways.