### PR TITLE
Align Ruby IRB dependency with lockfile

### DIFF
--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -3,6 +3,6 @@ source "https://rubygems.org"
 gem 'base64'
 gem 'logger'
 gem 'ostruct'
-gem "irb"
+gem "irb", "~> 1.18"
 
 gemspec


### PR DESCRIPTION
## Motivation

Fixes #2599.

The Ruby `Gemfile` leaves `irb` unconstrained while `Gemfile.lock` records `irb (~> 1.18)`. Bundler consequently rewrites the lockfile during release packaging.

## Solution

Declare the existing `~> 1.18` IRB constraint in the `Gemfile` so the dependency declaration and lock metadata agree.

Validation:

- `bundle lock --update irb` leaves `Gemfile.lock` unchanged
- `bundle exec rake build`
- `bundle exec rspec --exclude-pattern spec/kitchen_sink_spec.rb` (56 examples)
