### PR TITLE
libs/ruby: remove irb dependency

### DIFF
--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -3,6 +3,5 @@ source "https://rubygems.org"
 gem 'base64'
 gem 'logger'
 gem 'ostruct'
-gem "irb"
 
 gemspec

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -16,33 +16,11 @@ GEM
       bigdecimal
       rexml
     diff-lcs (1.6.2)
-    erb (6.0.7)
     hashdiff (1.2.1)
-    io-console (0.9.2)
-    irb (1.18.0)
-      pp (>= 0.6.0)
-      prism (>= 1.3.0)
-      rdoc (>= 4.0.0)
-      reline (>= 0.4.2)
     logger (1.7.0)
     ostruct (0.6.3)
-    pp (0.6.4)
-      prettyprint
-    prettyprint (0.2.0)
-    prism (1.9.0)
     public_suffix (7.0.5)
     rake (13.4.1)
-    rbs (4.1.3)
-      logger
-      prism (>= 1.6.0)
-      tsort
-    rdoc (8.0.0)
-      erb
-      prism (>= 1.6.0)
-      rbs (>= 4.0.0)
-      tsort
-    reline (0.7.0)
-      io-console (~> 0.5)
     rexml (3.4.4)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)
@@ -58,7 +36,6 @@ GEM
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
     subprocess (1.5.7)
-    tsort (0.2.0)
     webmock (3.26.2)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -69,7 +46,6 @@ PLATFORMS
 
 DEPENDENCIES
   base64
-  irb (~> 1.18)
   logger
   ostruct
   rake (~> 13.0)


### PR DESCRIPTION
Fixes #2599. I checked this in by accident in #2558 while debugging