### PR TITLE
Release server v1.101.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,8 +9,7 @@ The Svix Bridge changelog has moved to [bridge/ChangeLog.md](./bridge/ChangeLog.
 
 ## Version 2.1.0
 * Libs/All: Add support for new bulk-expunge endpoint (`svix.message.bulkExpungeContent`)
-  * At the time of writing, it is a cloud-only endpoint, but it is in the process of being added
-    to Svix Server OSS as well (likely to be released in Server v1.101.0)
+  * For Svix Server OSS, this endpoint is available as of v1.101.0
 * Libs/Rust: Add `Svix::server_url` accessor method
 
 ## Version 2.0.0

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -5257,7 +5257,7 @@ dependencies = [
 
 [[package]]
 name = "svix-server"
-version = "1.100.0"
+version = "1.101.0"
 dependencies = [
  "aide",
  "anyhow",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "svix-server-derive"
-version = "1.99.0"
+version = "1.101.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -23,7 +23,7 @@ uninlined_format_args = "warn"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "1.99.0"
+version = "1.101.0"
 
 [profile.dev]
 # optimize host dependencies for faster rebuilds.

--- a/server/ChangeLog.md
+++ b/server/ChangeLog.md
@@ -1,7 +1,11 @@
 # Changelog
 
 ## Unreleased
+
+## Version 1.101.0
+* Add `v1.message.bulk-expunge-content` endpoint
 * Fix startup panic ("Could not automatically determine the process-level CryptoProvider") when connecting to Postgres with `sslmode=verify-ca`
+* Fix missing queue prefixes in redis queue migration code
 
 ## Version 1.100.0
 * Upgrade dependencies

--- a/server/svix-server/Cargo.toml
+++ b/server/svix-server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "svix-server"
 description = "Svix webhooks server"
 publish = false
-version = "1.100.0"
+version.workspace = true
 edition.workspace = true
 license.workspace = true
 # bump .github/workflows/server-ci.yml when changing this


### PR DESCRIPTION
## What's Changed
* Add `v1.message.bulk-expunge-content` endpoint
* Fix startup panic ("Could not automatically determine the process-level CryptoProvider") when connecting to Postgres with `sslmode=verify-ca`
* Fix missing queue prefixes in redis queue migration code