### PR TITLE
kotlin: Set Content-Type application/json on request bodies

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@ The Svix Server changelog has moved to [server/ChangeLog.md](./server/ChangeLog.
 The Svix Bridge changelog has moved to [bridge/ChangeLog.md](./bridge/ChangeLog.md).
 
 ## Unreleased
-*
+* Libs/Kotlin: Fix requests with body not having `content-type`
 
 ## Version 2.4.0
 * Libs **(New)**: Add `destination` API support

--- a/kotlin/lib/src/main/kotlin/SvixHttpClient.kt
+++ b/kotlin/lib/src/main/kotlin/SvixHttpClient.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.delay
 import kotlinx.serialization.json.Json
 import okhttp3.*
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.util.UUID
 
@@ -54,7 +55,10 @@ internal constructor(
     ): Res {
         val reqBuilder = Request.Builder().url(url)
         if (reqBody != null) {
-            reqBuilder.method(method, Json.encodeToString(reqBody).toRequestBody())
+            reqBuilder.method(
+                method,
+                Json.encodeToString(reqBody).toRequestBody("application/json".toMediaType()),
+            )
         } else {
             reqBuilder.method(method, null)
         }


### PR DESCRIPTION
This was making some API calls fail, since the API rejected the request with missing content type