### PR TITLE
csharp: Support absent struct enum content field

### DIFF
--- a/codegen/templates/csharp/types/struct_enum.cs.jinja
+++ b/codegen/templates/csharp/types/struct_enum.cs.jinja
@@ -121,16 +121,16 @@ namespace Svix.Models {
                 // unreachable
                 _ => throw new InvalidOperationException("Unknown config type")
             };
-
         }
+
         public void Switch(
             {% set func_args -%}
                 {%- for v in type.variants -%}
-                    {%- if v.schema_ref is defined -%}
-                    Action<{{ v.schema_ref | to_upper_camel_case }}> on{{ v.name | to_upper_camel_case }},
-                    {%- else -%}
-                    Action on{{ v.name | to_upper_camel_case }},
+                    Action
+                    {%- if v.schema_ref is defined %}
+                    <{{ v.schema_ref | to_upper_camel_case }}>
                     {%- endif -%}
+                    ? on{{ v.name | to_upper_camel_case }} = null,
                 {%- endfor -%}
             {% endset -%}
             {{ func_args | strip_trailing_comma }}
@@ -140,20 +140,21 @@ namespace Svix.Models {
             {
                 {% for v in type.variants -%}
                 case {{ content_field_name }}Type.{{ v.name | to_upper_camel_case }}:
-                    on{{ v.name | to_upper_camel_case }}(
-                        {%- if v.schema_ref is defined -%}
-                        ({{ v.schema_ref | to_upper_camel_case }})_value
-                        {%- endif -%}
-                    );
+                    if (on{{ v.name | to_upper_camel_case }} != null)
+                    {
+                        on{{ v.name | to_upper_camel_case }}(
+                            {%- if v.schema_ref is defined -%}
+                            ({{ v.schema_ref | to_upper_camel_case }})_value
+                            {%- endif -%}
+                        );
+                    }
                     break;
                 {% endfor -%}
                 default:
                     // unreachable
                     throw new InvalidOperationException("Unknown config type");
             }
-
         }
-
     }
 
     internal class {{ type_name }}Surrogate
@@ -162,9 +163,8 @@ namespace Svix.Models {
         [JsonProperty("{{ type.discriminator_field }}", Required = Required.Always)]
         public required string {{ discriminator_field_name }} { get; set; }
 
-        [JsonProperty("{{ type.content_field }}", Required = Required.Always)]
-        public required JObject {{ content_field_name }} { get; set; }
-
+        [JsonProperty("{{ type.content_field }}")]
+        public JObject? {{ content_field_name }} { get; set; }
     }
 
     public class {{ type_name }}Converter : JsonConverter

--- a/csharp/Svix.Tests/WiremockTests.cs
+++ b/csharp/Svix.Tests/WiremockTests.cs
@@ -422,5 +422,48 @@ namespace Svix.Tests
             Assert.Equal(1, stub.LogEntries.Count);
             Assert.Equal("?with_content=false", stub.LogEntries[0].RequestMessage.RawQuery);
         }
+
+        [Fact]
+        public void AbsentContentFieldInResponseStructEnum()
+        {
+            var strmId = "strm_31Dc0DD72P5AddYUguyBd";
+            var sinkId = "sink_31Dc11sPYY9aLDkwPuGMa";
+            var responseJson = """
+                    {
+                        "batchSize": 1,
+                        "channels": [],
+                        "createdAt": "2026-09-07T16:32:02.696Z",
+                        "currentIterator": "string",
+                        "eventTypes": [],
+                        "failureReason": null,
+                        "id": "sink_2yZwUhtgs5Ai8T9yRQJXA",
+                        "maxWaitSecs": 1,
+                        "metadata": {
+                            "additionalProperty": "string"
+                        },
+                        "nextRetryAt": "2026-09-07T16:32:02.696Z",
+                        "status": "enabled",
+                        "uid": "unique-identifier",
+                        "updatedAt": "2026-09-07T16:32:02.696Z",
+                        "type": "poller"
+                    }
+                """;
+            stub.Given(
+                    Request.Create().WithPath($"/api/v1/stream/{strmId}/sink/{sinkId}").UsingGet()
+                )
+                .RespondWith(Response.Create().WithStatusCode(200).WithBody(responseJson));
+
+            var response = client.Streaming.Sink.Get(strmId, sinkId);
+
+            Assert.Equal(response.Uid, "unique-identifier");
+
+            var isPoller = false;
+            response.Config.Switch(onPoller: () =>
+            {
+                isPoller = true;
+            });
+
+            Assert.True(isPoller);
+        }
     }
 }

--- a/csharp/Svix/Models/AutoConfigSinkType.cs
+++ b/csharp/Svix/Models/AutoConfigSinkType.cs
@@ -93,15 +93,21 @@ namespace Svix.Models
             };
         }
 
-        public void Switch(Action<SinkInCommon> onPoller, Action<EndpointIn> onHttp)
+        public void Switch(Action<SinkInCommon>? onPoller = null, Action<EndpointIn>? onHttp = null)
         {
             switch (_type)
             {
                 case ConfigType.Poller:
-                    onPoller((SinkInCommon)_value);
+                    if (onPoller != null)
+                    {
+                        onPoller((SinkInCommon)_value);
+                    }
                     break;
                 case ConfigType.Http:
-                    onHttp((EndpointIn)_value);
+                    if (onHttp != null)
+                    {
+                        onHttp((EndpointIn)_value);
+                    }
                     break;
                 default:
                     // unreachable
@@ -115,8 +121,8 @@ namespace Svix.Models
         [JsonProperty("type", Required = Required.Always)]
         public required string Type { get; set; }
 
-        [JsonProperty("config", Required = Required.Always)]
-        public required JObject Config { get; set; }
+        [JsonProperty("config")]
+        public JObject? Config { get; set; }
     }
 
     public class AutoConfigSinkTypeConverter : JsonConverter

--- a/csharp/Svix/Models/DestinationIn.cs
+++ b/csharp/Svix/Models/DestinationIn.cs
@@ -244,73 +244,121 @@ namespace Svix.Models
         }
 
         public void Switch(
-            Action onPollingEndpoint,
-            Action<AzureBlobStorageConfigIn> onAzureBlobStorage,
-            Action<OtelTracingConfigIn> onOtelTracing,
-            Action<FifoEndpointConfigIn> onFifoEndpoint,
-            Action<S3ConfigIn> onAmazonS3,
-            Action<GoogleCloudStorageConfigIn> onGoogleCloudStorage,
-            Action<GoogleCloudPubSubConfigIn> onGoogleCloudPubSub,
-            Action<SqsConfigIn> onSqs,
-            Action<SnsConfigIn> onSns,
-            Action<BigQueryConfigIn> onBigQuery,
-            Action<ClickhouseConfigIn> onClickhouse,
-            Action<EventBridgeConfigIn> onEventBridge,
-            Action<SnowflakeConfigIn> onSnowflake,
-            Action<RabbitMqConfigIn> onRabbitMq,
-            Action<RedshiftConfigIn> onRedshift,
-            Action<PostgresConfigIn> onPostgres
+            Action? onPollingEndpoint = null,
+            Action<AzureBlobStorageConfigIn>? onAzureBlobStorage = null,
+            Action<OtelTracingConfigIn>? onOtelTracing = null,
+            Action<FifoEndpointConfigIn>? onFifoEndpoint = null,
+            Action<S3ConfigIn>? onAmazonS3 = null,
+            Action<GoogleCloudStorageConfigIn>? onGoogleCloudStorage = null,
+            Action<GoogleCloudPubSubConfigIn>? onGoogleCloudPubSub = null,
+            Action<SqsConfigIn>? onSqs = null,
+            Action<SnsConfigIn>? onSns = null,
+            Action<BigQueryConfigIn>? onBigQuery = null,
+            Action<ClickhouseConfigIn>? onClickhouse = null,
+            Action<EventBridgeConfigIn>? onEventBridge = null,
+            Action<SnowflakeConfigIn>? onSnowflake = null,
+            Action<RabbitMqConfigIn>? onRabbitMq = null,
+            Action<RedshiftConfigIn>? onRedshift = null,
+            Action<PostgresConfigIn>? onPostgres = null
         )
         {
             switch (_type)
             {
                 case ConfigType.PollingEndpoint:
-                    onPollingEndpoint();
+                    if (onPollingEndpoint != null)
+                    {
+                        onPollingEndpoint();
+                    }
                     break;
                 case ConfigType.AzureBlobStorage:
-                    onAzureBlobStorage((AzureBlobStorageConfigIn)_value);
+                    if (onAzureBlobStorage != null)
+                    {
+                        onAzureBlobStorage((AzureBlobStorageConfigIn)_value);
+                    }
                     break;
                 case ConfigType.OtelTracing:
-                    onOtelTracing((OtelTracingConfigIn)_value);
+                    if (onOtelTracing != null)
+                    {
+                        onOtelTracing((OtelTracingConfigIn)_value);
+                    }
                     break;
                 case ConfigType.FifoEndpoint:
-                    onFifoEndpoint((FifoEndpointConfigIn)_value);
+                    if (onFifoEndpoint != null)
+                    {
+                        onFifoEndpoint((FifoEndpointConfigIn)_value);
+                    }
                     break;
                 case ConfigType.AmazonS3:
-                    onAmazonS3((S3ConfigIn)_value);
+                    if (onAmazonS3 != null)
+                    {
+                        onAmazonS3((S3ConfigIn)_value);
+                    }
                     break;
                 case ConfigType.GoogleCloudStorage:
-                    onGoogleCloudStorage((GoogleCloudStorageConfigIn)_value);
+                    if (onGoogleCloudStorage != null)
+                    {
+                        onGoogleCloudStorage((GoogleCloudStorageConfigIn)_value);
+                    }
                     break;
                 case ConfigType.GoogleCloudPubSub:
-                    onGoogleCloudPubSub((GoogleCloudPubSubConfigIn)_value);
+                    if (onGoogleCloudPubSub != null)
+                    {
+                        onGoogleCloudPubSub((GoogleCloudPubSubConfigIn)_value);
+                    }
                     break;
                 case ConfigType.Sqs:
-                    onSqs((SqsConfigIn)_value);
+                    if (onSqs != null)
+                    {
+                        onSqs((SqsConfigIn)_value);
+                    }
                     break;
                 case ConfigType.Sns:
-                    onSns((SnsConfigIn)_value);
+                    if (onSns != null)
+                    {
+                        onSns((SnsConfigIn)_value);
+                    }
                     break;
                 case ConfigType.BigQuery:
-                    onBigQuery((BigQueryConfigIn)_value);
+                    if (onBigQuery != null)
+                    {
+                        onBigQuery((BigQueryConfigIn)_value);
+                    }
                     break;
                 case ConfigType.Clickhouse:
-                    onClickhouse((ClickhouseConfigIn)_value);
+                    if (onClickhouse != null)
+                    {
+                        onClickhouse((ClickhouseConfigIn)_value);
+                    }
                     break;
                 case ConfigType.EventBridge:
-                    onEventBridge((EventBridgeConfigIn)_value);
+                    if (onEventBridge != null)
+                    {
+                        onEventBridge((EventBridgeConfigIn)_value);
+                    }
                     break;
                 case ConfigType.Snowflake:
-                    onSnowflake((SnowflakeConfigIn)_value);
+                    if (onSnowflake != null)
+                    {
+                        onSnowflake((SnowflakeConfigIn)_value);
+                    }
                     break;
                 case ConfigType.RabbitMq:
-                    onRabbitMq((RabbitMqConfigIn)_value);
+                    if (onRabbitMq != null)
+                    {
+                        onRabbitMq((RabbitMqConfigIn)_value);
+                    }
                     break;
                 case ConfigType.Redshift:
-                    onRedshift((RedshiftConfigIn)_value);
+                    if (onRedshift != null)
+                    {
+                        onRedshift((RedshiftConfigIn)_value);
+                    }
                     break;
                 case ConfigType.Postgres:
-                    onPostgres((PostgresConfigIn)_value);
+                    if (onPostgres != null)
+                    {
+                        onPostgres((PostgresConfigIn)_value);
+                    }
                     break;
                 default:
                     // unreachable
@@ -345,8 +393,8 @@ namespace Svix.Models
         [JsonProperty("type", Required = Required.Always)]
         public required string Type { get; set; }
 
-        [JsonProperty("config", Required = Required.Always)]
-        public required JObject Config { get; set; }
+        [JsonProperty("config")]
+        public JObject? Config { get; set; }
     }
 
     public class DestinationInConverter : JsonConverter

--- a/csharp/Svix/Models/DestinationOut.cs
+++ b/csharp/Svix/Models/DestinationOut.cs
@@ -270,73 +270,121 @@ namespace Svix.Models
         }
 
         public void Switch(
-            Action onPollingEndpoint,
-            Action<AzureBlobStorageConfigOut> onAzureBlobStorage,
-            Action<OtelTracingConfigOut> onOtelTracing,
-            Action<SinkHttpConfigOut> onFifoEndpoint,
-            Action<S3ConfigOut> onAmazonS3,
-            Action<SnowflakeConfigOut> onSnowflake,
-            Action<GoogleCloudStorageConfigOut> onGoogleCloudStorage,
-            Action<GoogleCloudPubSubConfigOut> onGoogleCloudPubSub,
-            Action<RedshiftConfigOut> onRedshift,
-            Action<BigQueryConfigOut> onBigQuery,
-            Action<ClickhouseConfigOut> onClickhouse,
-            Action<RabbitMqConfigOut> onRabbitMq,
-            Action<SqsConfigOut> onSqs,
-            Action<EventBridgeConfigOut> onEventBridge,
-            Action<SnsConfigOut> onSns,
-            Action<PostgresConfigOut> onPostgres
+            Action? onPollingEndpoint = null,
+            Action<AzureBlobStorageConfigOut>? onAzureBlobStorage = null,
+            Action<OtelTracingConfigOut>? onOtelTracing = null,
+            Action<SinkHttpConfigOut>? onFifoEndpoint = null,
+            Action<S3ConfigOut>? onAmazonS3 = null,
+            Action<SnowflakeConfigOut>? onSnowflake = null,
+            Action<GoogleCloudStorageConfigOut>? onGoogleCloudStorage = null,
+            Action<GoogleCloudPubSubConfigOut>? onGoogleCloudPubSub = null,
+            Action<RedshiftConfigOut>? onRedshift = null,
+            Action<BigQueryConfigOut>? onBigQuery = null,
+            Action<ClickhouseConfigOut>? onClickhouse = null,
+            Action<RabbitMqConfigOut>? onRabbitMq = null,
+            Action<SqsConfigOut>? onSqs = null,
+            Action<EventBridgeConfigOut>? onEventBridge = null,
+            Action<SnsConfigOut>? onSns = null,
+            Action<PostgresConfigOut>? onPostgres = null
         )
         {
             switch (_type)
             {
                 case ConfigType.PollingEndpoint:
-                    onPollingEndpoint();
+                    if (onPollingEndpoint != null)
+                    {
+                        onPollingEndpoint();
+                    }
                     break;
                 case ConfigType.AzureBlobStorage:
-                    onAzureBlobStorage((AzureBlobStorageConfigOut)_value);
+                    if (onAzureBlobStorage != null)
+                    {
+                        onAzureBlobStorage((AzureBlobStorageConfigOut)_value);
+                    }
                     break;
                 case ConfigType.OtelTracing:
-                    onOtelTracing((OtelTracingConfigOut)_value);
+                    if (onOtelTracing != null)
+                    {
+                        onOtelTracing((OtelTracingConfigOut)_value);
+                    }
                     break;
                 case ConfigType.FifoEndpoint:
-                    onFifoEndpoint((SinkHttpConfigOut)_value);
+                    if (onFifoEndpoint != null)
+                    {
+                        onFifoEndpoint((SinkHttpConfigOut)_value);
+                    }
                     break;
                 case ConfigType.AmazonS3:
-                    onAmazonS3((S3ConfigOut)_value);
+                    if (onAmazonS3 != null)
+                    {
+                        onAmazonS3((S3ConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Snowflake:
-                    onSnowflake((SnowflakeConfigOut)_value);
+                    if (onSnowflake != null)
+                    {
+                        onSnowflake((SnowflakeConfigOut)_value);
+                    }
                     break;
                 case ConfigType.GoogleCloudStorage:
-                    onGoogleCloudStorage((GoogleCloudStorageConfigOut)_value);
+                    if (onGoogleCloudStorage != null)
+                    {
+                        onGoogleCloudStorage((GoogleCloudStorageConfigOut)_value);
+                    }
                     break;
                 case ConfigType.GoogleCloudPubSub:
-                    onGoogleCloudPubSub((GoogleCloudPubSubConfigOut)_value);
+                    if (onGoogleCloudPubSub != null)
+                    {
+                        onGoogleCloudPubSub((GoogleCloudPubSubConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Redshift:
-                    onRedshift((RedshiftConfigOut)_value);
+                    if (onRedshift != null)
+                    {
+                        onRedshift((RedshiftConfigOut)_value);
+                    }
                     break;
                 case ConfigType.BigQuery:
-                    onBigQuery((BigQueryConfigOut)_value);
+                    if (onBigQuery != null)
+                    {
+                        onBigQuery((BigQueryConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Clickhouse:
-                    onClickhouse((ClickhouseConfigOut)_value);
+                    if (onClickhouse != null)
+                    {
+                        onClickhouse((ClickhouseConfigOut)_value);
+                    }
                     break;
                 case ConfigType.RabbitMq:
-                    onRabbitMq((RabbitMqConfigOut)_value);
+                    if (onRabbitMq != null)
+                    {
+                        onRabbitMq((RabbitMqConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Sqs:
-                    onSqs((SqsConfigOut)_value);
+                    if (onSqs != null)
+                    {
+                        onSqs((SqsConfigOut)_value);
+                    }
                     break;
                 case ConfigType.EventBridge:
-                    onEventBridge((EventBridgeConfigOut)_value);
+                    if (onEventBridge != null)
+                    {
+                        onEventBridge((EventBridgeConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Sns:
-                    onSns((SnsConfigOut)_value);
+                    if (onSns != null)
+                    {
+                        onSns((SnsConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Postgres:
-                    onPostgres((PostgresConfigOut)_value);
+                    if (onPostgres != null)
+                    {
+                        onPostgres((PostgresConfigOut)_value);
+                    }
                     break;
                 default:
                     // unreachable
@@ -389,8 +437,8 @@ namespace Svix.Models
         [JsonProperty("type", Required = Required.Always)]
         public required string Type { get; set; }
 
-        [JsonProperty("config", Required = Required.Always)]
-        public required JObject Config { get; set; }
+        [JsonProperty("config")]
+        public JObject? Config { get; set; }
     }
 
     public class DestinationOutConverter : JsonConverter

--- a/csharp/Svix/Models/IngestSourceIn.cs
+++ b/csharp/Svix/Models/IngestSourceIn.cs
@@ -434,181 +434,310 @@ namespace Svix.Models
         }
 
         public void Switch(
-            Action onGenericWebhook,
-            Action<CronConfig> onCron,
-            Action<AdobeSignConfig> onAdobeSign,
-            Action<SvixConfig> onBeehiiv,
-            Action<SvixConfig> onBrex,
-            Action<CheckbookConfig> onCheckbook,
-            Action<SvixConfig> onClerk,
-            Action<DocusignConfig> onDocusign,
-            Action<EasypostConfig> onEasypost,
-            Action<GithubConfig> onGithub,
-            Action<SvixConfig> onGuesty,
-            Action<HubspotConfig> onHubspot,
-            Action<SvixConfig> onIncidentIo,
-            Action<SvixConfig> onLithic,
-            Action<MetaConfig> onMeta,
-            Action<NangoConfig> onNango,
-            Action<SvixConfig> onNash,
-            Action<OpenClawConfig> onOpenclaw,
-            Action<OrumIoConfig> onOrumIo,
-            Action<PandaDocConfig> onPandaDoc,
-            Action<PortIoConfig> onPortIo,
-            Action<SvixConfig> onPleo,
-            Action<SvixConfig> onPsiFi,
-            Action<SvixConfig> onReplicate,
-            Action<SvixConfig> onResend,
-            Action<RutterConfig> onRutter,
-            Action<SvixConfig> onSafebase,
-            Action<SvixConfig> onSardine,
-            Action<SegmentConfig> onSegment,
-            Action<ShopifyConfig> onShopify,
-            Action<SlackConfig> onSlack,
-            Action<StripeConfig> onStripe,
-            Action<SvixConfig> onStych,
-            Action<SvixConfig> onSvix,
-            Action<ZoomConfig> onZoom,
-            Action<TailscaleConfig> onTailscale,
-            Action<TelnyxConfig> onTelnyx,
-            Action<VapiConfig> onVapi,
-            Action<SvixConfig> onOpenAi,
-            Action<SvixConfig> onRender,
-            Action<VeriffConfig> onVeriff,
-            Action<AirwallexConfig> onAirwallex,
-            Action<VgsConfig> onVgs
+            Action? onGenericWebhook = null,
+            Action<CronConfig>? onCron = null,
+            Action<AdobeSignConfig>? onAdobeSign = null,
+            Action<SvixConfig>? onBeehiiv = null,
+            Action<SvixConfig>? onBrex = null,
+            Action<CheckbookConfig>? onCheckbook = null,
+            Action<SvixConfig>? onClerk = null,
+            Action<DocusignConfig>? onDocusign = null,
+            Action<EasypostConfig>? onEasypost = null,
+            Action<GithubConfig>? onGithub = null,
+            Action<SvixConfig>? onGuesty = null,
+            Action<HubspotConfig>? onHubspot = null,
+            Action<SvixConfig>? onIncidentIo = null,
+            Action<SvixConfig>? onLithic = null,
+            Action<MetaConfig>? onMeta = null,
+            Action<NangoConfig>? onNango = null,
+            Action<SvixConfig>? onNash = null,
+            Action<OpenClawConfig>? onOpenclaw = null,
+            Action<OrumIoConfig>? onOrumIo = null,
+            Action<PandaDocConfig>? onPandaDoc = null,
+            Action<PortIoConfig>? onPortIo = null,
+            Action<SvixConfig>? onPleo = null,
+            Action<SvixConfig>? onPsiFi = null,
+            Action<SvixConfig>? onReplicate = null,
+            Action<SvixConfig>? onResend = null,
+            Action<RutterConfig>? onRutter = null,
+            Action<SvixConfig>? onSafebase = null,
+            Action<SvixConfig>? onSardine = null,
+            Action<SegmentConfig>? onSegment = null,
+            Action<ShopifyConfig>? onShopify = null,
+            Action<SlackConfig>? onSlack = null,
+            Action<StripeConfig>? onStripe = null,
+            Action<SvixConfig>? onStych = null,
+            Action<SvixConfig>? onSvix = null,
+            Action<ZoomConfig>? onZoom = null,
+            Action<TailscaleConfig>? onTailscale = null,
+            Action<TelnyxConfig>? onTelnyx = null,
+            Action<VapiConfig>? onVapi = null,
+            Action<SvixConfig>? onOpenAi = null,
+            Action<SvixConfig>? onRender = null,
+            Action<VeriffConfig>? onVeriff = null,
+            Action<AirwallexConfig>? onAirwallex = null,
+            Action<VgsConfig>? onVgs = null
         )
         {
             switch (_type)
             {
                 case ConfigType.GenericWebhook:
-                    onGenericWebhook();
+                    if (onGenericWebhook != null)
+                    {
+                        onGenericWebhook();
+                    }
                     break;
                 case ConfigType.Cron:
-                    onCron((CronConfig)_value);
+                    if (onCron != null)
+                    {
+                        onCron((CronConfig)_value);
+                    }
                     break;
                 case ConfigType.AdobeSign:
-                    onAdobeSign((AdobeSignConfig)_value);
+                    if (onAdobeSign != null)
+                    {
+                        onAdobeSign((AdobeSignConfig)_value);
+                    }
                     break;
                 case ConfigType.Beehiiv:
-                    onBeehiiv((SvixConfig)_value);
+                    if (onBeehiiv != null)
+                    {
+                        onBeehiiv((SvixConfig)_value);
+                    }
                     break;
                 case ConfigType.Brex:
-                    onBrex((SvixConfig)_value);
+                    if (onBrex != null)
+                    {
+                        onBrex((SvixConfig)_value);
+                    }
                     break;
                 case ConfigType.Checkbook:
-                    onCheckbook((CheckbookConfig)_value);
+                    if (onCheckbook != null)
+                    {
+                        onCheckbook((CheckbookConfig)_value);
+                    }
                     break;
                 case ConfigType.Clerk:
-                    onClerk((SvixConfig)_value);
+                    if (onClerk != null)
+                    {
+                        onClerk((SvixConfig)_value);
+                    }
                     break;
                 case ConfigType.Docusign:
-                    onDocusign((DocusignConfig)_value);
+                    if (onDocusign != null)
+                    {
+                        onDocusign((DocusignConfig)_value);
+                    }
                     break;
                 case ConfigType.Easypost:
-                    onEasypost((EasypostConfig)_value);
+                    if (onEasypost != null)
+                    {
+                        onEasypost((EasypostConfig)_value);
+                    }
                     break;
                 case ConfigType.Github:
-                    onGithub((GithubConfig)_value);
+                    if (onGithub != null)
+                    {
+                        onGithub((GithubConfig)_value);
+                    }
                     break;
                 case ConfigType.Guesty:
-                    onGuesty((SvixConfig)_value);
+                    if (onGuesty != null)
+                    {
+                        onGuesty((SvixConfig)_value);
+                    }
                     break;
                 case ConfigType.Hubspot:
-                    onHubspot((HubspotConfig)_value);
+                    if (onHubspot != null)
+                    {
+                        onHubspot((HubspotConfig)_value);
+                    }
                     break;
                 case ConfigType.IncidentIo:
-                    onIncidentIo((SvixConfig)_value);
+                    if (onIncidentIo != null)
+                    {
+                        onIncidentIo((SvixConfig)_value);
+                    }
                     break;
                 case ConfigType.Lithic:
-                    onLithic((SvixConfig)_value);
+                    if (onLithic != null)
+                    {
+                        onLithic((SvixConfig)_value);
+                    }
                     break;
                 case ConfigType.Meta:
-                    onMeta((MetaConfig)_value);
+                    if (onMeta != null)
+                    {
+                        onMeta((MetaConfig)_value);
+                    }
                     break;
                 case ConfigType.Nango:
-                    onNango((NangoConfig)_value);
+                    if (onNango != null)
+                    {
+                        onNango((NangoConfig)_value);
+                    }
                     break;
                 case ConfigType.Nash:
-                    onNash((SvixConfig)_value);
+                    if (onNash != null)
+                    {
+                        onNash((SvixConfig)_value);
+                    }
                     break;
                 case ConfigType.Openclaw:
-                    onOpenclaw((OpenClawConfig)_value);
+                    if (onOpenclaw != null)
+                    {
+                        onOpenclaw((OpenClawConfig)_value);
+                    }
                     break;
                 case ConfigType.OrumIo:
-                    onOrumIo((OrumIoConfig)_value);
+                    if (onOrumIo != null)
+                    {
+                        onOrumIo((OrumIoConfig)_value);
+                    }
                     break;
                 case ConfigType.PandaDoc:
-                    onPandaDoc((PandaDocConfig)_value);
+                    if (onPandaDoc != null)
+                    {
+                        onPandaDoc((PandaDocConfig)_value);
+                    }
                     break;
                 case ConfigType.PortIo:
-                    onPortIo((PortIoConfig)_value);
+                    if (onPortIo != null)
+                    {
+                        onPortIo((PortIoConfig)_value);
+                    }
                     break;
                 case ConfigType.Pleo:
-                    onPleo((SvixConfig)_value);
+                    if (onPleo != null)
+                    {
+                        onPleo((SvixConfig)_value);
+                    }
                     break;
                 case ConfigType.PsiFi:
-                    onPsiFi((SvixConfig)_value);
+                    if (onPsiFi != null)
+                    {
+                        onPsiFi((SvixConfig)_value);
+                    }
                     break;
                 case ConfigType.Replicate:
-                    onReplicate((SvixConfig)_value);
+                    if (onReplicate != null)
+                    {
+                        onReplicate((SvixConfig)_value);
+                    }
                     break;
                 case ConfigType.Resend:
-                    onResend((SvixConfig)_value);
+                    if (onResend != null)
+                    {
+                        onResend((SvixConfig)_value);
+                    }
                     break;
                 case ConfigType.Rutter:
-                    onRutter((RutterConfig)_value);
+                    if (onRutter != null)
+                    {
+                        onRutter((RutterConfig)_value);
+                    }
                     break;
                 case ConfigType.Safebase:
-                    onSafebase((SvixConfig)_value);
+                    if (onSafebase != null)
+                    {
+                        onSafebase((SvixConfig)_value);
+                    }
                     break;
                 case ConfigType.Sardine:
-                    onSardine((SvixConfig)_value);
+                    if (onSardine != null)
+                    {
+                        onSardine((SvixConfig)_value);
+                    }
                     break;
                 case ConfigType.Segment:
-                    onSegment((SegmentConfig)_value);
+                    if (onSegment != null)
+                    {
+                        onSegment((SegmentConfig)_value);
+                    }
                     break;
                 case ConfigType.Shopify:
-                    onShopify((ShopifyConfig)_value);
+                    if (onShopify != null)
+                    {
+                        onShopify((ShopifyConfig)_value);
+                    }
                     break;
                 case ConfigType.Slack:
-                    onSlack((SlackConfig)_value);
+                    if (onSlack != null)
+                    {
+                        onSlack((SlackConfig)_value);
+                    }
                     break;
                 case ConfigType.Stripe:
-                    onStripe((StripeConfig)_value);
+                    if (onStripe != null)
+                    {
+                        onStripe((StripeConfig)_value);
+                    }
                     break;
                 case ConfigType.Stych:
-                    onStych((SvixConfig)_value);
+                    if (onStych != null)
+                    {
+                        onStych((SvixConfig)_value);
+                    }
                     break;
                 case ConfigType.Svix:
-                    onSvix((SvixConfig)_value);
+                    if (onSvix != null)
+                    {
+                        onSvix((SvixConfig)_value);
+                    }
                     break;
                 case ConfigType.Zoom:
-                    onZoom((ZoomConfig)_value);
+                    if (onZoom != null)
+                    {
+                        onZoom((ZoomConfig)_value);
+                    }
                     break;
                 case ConfigType.Tailscale:
-                    onTailscale((TailscaleConfig)_value);
+                    if (onTailscale != null)
+                    {
+                        onTailscale((TailscaleConfig)_value);
+                    }
                     break;
                 case ConfigType.Telnyx:
-                    onTelnyx((TelnyxConfig)_value);
+                    if (onTelnyx != null)
+                    {
+                        onTelnyx((TelnyxConfig)_value);
+                    }
                     break;
                 case ConfigType.Vapi:
-                    onVapi((VapiConfig)_value);
+                    if (onVapi != null)
+                    {
+                        onVapi((VapiConfig)_value);
+                    }
                     break;
                 case ConfigType.OpenAi:
-                    onOpenAi((SvixConfig)_value);
+                    if (onOpenAi != null)
+                    {
+                        onOpenAi((SvixConfig)_value);
+                    }
                     break;
                 case ConfigType.Render:
-                    onRender((SvixConfig)_value);
+                    if (onRender != null)
+                    {
+                        onRender((SvixConfig)_value);
+                    }
                     break;
                 case ConfigType.Veriff:
-                    onVeriff((VeriffConfig)_value);
+                    if (onVeriff != null)
+                    {
+                        onVeriff((VeriffConfig)_value);
+                    }
                     break;
                 case ConfigType.Airwallex:
-                    onAirwallex((AirwallexConfig)_value);
+                    if (onAirwallex != null)
+                    {
+                        onAirwallex((AirwallexConfig)_value);
+                    }
                     break;
                 case ConfigType.Vgs:
-                    onVgs((VgsConfig)_value);
+                    if (onVgs != null)
+                    {
+                        onVgs((VgsConfig)_value);
+                    }
                     break;
                 default:
                     // unreachable
@@ -631,8 +760,8 @@ namespace Svix.Models
         [JsonProperty("type", Required = Required.Always)]
         public required string Type { get; set; }
 
-        [JsonProperty("config", Required = Required.Always)]
-        public required JObject Config { get; set; }
+        [JsonProperty("config")]
+        public JObject? Config { get; set; }
     }
 
     public class IngestSourceInConverter : JsonConverter

--- a/csharp/Svix/Models/IngestSourceOut.cs
+++ b/csharp/Svix/Models/IngestSourceOut.cs
@@ -450,181 +450,310 @@ namespace Svix.Models
         }
 
         public void Switch(
-            Action onGenericWebhook,
-            Action<CronConfig> onCron,
-            Action<AdobeSignConfigOut> onAdobeSign,
-            Action<SvixConfigOut> onBeehiiv,
-            Action<SvixConfigOut> onBrex,
-            Action<CheckbookConfigOut> onCheckbook,
-            Action<SvixConfigOut> onClerk,
-            Action<DocusignConfigOut> onDocusign,
-            Action<EasypostConfigOut> onEasypost,
-            Action<GithubConfigOut> onGithub,
-            Action<SvixConfigOut> onGuesty,
-            Action<HubspotConfigOut> onHubspot,
-            Action<SvixConfigOut> onIncidentIo,
-            Action<SvixConfigOut> onLithic,
-            Action<MetaConfigOut> onMeta,
-            Action<NangoConfigOut> onNango,
-            Action<SvixConfigOut> onNash,
-            Action<OpenClawConfigOut> onOpenclaw,
-            Action<OrumIoConfigOut> onOrumIo,
-            Action<PandaDocConfigOut> onPandaDoc,
-            Action<PortIoConfigOut> onPortIo,
-            Action<SvixConfigOut> onPsiFi,
-            Action<SvixConfigOut> onPleo,
-            Action<SvixConfigOut> onReplicate,
-            Action<SvixConfigOut> onResend,
-            Action<RutterConfigOut> onRutter,
-            Action<SvixConfigOut> onSafebase,
-            Action<SvixConfigOut> onSardine,
-            Action<SegmentConfigOut> onSegment,
-            Action<ShopifyConfigOut> onShopify,
-            Action<SlackConfigOut> onSlack,
-            Action<StripeConfigOut> onStripe,
-            Action<SvixConfigOut> onStych,
-            Action<SvixConfigOut> onSvix,
-            Action<ZoomConfigOut> onZoom,
-            Action<TailscaleConfigOut> onTailscale,
-            Action<TelnyxConfigOut> onTelnyx,
-            Action<VapiConfigOut> onVapi,
-            Action<SvixConfigOut> onOpenAi,
-            Action<SvixConfigOut> onRender,
-            Action<VeriffConfigOut> onVeriff,
-            Action<AirwallexConfigOut> onAirwallex,
-            Action<VgsConfigOut> onVgs
+            Action? onGenericWebhook = null,
+            Action<CronConfig>? onCron = null,
+            Action<AdobeSignConfigOut>? onAdobeSign = null,
+            Action<SvixConfigOut>? onBeehiiv = null,
+            Action<SvixConfigOut>? onBrex = null,
+            Action<CheckbookConfigOut>? onCheckbook = null,
+            Action<SvixConfigOut>? onClerk = null,
+            Action<DocusignConfigOut>? onDocusign = null,
+            Action<EasypostConfigOut>? onEasypost = null,
+            Action<GithubConfigOut>? onGithub = null,
+            Action<SvixConfigOut>? onGuesty = null,
+            Action<HubspotConfigOut>? onHubspot = null,
+            Action<SvixConfigOut>? onIncidentIo = null,
+            Action<SvixConfigOut>? onLithic = null,
+            Action<MetaConfigOut>? onMeta = null,
+            Action<NangoConfigOut>? onNango = null,
+            Action<SvixConfigOut>? onNash = null,
+            Action<OpenClawConfigOut>? onOpenclaw = null,
+            Action<OrumIoConfigOut>? onOrumIo = null,
+            Action<PandaDocConfigOut>? onPandaDoc = null,
+            Action<PortIoConfigOut>? onPortIo = null,
+            Action<SvixConfigOut>? onPsiFi = null,
+            Action<SvixConfigOut>? onPleo = null,
+            Action<SvixConfigOut>? onReplicate = null,
+            Action<SvixConfigOut>? onResend = null,
+            Action<RutterConfigOut>? onRutter = null,
+            Action<SvixConfigOut>? onSafebase = null,
+            Action<SvixConfigOut>? onSardine = null,
+            Action<SegmentConfigOut>? onSegment = null,
+            Action<ShopifyConfigOut>? onShopify = null,
+            Action<SlackConfigOut>? onSlack = null,
+            Action<StripeConfigOut>? onStripe = null,
+            Action<SvixConfigOut>? onStych = null,
+            Action<SvixConfigOut>? onSvix = null,
+            Action<ZoomConfigOut>? onZoom = null,
+            Action<TailscaleConfigOut>? onTailscale = null,
+            Action<TelnyxConfigOut>? onTelnyx = null,
+            Action<VapiConfigOut>? onVapi = null,
+            Action<SvixConfigOut>? onOpenAi = null,
+            Action<SvixConfigOut>? onRender = null,
+            Action<VeriffConfigOut>? onVeriff = null,
+            Action<AirwallexConfigOut>? onAirwallex = null,
+            Action<VgsConfigOut>? onVgs = null
         )
         {
             switch (_type)
             {
                 case ConfigType.GenericWebhook:
-                    onGenericWebhook();
+                    if (onGenericWebhook != null)
+                    {
+                        onGenericWebhook();
+                    }
                     break;
                 case ConfigType.Cron:
-                    onCron((CronConfig)_value);
+                    if (onCron != null)
+                    {
+                        onCron((CronConfig)_value);
+                    }
                     break;
                 case ConfigType.AdobeSign:
-                    onAdobeSign((AdobeSignConfigOut)_value);
+                    if (onAdobeSign != null)
+                    {
+                        onAdobeSign((AdobeSignConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Beehiiv:
-                    onBeehiiv((SvixConfigOut)_value);
+                    if (onBeehiiv != null)
+                    {
+                        onBeehiiv((SvixConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Brex:
-                    onBrex((SvixConfigOut)_value);
+                    if (onBrex != null)
+                    {
+                        onBrex((SvixConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Checkbook:
-                    onCheckbook((CheckbookConfigOut)_value);
+                    if (onCheckbook != null)
+                    {
+                        onCheckbook((CheckbookConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Clerk:
-                    onClerk((SvixConfigOut)_value);
+                    if (onClerk != null)
+                    {
+                        onClerk((SvixConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Docusign:
-                    onDocusign((DocusignConfigOut)_value);
+                    if (onDocusign != null)
+                    {
+                        onDocusign((DocusignConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Easypost:
-                    onEasypost((EasypostConfigOut)_value);
+                    if (onEasypost != null)
+                    {
+                        onEasypost((EasypostConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Github:
-                    onGithub((GithubConfigOut)_value);
+                    if (onGithub != null)
+                    {
+                        onGithub((GithubConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Guesty:
-                    onGuesty((SvixConfigOut)_value);
+                    if (onGuesty != null)
+                    {
+                        onGuesty((SvixConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Hubspot:
-                    onHubspot((HubspotConfigOut)_value);
+                    if (onHubspot != null)
+                    {
+                        onHubspot((HubspotConfigOut)_value);
+                    }
                     break;
                 case ConfigType.IncidentIo:
-                    onIncidentIo((SvixConfigOut)_value);
+                    if (onIncidentIo != null)
+                    {
+                        onIncidentIo((SvixConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Lithic:
-                    onLithic((SvixConfigOut)_value);
+                    if (onLithic != null)
+                    {
+                        onLithic((SvixConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Meta:
-                    onMeta((MetaConfigOut)_value);
+                    if (onMeta != null)
+                    {
+                        onMeta((MetaConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Nango:
-                    onNango((NangoConfigOut)_value);
+                    if (onNango != null)
+                    {
+                        onNango((NangoConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Nash:
-                    onNash((SvixConfigOut)_value);
+                    if (onNash != null)
+                    {
+                        onNash((SvixConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Openclaw:
-                    onOpenclaw((OpenClawConfigOut)_value);
+                    if (onOpenclaw != null)
+                    {
+                        onOpenclaw((OpenClawConfigOut)_value);
+                    }
                     break;
                 case ConfigType.OrumIo:
-                    onOrumIo((OrumIoConfigOut)_value);
+                    if (onOrumIo != null)
+                    {
+                        onOrumIo((OrumIoConfigOut)_value);
+                    }
                     break;
                 case ConfigType.PandaDoc:
-                    onPandaDoc((PandaDocConfigOut)_value);
+                    if (onPandaDoc != null)
+                    {
+                        onPandaDoc((PandaDocConfigOut)_value);
+                    }
                     break;
                 case ConfigType.PortIo:
-                    onPortIo((PortIoConfigOut)_value);
+                    if (onPortIo != null)
+                    {
+                        onPortIo((PortIoConfigOut)_value);
+                    }
                     break;
                 case ConfigType.PsiFi:
-                    onPsiFi((SvixConfigOut)_value);
+                    if (onPsiFi != null)
+                    {
+                        onPsiFi((SvixConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Pleo:
-                    onPleo((SvixConfigOut)_value);
+                    if (onPleo != null)
+                    {
+                        onPleo((SvixConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Replicate:
-                    onReplicate((SvixConfigOut)_value);
+                    if (onReplicate != null)
+                    {
+                        onReplicate((SvixConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Resend:
-                    onResend((SvixConfigOut)_value);
+                    if (onResend != null)
+                    {
+                        onResend((SvixConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Rutter:
-                    onRutter((RutterConfigOut)_value);
+                    if (onRutter != null)
+                    {
+                        onRutter((RutterConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Safebase:
-                    onSafebase((SvixConfigOut)_value);
+                    if (onSafebase != null)
+                    {
+                        onSafebase((SvixConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Sardine:
-                    onSardine((SvixConfigOut)_value);
+                    if (onSardine != null)
+                    {
+                        onSardine((SvixConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Segment:
-                    onSegment((SegmentConfigOut)_value);
+                    if (onSegment != null)
+                    {
+                        onSegment((SegmentConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Shopify:
-                    onShopify((ShopifyConfigOut)_value);
+                    if (onShopify != null)
+                    {
+                        onShopify((ShopifyConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Slack:
-                    onSlack((SlackConfigOut)_value);
+                    if (onSlack != null)
+                    {
+                        onSlack((SlackConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Stripe:
-                    onStripe((StripeConfigOut)_value);
+                    if (onStripe != null)
+                    {
+                        onStripe((StripeConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Stych:
-                    onStych((SvixConfigOut)_value);
+                    if (onStych != null)
+                    {
+                        onStych((SvixConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Svix:
-                    onSvix((SvixConfigOut)_value);
+                    if (onSvix != null)
+                    {
+                        onSvix((SvixConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Zoom:
-                    onZoom((ZoomConfigOut)_value);
+                    if (onZoom != null)
+                    {
+                        onZoom((ZoomConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Tailscale:
-                    onTailscale((TailscaleConfigOut)_value);
+                    if (onTailscale != null)
+                    {
+                        onTailscale((TailscaleConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Telnyx:
-                    onTelnyx((TelnyxConfigOut)_value);
+                    if (onTelnyx != null)
+                    {
+                        onTelnyx((TelnyxConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Vapi:
-                    onVapi((VapiConfigOut)_value);
+                    if (onVapi != null)
+                    {
+                        onVapi((VapiConfigOut)_value);
+                    }
                     break;
                 case ConfigType.OpenAi:
-                    onOpenAi((SvixConfigOut)_value);
+                    if (onOpenAi != null)
+                    {
+                        onOpenAi((SvixConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Render:
-                    onRender((SvixConfigOut)_value);
+                    if (onRender != null)
+                    {
+                        onRender((SvixConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Veriff:
-                    onVeriff((VeriffConfigOut)_value);
+                    if (onVeriff != null)
+                    {
+                        onVeriff((VeriffConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Airwallex:
-                    onAirwallex((AirwallexConfigOut)_value);
+                    if (onAirwallex != null)
+                    {
+                        onAirwallex((AirwallexConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Vgs:
-                    onVgs((VgsConfigOut)_value);
+                    if (onVgs != null)
+                    {
+                        onVgs((VgsConfigOut)_value);
+                    }
                     break;
                 default:
                     // unreachable
@@ -659,8 +788,8 @@ namespace Svix.Models
         [JsonProperty("type", Required = Required.Always)]
         public required string Type { get; set; }
 
-        [JsonProperty("config", Required = Required.Always)]
-        public required JObject Config { get; set; }
+        [JsonProperty("config")]
+        public JObject? Config { get; set; }
     }
 
     public class IngestSourceOutConverter : JsonConverter

--- a/csharp/Svix/Models/StreamSinkIn.cs
+++ b/csharp/Svix/Models/StreamSinkIn.cs
@@ -241,73 +241,121 @@ namespace Svix.Models
         }
 
         public void Switch(
-            Action onPoller,
-            Action<AzureBlobStorageConfigIn> onAzureBlobStorage,
-            Action<OtelTracingConfigIn> onOtelTracing,
-            Action<SinkHttpConfigIn> onHttp,
-            Action<S3ConfigIn> onAmazonS3,
-            Action<GoogleCloudStorageConfigIn> onGoogleCloudStorage,
-            Action<GoogleCloudPubSubConfigIn> onGoogleCloudPubSub,
-            Action<SqsConfigIn> onSqs,
-            Action<SnsConfigIn> onSns,
-            Action<BigQueryConfigIn> onBigQuery,
-            Action<ClickhouseConfigIn> onClickhouse,
-            Action<EventBridgeConfigIn> onEventBridge,
-            Action<SnowflakeConfigIn> onSnowflake,
-            Action<RabbitMqConfigIn> onRabbitMq,
-            Action<RedshiftConfigIn> onRedshift,
-            Action<PostgresConfigIn> onPostgres
+            Action? onPoller = null,
+            Action<AzureBlobStorageConfigIn>? onAzureBlobStorage = null,
+            Action<OtelTracingConfigIn>? onOtelTracing = null,
+            Action<SinkHttpConfigIn>? onHttp = null,
+            Action<S3ConfigIn>? onAmazonS3 = null,
+            Action<GoogleCloudStorageConfigIn>? onGoogleCloudStorage = null,
+            Action<GoogleCloudPubSubConfigIn>? onGoogleCloudPubSub = null,
+            Action<SqsConfigIn>? onSqs = null,
+            Action<SnsConfigIn>? onSns = null,
+            Action<BigQueryConfigIn>? onBigQuery = null,
+            Action<ClickhouseConfigIn>? onClickhouse = null,
+            Action<EventBridgeConfigIn>? onEventBridge = null,
+            Action<SnowflakeConfigIn>? onSnowflake = null,
+            Action<RabbitMqConfigIn>? onRabbitMq = null,
+            Action<RedshiftConfigIn>? onRedshift = null,
+            Action<PostgresConfigIn>? onPostgres = null
         )
         {
             switch (_type)
             {
                 case ConfigType.Poller:
-                    onPoller();
+                    if (onPoller != null)
+                    {
+                        onPoller();
+                    }
                     break;
                 case ConfigType.AzureBlobStorage:
-                    onAzureBlobStorage((AzureBlobStorageConfigIn)_value);
+                    if (onAzureBlobStorage != null)
+                    {
+                        onAzureBlobStorage((AzureBlobStorageConfigIn)_value);
+                    }
                     break;
                 case ConfigType.OtelTracing:
-                    onOtelTracing((OtelTracingConfigIn)_value);
+                    if (onOtelTracing != null)
+                    {
+                        onOtelTracing((OtelTracingConfigIn)_value);
+                    }
                     break;
                 case ConfigType.Http:
-                    onHttp((SinkHttpConfigIn)_value);
+                    if (onHttp != null)
+                    {
+                        onHttp((SinkHttpConfigIn)_value);
+                    }
                     break;
                 case ConfigType.AmazonS3:
-                    onAmazonS3((S3ConfigIn)_value);
+                    if (onAmazonS3 != null)
+                    {
+                        onAmazonS3((S3ConfigIn)_value);
+                    }
                     break;
                 case ConfigType.GoogleCloudStorage:
-                    onGoogleCloudStorage((GoogleCloudStorageConfigIn)_value);
+                    if (onGoogleCloudStorage != null)
+                    {
+                        onGoogleCloudStorage((GoogleCloudStorageConfigIn)_value);
+                    }
                     break;
                 case ConfigType.GoogleCloudPubSub:
-                    onGoogleCloudPubSub((GoogleCloudPubSubConfigIn)_value);
+                    if (onGoogleCloudPubSub != null)
+                    {
+                        onGoogleCloudPubSub((GoogleCloudPubSubConfigIn)_value);
+                    }
                     break;
                 case ConfigType.Sqs:
-                    onSqs((SqsConfigIn)_value);
+                    if (onSqs != null)
+                    {
+                        onSqs((SqsConfigIn)_value);
+                    }
                     break;
                 case ConfigType.Sns:
-                    onSns((SnsConfigIn)_value);
+                    if (onSns != null)
+                    {
+                        onSns((SnsConfigIn)_value);
+                    }
                     break;
                 case ConfigType.BigQuery:
-                    onBigQuery((BigQueryConfigIn)_value);
+                    if (onBigQuery != null)
+                    {
+                        onBigQuery((BigQueryConfigIn)_value);
+                    }
                     break;
                 case ConfigType.Clickhouse:
-                    onClickhouse((ClickhouseConfigIn)_value);
+                    if (onClickhouse != null)
+                    {
+                        onClickhouse((ClickhouseConfigIn)_value);
+                    }
                     break;
                 case ConfigType.EventBridge:
-                    onEventBridge((EventBridgeConfigIn)_value);
+                    if (onEventBridge != null)
+                    {
+                        onEventBridge((EventBridgeConfigIn)_value);
+                    }
                     break;
                 case ConfigType.Snowflake:
-                    onSnowflake((SnowflakeConfigIn)_value);
+                    if (onSnowflake != null)
+                    {
+                        onSnowflake((SnowflakeConfigIn)_value);
+                    }
                     break;
                 case ConfigType.RabbitMq:
-                    onRabbitMq((RabbitMqConfigIn)_value);
+                    if (onRabbitMq != null)
+                    {
+                        onRabbitMq((RabbitMqConfigIn)_value);
+                    }
                     break;
                 case ConfigType.Redshift:
-                    onRedshift((RedshiftConfigIn)_value);
+                    if (onRedshift != null)
+                    {
+                        onRedshift((RedshiftConfigIn)_value);
+                    }
                     break;
                 case ConfigType.Postgres:
-                    onPostgres((PostgresConfigIn)_value);
+                    if (onPostgres != null)
+                    {
+                        onPostgres((PostgresConfigIn)_value);
+                    }
                     break;
                 default:
                     // unreachable
@@ -342,8 +390,8 @@ namespace Svix.Models
         [JsonProperty("type", Required = Required.Always)]
         public required string Type { get; set; }
 
-        [JsonProperty("config", Required = Required.Always)]
-        public required JObject Config { get; set; }
+        [JsonProperty("config")]
+        public JObject? Config { get; set; }
     }
 
     public class StreamSinkInConverter : JsonConverter

--- a/csharp/Svix/Models/StreamSinkOut.cs
+++ b/csharp/Svix/Models/StreamSinkOut.cs
@@ -267,73 +267,121 @@ namespace Svix.Models
         }
 
         public void Switch(
-            Action onPoller,
-            Action<AzureBlobStorageConfigOut> onAzureBlobStorage,
-            Action<OtelTracingConfigOut> onOtelTracing,
-            Action<SinkHttpConfigOut> onHttp,
-            Action<S3ConfigOut> onAmazonS3,
-            Action<SnowflakeConfigOut> onSnowflake,
-            Action<GoogleCloudStorageConfigOut> onGoogleCloudStorage,
-            Action<GoogleCloudPubSubConfigOut> onGoogleCloudPubSub,
-            Action<RedshiftConfigOut> onRedshift,
-            Action<BigQueryConfigOut> onBigQuery,
-            Action<ClickhouseConfigOut> onClickhouse,
-            Action<RabbitMqConfigOut> onRabbitMq,
-            Action<SqsConfigOut> onSqs,
-            Action<EventBridgeConfigOut> onEventBridge,
-            Action<SnsConfigOut> onSns,
-            Action<PostgresConfigOut> onPostgres
+            Action? onPoller = null,
+            Action<AzureBlobStorageConfigOut>? onAzureBlobStorage = null,
+            Action<OtelTracingConfigOut>? onOtelTracing = null,
+            Action<SinkHttpConfigOut>? onHttp = null,
+            Action<S3ConfigOut>? onAmazonS3 = null,
+            Action<SnowflakeConfigOut>? onSnowflake = null,
+            Action<GoogleCloudStorageConfigOut>? onGoogleCloudStorage = null,
+            Action<GoogleCloudPubSubConfigOut>? onGoogleCloudPubSub = null,
+            Action<RedshiftConfigOut>? onRedshift = null,
+            Action<BigQueryConfigOut>? onBigQuery = null,
+            Action<ClickhouseConfigOut>? onClickhouse = null,
+            Action<RabbitMqConfigOut>? onRabbitMq = null,
+            Action<SqsConfigOut>? onSqs = null,
+            Action<EventBridgeConfigOut>? onEventBridge = null,
+            Action<SnsConfigOut>? onSns = null,
+            Action<PostgresConfigOut>? onPostgres = null
         )
         {
             switch (_type)
             {
                 case ConfigType.Poller:
-                    onPoller();
+                    if (onPoller != null)
+                    {
+                        onPoller();
+                    }
                     break;
                 case ConfigType.AzureBlobStorage:
-                    onAzureBlobStorage((AzureBlobStorageConfigOut)_value);
+                    if (onAzureBlobStorage != null)
+                    {
+                        onAzureBlobStorage((AzureBlobStorageConfigOut)_value);
+                    }
                     break;
                 case ConfigType.OtelTracing:
-                    onOtelTracing((OtelTracingConfigOut)_value);
+                    if (onOtelTracing != null)
+                    {
+                        onOtelTracing((OtelTracingConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Http:
-                    onHttp((SinkHttpConfigOut)_value);
+                    if (onHttp != null)
+                    {
+                        onHttp((SinkHttpConfigOut)_value);
+                    }
                     break;
                 case ConfigType.AmazonS3:
-                    onAmazonS3((S3ConfigOut)_value);
+                    if (onAmazonS3 != null)
+                    {
+                        onAmazonS3((S3ConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Snowflake:
-                    onSnowflake((SnowflakeConfigOut)_value);
+                    if (onSnowflake != null)
+                    {
+                        onSnowflake((SnowflakeConfigOut)_value);
+                    }
                     break;
                 case ConfigType.GoogleCloudStorage:
-                    onGoogleCloudStorage((GoogleCloudStorageConfigOut)_value);
+                    if (onGoogleCloudStorage != null)
+                    {
+                        onGoogleCloudStorage((GoogleCloudStorageConfigOut)_value);
+                    }
                     break;
                 case ConfigType.GoogleCloudPubSub:
-                    onGoogleCloudPubSub((GoogleCloudPubSubConfigOut)_value);
+                    if (onGoogleCloudPubSub != null)
+                    {
+                        onGoogleCloudPubSub((GoogleCloudPubSubConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Redshift:
-                    onRedshift((RedshiftConfigOut)_value);
+                    if (onRedshift != null)
+                    {
+                        onRedshift((RedshiftConfigOut)_value);
+                    }
                     break;
                 case ConfigType.BigQuery:
-                    onBigQuery((BigQueryConfigOut)_value);
+                    if (onBigQuery != null)
+                    {
+                        onBigQuery((BigQueryConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Clickhouse:
-                    onClickhouse((ClickhouseConfigOut)_value);
+                    if (onClickhouse != null)
+                    {
+                        onClickhouse((ClickhouseConfigOut)_value);
+                    }
                     break;
                 case ConfigType.RabbitMq:
-                    onRabbitMq((RabbitMqConfigOut)_value);
+                    if (onRabbitMq != null)
+                    {
+                        onRabbitMq((RabbitMqConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Sqs:
-                    onSqs((SqsConfigOut)_value);
+                    if (onSqs != null)
+                    {
+                        onSqs((SqsConfigOut)_value);
+                    }
                     break;
                 case ConfigType.EventBridge:
-                    onEventBridge((EventBridgeConfigOut)_value);
+                    if (onEventBridge != null)
+                    {
+                        onEventBridge((EventBridgeConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Sns:
-                    onSns((SnsConfigOut)_value);
+                    if (onSns != null)
+                    {
+                        onSns((SnsConfigOut)_value);
+                    }
                     break;
                 case ConfigType.Postgres:
-                    onPostgres((PostgresConfigOut)_value);
+                    if (onPostgres != null)
+                    {
+                        onPostgres((PostgresConfigOut)_value);
+                    }
                     break;
                 default:
                     // unreachable
@@ -386,8 +434,8 @@ namespace Svix.Models
         [JsonProperty("type", Required = Required.Always)]
         public required string Type { get; set; }
 
-        [JsonProperty("config", Required = Required.Always)]
-        public required JObject Config { get; set; }
+        [JsonProperty("config")]
+        public JObject? Config { get; set; }
     }
 
     public class StreamSinkOutConverter : JsonConverter

--- a/csharp/Svix/Models/StreamSinkPatch.cs
+++ b/csharp/Svix/Models/StreamSinkPatch.cs
@@ -260,73 +260,121 @@ namespace Svix.Models
         }
 
         public void Switch(
-            Action onPoller,
-            Action<AzureBlobStorageConfigPatch> onAzureBlobStorage,
-            Action<OtelTracingConfigPatch> onOtelTracing,
-            Action<SinkHttpConfigPatch> onHttp,
-            Action<S3ConfigPatch> onAmazonS3,
-            Action<GoogleCloudStorageConfigPatch> onGoogleCloudStorage,
-            Action<GoogleCloudPubSubConfigPatch> onGoogleCloudPubSub,
-            Action<SqsConfigPatch> onSqs,
-            Action<SnsConfigPatch> onSns,
-            Action<BigQueryConfigPatch> onBigQuery,
-            Action<ClickhouseConfigPatch> onClickhouse,
-            Action<EventBridgeConfigPatch> onEventBridge,
-            Action<SnowflakeConfigPatch> onSnowflake,
-            Action<RabbitMqConfigPatch> onRabbitMq,
-            Action<RedshiftConfigPatch> onRedshift,
-            Action<PostgresConfigPatch> onPostgres
+            Action? onPoller = null,
+            Action<AzureBlobStorageConfigPatch>? onAzureBlobStorage = null,
+            Action<OtelTracingConfigPatch>? onOtelTracing = null,
+            Action<SinkHttpConfigPatch>? onHttp = null,
+            Action<S3ConfigPatch>? onAmazonS3 = null,
+            Action<GoogleCloudStorageConfigPatch>? onGoogleCloudStorage = null,
+            Action<GoogleCloudPubSubConfigPatch>? onGoogleCloudPubSub = null,
+            Action<SqsConfigPatch>? onSqs = null,
+            Action<SnsConfigPatch>? onSns = null,
+            Action<BigQueryConfigPatch>? onBigQuery = null,
+            Action<ClickhouseConfigPatch>? onClickhouse = null,
+            Action<EventBridgeConfigPatch>? onEventBridge = null,
+            Action<SnowflakeConfigPatch>? onSnowflake = null,
+            Action<RabbitMqConfigPatch>? onRabbitMq = null,
+            Action<RedshiftConfigPatch>? onRedshift = null,
+            Action<PostgresConfigPatch>? onPostgres = null
         )
         {
             switch (_type)
             {
                 case ConfigType.Poller:
-                    onPoller();
+                    if (onPoller != null)
+                    {
+                        onPoller();
+                    }
                     break;
                 case ConfigType.AzureBlobStorage:
-                    onAzureBlobStorage((AzureBlobStorageConfigPatch)_value);
+                    if (onAzureBlobStorage != null)
+                    {
+                        onAzureBlobStorage((AzureBlobStorageConfigPatch)_value);
+                    }
                     break;
                 case ConfigType.OtelTracing:
-                    onOtelTracing((OtelTracingConfigPatch)_value);
+                    if (onOtelTracing != null)
+                    {
+                        onOtelTracing((OtelTracingConfigPatch)_value);
+                    }
                     break;
                 case ConfigType.Http:
-                    onHttp((SinkHttpConfigPatch)_value);
+                    if (onHttp != null)
+                    {
+                        onHttp((SinkHttpConfigPatch)_value);
+                    }
                     break;
                 case ConfigType.AmazonS3:
-                    onAmazonS3((S3ConfigPatch)_value);
+                    if (onAmazonS3 != null)
+                    {
+                        onAmazonS3((S3ConfigPatch)_value);
+                    }
                     break;
                 case ConfigType.GoogleCloudStorage:
-                    onGoogleCloudStorage((GoogleCloudStorageConfigPatch)_value);
+                    if (onGoogleCloudStorage != null)
+                    {
+                        onGoogleCloudStorage((GoogleCloudStorageConfigPatch)_value);
+                    }
                     break;
                 case ConfigType.GoogleCloudPubSub:
-                    onGoogleCloudPubSub((GoogleCloudPubSubConfigPatch)_value);
+                    if (onGoogleCloudPubSub != null)
+                    {
+                        onGoogleCloudPubSub((GoogleCloudPubSubConfigPatch)_value);
+                    }
                     break;
                 case ConfigType.Sqs:
-                    onSqs((SqsConfigPatch)_value);
+                    if (onSqs != null)
+                    {
+                        onSqs((SqsConfigPatch)_value);
+                    }
                     break;
                 case ConfigType.Sns:
-                    onSns((SnsConfigPatch)_value);
+                    if (onSns != null)
+                    {
+                        onSns((SnsConfigPatch)_value);
+                    }
                     break;
                 case ConfigType.BigQuery:
-                    onBigQuery((BigQueryConfigPatch)_value);
+                    if (onBigQuery != null)
+                    {
+                        onBigQuery((BigQueryConfigPatch)_value);
+                    }
                     break;
                 case ConfigType.Clickhouse:
-                    onClickhouse((ClickhouseConfigPatch)_value);
+                    if (onClickhouse != null)
+                    {
+                        onClickhouse((ClickhouseConfigPatch)_value);
+                    }
                     break;
                 case ConfigType.EventBridge:
-                    onEventBridge((EventBridgeConfigPatch)_value);
+                    if (onEventBridge != null)
+                    {
+                        onEventBridge((EventBridgeConfigPatch)_value);
+                    }
                     break;
                 case ConfigType.Snowflake:
-                    onSnowflake((SnowflakeConfigPatch)_value);
+                    if (onSnowflake != null)
+                    {
+                        onSnowflake((SnowflakeConfigPatch)_value);
+                    }
                     break;
                 case ConfigType.RabbitMq:
-                    onRabbitMq((RabbitMqConfigPatch)_value);
+                    if (onRabbitMq != null)
+                    {
+                        onRabbitMq((RabbitMqConfigPatch)_value);
+                    }
                     break;
                 case ConfigType.Redshift:
-                    onRedshift((RedshiftConfigPatch)_value);
+                    if (onRedshift != null)
+                    {
+                        onRedshift((RedshiftConfigPatch)_value);
+                    }
                     break;
                 case ConfigType.Postgres:
-                    onPostgres((PostgresConfigPatch)_value);
+                    if (onPostgres != null)
+                    {
+                        onPostgres((PostgresConfigPatch)_value);
+                    }
                     break;
                 default:
                     // unreachable
@@ -375,8 +423,8 @@ namespace Svix.Models
         [JsonProperty("type", Required = Required.Always)]
         public required string Type { get; set; }
 
-        [JsonProperty("config", Required = Required.Always)]
-        public required JObject Config { get; set; }
+        [JsonProperty("config")]
+        public JObject? Config { get; set; }
     }
 
     public class StreamSinkPatchConverter : JsonConverter


### PR DESCRIPTION
Routes that use struct enums in responses are currently somewhat broken in the C# SDK -  if a variant doesn't have a content field, it can't be parsed. This fixes that.

Actually, a larger part of the diff is making the `Switch` method more ergonomic by making all arguments optional (used by the new regression test).