### PR TITLE
cli: bump wolfi-base

### DIFF
--- a/svix-cli/Dockerfile
+++ b/svix-cli/Dockerfile
@@ -3,7 +3,7 @@
 # NOTE: this should be built from the root of `svix-webhooks`
 # with `docker build -f svix-cli/Dockerfile .`# Base build
 
-FROM cgr.dev/chainguard/wolfi-base@sha256:a31344ab2cb8618db84f535eec56f76f6178b142cb92cb2e48676cc2dcebea72 AS build
+FROM cgr.dev/chainguard/wolfi-base@sha256:57108e597a8cf3bd376b810f1c3539c21942daefa242cb9dddaae30f8aac735d AS build
 SHELL ["/bin/sh", "-eux", "-c"]
 RUN --mount=target=/var/cache/apk,type=cache,sharing=locked --mount=target=/tmp,type=cache,sharing=locked <<EOF
     apk add rust~1.96.1 \


### PR DESCRIPTION
The version of libLLVM was linking glibc 2.44, but that SHA of wolfi only had glibc 2.43. This is already fixed upstream, so just a matter of bumping to the latest wolfi image.