### PR TITLE
fix(server): report validation locations without the __all__ placeholder

### DIFF
--- a/server/svix-server/src/core/types/mod.rs
+++ b/server/svix-server/src/core/types/mod.rs
@@ -25,7 +25,7 @@ pub use case_preserving_header_map::CasePreservingHeaderMap;
 
 use super::cryptography::{AsymmetricKey, Encryption};
 
-const ALL_ERROR: &str = "__all__";
+pub(crate) const ALL_ERROR: &str = "__all__";
 
 macro_rules! enum_wrapper {
     ($name_id:ty) => {

--- a/server/svix-server/src/v1/utils/mod.rs
+++ b/server/svix-server/src/v1/utils/mod.rs
@@ -31,7 +31,7 @@ use validator::{Validate, ValidationError};
 
 use crate::{
     core::types::{
-        ApplicationIdOrUid, BaseId, EndpointIdOrUid, EventTypeName, EventTypeNameSet,
+        ALL_ERROR, ApplicationIdOrUid, BaseId, EndpointIdOrUid, EventTypeName, EventTypeNameSet,
         MessageAttemptId, MessageIdOrUid,
     },
     error::{Error, HttpError, Result, ValidationErrorItem},
@@ -470,9 +470,13 @@ pub fn validation_errors(
     err.into_errors()
         .into_iter()
         .flat_map(|(k, v)| {
-            // Add the next field to the location
+            // Add the next field to the location. The `__all__` key is a placeholder the
+            // wrapper-type validators in `core::types` use for errors on the value itself,
+            // and carries no meaning for the reported location, so it is skipped.
             let mut loc = acc_path.clone();
-            loc.push(k.into_owned());
+            if k != ALL_ERROR {
+                loc.push(k.into_owned());
+            }
 
             match v {
                 // If it's a [`validator::ValidationErrorsKind::Field`], then it will be a vector of
@@ -634,7 +638,10 @@ where
         } else {
             let event_types = EventTypeNameSet(event_types);
             event_types.validate().map_err(|e| {
-                HttpError::unprocessable_entity(validation_errors(vec!["query".to_owned()], e))
+                HttpError::unprocessable_entity(validation_errors(
+                    vec!["query".to_owned(), "event_types".to_owned()],
+                    e,
+                ))
             })?;
             Ok(Self(Some(event_types)))
         }
@@ -829,7 +836,10 @@ mod tests {
     use validator::Validate;
 
     use super::{Pagination, default_limit, validate_no_control_characters, validation_errors};
-    use crate::{core::types::ApplicationUid, error::ValidationErrorItem};
+    use crate::{
+        core::types::{ApplicationUid, EventTypeName, EventTypeNameSet},
+        error::ValidationErrorItem,
+    };
 
     #[derive(Debug, Validate)]
     struct ValidationErrorTestStruct {
@@ -897,6 +907,22 @@ mod tests {
             msg: "Above 10".to_owned(),
             ty: "value_error".to_owned(),
         }));
+    }
+
+    #[test]
+    fn test_validation_errors_wrapper_type_location() {
+        let set = EventTypeNameSet([EventTypeName("1,".to_owned())].into());
+        let errs = set.validate().unwrap_err();
+        let errs = validation_errors(vec!["query".to_owned(), "event_types".to_owned()], errs);
+
+        assert_eq!(
+            errs,
+            vec![ValidationErrorItem {
+                loc: vec!["query".to_owned(), "event_types".to_owned()],
+                msg: "String must match the following pattern: [a-zA-Z0-9\\-_.].".to_owned(),
+                ty: "value_error".to_owned(),
+            }]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #920

## Problem

Wrapper-type validators in `core::types` (e.g. `EventTypeName` via `validate_limited_str`, `BaseUid`) key their errors under the validator crate's `__all__` placeholder. When such a type is validated at the top level of a request, the placeholder leaks into the user-facing location. Listing messages with `?event_types=1,` currently returns:

```json
{"loc": ["query", "__all__"], "msg": "String must match the following pattern: [a-zA-Z0-9\-_.]."}
```

## Fix

- `validation_errors` now skips the `__all__` key when flattening the error tree, so wrapper-type errors render at their parent location. This also cleans up other paths that leaked the placeholder, e.g. an invalid endpoint `uid` previously reported `["body", "uid", "__all__"]` and now reports `["body", "uid"]`.
- The `event_types` query extractor now names the parameter, so the location is `["query", "event_types"]` as the issue requests.

Reported per-element locations like `["query", "event_types", "0"]` are not meaningful here because the parameter is parsed into an unordered `HashSet`, so the parameter-level location is used instead.

## Testing

- New unit test `test_validation_errors_wrapper_type_location` asserts the reported location and message.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, the `v1::utils` unit tests, and `./generate-openapi.sh --check` all pass on Rust 1.88 (matching the CI matrix).