### PR TITLE
rust: Re-export commonly used types at the crate root

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@ The Svix Server changelog has moved to [server/ChangeLog.md](./server/ChangeLog.
 The Svix Bridge changelog has moved to [bridge/ChangeLog.md](./bridge/ChangeLog.md).
 
 ## Unreleased
+* Libs/Rust: Re-export `Svix`, `Webhook`, `AutoConfig` and `AutoConfigConsumer`,
+  `Error` and `Result` at the crate root
 
 ## Version 2.1.0
 * Libs/All: Add support for new bulk-expunge endpoint (`svix.message.bulkExpungeContent`)

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2,9 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 //! Rust client library for Svix.
-//!
-//! The main entry points of this library are the API client [`api::Svix`], and
-//! [`webhooks::Webhook`].
 
 #![forbid(unsafe_code)]
 
@@ -19,4 +16,12 @@ pub mod models;
 mod request;
 pub mod webhooks;
 
-pub(crate) use api::client::Configuration;
+pub(crate) use crate::api::client::Configuration;
+
+pub use crate::{
+    api::Svix,
+    autoconfig::AutoConfig,
+    autoconfig_consumer::AutoConfigConsumer,
+    error::{Error, Result},
+    webhooks::Webhook,
+};


### PR DESCRIPTION
I noticed that in the frontend, we have a code sample that uses `svix::AutoConfigConsumer`. This isn't currently a thing, but it really should be.