### PR TITLE
cli: Don't follow redirects returned by local service in listen mode

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ The Svix Bridge changelog has moved to [bridge/ChangeLog.md](./bridge/ChangeLog.
 * Libs/All: AutoConfig v2. Add support for updated AutoConfig token format (`auto_v2` prefix)
 * Libs/All **(Breaking)**: `AutoConfigConsumer.subscribe()` return type changed from `EndpointOut` to `DestinationOut`
 * Libs/PHP **(Breaking)**: Remove `AutoConfigConsumer` class
+* CLI: In `listen` mode, don't follow redirects returned by the local service
 
 ## Version 2.3.0
 * Libs/All: Add new streaming sink types

--- a/svix-cli/src/relay/mod.rs
+++ b/svix-cli/src/relay/mod.rs
@@ -12,6 +12,7 @@ use futures_util::{
 use http::{HeaderMap, HeaderName, HeaderValue};
 use indoc::printdoc;
 use message::{MessageIn, MessageInEvent};
+use reqwest::redirect;
 use tokio::{
     net::TcpStream,
     sync::mpsc::{UnboundedReceiver, UnboundedSender},
@@ -224,6 +225,7 @@ pub async fn listen(
     let websocket_url = format!("{scheme}://{api_host}/{API_PREFIX}/listen/").parse()?;
 
     let http_client = HttpClient::builder()
+        .redirect(redirect::Policy::none())
         .danger_accept_invalid_certs(disable_tls_verification)
         .build()?;
 


### PR DESCRIPTION
We want to relay the reponse from the local service as-is.