### PR TITLE
Only write executable metadata in Docker builds

### DIFF
--- a/bridge/Dockerfile
+++ b/bridge/Dockerfile
@@ -57,6 +57,9 @@ RUN <<EOF
 EOF
 
 COPY bridge /app/bridge
+
+ARG WRITE_EXECUTABLE_METADATA="1"
+
 # touching the lib.rs/main.rs ensures cargo rebuilds them instead of considering them already built.
 RUN touch ./*/src/lib.rs && touch ./*/src/main.rs
 RUN cargo build --release --frozen

--- a/bridge/svix-bridge/build.rs
+++ b/bridge/svix-bridge/build.rs
@@ -1,18 +1,19 @@
 fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-
-    let mut package_metadata =
-        rust_executable_metadata::PackageMetadataBuilder::new_from_cargo("svix")
+    println!("cargo:rerun-if-env-changed=WRITE_EXECUTABLE_METADATA");
+    if std::env::var("WRITE_EXECUTABLE_METADATA").is_ok_and(|v| v == "1") {
+        let mut package_metadata =
+            rust_executable_metadata::PackageMetadataBuilder::new_from_cargo("svix")
+                .unwrap()
+                .license("MIT")
+                .maintainer("support@svix.com")
+                .copyright("Svix Inc");
+        if let Ok(sha) = std::env::var("GITHUB_SHA") {
+            package_metadata = package_metadata.hash(sha);
+        }
+        package_metadata
+            .build()
             .unwrap()
-            .license("MIT")
-            .maintainer("support@svix.com")
-            .copyright("Svix Inc");
-    if let Ok(sha) = std::env::var("GITHUB_SHA") {
-        package_metadata = package_metadata.hash(sha);
+            .write_linker_script_and_inject_argument()
+            .unwrap();
     }
-    package_metadata
-        .build()
-        .unwrap()
-        .write_linker_script_and_inject_argument()
-        .unwrap();
 }

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -46,6 +46,8 @@ RUN cargo chef cook --release --package svix-server --bin svix-server --recipe-p
 
 # Build the server
 COPY . .
+
+ARG WRITE_EXECUTABLE_METADATA="1"
 RUN cargo build --release --package svix-server --bin svix-server --frozen
 
 # Production

--- a/server/svix-server/build.rs
+++ b/server/svix-server/build.rs
@@ -2,20 +2,21 @@ fn main() {
     // trigger recompilation when a new migration is added
     println!("cargo:rerun-if-changed=migrations");
 
-    println!("cargo:rerun-if-changed=build.rs");
-
-    let mut package_metadata =
-        rust_executable_metadata::PackageMetadataBuilder::new_from_cargo("svix")
+    println!("cargo:rerun-if-env-changed=WRITE_EXECUTABLE_METADATA");
+    if std::env::var("WRITE_EXECUTABLE_METADATA").is_ok_and(|v| v == "1") {
+        let mut package_metadata =
+            rust_executable_metadata::PackageMetadataBuilder::new_from_cargo("svix")
+                .unwrap()
+                .license("MIT")
+                .maintainer("support@svix.com")
+                .copyright("Svix Inc");
+        if let Ok(sha) = std::env::var("GITHUB_SHA") {
+            package_metadata = package_metadata.hash(sha);
+        }
+        package_metadata
+            .build()
             .unwrap()
-            .license("MIT")
-            .maintainer("support@svix.com")
-            .copyright("Svix Inc");
-    if let Ok(sha) = std::env::var("GITHUB_SHA") {
-        package_metadata = package_metadata.hash(sha);
+            .write_linker_script_and_inject_argument()
+            .unwrap();
     }
-    package_metadata
-        .build()
-        .unwrap()
-        .write_linker_script_and_inject_argument()
-        .unwrap();
 }

--- a/svix-cli/Dockerfile
+++ b/svix-cli/Dockerfile
@@ -30,6 +30,7 @@ WORKDIR /app/svix-cli
 COPY rust /app/rust
 COPY svix-cli /app/svix-cli
 
+ARG WRITE_EXECUTABLE_METADATA="1"
 RUN <<EOF
     cargo build --release
     cargo sbom > /app/svix-cli.spdx

--- a/svix-cli/build.rs
+++ b/svix-cli/build.rs
@@ -1,18 +1,19 @@
 fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-
-    let mut package_metadata =
-        rust_executable_metadata::PackageMetadataBuilder::new_from_cargo("svix")
+    println!("cargo:rerun-if-env-changed=WRITE_EXECUTABLE_METADATA");
+    if std::env::var("WRITE_EXECUTABLE_METADATA").is_ok_and(|v| v == "1") {
+        let mut package_metadata =
+            rust_executable_metadata::PackageMetadataBuilder::new_from_cargo("svix")
+                .unwrap()
+                .license("MIT")
+                .maintainer("support@svix.com")
+                .copyright("Svix Inc");
+        if let Ok(sha) = std::env::var("GITHUB_SHA") {
+            package_metadata = package_metadata.hash(sha);
+        }
+        package_metadata
+            .build()
             .unwrap()
-            .license("MIT")
-            .maintainer("support@svix.com")
-            .copyright("Svix Inc");
-    if let Ok(sha) = std::env::var("GITHUB_SHA") {
-        package_metadata = package_metadata.hash(sha);
+            .write_linker_script_and_inject_argument()
+            .unwrap();
     }
-    package_metadata
-        .build()
-        .unwrap()
-        .write_linker_script_and_inject_argument()
-        .unwrap();
 }


### PR DESCRIPTION
Allow local dev with linkers that don't fully support linker scripts (like wild).