### PR TITLE
Accept symbol keys in Ruby struct enums

### DIFF
--- a/codegen/templates/ruby/types/struct_enum.rb.jinja
+++ b/codegen/templates/ruby/types/struct_enum.rb.jinja
@@ -69,7 +69,7 @@ module Svix
         unless ALL_FIELD.include?(k.to_s)
           fail(ArgumentError, "The field #{k} is not part of Svix::{{ class_ty }}")
         end
-        if k == "{{type.content_field | to_snake_case }}"
+        if k.to_s == "{{type.content_field | to_snake_case }}"
           unless TYPE_TO_NAME.key?(v.class)
             fail(ArgumentError, "The field #{k} can't be a `#{v.class}` expected one of #{TYPE_TO_NAME.keys}")
           end

--- a/ruby/lib/svix/models/auto_config_sink_type.rb
+++ b/ruby/lib/svix/models/auto_config_sink_type.rb
@@ -40,7 +40,7 @@ module Svix
           fail(ArgumentError, "The field #{k} is not part of Svix::AutoConfigSinkType")
         end
 
-        if k == "config"
+        if k.to_s == "config"
           unless TYPE_TO_NAME.key?(v.class)
             fail(ArgumentError, "The field #{k} can't be a `#{v.class}` expected one of #{TYPE_TO_NAME.keys}")
           end

--- a/ruby/lib/svix/models/ingest_source_in.rb
+++ b/ruby/lib/svix/models/ingest_source_in.rb
@@ -245,7 +245,7 @@ module Svix
           fail(ArgumentError, "The field #{k} is not part of Svix::IngestSourceIn")
         end
 
-        if k == "config"
+        if k.to_s == "config"
           unless TYPE_TO_NAME.key?(v.class)
             fail(ArgumentError, "The field #{k} can't be a `#{v.class}` expected one of #{TYPE_TO_NAME.keys}")
           end

--- a/ruby/lib/svix/models/ingest_source_out.rb
+++ b/ruby/lib/svix/models/ingest_source_out.rb
@@ -250,7 +250,7 @@ module Svix
           fail(ArgumentError, "The field #{k} is not part of Svix::IngestSourceOut")
         end
 
-        if k == "config"
+        if k.to_s == "config"
           unless TYPE_TO_NAME.key?(v.class)
             fail(ArgumentError, "The field #{k} can't be a `#{v.class}` expected one of #{TYPE_TO_NAME.keys}")
           end

--- a/ruby/lib/svix/models/stream_sink_in.rb
+++ b/ruby/lib/svix/models/stream_sink_in.rb
@@ -138,7 +138,7 @@ module Svix
           fail(ArgumentError, "The field #{k} is not part of Svix::StreamSinkIn")
         end
 
-        if k == "config"
+        if k.to_s == "config"
           unless TYPE_TO_NAME.key?(v.class)
             fail(ArgumentError, "The field #{k} can't be a `#{v.class}` expected one of #{TYPE_TO_NAME.keys}")
           end

--- a/ruby/lib/svix/models/stream_sink_out.rb
+++ b/ruby/lib/svix/models/stream_sink_out.rb
@@ -148,7 +148,7 @@ module Svix
           fail(ArgumentError, "The field #{k} is not part of Svix::StreamSinkOut")
         end
 
-        if k == "config"
+        if k.to_s == "config"
           unless TYPE_TO_NAME.key?(v.class)
             fail(ArgumentError, "The field #{k} can't be a `#{v.class}` expected one of #{TYPE_TO_NAME.keys}")
           end

--- a/ruby/lib/svix/models/stream_sink_patch.rb
+++ b/ruby/lib/svix/models/stream_sink_patch.rb
@@ -126,7 +126,7 @@ module Svix
           fail(ArgumentError, "The field #{k} is not part of Svix::StreamSinkPatch")
         end
 
-        if k == "config"
+        if k.to_s == "config"
           unless TYPE_TO_NAME.key?(v.class)
             fail(ArgumentError, "The field #{k} can't be a `#{v.class}` expected one of #{TYPE_TO_NAME.keys}")
           end

--- a/ruby/spec/webmock_tests_spec.rb
+++ b/ruby/spec/webmock_tests_spec.rb
@@ -306,6 +306,19 @@ describe "API Client" do
     )
   end
 
+  it "accepts symbol keys for struct enum content" do
+    sink = Svix::AutoConfigSinkType.new(
+      config: Svix::AutoConfigSinkTypeConfig::Http.new(url: "https://example.com/webhook")
+    )
+
+    expect(sink.serialize).to(
+      eq(
+        "type" => "http",
+        "config" => {"url" => "https://example.com/webhook"}
+      )
+    )
+  end
+
   it "serializes false values in patch models" do
     expect(Svix::EndpointTransformationPatch.new(enabled: false).serialize)
       .to(eq({"enabled" => false}))


### PR DESCRIPTION
## Motivation

Fixes #2596.

Generated Ruby struct enums accept symbol keys during field validation, but compare the discriminator content key only as a string. A valid symbol-keyed `config:` value is then left without its generated type discriminator.

## Solution

Normalize the content key with `to_s` in the Ruby struct-enum template and regenerate all affected models.

Added regression coverage that constructs and serializes a struct enum with a symbol-keyed `config` field.

Validation:

- `./regen_openapi.py`
- `bundle exec rake build`
- `bundle exec rspec --exclude-pattern spec/kitchen_sink_spec.rb` (57 examples)
