### PR TITLE
docker: bump debian base images for bridge and server

### DIFF
--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -62,7 +62,7 @@ RUN touch ./*/src/lib.rs && touch ./*/src/main.rs
 RUN cargo build --release --frozen
 
 # Production
-FROM docker.io/debian:trixie-20260713-slim AS prod
+FROM docker.io/debian:trixie-20260824-slim AS prod
 
 SHELL ["/bin/bash", "-eux", "-o", "pipefail", "-c"]
 RUN <<EOF

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -49,7 +49,7 @@ COPY . .
 RUN cargo build --release --package svix-server --bin svix-server --frozen
 
 # Production
-FROM docker.io/debian:trixie-20260713-slim AS prod
+FROM docker.io/debian:trixie-20260824-slim AS prod
 
 SHELL ["/bin/bash", "-eux", "-o", "pipefail", "-c"]
 RUN <<EOF


### PR DESCRIPTION
Debian 13.5 -> [13.6](https://www.debian.org/News/2026/20260711)
