### PR TITLE
js: Remove JSON parsing from Webhook.verify

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,12 @@ The Svix Server changelog has moved to [server/ChangeLog.md](./server/ChangeLog.
 The Svix Bridge changelog has moved to [bridge/ChangeLog.md](./bridge/ChangeLog.md).
 
 ## Unreleased
+* Libs/JavaScript **(Breaking)**: Remove JSON parsing from `Webhook.verify`, for consistency with
+  SDKs for other languages (this was meant to be part of the recently-released v2.0.0 but forgotten
+  for JavaScript and PHP - we're yanking v2.0.0 and v2.1.0 of the JS SDK in response)
+* Libs/PHP **(Breaking)**: Remove JSON parsing from `Webhook.verify`, for consistency with
+  SDKs for other languages (this was meant to be part of the recently-released v2.0.0 but forgotten
+  for JavaScript and PHP - we're yanking v2.0.0 and v2.1.0 of the PHP SDK in response)
 * Libs/Rust: Re-export `Svix`, `Webhook`, `AutoConfig` and `AutoConfigConsumer`,
   `Error` and `Result` at the crate root
 

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
-        "standardwebhooks": "1.0.0"
+        "standardwebhooks": "^1.1.1"
       },
       "devDependencies": {
         "@biomejs/biome": "2.2.4",
@@ -3447,9 +3447,9 @@
       }
     },
     "node_modules/standardwebhooks": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
-      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.1.1.tgz",
+      "integrity": "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==",
       "license": "MIT",
       "dependencies": {
         "@stablelib/base64": "^1.0.0",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -35,7 +35,7 @@
     "fmt": "biome format --write"
   },
   "dependencies": {
-    "standardwebhooks": "1.0.0"
+    "standardwebhooks": "^1.1.1"
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.4",

--- a/javascript/src/webhook.test.ts
+++ b/javascript/src/webhook.test.ts
@@ -124,7 +124,7 @@ test("partial signature throws error", () => {
   }, WebhookVerificationError);
 });
 
-test("valid signature is valid and returns valid json", () => {
+test("valid signature is valid", () => {
   const wh = new Webhook("MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw");
 
   const testPayload = new TestPayload();
@@ -132,7 +132,7 @@ test("valid signature is valid and returns valid json", () => {
   wh.verify(testPayload.payload, testPayload.header);
 });
 
-test("valid unbranded signature is valid and returns valid json", () => {
+test("valid unbranded signature is valid", () => {
   const wh = new Webhook("MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw");
 
   const testPayload = new TestPayload();

--- a/javascript/src/webhook.ts
+++ b/javascript/src/webhook.ts
@@ -30,7 +30,7 @@ export class Webhook {
       | WebhookRequiredHeaders
       | WebhookUnbrandedRequiredHeaders
       | Record<string, string>
-  ): unknown {
+  ): undefined {
     const headers: Record<string, string> = {};
     for (const key of Object.keys(headers_)) {
       headers[key.toLowerCase()] = (headers_ as Record<string, string>)[key];
@@ -42,7 +42,7 @@ export class Webhook {
     headers["webhook-timestamp"] =
       headers["svix-timestamp"] ?? headers["webhook-timestamp"] ?? "";
 
-    return this.inner.verify(payload, headers);
+    this.inner.verify(payload, headers, { jsonParse: false });
   }
 
   public sign(msgId: string, timestamp: Date, payload: string | Buffer): string {


### PR DESCRIPTION
Same as #2593, but for the JS SDK.