### PR TITLE
ruby: fix deserialization of struct enum with absent content field

### DIFF
--- a/codegen/templates/ruby/types/struct_enum.rb.jinja
+++ b/codegen/templates/ruby/types/struct_enum.rb.jinja
@@ -92,10 +92,7 @@ module Svix
       unless NAME_TO_TYPE.key?(attributes["{{ type.discriminator_field }}"])
         fail(ArgumentError, "Invalid {{ type.discriminator_field | to_snake_case }} `#{attributes["{{ type.discriminator_field }}"]}` expected on of #{NAME_TO_TYPE.keys}")
       end
-      unless attributes.key? "{{ type.content_field }}"
-        fail(ArgumentError, "Missing required field {{ type.content_field }}")
-      end
-      attrs["{{ type.content_field }}"] = NAME_TO_TYPE[attributes["{{ type.discriminator_field }}"]].deserialize(attributes["{{ type.content_field }}"])
+      attrs["{{ type.content_field }}"] = NAME_TO_TYPE[attributes["{{ type.discriminator_field }}"]].deserialize(attributes["{{ type.content_field }}"] || {})
       new(attrs)
     end
 

--- a/ruby/lib/svix/models/auto_config_sink_type.rb
+++ b/ruby/lib/svix/models/auto_config_sink_type.rb
@@ -64,11 +64,7 @@ module Svix
         fail(ArgumentError, "Invalid type `#{attributes["type"]}` expected on of #{NAME_TO_TYPE.keys}")
       end
 
-      unless attributes.key?("config")
-        fail(ArgumentError, "Missing required field config")
-      end
-
-      attrs["config"] = NAME_TO_TYPE[attributes["type"]].deserialize(attributes["config"])
+      attrs["config"] = NAME_TO_TYPE[attributes["type"]].deserialize(attributes["config"] || {})
       new(attrs)
     end
 

--- a/ruby/lib/svix/models/destination_in.rb
+++ b/ruby/lib/svix/models/destination_in.rb
@@ -176,11 +176,7 @@ module Svix
         fail(ArgumentError, "Invalid type `#{attributes["type"]}` expected on of #{NAME_TO_TYPE.keys}")
       end
 
-      unless attributes.key?("config")
-        fail(ArgumentError, "Missing required field config")
-      end
-
-      attrs["config"] = NAME_TO_TYPE[attributes["type"]].deserialize(attributes["config"])
+      attrs["config"] = NAME_TO_TYPE[attributes["type"]].deserialize(attributes["config"] || {})
       new(attrs)
     end
 

--- a/ruby/lib/svix/models/destination_out.rb
+++ b/ruby/lib/svix/models/destination_out.rb
@@ -191,11 +191,7 @@ module Svix
         fail(ArgumentError, "Invalid type `#{attributes["type"]}` expected on of #{NAME_TO_TYPE.keys}")
       end
 
-      unless attributes.key?("config")
-        fail(ArgumentError, "Missing required field config")
-      end
-
-      attrs["config"] = NAME_TO_TYPE[attributes["type"]].deserialize(attributes["config"])
+      attrs["config"] = NAME_TO_TYPE[attributes["type"]].deserialize(attributes["config"] || {})
       new(attrs)
     end
 

--- a/ruby/lib/svix/models/ingest_source_in.rb
+++ b/ruby/lib/svix/models/ingest_source_in.rb
@@ -277,11 +277,7 @@ module Svix
         fail(ArgumentError, "Invalid type `#{attributes["type"]}` expected on of #{NAME_TO_TYPE.keys}")
       end
 
-      unless attributes.key?("config")
-        fail(ArgumentError, "Missing required field config")
-      end
-
-      attrs["config"] = NAME_TO_TYPE[attributes["type"]].deserialize(attributes["config"])
+      attrs["config"] = NAME_TO_TYPE[attributes["type"]].deserialize(attributes["config"] || {})
       new(attrs)
     end
 

--- a/ruby/lib/svix/models/ingest_source_out.rb
+++ b/ruby/lib/svix/models/ingest_source_out.rb
@@ -286,11 +286,7 @@ module Svix
         fail(ArgumentError, "Invalid type `#{attributes["type"]}` expected on of #{NAME_TO_TYPE.keys}")
       end
 
-      unless attributes.key?("config")
-        fail(ArgumentError, "Missing required field config")
-      end
-
-      attrs["config"] = NAME_TO_TYPE[attributes["type"]].deserialize(attributes["config"])
+      attrs["config"] = NAME_TO_TYPE[attributes["type"]].deserialize(attributes["config"] || {})
       new(attrs)
     end
 

--- a/ruby/lib/svix/models/stream_sink_in.rb
+++ b/ruby/lib/svix/models/stream_sink_in.rb
@@ -174,11 +174,7 @@ module Svix
         fail(ArgumentError, "Invalid type `#{attributes["type"]}` expected on of #{NAME_TO_TYPE.keys}")
       end
 
-      unless attributes.key?("config")
-        fail(ArgumentError, "Missing required field config")
-      end
-
-      attrs["config"] = NAME_TO_TYPE[attributes["type"]].deserialize(attributes["config"])
+      attrs["config"] = NAME_TO_TYPE[attributes["type"]].deserialize(attributes["config"] || {})
       new(attrs)
     end
 

--- a/ruby/lib/svix/models/stream_sink_out.rb
+++ b/ruby/lib/svix/models/stream_sink_out.rb
@@ -190,11 +190,7 @@ module Svix
         fail(ArgumentError, "Invalid type `#{attributes["type"]}` expected on of #{NAME_TO_TYPE.keys}")
       end
 
-      unless attributes.key?("config")
-        fail(ArgumentError, "Missing required field config")
-      end
-
-      attrs["config"] = NAME_TO_TYPE[attributes["type"]].deserialize(attributes["config"])
+      attrs["config"] = NAME_TO_TYPE[attributes["type"]].deserialize(attributes["config"] || {})
       new(attrs)
     end
 

--- a/ruby/lib/svix/models/stream_sink_patch.rb
+++ b/ruby/lib/svix/models/stream_sink_patch.rb
@@ -162,11 +162,7 @@ module Svix
         fail(ArgumentError, "Invalid type `#{attributes["type"]}` expected on of #{NAME_TO_TYPE.keys}")
       end
 
-      unless attributes.key?("config")
-        fail(ArgumentError, "Missing required field config")
-      end
-
-      attrs["config"] = NAME_TO_TYPE[attributes["type"]].deserialize(attributes["config"])
+      attrs["config"] = NAME_TO_TYPE[attributes["type"]].deserialize(attributes["config"] || {})
       new(attrs)
     end
 

--- a/ruby/spec/webmock_tests_spec.rb
+++ b/ruby/spec/webmock_tests_spec.rb
@@ -442,6 +442,11 @@ describe "API Client" do
     expect(loaded_from_json.config.schedule).to eql(source_in.config.schedule)
   end
 
+  it "deserializes struct enum when config is omitted" do
+    loaded = Svix::DestinationIn.deserialize(JSON.parse('{"type":"pollingEndpoint"}'))
+    expect(loaded.config).to be_a(Svix::DestinationInConfig::PollingEndpoint)
+  end
+
   it "struct enum without any fields" do
     json_source_in = '{"name":"My Stripe Source","uid":"src_123","type":"generic-webhook","config":{}}'
     source_in = Svix::IngestSourceIn.new(


### PR DESCRIPTION
Routes that use struct enums in responses were broken in the Ruby SDK - if a variant doesn't have a content field, it can't be deserialized. This adds a default value for the content field so it no longer fails.

Same as https://github.com/svix/svix-webhooks/pull/2628 