### PR TITLE
libs/ruby: support nested model JSON generation

### DIFF
--- a/codegen/templates/ruby/types/struct.rb.jinja
+++ b/codegen/templates/ruby/types/struct.rb.jinja
@@ -54,8 +54,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/codegen/templates/ruby/types/struct_enum.rb.jinja
+++ b/codegen/templates/ruby/types/struct_enum.rb.jinja
@@ -22,8 +22,8 @@ module Svix
       end
       # Serializes the object to a json string
       # @return String
-      def to_json
-        JSON.dump(serialize)
+      def to_json(*args)
+        serialize.to_json(*args)
       end
       {% endif -%}
     end
@@ -111,8 +111,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
 
   end

--- a/ruby/lib/svix/models/adobe_sign_config.rb
+++ b/ruby/lib/svix/models/adobe_sign_config.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/adobe_sign_config_out.rb
+++ b/ruby/lib/svix/models/adobe_sign_config_out.rb
@@ -36,8 +36,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/aggregate_event_types_out.rb
+++ b/ruby/lib/svix/models/aggregate_event_types_out.rb
@@ -52,8 +52,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/airwallex_config.rb
+++ b/ruby/lib/svix/models/airwallex_config.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/airwallex_config_out.rb
+++ b/ruby/lib/svix/models/airwallex_config_out.rb
@@ -36,8 +36,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/api_token_out.rb
+++ b/ruby/lib/svix/models/api_token_out.rb
@@ -54,8 +54,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/app_portal_access_in.rb
+++ b/ruby/lib/svix/models/app_portal_access_in.rb
@@ -85,8 +85,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/app_portal_access_out.rb
+++ b/ruby/lib/svix/models/app_portal_access_out.rb
@@ -42,8 +42,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/app_usage_stats_in.rb
+++ b/ruby/lib/svix/models/app_usage_stats_in.rb
@@ -48,8 +48,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/app_usage_stats_out.rb
+++ b/ruby/lib/svix/models/app_usage_stats_out.rb
@@ -55,8 +55,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/application_in.rb
+++ b/ruby/lib/svix/models/application_in.rb
@@ -53,8 +53,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/application_out.rb
+++ b/ruby/lib/svix/models/application_out.rb
@@ -63,8 +63,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/application_patch.rb
+++ b/ruby/lib/svix/models/application_patch.rb
@@ -52,8 +52,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/application_token_expire_in.rb
+++ b/ruby/lib/svix/models/application_token_expire_in.rb
@@ -49,8 +49,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/auto_config_sink_type.rb
+++ b/ruby/lib/svix/models/auto_config_sink_type.rb
@@ -81,8 +81,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
 
   end

--- a/ruby/lib/svix/models/azure_blob_storage_config_in.rb
+++ b/ruby/lib/svix/models/azure_blob_storage_config_in.rb
@@ -51,8 +51,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/azure_blob_storage_config_out.rb
+++ b/ruby/lib/svix/models/azure_blob_storage_config_out.rb
@@ -45,8 +45,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/azure_blob_storage_config_patch.rb
+++ b/ruby/lib/svix/models/azure_blob_storage_config_patch.rb
@@ -48,8 +48,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/background_task_out.rb
+++ b/ruby/lib/svix/models/background_task_out.rb
@@ -52,8 +52,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/big_query_config_in.rb
+++ b/ruby/lib/svix/models/big_query_config_in.rb
@@ -50,8 +50,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/big_query_config_out.rb
+++ b/ruby/lib/svix/models/big_query_config_out.rb
@@ -45,8 +45,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/big_query_config_patch.rb
+++ b/ruby/lib/svix/models/big_query_config_patch.rb
@@ -48,8 +48,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/bulk_expunge_contents_in.rb
+++ b/ruby/lib/svix/models/bulk_expunge_contents_in.rb
@@ -43,8 +43,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/bulk_expunge_contents_out.rb
+++ b/ruby/lib/svix/models/bulk_expunge_contents_out.rb
@@ -43,8 +43,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/bulk_replay_in.rb
+++ b/ruby/lib/svix/models/bulk_replay_in.rb
@@ -60,8 +60,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/checkbook_config.rb
+++ b/ruby/lib/svix/models/checkbook_config.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/checkbook_config_out.rb
+++ b/ruby/lib/svix/models/checkbook_config_out.rb
@@ -36,8 +36,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/clickhouse_config_in.rb
+++ b/ruby/lib/svix/models/clickhouse_config_in.rb
@@ -60,8 +60,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/clickhouse_config_out.rb
+++ b/ruby/lib/svix/models/clickhouse_config_out.rb
@@ -48,8 +48,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/clickhouse_config_patch.rb
+++ b/ruby/lib/svix/models/clickhouse_config_patch.rb
@@ -54,8 +54,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/connector_in.rb
+++ b/ruby/lib/svix/models/connector_in.rb
@@ -81,8 +81,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/connector_out.rb
+++ b/ruby/lib/svix/models/connector_out.rb
@@ -103,8 +103,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/connector_patch.rb
+++ b/ruby/lib/svix/models/connector_patch.rb
@@ -69,8 +69,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/connector_upsert_in.rb
+++ b/ruby/lib/svix/models/connector_upsert_in.rb
@@ -69,8 +69,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/create_stream_events_in.rb
+++ b/ruby/lib/svix/models/create_stream_events_in.rb
@@ -45,8 +45,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/create_stream_events_out.rb
+++ b/ruby/lib/svix/models/create_stream_events_out.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/cron_config.rb
+++ b/ruby/lib/svix/models/cron_config.rb
@@ -48,8 +48,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/docusign_config.rb
+++ b/ruby/lib/svix/models/docusign_config.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/docusign_config_out.rb
+++ b/ruby/lib/svix/models/docusign_config_out.rb
@@ -36,8 +36,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/easypost_config.rb
+++ b/ruby/lib/svix/models/easypost_config.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/easypost_config_out.rb
+++ b/ruby/lib/svix/models/easypost_config_out.rb
@@ -36,8 +36,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/empty_response.rb
+++ b/ruby/lib/svix/models/empty_response.rb
@@ -36,8 +36,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/endpoint_headers_in.rb
+++ b/ruby/lib/svix/models/endpoint_headers_in.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/endpoint_headers_out.rb
+++ b/ruby/lib/svix/models/endpoint_headers_out.rb
@@ -45,8 +45,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/endpoint_headers_patch_in.rb
+++ b/ruby/lib/svix/models/endpoint_headers_patch_in.rb
@@ -46,8 +46,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/endpoint_in.rb
+++ b/ruby/lib/svix/models/endpoint_in.rb
@@ -86,8 +86,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/endpoint_message_out.rb
+++ b/ruby/lib/svix/models/endpoint_message_out.rb
@@ -86,8 +86,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/endpoint_out.rb
+++ b/ruby/lib/svix/models/endpoint_out.rb
@@ -87,8 +87,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/endpoint_patch.rb
+++ b/ruby/lib/svix/models/endpoint_patch.rb
@@ -64,8 +64,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/endpoint_secret_out.rb
+++ b/ruby/lib/svix/models/endpoint_secret_out.rb
@@ -43,8 +43,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/endpoint_secret_rotate_in.rb
+++ b/ruby/lib/svix/models/endpoint_secret_rotate_in.rb
@@ -52,8 +52,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/endpoint_stats.rb
+++ b/ruby/lib/svix/models/endpoint_stats.rb
@@ -51,8 +51,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/endpoint_transformation_in.rb
+++ b/ruby/lib/svix/models/endpoint_transformation_in.rb
@@ -45,8 +45,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/endpoint_transformation_out.rb
+++ b/ruby/lib/svix/models/endpoint_transformation_out.rb
@@ -51,8 +51,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/endpoint_transformation_patch.rb
+++ b/ruby/lib/svix/models/endpoint_transformation_patch.rb
@@ -48,8 +48,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/endpoint_upsert_in.rb
+++ b/ruby/lib/svix/models/endpoint_upsert_in.rb
@@ -65,8 +65,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/environment_in.rb
+++ b/ruby/lib/svix/models/environment_in.rb
@@ -51,8 +51,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/environment_out.rb
+++ b/ruby/lib/svix/models/environment_out.rb
@@ -51,8 +51,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/event_bridge_config_in.rb
+++ b/ruby/lib/svix/models/event_bridge_config_in.rb
@@ -62,8 +62,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/event_bridge_config_out.rb
+++ b/ruby/lib/svix/models/event_bridge_config_out.rb
@@ -48,8 +48,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/event_bridge_config_patch.rb
+++ b/ruby/lib/svix/models/event_bridge_config_patch.rb
@@ -54,8 +54,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/event_example_in.rb
+++ b/ruby/lib/svix/models/event_example_in.rb
@@ -46,8 +46,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/event_in.rb
+++ b/ruby/lib/svix/models/event_in.rb
@@ -43,8 +43,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/event_out.rb
+++ b/ruby/lib/svix/models/event_out.rb
@@ -46,8 +46,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/event_stream_out.rb
+++ b/ruby/lib/svix/models/event_stream_out.rb
@@ -45,8 +45,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/event_type_from_open_api.rb
+++ b/ruby/lib/svix/models/event_type_from_open_api.rb
@@ -56,8 +56,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/event_type_import_open_api_in.rb
+++ b/ruby/lib/svix/models/event_type_import_open_api_in.rb
@@ -58,8 +58,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/event_type_import_open_api_out.rb
+++ b/ruby/lib/svix/models/event_type_import_open_api_out.rb
@@ -42,8 +42,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/event_type_import_open_api_out_data.rb
+++ b/ruby/lib/svix/models/event_type_import_open_api_out_data.rb
@@ -48,8 +48,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/event_type_in.rb
+++ b/ruby/lib/svix/models/event_type_in.rb
@@ -60,8 +60,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/event_type_out.rb
+++ b/ruby/lib/svix/models/event_type_out.rb
@@ -80,8 +80,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/event_type_patch.rb
+++ b/ruby/lib/svix/models/event_type_patch.rb
@@ -55,8 +55,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/event_type_upsert_in.rb
+++ b/ruby/lib/svix/models/event_type_upsert_in.rb
@@ -56,8 +56,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/expunge_all_contents_out.rb
+++ b/ruby/lib/svix/models/expunge_all_contents_out.rb
@@ -52,8 +52,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/github_config.rb
+++ b/ruby/lib/svix/models/github_config.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/github_config_out.rb
+++ b/ruby/lib/svix/models/github_config_out.rb
@@ -36,8 +36,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/google_cloud_pub_sub_config_in.rb
+++ b/ruby/lib/svix/models/google_cloud_pub_sub_config_in.rb
@@ -49,8 +49,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/google_cloud_pub_sub_config_out.rb
+++ b/ruby/lib/svix/models/google_cloud_pub_sub_config_out.rb
@@ -45,8 +45,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/google_cloud_pub_sub_config_patch.rb
+++ b/ruby/lib/svix/models/google_cloud_pub_sub_config_patch.rb
@@ -48,8 +48,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/google_cloud_storage_config_in.rb
+++ b/ruby/lib/svix/models/google_cloud_storage_config_in.rb
@@ -49,8 +49,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/google_cloud_storage_config_out.rb
+++ b/ruby/lib/svix/models/google_cloud_storage_config_out.rb
@@ -42,8 +42,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/google_cloud_storage_config_patch.rb
+++ b/ruby/lib/svix/models/google_cloud_storage_config_patch.rb
@@ -45,8 +45,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/http_sink_headers_patch_in.rb
+++ b/ruby/lib/svix/models/http_sink_headers_patch_in.rb
@@ -42,8 +42,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/hubspot_config.rb
+++ b/ruby/lib/svix/models/hubspot_config.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/hubspot_config_out.rb
+++ b/ruby/lib/svix/models/hubspot_config_out.rb
@@ -36,8 +36,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/ingest_endpoint_headers_in.rb
+++ b/ruby/lib/svix/models/ingest_endpoint_headers_in.rb
@@ -42,8 +42,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/ingest_endpoint_headers_out.rb
+++ b/ruby/lib/svix/models/ingest_endpoint_headers_out.rb
@@ -45,8 +45,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/ingest_endpoint_in.rb
+++ b/ruby/lib/svix/models/ingest_endpoint_in.rb
@@ -68,8 +68,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/ingest_endpoint_out.rb
+++ b/ruby/lib/svix/models/ingest_endpoint_out.rb
@@ -78,8 +78,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/ingest_endpoint_secret_in.rb
+++ b/ruby/lib/svix/models/ingest_endpoint_secret_in.rb
@@ -52,8 +52,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/ingest_endpoint_secret_out.rb
+++ b/ruby/lib/svix/models/ingest_endpoint_secret_out.rb
@@ -46,8 +46,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/ingest_endpoint_transformation_out.rb
+++ b/ruby/lib/svix/models/ingest_endpoint_transformation_out.rb
@@ -48,8 +48,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/ingest_endpoint_transformation_patch.rb
+++ b/ruby/lib/svix/models/ingest_endpoint_transformation_patch.rb
@@ -48,8 +48,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/ingest_endpoint_upsert_in.rb
+++ b/ruby/lib/svix/models/ingest_endpoint_upsert_in.rb
@@ -61,8 +61,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/ingest_source_consumer_portal_access_in.rb
+++ b/ruby/lib/svix/models/ingest_source_consumer_portal_access_in.rb
@@ -49,8 +49,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/ingest_source_in.rb
+++ b/ruby/lib/svix/models/ingest_source_in.rb
@@ -42,8 +42,8 @@ module Svix
       end
       # Serializes the object to a json string
       # @return String
-      def to_json
-        JSON.dump(serialize)
+      def to_json(*args)
+        serialize.to_json(*args)
       end
     end
 
@@ -292,8 +292,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
 
   end

--- a/ruby/lib/svix/models/ingest_source_out.rb
+++ b/ruby/lib/svix/models/ingest_source_out.rb
@@ -42,8 +42,8 @@ module Svix
       end
       # Serializes the object to a json string
       # @return String
-      def to_json
-        JSON.dump(serialize)
+      def to_json(*args)
+        serialize.to_json(*args)
       end
     end
 
@@ -305,8 +305,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
 
   end

--- a/ruby/lib/svix/models/integration_in.rb
+++ b/ruby/lib/svix/models/integration_in.rb
@@ -43,8 +43,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/integration_key_out.rb
+++ b/ruby/lib/svix/models/integration_key_out.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/integration_out.rb
+++ b/ruby/lib/svix/models/integration_out.rb
@@ -53,8 +53,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/integration_update.rb
+++ b/ruby/lib/svix/models/integration_update.rb
@@ -43,8 +43,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/list_response_application_out.rb
+++ b/ruby/lib/svix/models/list_response_application_out.rb
@@ -51,8 +51,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/list_response_background_task_out.rb
+++ b/ruby/lib/svix/models/list_response_background_task_out.rb
@@ -51,8 +51,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/list_response_connector_out.rb
+++ b/ruby/lib/svix/models/list_response_connector_out.rb
@@ -51,8 +51,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/list_response_endpoint_message_out.rb
+++ b/ruby/lib/svix/models/list_response_endpoint_message_out.rb
@@ -51,8 +51,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/list_response_endpoint_out.rb
+++ b/ruby/lib/svix/models/list_response_endpoint_out.rb
@@ -51,8 +51,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/list_response_event_type_out.rb
+++ b/ruby/lib/svix/models/list_response_event_type_out.rb
@@ -51,8 +51,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/list_response_ingest_endpoint_out.rb
+++ b/ruby/lib/svix/models/list_response_ingest_endpoint_out.rb
@@ -51,8 +51,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/list_response_ingest_source_out.rb
+++ b/ruby/lib/svix/models/list_response_ingest_source_out.rb
@@ -51,8 +51,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/list_response_integration_out.rb
+++ b/ruby/lib/svix/models/list_response_integration_out.rb
@@ -51,8 +51,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/list_response_message_attempt_out.rb
+++ b/ruby/lib/svix/models/list_response_message_attempt_out.rb
@@ -51,8 +51,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/list_response_message_endpoint_out.rb
+++ b/ruby/lib/svix/models/list_response_message_endpoint_out.rb
@@ -51,8 +51,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/list_response_message_out.rb
+++ b/ruby/lib/svix/models/list_response_message_out.rb
@@ -51,8 +51,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/list_response_operational_webhook_endpoint_out.rb
+++ b/ruby/lib/svix/models/list_response_operational_webhook_endpoint_out.rb
@@ -51,8 +51,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/list_response_stream_event_type_out.rb
+++ b/ruby/lib/svix/models/list_response_stream_event_type_out.rb
@@ -51,8 +51,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/list_response_stream_out.rb
+++ b/ruby/lib/svix/models/list_response_stream_out.rb
@@ -51,8 +51,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/list_response_stream_sink_out.rb
+++ b/ruby/lib/svix/models/list_response_stream_sink_out.rb
@@ -51,8 +51,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/message_attempt_out.rb
+++ b/ruby/lib/svix/models/message_attempt_out.rb
@@ -89,8 +89,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/message_endpoint_out.rb
+++ b/ruby/lib/svix/models/message_endpoint_out.rb
@@ -95,8 +95,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/message_in.rb
+++ b/ruby/lib/svix/models/message_in.rb
@@ -93,8 +93,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/message_out.rb
+++ b/ruby/lib/svix/models/message_out.rb
@@ -64,8 +64,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/message_precheck_in.rb
+++ b/ruby/lib/svix/models/message_precheck_in.rb
@@ -43,8 +43,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/message_precheck_out.rb
+++ b/ruby/lib/svix/models/message_precheck_out.rb
@@ -40,8 +40,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/meta_config.rb
+++ b/ruby/lib/svix/models/meta_config.rb
@@ -42,8 +42,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/meta_config_out.rb
+++ b/ruby/lib/svix/models/meta_config_out.rb
@@ -36,8 +36,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/nango_config.rb
+++ b/ruby/lib/svix/models/nango_config.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/nango_config_out.rb
+++ b/ruby/lib/svix/models/nango_config_out.rb
@@ -36,8 +36,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/open_claw_config.rb
+++ b/ruby/lib/svix/models/open_claw_config.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/open_claw_config_out.rb
+++ b/ruby/lib/svix/models/open_claw_config_out.rb
@@ -36,8 +36,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/operational_webhook_endpoint_headers_in.rb
+++ b/ruby/lib/svix/models/operational_webhook_endpoint_headers_in.rb
@@ -42,8 +42,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/operational_webhook_endpoint_headers_out.rb
+++ b/ruby/lib/svix/models/operational_webhook_endpoint_headers_out.rb
@@ -45,8 +45,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/operational_webhook_endpoint_in.rb
+++ b/ruby/lib/svix/models/operational_webhook_endpoint_in.rb
@@ -84,8 +84,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/operational_webhook_endpoint_out.rb
+++ b/ruby/lib/svix/models/operational_webhook_endpoint_out.rb
@@ -85,8 +85,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/operational_webhook_endpoint_secret_in.rb
+++ b/ruby/lib/svix/models/operational_webhook_endpoint_secret_in.rb
@@ -52,8 +52,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/operational_webhook_endpoint_secret_out.rb
+++ b/ruby/lib/svix/models/operational_webhook_endpoint_secret_out.rb
@@ -46,8 +46,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/operational_webhook_endpoint_upsert_in.rb
+++ b/ruby/lib/svix/models/operational_webhook_endpoint_upsert_in.rb
@@ -64,8 +64,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/orum_io_config.rb
+++ b/ruby/lib/svix/models/orum_io_config.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/orum_io_config_out.rb
+++ b/ruby/lib/svix/models/orum_io_config_out.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/otel_tracing_config_in.rb
+++ b/ruby/lib/svix/models/otel_tracing_config_in.rb
@@ -42,8 +42,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/otel_tracing_config_out.rb
+++ b/ruby/lib/svix/models/otel_tracing_config_out.rb
@@ -42,8 +42,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/otel_tracing_config_patch.rb
+++ b/ruby/lib/svix/models/otel_tracing_config_patch.rb
@@ -42,8 +42,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/panda_doc_config.rb
+++ b/ruby/lib/svix/models/panda_doc_config.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/panda_doc_config_out.rb
+++ b/ruby/lib/svix/models/panda_doc_config_out.rb
@@ -36,8 +36,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/poller_v2_commit_in.rb
+++ b/ruby/lib/svix/models/poller_v2_commit_in.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/poller_v2_message_out.rb
+++ b/ruby/lib/svix/models/poller_v2_message_out.rb
@@ -82,8 +82,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/poller_v2_poll_out.rb
+++ b/ruby/lib/svix/models/poller_v2_poll_out.rb
@@ -42,8 +42,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/polling_endpoint_consumer_seek_in.rb
+++ b/ruby/lib/svix/models/polling_endpoint_consumer_seek_in.rb
@@ -42,8 +42,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/polling_endpoint_consumer_seek_out.rb
+++ b/ruby/lib/svix/models/polling_endpoint_consumer_seek_out.rb
@@ -42,8 +42,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/polling_endpoint_message_out.rb
+++ b/ruby/lib/svix/models/polling_endpoint_message_out.rb
@@ -71,8 +71,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/polling_endpoint_out.rb
+++ b/ruby/lib/svix/models/polling_endpoint_out.rb
@@ -45,8 +45,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/port_io_config.rb
+++ b/ruby/lib/svix/models/port_io_config.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/port_io_config_out.rb
+++ b/ruby/lib/svix/models/port_io_config_out.rb
@@ -36,8 +36,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/rabbit_mq_config_in.rb
+++ b/ruby/lib/svix/models/rabbit_mq_config_in.rb
@@ -43,8 +43,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/rabbit_mq_config_out.rb
+++ b/ruby/lib/svix/models/rabbit_mq_config_out.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/rabbit_mq_config_patch.rb
+++ b/ruby/lib/svix/models/rabbit_mq_config_patch.rb
@@ -42,8 +42,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/recover_in.rb
+++ b/ruby/lib/svix/models/recover_in.rb
@@ -42,8 +42,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/recover_out.rb
+++ b/ruby/lib/svix/models/recover_out.rb
@@ -49,8 +49,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/redshift_config_in.rb
+++ b/ruby/lib/svix/models/redshift_config_in.rb
@@ -97,8 +97,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/redshift_config_out.rb
+++ b/ruby/lib/svix/models/redshift_config_out.rb
@@ -78,8 +78,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/redshift_config_patch.rb
+++ b/ruby/lib/svix/models/redshift_config_patch.rb
@@ -63,8 +63,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/replay_in.rb
+++ b/ruby/lib/svix/models/replay_in.rb
@@ -42,8 +42,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/replay_out.rb
+++ b/ruby/lib/svix/models/replay_out.rb
@@ -49,8 +49,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/rotate_poller_token_in.rb
+++ b/ruby/lib/svix/models/rotate_poller_token_in.rb
@@ -48,8 +48,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/rotate_token_out.rb
+++ b/ruby/lib/svix/models/rotate_token_out.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/rutter_config.rb
+++ b/ruby/lib/svix/models/rutter_config.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/rutter_config_out.rb
+++ b/ruby/lib/svix/models/rutter_config_out.rb
@@ -36,8 +36,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/s3_config_in.rb
+++ b/ruby/lib/svix/models/s3_config_in.rb
@@ -60,8 +60,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/s3_config_out.rb
+++ b/ruby/lib/svix/models/s3_config_out.rb
@@ -48,8 +48,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/s3_config_patch.rb
+++ b/ruby/lib/svix/models/s3_config_patch.rb
@@ -51,8 +51,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/segment_config.rb
+++ b/ruby/lib/svix/models/segment_config.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/segment_config_out.rb
+++ b/ruby/lib/svix/models/segment_config_out.rb
@@ -36,8 +36,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/shopify_config.rb
+++ b/ruby/lib/svix/models/shopify_config.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/shopify_config_out.rb
+++ b/ruby/lib/svix/models/shopify_config_out.rb
@@ -36,8 +36,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/sink_http_config_in.rb
+++ b/ruby/lib/svix/models/sink_http_config_in.rb
@@ -45,8 +45,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/sink_http_config_out.rb
+++ b/ruby/lib/svix/models/sink_http_config_out.rb
@@ -42,8 +42,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/sink_http_config_patch.rb
+++ b/ruby/lib/svix/models/sink_http_config_patch.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/sink_in_common.rb
+++ b/ruby/lib/svix/models/sink_in_common.rb
@@ -69,8 +69,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/sink_secret_out.rb
+++ b/ruby/lib/svix/models/sink_secret_out.rb
@@ -43,8 +43,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/sink_transform_in.rb
+++ b/ruby/lib/svix/models/sink_transform_in.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/sink_transformation_out.rb
+++ b/ruby/lib/svix/models/sink_transformation_out.rb
@@ -45,8 +45,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/slack_config.rb
+++ b/ruby/lib/svix/models/slack_config.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/slack_config_out.rb
+++ b/ruby/lib/svix/models/slack_config_out.rb
@@ -36,8 +36,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/snowflake_config_in.rb
+++ b/ruby/lib/svix/models/snowflake_config_in.rb
@@ -71,8 +71,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/snowflake_config_out.rb
+++ b/ruby/lib/svix/models/snowflake_config_out.rb
@@ -60,8 +60,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/snowflake_config_patch.rb
+++ b/ruby/lib/svix/models/snowflake_config_patch.rb
@@ -63,8 +63,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/sns_config_in.rb
+++ b/ruby/lib/svix/models/sns_config_in.rb
@@ -61,8 +61,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/sns_config_out.rb
+++ b/ruby/lib/svix/models/sns_config_out.rb
@@ -45,8 +45,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/sns_config_patch.rb
+++ b/ruby/lib/svix/models/sns_config_patch.rb
@@ -51,8 +51,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/sqs_config_in.rb
+++ b/ruby/lib/svix/models/sqs_config_in.rb
@@ -61,8 +61,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/sqs_config_out.rb
+++ b/ruby/lib/svix/models/sqs_config_out.rb
@@ -48,8 +48,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/sqs_config_patch.rb
+++ b/ruby/lib/svix/models/sqs_config_patch.rb
@@ -51,8 +51,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/stream_event_type_in.rb
+++ b/ruby/lib/svix/models/stream_event_type_in.rb
@@ -52,8 +52,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/stream_event_type_out.rb
+++ b/ruby/lib/svix/models/stream_event_type_out.rb
@@ -58,8 +58,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/stream_event_type_patch.rb
+++ b/ruby/lib/svix/models/stream_event_type_patch.rb
@@ -48,8 +48,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/stream_in.rb
+++ b/ruby/lib/svix/models/stream_in.rb
@@ -47,8 +47,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/stream_out.rb
+++ b/ruby/lib/svix/models/stream_out.rb
@@ -57,8 +57,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/stream_patch.rb
+++ b/ruby/lib/svix/models/stream_patch.rb
@@ -47,8 +47,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/stream_portal_access_in.rb
+++ b/ruby/lib/svix/models/stream_portal_access_in.rb
@@ -52,8 +52,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/stream_sink_in.rb
+++ b/ruby/lib/svix/models/stream_sink_in.rb
@@ -31,8 +31,8 @@ module Svix
       end
       # Serializes the object to a json string
       # @return String
-      def to_json
-        JSON.dump(serialize)
+      def to_json(*args)
+        serialize.to_json(*args)
       end
     end
 
@@ -193,8 +193,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
 
   end

--- a/ruby/lib/svix/models/stream_sink_out.rb
+++ b/ruby/lib/svix/models/stream_sink_out.rb
@@ -31,8 +31,8 @@ module Svix
       end
       # Serializes the object to a json string
       # @return String
-      def to_json
-        JSON.dump(serialize)
+      def to_json(*args)
+        serialize.to_json(*args)
       end
     end
 
@@ -215,8 +215,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
 
   end

--- a/ruby/lib/svix/models/stream_sink_patch.rb
+++ b/ruby/lib/svix/models/stream_sink_patch.rb
@@ -31,8 +31,8 @@ module Svix
       end
       # Serializes the object to a json string
       # @return String
-      def to_json
-        JSON.dump(serialize)
+      def to_json(*args)
+        serialize.to_json(*args)
       end
     end
 
@@ -181,8 +181,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
 
   end

--- a/ruby/lib/svix/models/stream_token_expire_in.rb
+++ b/ruby/lib/svix/models/stream_token_expire_in.rb
@@ -46,8 +46,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/stripe_config.rb
+++ b/ruby/lib/svix/models/stripe_config.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/stripe_config_out.rb
+++ b/ruby/lib/svix/models/stripe_config_out.rb
@@ -36,8 +36,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/subscribe_in.rb
+++ b/ruby/lib/svix/models/subscribe_in.rb
@@ -42,8 +42,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/svix_config.rb
+++ b/ruby/lib/svix/models/svix_config.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/svix_config_out.rb
+++ b/ruby/lib/svix/models/svix_config_out.rb
@@ -36,8 +36,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/tailscale_config.rb
+++ b/ruby/lib/svix/models/tailscale_config.rb
@@ -46,8 +46,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/tailscale_config_out.rb
+++ b/ruby/lib/svix/models/tailscale_config_out.rb
@@ -36,8 +36,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/telnyx_config.rb
+++ b/ruby/lib/svix/models/telnyx_config.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/telnyx_config_out.rb
+++ b/ruby/lib/svix/models/telnyx_config_out.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/vapi_config.rb
+++ b/ruby/lib/svix/models/vapi_config.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/vapi_config_out.rb
+++ b/ruby/lib/svix/models/vapi_config_out.rb
@@ -36,8 +36,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/veriff_config.rb
+++ b/ruby/lib/svix/models/veriff_config.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/veriff_config_out.rb
+++ b/ruby/lib/svix/models/veriff_config_out.rb
@@ -36,8 +36,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/vgs_config.rb
+++ b/ruby/lib/svix/models/vgs_config.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/vgs_config_out.rb
+++ b/ruby/lib/svix/models/vgs_config_out.rb
@@ -36,8 +36,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/zoom_config.rb
+++ b/ruby/lib/svix/models/zoom_config.rb
@@ -39,8 +39,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/lib/svix/models/zoom_config_out.rb
+++ b/ruby/lib/svix/models/zoom_config_out.rb
@@ -36,8 +36,8 @@ module Svix
 
     # Serializes the object to a json string
     # @return String
-    def to_json
-      JSON.dump(serialize)
+    def to_json(*args)
+      serialize.to_json(*args)
     end
   end
 end

--- a/ruby/spec/webmock_tests_spec.rb
+++ b/ruby/spec/webmock_tests_spec.rb
@@ -337,6 +337,16 @@ describe "API Client" do
     )
   end
 
+  it "supports the JSON generator protocol for models" do
+    model = Svix::ApplicationIn.new(name: "example")
+
+    expect(model.to_json).to(eq('{"name":"example"}'))
+    expect(JSON.generate([model])).to(eq('[{"name":"example"}]'))
+    expect(JSON.parse(JSON.generate({model: model}, space: " "))).to(
+      eq("model" => {"name" => "example"})
+    )
+  end
+
   it "serializes false values in patch models" do
     expect(Svix::EndpointTransformationPatch.new(enabled: false).serialize)
       .to(eq({"enabled" => false}))


### PR DESCRIPTION
## Motivation

Fixes #2598.

Generated Ruby models define `to_json` without accepting JSON generator state. `JSON.generate` passes this state when a model is nested in an array or object, causing an argument-count error.

## Solution

Update both Ruby model templates to accept `to_json(*args)` and forward the JSON generator state through the serialized hash. Regenerated all affected Ruby models.

Added regression coverage for direct model serialization and models nested in arrays and objects.

Validation:

- `./regen_openapi.py`
- `bundle exec rake build`
- `bundle exec rspec --exclude-pattern spec/kitchen_sink_spec.rb` (57 examples)
