### PR TITLE
server: treat concurrent CREATE TABLE as success for background migrations

### DIFF
--- a/server/svix-server/src/db/background_migrations.rs
+++ b/server/svix-server/src/db/background_migrations.rs
@@ -66,8 +66,30 @@ fn lock_key(id: &str) -> i64 {
     0x7a9f2c51 * (CRC_IEEE.checksum(id.as_bytes()) as i64)
 }
 
+/// PostgreSQL `CREATE TABLE IF NOT EXISTS` is not atomic against a concurrent
+/// `CREATE TABLE`. Two sessions can both pass the existence check; the loser
+/// then fails while inserting the new type into `pg_type` (`23505`) or with
+/// `duplicate_table` (`42P07`). Either error means the table now exists.
+fn is_concurrent_create_table_error(err: &sqlx::Error) -> bool {
+    match err {
+        sqlx::Error::Database(db) => matches!(db.code().as_deref(), Some("23505") | Some("42P07")),
+        _ => false,
+    }
+}
+
+/// Run `CREATE TABLE IF NOT EXISTS`, treating a concurrent-create race as success.
+#[doc(hidden)]
+pub async fn create_table_if_not_exists(pool: &PgPool, sql: &str) -> Result<(), sqlx::Error> {
+    match sqlx::query(sql).execute(pool).await {
+        Ok(_) => Ok(()),
+        Err(e) if is_concurrent_create_table_error(&e) => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
 pub async fn ensure_table(pool: &PgPool) -> Result<(), sqlx::Error> {
-    sqlx::query(
+    create_table_if_not_exists(
+        pool,
         "CREATE TABLE IF NOT EXISTS _svix_background_migrations (
             id          TEXT        PRIMARY KEY,
             started_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -77,9 +99,7 @@ pub async fn ensure_table(pool: &PgPool) -> Result<(), sqlx::Error> {
             last_error  TEXT
         )",
     )
-    .execute(pool)
-    .await?;
-    Ok(())
+    .await
 }
 
 pub async fn run_migrations(

--- a/server/svix-server/tests/it/background_migrations.rs
+++ b/server/svix-server/tests/it/background_migrations.rs
@@ -3,7 +3,8 @@
 use futures::future::join_all;
 use sqlx::PgPool;
 use svix_server::db::background_migrations::{
-    BackgroundMigration, ensure_table, run_migrations, run_with_pool, try_revert,
+    BackgroundMigration, create_table_if_not_exists, ensure_table, run_migrations, run_with_pool,
+    try_revert,
 };
 
 use crate::utils::get_default_test_config;
@@ -295,6 +296,49 @@ async fn test_revert_unapplied_migration_errors() {
 
     let result = try_revert(&pool, &[migration], migration.id).await;
     assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_ensure_table_concurrent_create_from_absent() {
+    let pool = test_pool_with_conns(20).await;
+    let schema = format!("svix_ensure_race_{}", std::process::id());
+    sqlx::query(&format!("DROP SCHEMA IF EXISTS {schema} CASCADE"))
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query(&format!("CREATE SCHEMA {schema}"))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let sql = format!("CREATE TABLE IF NOT EXISTS {schema}.race (id TEXT PRIMARY KEY)");
+    let results = join_all((0..16).map(|_| {
+        let pool = pool.clone();
+        let sql = sql.clone();
+        async move { create_table_if_not_exists(&pool, &sql).await }
+    }))
+    .await;
+
+    for result in results {
+        result.expect("concurrent CREATE TABLE IF NOT EXISTS should succeed");
+    }
+
+    let exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS (
+            SELECT 1 FROM information_schema.tables
+            WHERE table_schema = $1 AND table_name = 'race'
+        )",
+    )
+    .bind(&schema)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(exists);
+
+    sqlx::query(&format!("DROP SCHEMA {schema} CASCADE"))
+        .execute(&pool)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

When several `svix-server` replicas start together against a database that does not yet have `_svix_background_migrations`, PostgreSQL can reject `CREATE TABLE IF NOT EXISTS` with `23505` (`pg_type_typname_nsp_index`) or `42P07`. `ensure_table` then returns an error, and `run_with_pool` returns early, so the losing replica skips background migrations for the rest of its lifetime.

This was observed on `svix-server` v1.101.0 (see #2589). The migration itself still ran on the replica that won the race; the losing replica logged an error and never contended for the advisory lock.

## Reproduction

1. Drop `_svix_background_migrations` (or start from an empty database).
2. Start several server processes at once so they all reach `ensure_table` together.
3. One process logs `Failed to create _svix_background_migrations table` with a duplicate-key error on `pg_type_typname_nsp_index`.

Locally the new test races `CREATE TABLE IF NOT EXISTS` in an isolated schema:

```text
cargo test -p svix-server --test it test_ensure_table_concurrent_create_from_absent
```

## Root cause

`CREATE TABLE IF NOT EXISTS` is not atomic against a concurrent `CREATE TABLE`. Two sessions can both pass the existence check. The loser fails while inserting the new row type into `pg_type`.

## Fix

Treat PostgreSQL `23505` and `42P07` from that `CREATE TABLE IF NOT EXISTS` as success: another replica created the table, which is the desired end state. `run_with_pool` then continues to the existing advisory lock.

## Regression test

`test_ensure_table_concurrent_create_from_absent` issues 16 concurrent `CREATE TABLE IF NOT EXISTS` statements against a fresh schema and asserts every caller succeeds and the table exists.

## Verification

- `git diff --check` (no whitespace errors)
- `rustfmt` on the two touched files
- Targeted cargo test was not run on this Windows host (no local Postgres for the svix-server integration suite). CI should run the existing background-migration tests plus the new race test.

## Scope

No change to migration SQL, advisory locking, or retry backoff.

Fixes #2589