### PR TITLE
kotlin: fix deserialization of struct enum with absent content field

### DIFF
--- a/codegen/templates/kotlin/types/struct_enum.kt.jinja
+++ b/codegen/templates/kotlin/types/struct_enum.kt.jinja
@@ -70,7 +70,7 @@ class {{ type_name }}Serializer : KSerializer<{{ type_name }}> {
     private data class {{ type_name }}Surrogate(
         {% include "types/struct_fields.kt.jinja" %}
         val {{ discriminator_field_name }}: String,
-        val {{ content_field_name }}: JsonElement,
+        val {{ content_field_name }}: JsonElement = buildJsonObject {},
     )
 
     override val descriptor: SerialDescriptor = {{ type_name }}Surrogate.serializer().descriptor

--- a/kotlin/lib/src/main/kotlin/models/AutoConfigSinkType.kt
+++ b/kotlin/lib/src/main/kotlin/models/AutoConfigSinkType.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.buildJsonObject
 
 @Serializable(with = AutoConfigSinkTypeSerializer::class)
 data class AutoConfigSinkType(val config: AutoConfigSinkTypeConfig)
@@ -52,7 +53,10 @@ sealed class AutoConfigSinkTypeConfig {
 
 class AutoConfigSinkTypeSerializer : KSerializer<AutoConfigSinkType> {
     @Serializable
-    private data class AutoConfigSinkTypeSurrogate(val type: String, val config: JsonElement)
+    private data class AutoConfigSinkTypeSurrogate(
+        val type: String,
+        val config: JsonElement = buildJsonObject {},
+    )
 
     override val descriptor: SerialDescriptor = AutoConfigSinkTypeSurrogate.serializer().descriptor
 

--- a/kotlin/lib/src/main/kotlin/models/DestinationIn.kt
+++ b/kotlin/lib/src/main/kotlin/models/DestinationIn.kt
@@ -288,7 +288,7 @@ class DestinationInSerializer : KSerializer<DestinationIn> {
         val channels: List<String>? = null,
         val metadata: Map<String, String>? = null,
         val type: String,
-        val config: JsonElement,
+        val config: JsonElement = buildJsonObject {},
     )
 
     override val descriptor: SerialDescriptor = DestinationInSurrogate.serializer().descriptor

--- a/kotlin/lib/src/main/kotlin/models/DestinationOut.kt
+++ b/kotlin/lib/src/main/kotlin/models/DestinationOut.kt
@@ -251,7 +251,7 @@ class DestinationOutSerializer : KSerializer<DestinationOut> {
         val nextRetryAt: Instant? = null,
         val metadata: Map<String, String>,
         val type: String,
-        val config: JsonElement,
+        val config: JsonElement = buildJsonObject {},
     )
 
     override val descriptor: SerialDescriptor = DestinationOutSurrogate.serializer().descriptor

--- a/kotlin/lib/src/main/kotlin/models/IngestSourceIn.kt
+++ b/kotlin/lib/src/main/kotlin/models/IngestSourceIn.kt
@@ -448,7 +448,7 @@ class IngestSourceInSerializer : KSerializer<IngestSourceIn> {
         val uid: String? = null,
         val metadata: Map<String, String>? = null,
         val type: String,
-        val config: JsonElement,
+        val config: JsonElement = buildJsonObject {},
     )
 
     override val descriptor: SerialDescriptor = IngestSourceInSurrogate.serializer().descriptor

--- a/kotlin/lib/src/main/kotlin/models/IngestSourceOut.kt
+++ b/kotlin/lib/src/main/kotlin/models/IngestSourceOut.kt
@@ -480,7 +480,7 @@ class IngestSourceOutSerializer : KSerializer<IngestSourceOut> {
         val updatedAt: Instant,
         val metadata: Map<String, String>,
         val type: String,
-        val config: JsonElement,
+        val config: JsonElement = buildJsonObject {},
     )
 
     override val descriptor: SerialDescriptor = IngestSourceOutSurrogate.serializer().descriptor

--- a/kotlin/lib/src/main/kotlin/models/StreamSinkIn.kt
+++ b/kotlin/lib/src/main/kotlin/models/StreamSinkIn.kt
@@ -277,7 +277,7 @@ class StreamSinkInSerializer : KSerializer<StreamSinkIn> {
         val channels: List<String>? = null,
         val metadata: Map<String, String>? = null,
         val type: String,
-        val config: JsonElement,
+        val config: JsonElement = buildJsonObject {},
     )
 
     override val descriptor: SerialDescriptor = StreamSinkInSurrogate.serializer().descriptor

--- a/kotlin/lib/src/main/kotlin/models/StreamSinkOut.kt
+++ b/kotlin/lib/src/main/kotlin/models/StreamSinkOut.kt
@@ -249,7 +249,7 @@ class StreamSinkOutSerializer : KSerializer<StreamSinkOut> {
         val nextRetryAt: Instant? = null,
         val metadata: Map<String, String>,
         val type: String,
-        val config: JsonElement,
+        val config: JsonElement = buildJsonObject {},
     )
 
     override val descriptor: SerialDescriptor = StreamSinkOutSurrogate.serializer().descriptor

--- a/kotlin/lib/src/main/kotlin/models/StreamSinkPatch.kt
+++ b/kotlin/lib/src/main/kotlin/models/StreamSinkPatch.kt
@@ -244,7 +244,7 @@ class StreamSinkPatchSerializer : KSerializer<StreamSinkPatch> {
         val channels: List<String>? = null,
         val metadata: Map<String, String>? = null,
         val type: String,
-        val config: JsonElement,
+        val config: JsonElement = buildJsonObject {},
     )
 
     override val descriptor: SerialDescriptor = StreamSinkPatchSurrogate.serializer().descriptor

--- a/kotlin/lib/src/test/com/svix/kotlin/SerializationTests.kt
+++ b/kotlin/lib/src/test/com/svix/kotlin/SerializationTests.kt
@@ -1,6 +1,8 @@
 package com.svix.kotlin
 
 import com.svix.kotlin.models.CronConfig
+import com.svix.kotlin.models.DestinationIn
+import com.svix.kotlin.models.DestinationInConfig
 import com.svix.kotlin.models.IngestSourceIn
 import com.svix.kotlin.models.IngestSourceInConfig
 import com.svix.kotlin.models.IngestSourceInConfig.Cron
@@ -33,8 +35,15 @@ class SerializationTests {
     }
 
     @Test
+    fun structEnumWhenConfigIsOmitted() {
+        val dest = Json.decodeFromString<DestinationIn>("""{"type":"pollingEndpoint"}""")
+        assertEquals(DestinationInConfig.PollingEndpoint, dest.config)
+    }
+
+    @Test
     fun structEnumWithNoExtraFields() {
-        val jsonSource =
+        val jsonSource = """{"name":"mendy is","uid":"very unique","type":"generic-webhook"}"""
+        val jsonSourceWithEmptyConfig =
             """{"name":"mendy is","uid":"very unique","type":"generic-webhook","config":{}}"""
         val sourceIn =
             IngestSourceIn(
@@ -45,6 +54,7 @@ class SerializationTests {
         // de/serialization works both ways
         assertEquals(jsonSource, Json.encodeToString(sourceIn))
         assertEquals(sourceIn, Json.decodeFromString(jsonSource))
+        assertEquals(sourceIn, Json.decodeFromString(jsonSourceWithEmptyConfig))
     }
 
     @Test


### PR DESCRIPTION
Routes that use struct enums in responses were broken in the Kotlin SDK - if a variant doesn't have a content field, it can't be deserialized. This adds a default value for the content field so it no longer fails.



