### PR TITLE
php: Remove JSON decoding from Webhook.verify

### DIFF
--- a/php/src/Webhook.php
+++ b/php/src/Webhook.php
@@ -82,7 +82,7 @@ class Webhook
             }
 
             if (hash_equals($expectedSignature, $passedSignature)) {
-                return json_decode($payload, true);
+                return;
             }
         }
         throw new Exception\WebhookVerificationException("No matching signature found");

--- a/php/tests/WebhookTest.php
+++ b/php/tests/WebhookTest.php
@@ -6,21 +6,15 @@ final class WebhookTest extends \PHPUnit\Framework\TestCase
 {
     private const TOLERANCE = 5 * 60;
 
-    public function testValidSignatureIsValidAndReturnsJson()
+    public function testValidSignatureIsValid()
     {
         $testPayload = new TestPayload(time());
 
         $wh = new \Svix\Webhook($testPayload->secret);
         $json = $wh->verify($testPayload->payload, $testPayload->header);
-
-        $this->assertEquals(
-            $json['test'],
-            2432232315,
-            "did not return expected json"
-        );
     }
 
-    public function testValidBrandlessSignatureIsValidAndReturnsJson()
+    public function testValidBrandlessSignatureIsValid()
     {
         $testPayload = new TestPayload(time());
         $unbrandedHeaders = array(
@@ -32,12 +26,6 @@ final class WebhookTest extends \PHPUnit\Framework\TestCase
 
         $wh = new \Svix\Webhook($testPayload->secret);
         $json = $wh->verify($testPayload->payload, $testPayload->header);
-
-        $this->assertEquals(
-            $json['test'],
-            2432232315,
-            "did not return expected json"
-        );
     }
 
     public function testInvalidSignatureThrowsException()
@@ -128,12 +116,6 @@ final class WebhookTest extends \PHPUnit\Framework\TestCase
 
         $wh = new \Svix\Webhook($testPayload->secret, 3 * self::TOLERANCE);
         $json = $wh->verify($testPayload->payload, $testPayload->header);
-
-        $this->assertEquals(
-            $json['test'],
-            2432232315,
-            "did not return expected json"
-        );
     }
 
     public function testCustomToleranceRejectsOldTimestampInsideDefault()
@@ -153,12 +135,6 @@ final class WebhookTest extends \PHPUnit\Framework\TestCase
 
         $wh = new \Svix\Webhook($testPayload->secret, 3 * self::TOLERANCE);
         $json = $wh->verify($testPayload->payload, $testPayload->header);
-
-        $this->assertEquals(
-            $json['test'],
-            2432232315,
-            "did not return expected json"
-        );
     }
 
     public function testCustomToleranceRejectsNewTimestampInsideDefault()


### PR DESCRIPTION
This is something we did for Python and Ruby as part of 2.0.0, and thought was not present in any other SDKs. It's a breaking change, but we have not seen any use of the new PHP SDK against our cloud service yet, so it seems unlikely anybody is relying on this. We will yank 2.0.0 and 2.1.0 when this is released, if possible in php land.