### PR TITLE
server: Install a rustls CryptoProvider at startup

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -5312,6 +5312,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rust-executable-metadata",
+ "rustls",
  "schemars",
  "sea-orm",
  "sentry",

--- a/server/ChangeLog.md
+++ b/server/ChangeLog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Fix startup panic ("Could not automatically determine the process-level CryptoProvider") when connecting to Postgres with `sslmode=verify-ca`
 
 ## Version 1.100.0
 * Upgrade dependencies

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -72,6 +72,7 @@ rand = "0.10"
 redis = { version = "0.32.5", features = ["tokio-comp", "tokio-native-tls-comp", "streams", "cluster-async", "tcp_nodelay", "connection-manager", "sentinel"] }
 regex = "1.5.5"
 reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls", "hickory-dns"] }
+rustls = "0.23.43"
 schemars = { version = "0.8.11", features = ["chrono", "url", "preserve_order"] }
 sea-orm = { version = "1.1.1", features = ["sqlx-postgres", "runtime-tokio-rustls", "macros", "with-chrono", "with-json"], default-features = false }
 sentry = { version = "0.48.2", default-features = false, features = ["backtrace", "contexts", "debug-images", "panic", "tracing", "transport"] }

--- a/server/svix-server/src/main.rs
+++ b/server/svix-server/src/main.rs
@@ -146,6 +146,12 @@ fn org_id_parser(s: &str) -> Result<OrganizationId, String> {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // rustls requires a crypto backend ("provider") choice to be made explicitly when more than
+    // one is compiled in, which is the case here: reqwest enables aws-lc-rs while sqlx and sea-orm
+    // enable ring. Without this, the first code path that asks rustls for the process-level default
+    // provider panics (for example when connecting to Postgres with `sslmode=verify-ca`).
+    _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     dotenv().ok();
 
     let args = Args::parse();


### PR DESCRIPTION
## Motivation

Since the dependency update in v1.87.0, `svix-server` panics and exits 101 before logging anything whenever rustls has to build a custom root store — most visibly when connecting to Postgres with `sslmode=verify-ca` and an explicit `sslrootcert`, a common RDS/Aurora setup:

```
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
```

Both rustls backends are enabled in the server's graph, so rustls cannot pick one:

- `aws-lc-rs` — `reqwest`'s `rustls` feature (also `jsonschema`, the `svix` SDK, `lapin`)
- `ring` — `sqlx` and `sea-orm` via `runtime-tokio-rustls`

`sslmode=require` builds no custom root store and still works, which is why a TLS-enabled Postgres smoke test passes on the affected builds.

Fixes #2579

## Solution

Install the `aws-lc-rs` provider as the first statement of `main()`, mirroring what `svix-cli/src/main.rs` already does for the same symptom. Requires `rustls` as a direct dependency of `svix-server`.

Pinning crate features so exactly one backend is enabled would also work, but `sea-orm` exposes no `aws-lc-rs` TLS feature of its own, and any future dependency re-enabling `rustls/ring` would silently bring the panic back.

### Verification

Docker image built from this branch, against Postgres with a leaf cert signed by a local CA:

| build | `sslmode=verify-ca&sslrootcert=…` |
|---|---|
| `svix/svix-server:latest` | CryptoProvider panic, exit 101 |
| this branch | migrations complete, server starts and serves |

`pg_stat_ssl` confirms `TLSv1.3` on the connection; `sslmode=require` still starts clean. `cargo clippy --all-targets --all-features -- -D warnings` is clean, and the `queue=memory,cache=none` configuration of `run-tests.sh` passes (161 tests).

No test is included: the failure is process-global rustls state at startup, which the integration suite (running in-process against a non-TLS Postgres) cannot observe.

### Disclaimer

Created with the assistance of Claude Opus 5, but with human oversight.