### PR TITLE
feat(server): allow skipping migrations in the docker image via RUN_MIGRATIONS

### DIFF
--- a/server/scripts/launch-svix-server
+++ b/server/scripts/launch-svix-server
@@ -4,7 +4,12 @@
 
 set -xeuo pipefail
 
-args=("--run-migrations")
+args=()
+# Migrations run by default. Set RUN_MIGRATIONS=0 to skip them (e.g. when the
+# database is managed elsewhere or migrations are run by a separate job).
+if [[ "${RUN_MIGRATIONS:-1}" != "0" ]]; then
+    args+=("--run-migrations")
+fi
 if [[ -n "${WAIT_FOR:-}" ]]; then
     args+=("--wait-for" "15")
 fi


### PR DESCRIPTION
Fixes #458

The docker entrypoint (`launch-svix-server`) always passed `--run-migrations`, so there was no way to start the container without touching the database schema.

The entrypoint now honors a `RUN_MIGRATIONS` env var: migrations still run by default (no behavior change for existing deployments), and setting `RUN_MIGRATIONS=0` skips them. This is useful when migrations are run out of band (e.g. by a separate job) or when the container connects with a database user that should not own schema changes.

The variable naming follows the existing `WAIT_FOR` convention in the same script.