### PR TITLE
csharp: Strip trailing slashes from server URLs

### DIFF
--- a/csharp/Svix.Tests/WiremockTests.cs
+++ b/csharp/Svix.Tests/WiremockTests.cs
@@ -71,6 +71,27 @@ namespace Svix.Tests
             );
         }
 
+        [Theory]
+        [InlineData("", "/api/v1/app/app1")]
+        [InlineData("/", "/api/v1/app/app1")]
+        [InlineData("///", "/api/v1/app/app1")]
+        [InlineData("/proxy", "/proxy/api/v1/app/app1")]
+        [InlineData("/proxy/", "/proxy/api/v1/app/app1")]
+        [InlineData("/proxy///", "/proxy/api/v1/app/app1")]
+        [InlineData("/proxy//nested/", "/proxy//nested/api/v1/app/app1")]
+        public void ServerUrlTrailingSlashesAreIgnored(string suffix, string expectedPath)
+        {
+            stub.Given(Request.Create().WithPath(expectedPath).UsingGet())
+                .RespondWith(Response.Create().WithStatusCode(200).WithBody(applicationOutJsonStr));
+
+            var svx = new SvixClient("", new SvixOptions(baseUrl + suffix));
+            var application = svx.Application.Get("app1");
+
+            Assert.Equal("app_2raC7cFHmm6rLPcBjbVgeGQOnzr", application.Id);
+            Assert.Single(stub.LogEntries);
+            Assert.Equal(expectedPath, stub.LogEntries[0].RequestMessage.Path);
+        }
+
         [Fact]
         public void NonCamelCaseIsCorrectlySerialized()
         {

--- a/csharp/Svix/SvixHttpClient.cs
+++ b/csharp/Svix/SvixHttpClient.cs
@@ -14,7 +14,7 @@ namespace Svix
     )
     {
         private readonly List<int> retryScheduleMilliseconds = retryScheduleMilliseconds;
-        private readonly string serverUrl = serverUrl;
+        private readonly string serverUrl = serverUrl.TrimEnd('/');
         private readonly HttpClient _httpClient = new();
         private readonly string _token = token;
         private readonly JsonSerializerSettings patchJsonOptions = new();


### PR DESCRIPTION
﻿## Motivation

A C# client configured with `https://api.svix.com/` appends resource paths directly to that URL, producing requests such as `https://api.svix.com//api/v1/app/app1`. This follows up on #1154 for the C# SDK.

## Solution

Trim trailing `/` characters once when constructing `SvixHttpClient`. This preserves reverse-proxy path prefixes and internal slashes.

Add seven mock-server cases covering URLs with no trailing slash, one or several trailing slashes, and path prefixes. Five cases fail against the original code; the two URLs without trailing slashes pass as controls. The updated C# suite passes 53 tests and skips one credential-dependent integration test. CSharpier 1.0.1 passes on both changed files.

Related to #1154. Other SDKs remain outside this patch, so the issue should stay open.

Prepared with Codex assistance.
