### PR TITLE
sdks: explain unsupported autoconfig token version

### DIFF
--- a/csharp/Svix.Tests/AutoConfigTest.cs
+++ b/csharp/Svix.Tests/AutoConfigTest.cs
@@ -30,8 +30,12 @@ namespace Svix.Tests
             var json = """{"aid":"a","eid":"e","surl":"https://x","esec":"whsec_Zm9v","tok":"t"}""";
             var token = "wrong_" + Convert.ToBase64String(Encoding.UTF8.GetBytes(json));
 
-            Assert.Throws<AutoConfigException>(() =>
+            var ex = Assert.Throws<AutoConfigException>(() =>
                 new AutoConfig(token, new EndpointIn { Url = "https://hook.example.test" })
+            );
+            Assert.Equal(
+                "Unsupported token version. You might need to update the Svix SDK to use this token",
+                ex.Message
             );
         }
 

--- a/csharp/Svix/AutoConfig.cs
+++ b/csharp/Svix/AutoConfig.cs
@@ -20,6 +20,8 @@ namespace Svix
     public class AutoConfig
     {
         private const string AUTOCONFIG_TOKEN_PREFIX_V1 = "auto_v1_";
+        private const string UnsupportedTokenVersion =
+            "Unsupported token version. You might need to update the Svix SDK to use this token";
 
         private readonly string appId;
         private readonly string endpointId;
@@ -106,7 +108,7 @@ namespace Svix
 
             if (!token.StartsWith(AUTOCONFIG_TOKEN_PREFIX_V1, StringComparison.Ordinal))
             {
-                throw new AutoConfigException();
+                throw new AutoConfigException(UnsupportedTokenVersion);
             }
 
             var b64 = token.Substring(AUTOCONFIG_TOKEN_PREFIX_V1.Length);

--- a/go/autoconfig.go
+++ b/go/autoconfig.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -14,6 +15,7 @@ import (
 )
 
 const autoConfigTokenPrefixV1 = "auto_v1_"
+const unsupportedTokenVersion = "Unsupported token version. You might need to update the Svix SDK to use this token"
 
 var ErrInvalidAutoConfigToken = errors.New("invalid token")
 
@@ -38,7 +40,7 @@ type AutoConfig struct {
 func decodeAutoConfigTokenV1(token string) (*autoConfigTokenContentV1, error) {
 	token, ok := strings.CutPrefix(token, autoConfigTokenPrefixV1)
 	if !ok {
-		return nil, ErrInvalidAutoConfigToken
+		return nil, fmt.Errorf("%w: %s", ErrInvalidAutoConfigToken, unsupportedTokenVersion)
 	}
 
 	decoded, err := base64.StdEncoding.DecodeString(token)

--- a/go/autoconfig_test.go
+++ b/go/autoconfig_test.go
@@ -3,6 +3,7 @@ package svix
 import (
 	"encoding/base64"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -38,6 +39,9 @@ func TestDecodeAutoConfigTokenV1RejectsBadPrefix(t *testing.T) {
 	_, err := decodeAutoConfigTokenV1(token)
 	if !errors.Is(err, ErrInvalidAutoConfigToken) {
 		t.Fatalf("expected ErrInvalidAutoConfigToken, got %v", err)
+	}
+	if !strings.Contains(err.Error(), unsupportedTokenVersion) {
+		t.Fatalf("expected unsupported token version detail, got %v", err)
 	}
 }
 

--- a/java/lib/src/main/java/com/svix/AutoConfig.java
+++ b/java/lib/src/main/java/com/svix/AutoConfig.java
@@ -15,6 +15,8 @@ import java.util.Map;
 
 public final class AutoConfig {
   static final String AUTOCONFIG_TOKEN_PREFIX_V1 = "auto_v1_";
+  static final String UNSUPPORTED_TOKEN_VERSION =
+      "Unsupported token version. You might need to update the Svix SDK to use this token";
 
   private final String appId;
   private final String endpointId;
@@ -75,7 +77,7 @@ public final class AutoConfig {
    */
   static DecodedTokenContent decodeToken(final String token) throws InvalidTokenException {
     if (token == null || !token.startsWith(AUTOCONFIG_TOKEN_PREFIX_V1)) {
-      throw new InvalidTokenException();
+      throw new InvalidTokenException(UNSUPPORTED_TOKEN_VERSION);
     }
 
     final byte[] decoded;
@@ -154,6 +156,10 @@ public final class AutoConfig {
   public static final class InvalidTokenException extends Exception {
     public InvalidTokenException() {
       super("invalid token");
+    }
+
+    public InvalidTokenException(final String detail) {
+      super(detail);
     }
 
     public InvalidTokenException(final Throwable cause) {

--- a/java/lib/src/test/com/svix/AutoConfigTest.java
+++ b/java/lib/src/test/com/svix/AutoConfigTest.java
@@ -30,8 +30,10 @@ public class AutoConfigTest {
                 String token = "wrong_" + Base64.getEncoder()
                                 .encodeToString(json.getBytes(StandardCharsets.UTF_8));
 
-                assertThrows(AutoConfig.InvalidTokenException.class,
+                AutoConfig.InvalidTokenException ex = assertThrows(
+                                AutoConfig.InvalidTokenException.class,
                                 () -> AutoConfig.decodeToken(token));
+                assertEquals(AutoConfig.UNSUPPORTED_TOKEN_VERSION, ex.getMessage());
         }
 
         @Test

--- a/javascript/src/autoconfig.test.ts
+++ b/javascript/src/autoconfig.test.ts
@@ -42,7 +42,13 @@ test("AutoConfig rejects wrong prefix", () => {
     tok: "t",
   });
   const token = `wrong_${Buffer.from(json, "utf8").toString("base64")}`;
-  assert.throws(() => new AutoConfig(token, { url: "https://x" }), AutoConfigError);
+  assert.throws(
+    () => new AutoConfig(token, { url: "https://x" }),
+    (err: unknown) =>
+      err instanceof AutoConfigError &&
+      err.message ===
+        "Unsupported token version. You might need to update the Svix SDK to use this token"
+  );
 });
 
 test("AutoConfig rejects invalid JSON payload", () => {

--- a/javascript/src/autoconfig.ts
+++ b/javascript/src/autoconfig.ts
@@ -10,6 +10,8 @@ import {
 } from "./webhook";
 
 const AUTOCONFIG_TOKEN_PREFIX_V1 = "auto_v1_";
+const UNSUPPORTED_TOKEN_VERSION =
+  "Unsupported token version. You might need to update the Svix SDK to use this token";
 
 export interface AutoConfigTokenContentV1 {
   aid: string;
@@ -45,7 +47,7 @@ export function isAutoConfigTokenContentV1(
 
 export function decodeAutoconfigTokenV1(token: string): AutoConfigTokenContentV1 {
   if (!token.startsWith(AUTOCONFIG_TOKEN_PREFIX_V1)) {
-    throw new AutoConfigError();
+    throw new AutoConfigError(UNSUPPORTED_TOKEN_VERSION);
   }
   const b64 = token.slice(AUTOCONFIG_TOKEN_PREFIX_V1.length);
   let json: string;

--- a/kotlin/lib/src/main/kotlin/AutoConfig.kt
+++ b/kotlin/lib/src/main/kotlin/AutoConfig.kt
@@ -15,6 +15,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 
 class InvalidAutoConfigTokenException : Exception {
     constructor() : super("invalid token")
+    constructor(detail: String) : super(detail)
     constructor(cause: Throwable) : super("invalid token", cause)
 }
 
@@ -69,13 +70,15 @@ constructor(token: String, endpoint: EndpointIn) {
 
     companion object {
         private const val AUTOCONFIG_TOKEN_PREFIX_V1 = "auto_v1_"
+        private const val UNSUPPORTED_TOKEN_VERSION =
+            "Unsupported token version. You might need to update the Svix SDK to use this token"
 
         private val json = Json { ignoreUnknownKeys = true }
 
         @Throws(InvalidAutoConfigTokenException::class)
         internal fun decodeAutoConfigTokenV1(token: String): AutoConfigTokenContentV1 {
             if (!token.startsWith(AUTOCONFIG_TOKEN_PREFIX_V1)) {
-                throw InvalidAutoConfigTokenException()
+                throw InvalidAutoConfigTokenException(UNSUPPORTED_TOKEN_VERSION)
             }
             val b64 = token.substring(AUTOCONFIG_TOKEN_PREFIX_V1.length)
 

--- a/kotlin/lib/src/test/com/svix/kotlin/AutoConfigTest.kt
+++ b/kotlin/lib/src/test/com/svix/kotlin/AutoConfigTest.kt
@@ -3,6 +3,7 @@ package com.svix.kotlin
 import com.svix.kotlin.models.EndpointIn
 import java.util.Base64
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class AutoConfigTest {
@@ -27,7 +28,12 @@ class AutoConfigTest {
             """{"aid":"a","eid":"e","surl":"https://x","esec":"whsec_Zm9v","tok":"t"}"""
         val token = "wrong_" + Base64.getEncoder().encodeToString(json.toByteArray(Charsets.UTF_8))
 
-        assertFailsWith<InvalidAutoConfigTokenException> { AutoConfig(token, minimalEndpoint()) }
+        val ex =
+            assertFailsWith<InvalidAutoConfigTokenException> { AutoConfig(token, minimalEndpoint()) }
+        assertEquals(
+            "Unsupported token version. You might need to update the Svix SDK to use this token",
+            ex.message,
+        )
     }
 
     @Test

--- a/php/src/AutoConfig.php
+++ b/php/src/AutoConfig.php
@@ -15,6 +15,7 @@ use Svix\Request\SvixHttpClient;
 final class AutoConfig
 {
     private const AUTOCONFIG_TOKEN_PREFIX_V1 = 'auto_v1_';
+    private const UNSUPPORTED_TOKEN_VERSION = 'Unsupported token version. You might need to update the Svix SDK to use this token';
 
     private string $appId;
 
@@ -84,7 +85,7 @@ final class AutoConfig
     public static function decodeToken(string $token): array
     {
         if (!str_starts_with($token, self::AUTOCONFIG_TOKEN_PREFIX_V1)) {
-            throw new \InvalidArgumentException('invalid token');
+            throw new \InvalidArgumentException(self::UNSUPPORTED_TOKEN_VERSION);
         }
 
         $encoded = substr($token, strlen(self::AUTOCONFIG_TOKEN_PREFIX_V1));

--- a/php/tests/AutoConfigTest.php
+++ b/php/tests/AutoConfigTest.php
@@ -39,7 +39,9 @@ final class AutoConfigTest extends TestCase
     public function testWrongPrefixThrowsInvalidArgument(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('invalid token');
+        $this->expectExceptionMessage(
+            'Unsupported token version. You might need to update the Svix SDK to use this token',
+        );
 
         new AutoConfig(
             'not_auto_v1_' . base64_encode(json_encode(self::minimalValidPayload())),

--- a/python/svix/autoconfig.py
+++ b/python/svix/autoconfig.py
@@ -29,6 +29,9 @@ from .models import (
 from .webhooks import Webhook
 
 _AUTOCONFIG_TOKEN_PREFIX_V1 = "auto_v1_"
+_UNSUPPORTED_TOKEN_VERSION = (
+    "Unsupported token version. You might need to update the Svix SDK to use this token"
+)
 
 
 class AutoConfigError(Exception):
@@ -47,7 +50,7 @@ class _AutoConfigTokenContentV1(pydantic.BaseModel):
 
 def _decode_autoconfig_token_v1(token: str) -> _AutoConfigTokenContentV1:
     if not token.startswith(_AUTOCONFIG_TOKEN_PREFIX_V1):
-        raise AutoConfigError("invalid token")
+        raise AutoConfigError(_UNSUPPORTED_TOKEN_VERSION)
     b64 = token[len(_AUTOCONFIG_TOKEN_PREFIX_V1) :]
     # Ensure b64 has padding, which is required by the python base64 module
     try:

--- a/python/tests/test_autoconfig.py
+++ b/python/tests/test_autoconfig.py
@@ -4,7 +4,11 @@ import json
 import pytest
 
 from svix import AutoConfigConsumer, AutoConfigError
-from svix.autoconfig import _AUTOCONFIG_TOKEN_PREFIX_V1, _decode_autoconfig_token_v1
+from svix.autoconfig import (
+    _AUTOCONFIG_TOKEN_PREFIX_V1,
+    _UNSUPPORTED_TOKEN_VERSION,
+    _decode_autoconfig_token_v1,
+)
 from svix.models import SinkInCommon
 from svix.models.auto_config_sink_type import AutoConfigSinkType
 from svix.models.subscribe_in import SubscribeIn
@@ -55,8 +59,9 @@ def test_decode_autoconfig_token_v1_rejects_bad_prefix():
     raw = json.dumps(payload).encode()
     token = f"wrong_{base64.b64encode(raw).decode('ascii')}"
 
-    with pytest.raises(AutoConfigError):
+    with pytest.raises(AutoConfigError) as exc_info:
         _decode_autoconfig_token_v1(token)
+    assert str(exc_info.value) == _UNSUPPORTED_TOKEN_VERSION
 
 
 def test_decode_autoconfig_token_v1_rejects_invalid_json():

--- a/ruby/lib/svix/autoconfig.rb
+++ b/ruby/lib/svix/autoconfig.rb
@@ -10,6 +10,7 @@ require "svix/api_internal/endpoint_auto_config"
 module Svix
   class AutoConfig
     AUTOCONFIG_TOKEN_PREFIX_V1 = "auto_v1_"
+    UNSUPPORTED_TOKEN_VERSION = "Unsupported token version. You might need to update the Svix SDK to use this token"
 
     class InvalidTokenError < StandardError; end
 
@@ -42,7 +43,7 @@ module Svix
     class << self
       def decode_token!(token)
         unless token.is_a?(String) && token.start_with?(AUTOCONFIG_TOKEN_PREFIX_V1)
-          raise InvalidTokenError
+          raise InvalidTokenError, UNSUPPORTED_TOKEN_VERSION
         end
 
         encoded = token.byteslice(AUTOCONFIG_TOKEN_PREFIX_V1.length..-1)

--- a/ruby/spec/autoconfig_spec.rb
+++ b/ruby/spec/autoconfig_spec.rb
@@ -20,7 +20,10 @@ RSpec.describe Svix::AutoConfig do
     it "rejects a bad prefix" do
       json = '{"aid":"a","eid":"e","surl":"https://x","esec":"whsec_Zm9v","tok":"t"}'
       token = "wrong_#{Base64.strict_encode64(json)}"
-      expect { described_class.decode_token!(token) }.to raise_error(Svix::AutoConfig::InvalidTokenError)
+      expect { described_class.decode_token!(token) }.to raise_error(
+        Svix::AutoConfig::InvalidTokenError,
+        "Unsupported token version. You might need to update the Svix SDK to use this token"
+      )
     end
 
     it "rejects invalid json" do

--- a/rust/src/autoconfig.rs
+++ b/rust/src/autoconfig.rs
@@ -34,34 +34,39 @@ pub struct AutoConfig {
 }
 
 const AUTOCONFIG_TOKEN_PREFIX_V1: &str = "auto_v1_";
+const UNSUPPORTED_TOKEN_VERSION: &str =
+    "Unsupported token version. You might need to update the Svix SDK to use this token";
 
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
 pub enum AutoConfigError {
-    #[error("invalid token")]
-    InvalidToken,
+    #[error("{}", .detail.unwrap_or("invalid token"))]
+    InvalidToken { detail: Option<&'static str> },
 }
 
 pub fn decode_autoconfig_token_v1(
     token: &str,
 ) -> std::result::Result<AutoConfigTokenContentV1, AutoConfigError> {
-    let token = token
-        .strip_prefix(AUTOCONFIG_TOKEN_PREFIX_V1)
-        .ok_or(AutoConfigError::InvalidToken)?;
+    let token =
+        token
+            .strip_prefix(AUTOCONFIG_TOKEN_PREFIX_V1)
+            .ok_or(AutoConfigError::InvalidToken {
+                detail: Some(UNSUPPORTED_TOKEN_VERSION),
+            })?;
 
     let decoded = BASE64_STANDARD
         .decode(token)
-        .map_err(|_| AutoConfigError::InvalidToken)?;
+        .map_err(|_| AutoConfigError::InvalidToken { detail: None })?;
 
     serde_json::from_slice::<AutoConfigTokenContentV1>(&decoded)
-        .map_err(|_| AutoConfigError::InvalidToken)
+        .map_err(|_| AutoConfigError::InvalidToken { detail: None })
 }
 
 impl AutoConfig {
     pub fn new(token: String, endpoint: EndpointIn) -> std::result::Result<Self, AutoConfigError> {
         let content = decode_autoconfig_token_v1(&token)?;
-        let webhook =
-            Webhook::new(&content.endpoint_secret).map_err(|_| AutoConfigError::InvalidToken)?;
+        let webhook = Webhook::new(&content.endpoint_secret)
+            .map_err(|_| AutoConfigError::InvalidToken { detail: None })?;
 
         let svix = Svix::new(
             content.token_plaintext,
@@ -123,7 +128,9 @@ mod tests {
         let token = format!("wrong_{base64_json}");
         assert!(matches!(
             decode_autoconfig_token_v1(&token),
-            Err(AutoConfigError::InvalidToken)
+            Err(AutoConfigError::InvalidToken {
+                detail: Some(UNSUPPORTED_TOKEN_VERSION)
+            })
         ));
     }
 
@@ -133,7 +140,7 @@ mod tests {
         let token = format!("{AUTOCONFIG_TOKEN_PREFIX_V1}{base64_not_json}",);
         assert!(matches!(
             decode_autoconfig_token_v1(&token),
-            Err(AutoConfigError::InvalidToken)
+            Err(AutoConfigError::InvalidToken { detail: None })
         ));
     }
 }


### PR DESCRIPTION
When autoconfig token is not `auto_v1_`, return a clear invalid-token detail so callers know they may need a newer SDK.
