### PR TITLE
feat(server): add expired_message_cleaner_enabled config option

### DIFF
--- a/server/svix-server/config.default.toml
+++ b/server/svix-server/config.default.toml
@@ -109,6 +109,11 @@ api_enabled = true
 # Should this instance run the message worker
 worker_enabled = true
 
+# Should this instance run the expired message cleaner, which nulls payloads and deletes
+# message contents for messages past their expiration. Message rows themselves are kept
+# regardless, to preserve pagination, and can be deleted with the `prune` command.
+expired_message_cleaner_enabled = true
+
 # Should this instance run background migrations
 background_migrations_enabled = true
 

--- a/server/svix-server/src/cfg.rs
+++ b/server/svix-server/src/cfg.rs
@@ -216,6 +216,12 @@ pub struct ConfigurationInner {
     /// Should this instance run the message worker
     pub worker_enabled: bool,
 
+    /// Should this instance run the expired message cleaner, which nulls payloads and deletes
+    /// message contents for messages past their expiration. Message rows themselves are kept
+    /// regardless, to preserve pagination, and can be deleted with the `prune` command.
+    #[serde(default = "default_true")]
+    pub expired_message_cleaner_enabled: bool,
+
     /// Subnets to whitelist for outbound webhooks. Note that allowing endpoints in private IP space
     /// is a security risk and should only be allowed if you are using the service internally or for
     /// testing purposes. Should be specified in CIDR notation, e.g., `[127.0.0.1/32, 172.17.0.0/16, 192.168.0.0/16]`

--- a/server/svix-server/src/lib.rs
+++ b/server/svix-server/src/lib.rs
@@ -219,6 +219,7 @@ pub async fn run_with_prefix(
 
     let with_api = cfg.api_enabled;
     let with_worker = cfg.worker_enabled;
+    let with_expired_message_cleaner = cfg.expired_message_cleaner_enabled;
     let with_background_migrations = cfg.background_migrations_enabled;
     let listen_address = cfg.listen_address;
 
@@ -260,7 +261,7 @@ pub async fn run_with_prefix(
             }
         },
         async {
-            if with_worker {
+            if with_worker && with_expired_message_cleaner {
                 tracing::debug!("Expired message cleaner: Started");
                 expired_message_cleaner_loop(&pool).await
             } else {

--- a/server/svix-server/tests/config.rs
+++ b/server/svix-server/tests/config.rs
@@ -13,6 +13,25 @@ fn test_environment_parsing() {
     test_retry_schedule_parsing();
     test_retry_schedule_parsing_legacy();
     test_proxy_addr_from_env_parsing();
+    test_expired_message_cleaner_parsing();
+}
+
+#[allow(clippy::result_large_err)]
+fn test_expired_message_cleaner_parsing() {
+    figment::Jail::expect_with(|jail| {
+        jail.set_env("SVIX_JWT_SECRET", "x");
+
+        // Defaults to enabled
+        let cfg = load().unwrap();
+        assert!(cfg.expired_message_cleaner_enabled);
+
+        jail.set_env("SVIX_EXPIRED_MESSAGE_CLEANER_ENABLED", "false");
+
+        let cfg = load().unwrap();
+        assert!(!cfg.expired_message_cleaner_enabled);
+
+        Ok(())
+    });
 }
 
 #[allow(clippy::result_large_err)]


### PR DESCRIPTION
Fixes #1111

## Problem

The expired message cleaner, which nulls payloads and deletes `messagecontent` rows once a message's expiration has passed, always ran with the worker. From the discussion linked in the issue: message payloads persist only until expiration, and operators who want to keep them around (e.g. for their own retention tooling) had no way to opt out of the deletion.

## Fix

Add an `expired_message_cleaner_enabled` setting (`SVIX_EXPIRED_MESSAGE_CLEANER_ENABLED`), defaulting to `true` to preserve current behavior. When disabled, the cleaner loop is not started.

Message rows themselves are kept regardless (pagination iterators depend on them); full deletion of old messages remains available via the `svix-server prune` command.

The option is documented in `config.default.toml` and covered by environment parsing tests in `tests/config.rs`.

## Testing

- `cargo test --test config` passes (defaults to enabled, `SVIX_EXPIRED_MESSAGE_CLEANER_ENABLED=false` disables).
- `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` pass on Rust 1.88 (matching the CI matrix).