### PR TITLE
libs/ruby: fix scalar query parameter encoding

### DIFF
--- a/ruby/lib/svix/svix_http_client.rb
+++ b/ruby/lib/svix/svix_http_client.rb
@@ -113,7 +113,7 @@ module Svix
           elsif v.is_a?(Time)
             encoded_query_pairs.append("#{k}=#{CGI.escape(v.utc.to_datetime.rfc3339)}")
           else
-            encoded_query_pairs.append("#{k}=#{CGI.escape(v)}")
+            encoded_query_pairs.append("#{k}=#{CGI.escape(v.to_s)}")
           end
         elsif k == "with_content"
           # default with_content to false, it only defaults to true

--- a/ruby/spec/webmock_tests_spec.rb
+++ b/ruby/spec/webmock_tests_spec.rb
@@ -39,6 +39,24 @@ describe "API Client" do
     expect(WebMock).to(have_requested(:get, "#{host}/api/v1/app/app_id/attempt/endpoint/endpoint_id?expanded_statuses=true&with_content=false&tag=%23"))
   end
 
+  it "encodes integer and boolean query params" do
+    stub_request(:get, "#{host}/api/v1/app/app_id/msg")
+      .with(query: hash_including({}))
+      .to_return(
+        status: 200,
+        body: ListResponseMessageOut_JSON
+      )
+
+    svx.message.list("app_id", {limit: 5, with_content: true})
+
+    expect(WebMock).to(
+      have_requested(
+        :get,
+        "#{host}/api/v1/app/app_id/msg?limit=5&with_content=true"
+      )
+    )
+  end
+
   it "test Date in query param" do
     stub_request(:get, "#{host}/api/v1/app/app_id/attempt/endpoint/endpoint_id")
       .with(query: hash_including({}))


### PR DESCRIPTION
## Motivation

Fixes #2595.

The Ruby HTTP client passes ordinary query values directly to `CGI.escape`, which only accepts strings. Integer and boolean query parameters therefore raise `TypeError` before a request is sent.

## Solution

Convert ordinary scalar query values to strings before escaping them. Array and `Time` handling remain unchanged.

Added regression coverage for integer and boolean query parameters.

Validation:

- `bundle exec rake build`
- `bundle exec rspec --exclude-pattern spec/kitchen_sink_spec.rb` (57 examples)
